### PR TITLE
Statically find `msgSend` functions on apple devices

### DIFF
--- a/objc/src/message/apple/arm.rs
+++ b/objc/src/message/apple/arm.rs
@@ -1,8 +1,10 @@
-use core::any::{Any, TypeId};
 use core::mem;
 
+use super::MsgSendFn;
 use crate::runtime::Imp;
+use crate::{Encode, Encoding};
 
+// TODO: C-unwind
 extern "C" {
     fn objc_msgSend();
     fn objc_msgSend_stret();
@@ -11,32 +13,27 @@ extern "C" {
     fn objc_msgSendSuper_stret();
 }
 
-pub fn msg_send_fn<R: Any>() -> Imp {
-    // Double-word sized fundamental data types don't use stret,
-    // but any composite type larger than 4 bytes does.
-    // <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042e/IHI0042E_aapcs.pdf>
-
-    let type_id = TypeId::of::<R>();
-    if mem::size_of::<R>() <= 4
-        || type_id == TypeId::of::<i64>()
-        || type_id == TypeId::of::<u64>()
-        || type_id == TypeId::of::<f64>()
-    {
-        objc_msgSend
-    } else {
-        objc_msgSend_stret
-    }
-}
-
-pub fn msg_send_super_fn<R: Any>() -> Imp {
-    let type_id = TypeId::of::<R>();
-    if mem::size_of::<R>() <= 4
-        || type_id == TypeId::of::<i64>()
-        || type_id == TypeId::of::<u64>()
-        || type_id == TypeId::of::<f64>()
-    {
-        objc_msgSendSuper
-    } else {
-        objc_msgSendSuper_stret
-    }
+/// Double-word sized fundamental data types don't use stret, but any
+/// composite type larger than 4 bytes does.
+///
+/// <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042e/IHI0042E_aapcs.pdf>
+impl<T: Encode> MsgSendFn for T {
+    const MSG_SEND: Imp = {
+        if let Encoding::LongLong | Encoding::ULongLong | Encoding::Double = T::ENCODING {
+            objc_msgSend
+        } else if mem::size_of::<T>() <= 4 {
+            objc_msgSend
+        } else {
+            objc_msgSend_stret
+        }
+    };
+    const MSG_SEND_SUPER: Imp = {
+        if let Encoding::LongLong | Encoding::ULongLong | Encoding::Double = T::ENCODING {
+            objc_msgSendSuper
+        } else if mem::size_of::<T>() <= 4 {
+            objc_msgSendSuper
+        } else {
+            objc_msgSendSuper_stret
+        }
+    };
 }

--- a/objc/src/message/apple/arm64.rs
+++ b/objc/src/message/apple/arm64.rs
@@ -1,18 +1,18 @@
+use super::MsgSendFn;
 use crate::runtime::Imp;
+use crate::Encode;
 
+// TODO: C-unwind
 extern "C" {
     fn objc_msgSend();
 
     fn objc_msgSendSuper();
 }
 
-pub fn msg_send_fn<R>() -> Imp {
-    // stret is not even available in arm64.
-    // <https://twitter.com/gparker/status/378079715824660480>
-
-    objc_msgSend
-}
-
-pub fn msg_send_super_fn<R>() -> Imp {
-    objc_msgSendSuper
+/// `objc_msgSend_stret` is not even available in arm64.
+///
+/// <https://twitter.com/gparker/status/378079715824660480>
+impl<T: Encode> MsgSendFn for T {
+    const MSG_SEND: Imp = objc_msgSend;
+    const MSG_SEND_SUPER: Imp = objc_msgSendSuper;
 }

--- a/objc/src/message/apple/mod.rs
+++ b/objc/src/message/apple/mod.rs
@@ -1,7 +1,5 @@
-use core::any::Any;
-
-use super::{Message, MessageArguments, MessageError, Super};
-use crate::runtime::{Class, Object, Sel};
+use super::{Encode, Message, MessageArguments, MessageError, Super};
+use crate::runtime::{Class, Imp, Object, Sel};
 
 #[cfg(target_arch = "x86")]
 #[path = "x86.rs"]
@@ -16,16 +14,21 @@ mod arch;
 #[path = "arm64.rs"]
 mod arch;
 
-use self::arch::{msg_send_fn, msg_send_super_fn};
+/// On the above architectures we can statically find the correct method to
+/// call from the return type, by looking at it's `Encode` implementation.
+trait MsgSendFn: Encode {
+    const MSG_SEND: Imp;
+    const MSG_SEND_SUPER: Imp;
+}
 
 pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A) -> Result<R, MessageError>
 where
     T: Message,
     A: MessageArguments,
-    R: Any,
+    R: Encode,
 {
     let receiver = obj as *mut T as *mut Object;
-    let msg_send_fn = msg_send_fn::<R>();
+    let msg_send_fn = R::MSG_SEND;
     objc_try!({ A::invoke(msg_send_fn, receiver, sel, args) })
 }
 
@@ -38,13 +41,13 @@ pub unsafe fn send_super_unverified<T, A, R>(
 where
     T: Message,
     A: MessageArguments,
-    R: Any,
+    R: Encode,
 {
     let sup = Super {
         receiver: obj as *mut T as *mut Object,
         superclass,
     };
     let receiver = &sup as *const Super as *mut Object;
-    let msg_send_fn = msg_send_super_fn::<R>();
+    let msg_send_fn = R::MSG_SEND_SUPER;
     objc_try!({ A::invoke(msg_send_fn, receiver, sel, args) })
 }

--- a/objc/src/message/apple/x86.rs
+++ b/objc/src/message/apple/x86.rs
@@ -1,8 +1,10 @@
-use core::any::{Any, TypeId};
 use core::mem;
 
+use super::MsgSendFn;
 use crate::runtime::Imp;
+use crate::{Encode, Encoding};
 
+// TODO: C-unwind
 extern "C" {
     fn objc_msgSend();
     fn objc_msgSend_fpret();
@@ -12,28 +14,26 @@ extern "C" {
     fn objc_msgSendSuper_stret();
 }
 
-pub fn msg_send_fn<R: Any>() -> Imp {
-    // Structures 1 or 2 bytes in size are placed in EAX.
-    // Structures 4 or 8 bytes in size are placed in: EAX and EDX.
-    // Structures of other sizes are placed at the address supplied by the caller.
-    // <https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/LowLevelABI/130-IA-32_Function_Calling_Conventions/IA32.html>
-
-    let type_id = TypeId::of::<R>();
-    let size = mem::size_of::<R>();
-    if type_id == TypeId::of::<f32>() || type_id == TypeId::of::<f64>() {
-        objc_msgSend_fpret
-    } else if size == 0 || size == 1 || size == 2 || size == 4 || size == 8 {
-        objc_msgSend
-    } else {
-        objc_msgSend_stret
-    }
-}
-
-pub fn msg_send_super_fn<R: Any>() -> Imp {
-    let size = mem::size_of::<R>();
-    if size == 0 || size == 1 || size == 2 || size == 4 || size == 8 {
-        objc_msgSendSuper
-    } else {
-        objc_msgSendSuper_stret
-    }
+/// Structures 1 or 2 bytes in size are placed in EAX.
+/// Structures 4 or 8 bytes in size are placed in: EAX and EDX.
+/// Structures of other sizes are placed at the address supplied by the caller.
+///
+/// <https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/LowLevelABI/130-IA-32_Function_Calling_Conventions/IA32.html>
+impl<T: Encode> MsgSendFn for T {
+    const MSG_SEND: Imp = {
+        if let Encoding::Float | Encoding::Double = T::ENCODING {
+            objc_msgSend_fpret
+        } else if let 0 | 1 | 2 | 4 | 8 = mem::size_of::<T>() {
+            objc_msgSend
+        } else {
+            objc_msgSend_stret
+        }
+    };
+    const MSG_SEND_SUPER: Imp = {
+        if let 0 | 1 | 2 | 4 | 8 = mem::size_of::<T>() {
+            objc_msgSendSuper
+        } else {
+            objc_msgSendSuper_stret
+        }
+    };
 }

--- a/objc/src/message/apple/x86_64.rs
+++ b/objc/src/message/apple/x86_64.rs
@@ -1,7 +1,10 @@
 use core::mem;
 
+use super::MsgSendFn;
 use crate::runtime::Imp;
+use crate::Encode;
 
+// TODO: C-unwind
 extern "C" {
     fn objc_msgSend();
     fn objc_msgSend_stret();
@@ -10,23 +13,24 @@ extern "C" {
     fn objc_msgSendSuper_stret();
 }
 
-pub fn msg_send_fn<R>() -> Imp {
-    // If the size of an object is larger than two eightbytes, it has class MEMORY.
-    // If the type has class MEMORY, then the caller provides space for the return
-    // value and passes the address of this storage.
-    // <http://people.freebsd.org/~obrien/amd64-elf-abi.pdf>
-
-    if mem::size_of::<R>() <= 16 {
-        objc_msgSend
-    } else {
-        objc_msgSend_stret
-    }
-}
-
-pub fn msg_send_super_fn<R>() -> Imp {
-    if mem::size_of::<R>() <= 16 {
-        objc_msgSendSuper
-    } else {
-        objc_msgSendSuper_stret
-    }
+/// If the size of an object is larger than two eightbytes, it has class
+/// MEMORY. If the type has class MEMORY, then the caller provides space for
+/// the return value and passes the address of this storage.
+///
+/// <http://people.freebsd.org/~obrien/amd64-elf-abi.pdf>
+impl<T: Encode> MsgSendFn for T {
+    const MSG_SEND: Imp = {
+        if mem::size_of::<T>() <= 16 {
+            objc_msgSend
+        } else {
+            objc_msgSend_stret
+        }
+    };
+    const MSG_SEND_SUPER: Imp = {
+        if mem::size_of::<T>() <= 16 {
+            objc_msgSendSuper
+        } else {
+            objc_msgSendSuper_stret
+        }
+    };
 }

--- a/objc/src/message/gnustep.rs
+++ b/objc/src/message/gnustep.rs
@@ -1,7 +1,6 @@
-use core::any::Any;
 use core::mem;
 
-use super::{Message, MessageArguments, MessageError, Super};
+use super::{Encode, Message, MessageArguments, MessageError, Super};
 use crate::runtime::{Class, Imp, Object, Sel};
 
 extern "C" {
@@ -13,7 +12,7 @@ pub unsafe fn send_unverified<T, A, R>(obj: *const T, sel: Sel, args: A) -> Resu
 where
     T: Message,
     A: MessageArguments,
-    R: Any,
+    R: Encode,
 {
     if obj.is_null() {
         return mem::zeroed();
@@ -33,7 +32,7 @@ pub unsafe fn send_super_unverified<T, A, R>(
 where
     T: Message,
     A: MessageArguments,
-    R: Any,
+    R: Encode,
 {
     let receiver = obj as *mut T as *mut Object;
     let sup = Super {

--- a/objc/src/message/mod.rs
+++ b/objc/src/message/mod.rs
@@ -1,5 +1,4 @@
 use alloc::string::{String, ToString};
-use core::any::Any;
 use core::fmt;
 use core::mem;
 use std::error::Error;
@@ -80,7 +79,7 @@ pub unsafe trait Message: RefEncode {
     where
         Self: Sized,
         A: MessageArguments + EncodeArguments,
-        R: Any + Encode,
+        R: Encode,
     {
         send_message(self, sel, args)
     }
@@ -128,16 +127,13 @@ pub trait MessageArguments: Sized {
     /// This method is the primitive used when sending messages and should not
     /// be called directly; instead, use the `msg_send!` macro or, in cases
     /// with a dynamic selector, the [`Message::send_message`] method.
-    unsafe fn invoke<R>(imp: Imp, obj: *mut Object, sel: Sel, args: Self) -> R
-    where
-        R: Any;
+    unsafe fn invoke<R>(imp: Imp, obj: *mut Object, sel: Sel, args: Self) -> R;
 }
 
 macro_rules! message_args_impl {
     ($($a:ident : $t:ident),*) => (
         impl<$($t),*> MessageArguments for ($($t,)*) {
-            unsafe fn invoke<R>(imp: Imp, obj: *mut Object, sel: Sel, ($($a,)*): Self) -> R
-                    where R: Any {
+            unsafe fn invoke<R>(imp: Imp, obj: *mut Object, sel: Sel, ($($a,)*): Self) -> R {
                 let imp: unsafe extern fn(*mut Object, Sel $(, $t)*) -> R =
                     mem::transmute(imp);
                 imp(obj, sel $(, $a)*)
@@ -221,7 +217,7 @@ pub unsafe fn send_message<T, A, R>(obj: *const T, sel: Sel, args: A) -> Result<
 where
     T: Message,
     A: MessageArguments + EncodeArguments,
-    R: Any + Encode,
+    R: Encode,
 {
     #[cfg(feature = "verify_message")]
     {
@@ -247,7 +243,7 @@ pub unsafe fn send_super_message<T, A, R>(
 where
     T: Message,
     A: MessageArguments + EncodeArguments,
-    R: Any + Encode,
+    R: Encode,
 {
     #[cfg(feature = "verify_message")]
     {


### PR DESCRIPTION
The functions are found by looking at the `Encode::ENCODING` and size of the return type.

This ensures that we don't incur a performance overhead for that (though we probably didn't before anyways).

This is also more correct since it allows the following:
```rust
#[repr(transparent)]
struct Wrapper {
    inner: f32,
}
unsafe impl Encode for Wrapper {
    const ENCODING: Encoding<'static> = f32::ENCODING;
}
```
To use the correct `msgSend` implementation.