### PR TITLE
`Id` conversion traits

### DIFF
--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,4 +1,4 @@
-use objc2::rc::autoreleasepool;
+use objc2::rc::{autoreleasepool, FromId, Id, IntoId};
 use objc2_foundation::{
     INSArray, INSCopying, INSDictionary, INSString, NSArray, NSDictionary, NSObject, NSString,
 };
@@ -13,14 +13,14 @@ fn main() {
 
     // Create an NSArray from a Vec
     let objs = vec![obj, obj2];
-    let array = NSArray::from_vec(objs);
+    let array: Id<NSArray<_, _>, _> = objs.into_id();
     for obj in array.iter() {
         println!("{:?}", obj);
     }
     println!("{}", array.len());
 
     // Turn the NSArray back into a Vec
-    let mut objs = NSArray::into_vec(array);
+    let mut objs = Vec::from_id(array);
     let obj = objs.pop().unwrap();
 
     // Create an NSString from a str slice

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -169,13 +169,16 @@ impl<'a, C: INSFastEnumeration> Iterator for NSFastEnumerator<'a, C> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use objc2::rc::{Id, IntoId};
+
     use super::INSFastEnumeration;
     use crate::{INSArray, INSValue, NSArray, NSValue};
 
     #[test]
     fn test_enumerator() {
-        let vec = (0u32..4).map(NSValue::new).collect();
-        let array = NSArray::from_vec(vec);
+        let vec: Vec<_> = (0u32..4).map(NSValue::new).collect();
+        let array: Id<NSArray<_, _>, _> = vec.into_id();
 
         let enumerator = array.iter();
         assert!(enumerator.count() == 4);
@@ -186,8 +189,8 @@ mod tests {
 
     #[test]
     fn test_fast_enumerator() {
-        let vec = (0u32..4).map(NSValue::new).collect();
-        let array = NSArray::from_vec(vec);
+        let vec: Vec<_> = (0u32..4).map(NSValue::new).collect();
+        let array: Id<NSArray<_, _>, _> = vec.into_id();
 
         let enumerator = array.enumerator();
         assert!(enumerator.count() == 4);

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -35,7 +35,7 @@ mod weak_id;
 
 pub use self::autorelease::{autoreleasepool, AutoreleasePool, AutoreleaseSafe};
 pub use self::id::Id;
-pub use self::id_traits::{DefaultId, SliceId, SliceIdMut};
+pub use self::id_traits::{DefaultId, FromId, IntoId, SliceId, SliceIdMut, TryFromId, TryIntoId};
 pub use self::ownership::{Owned, Ownership, Shared};
 pub use self::weak_id::WeakId;
 


### PR DESCRIPTION
Proof-of-concept on fixing the remaining part of https://github.com/madsmtm/objc2/pull/41, identified in https://github.com/madsmtm/objc2/issues/39 (upstream https://github.com/SSheldon/rust-objc-foundation/issues/1).

Another alternative would be to mark `Id` with the unstable `#[fundamental]` attribute, see [RFC 1023](https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html) and [tracking issue](https://github.com/rust-lang/rust/issues/29635).