### PR TITLE
Make `Id` `#[fundamental]`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
       FEATURES: ${{ matrix.features || 'malloc,block,exception,catch_all,verify_message' }}
-      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe' }}
+      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-id-fundamental' }}
 
     runs-on: ${{ matrix.os }}
 

--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,4 +1,4 @@
-use objc2::rc::autoreleasepool;
+use objc2::rc::{autoreleasepool, Id};
 use objc2_foundation::{NSArray, NSCopying, NSDictionary, NSObject, NSString};
 
 fn main() {
@@ -14,14 +14,14 @@ fn main() {
 
     // Create an NSArray from a Vec
     let objs = vec![obj, obj2];
-    let array = NSArray::from_vec(objs);
+    let array: Id<NSArray<_, _>, _> = objs.into();
     for obj in array.iter() {
         println!("{:?}", obj);
     }
     println!("{}", array.len());
 
     // Turn the NSArray back into a Vec
-    let mut objs = NSArray::into_vec(array);
+    let mut objs = Vec::from(array);
     let obj = objs.pop().unwrap();
 
     // Create an NSString from a str slice

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -167,13 +167,16 @@ impl<'a, C: NSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use objc2::rc::Id;
+
     use super::NSFastEnumeration;
     use crate::{NSArray, NSValue};
 
     #[test]
     fn test_enumerator() {
-        let vec = (0usize..4).map(NSValue::new).collect();
-        let array = NSArray::from_vec(vec);
+        let vec: Vec<_> = (0usize..4).map(NSValue::new).collect();
+        let array: Id<NSArray<_, _>, _> = vec.into();
 
         let enumerator = array.iter();
         assert_eq!(enumerator.count(), 4);
@@ -184,8 +187,8 @@ mod tests {
 
     #[test]
     fn test_fast_enumerator() {
-        let vec = (0usize..4).map(NSValue::new).collect();
-        let array = NSArray::from_vec(vec);
+        let vec: Vec<_> = (0usize..4).map(NSValue::new).collect();
+        let array: Id<NSArray<_, _>, _> = vec.into();
 
         let enumerator = array.iter_fast();
         assert_eq!(enumerator.count(), 4);

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -40,6 +40,9 @@ malloc = ["malloc_buf"]
 # Uses nightly features to make AutoreleasePool zero-cost even in debug mode
 unstable-autoreleasesafe = []
 
+# Marks `rc::Id` with nightly `fundamental` feature.
+unstable-id-fundamental = []
+
 # Runtime selection. See `objc-sys` for details.
 apple = ["objc-sys/apple"]
 gnustep-1-7 = ["objc-sys/gnustep-1-7"]

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -168,6 +168,7 @@
     feature = "unstable-autoreleasesafe",
     feature(negative_impls, auto_traits)
 )]
+#![cfg_attr(feature = "unstable-id-fundamental", feature(fundamental))]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -96,6 +96,7 @@ use crate::Message;
 /// let cloned: Id<T, Shared> = shared.clone();
 /// // Do something with `&T` here
 /// ```
+#[cfg_attr(feature = "unstable-id-fundamental", fundamental)]
 #[repr(transparent)]
 // TODO: Figure out if `Message` bound on `T` would be better here?
 // TODO: Add `ptr::Thin` bound on `T` to allow for only extern types


### PR DESCRIPTION
Proof-of-concept on fixing the remaining part of https://github.com/madsmtm/objc2/pull/41, identified in https://github.com/madsmtm/objc2/issues/39 (upstream https://github.com/SSheldon/rust-objc-foundation/issues/1). Probably a better alternative than https://github.com/madsmtm/objc2/pull/48.

The `#[fundamental]` attribute is unstable, see [RFC 1023](https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html) and [tracking issue](https://github.com/rust-lang/rust/issues/29635), so I won't merge this.