### PR TITLE
Fix GNUStep `Foundation` linking when running tests

### DIFF
--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -100,3 +100,27 @@ pub mod runtime;
 
 #[cfg(test)]
 mod test_utils;
+
+/// Hacky way to make GNUStep link properly to Foundation while testing.
+///
+/// This is a temporary solution to make our CI work for now!
+#[doc(hidden)]
+#[cfg(not(target_vendor = "apple"))]
+pub mod __gnustep_hack {
+    use super::runtime::Class;
+
+    #[link(name = "gnustep-base", kind = "dylib")]
+    // This linking doesn't have to be on the correct `extern` block.
+    extern "C" {
+        static _OBJC_CLASS_NSObject: Class;
+    }
+
+    pub unsafe fn get_class_to_force_linkage() -> &'static Class {
+        &_OBJC_CLASS_NSObject
+    }
+
+    #[test]
+    fn ensure_linkage() {
+        unsafe { get_class_to_force_linkage() };
+    }
+}

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -216,7 +216,7 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 ///
 /// Basic usage:
 ///
-/// ```rust
+/// ```rust,no_run
 /// use objc2::{class, msg_send};
 /// use objc2::rc::{autoreleasepool, AutoreleasePool};
 /// use objc2::runtime::Object;

--- a/objc2_foundation/src/lib.rs
+++ b/objc2_foundation/src/lib.rs
@@ -26,24 +26,8 @@ pub use self::value::{INSValue, NSValue};
 extern "C" {}
 
 #[cfg(not(target_vendor = "apple"))]
-use objc2::runtime::Class;
-
-#[cfg(not(target_vendor = "apple"))]
 #[link(name = "gnustep-base", kind = "dylib")]
 extern "C" {}
-
-// Split up to illustrate that the linking doesn't have to be annotated on the
-// correct `extern` block.
-#[cfg(not(target_vendor = "apple"))]
-extern "C" {
-    static _OBJC_CLASS_NSObject: Class;
-}
-
-#[cfg(not(target_vendor = "apple"))]
-#[allow(dead_code)]
-unsafe fn get_class_to_force_linkage() -> &'static Class {
-    &_OBJC_CLASS_NSObject
-}
 
 #[macro_use]
 mod macros;

--- a/objc2_foundation/src/string.rs
+++ b/objc2_foundation/src/string.rs
@@ -95,7 +95,7 @@ mod tests {
     #[cfg(not(target_vendor = "apple"))]
     #[test]
     fn ensure_linkage() {
-        unsafe { crate::get_class_to_force_linkage() };
+        unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
     }
 
     #[test]


### PR DESCRIPTION
This is a temporary fix. In the future we should statically link to class symbols in the `class!` macro