### PR TITLE
Fix `Send` and `Sync` implementations on `Id` and `WeakId`

### DIFF
--- a/objc_id/src/id.rs
+++ b/objc_id/src/id.rs
@@ -215,9 +215,11 @@ where
     }
 }
 
-unsafe impl<T> Sync for WeakId<T> where T: Sync {}
+/// This implementation follows the same reasoning as `Id<T, Shared>`.
+unsafe impl<T: Sync + Send> Sync for WeakId<T> {}
 
-unsafe impl<T> Send for WeakId<T> where T: Sync {}
+/// This implementation follows the same reasoning as `Id<T, Shared>`.
+unsafe impl<T: Sync + Send> Send for WeakId<T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
See comments in the code for reasoning.

The impl for `Id<T, Shared>` is the same as `Arc<T>`, the impl for `Id<T, Owned>` is the same as `Box<T>` and the impl for `WeakId` is the same as `Id<T, Shared>` (because you can get the latter from the former).

See [this blog post](https://nyanpasu64.github.io/blog/an-unsafe-tour-of-rust-s-send-and-sync/#smart-pointers-arct-atomic-refcounting) by `nyanpasu64` for more information on this.

Replaces https://github.com/SSheldon/rust-objc-id/pull/8.