### PR TITLE
Add `global_block!` macro

### DIFF
--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* `GlobalBlock` and corresponding `global_block!` macro, allowing statically
+  creating blocks that don't reference their environment.
+
 
 ## 0.2.0-alpha.1 - 2021-11-22
 

--- a/block2/src/global.rs
+++ b/block2/src/global.rs
@@ -1,0 +1,184 @@
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Deref;
+use std::os::raw::c_ulong;
+
+use objc2_encode::{Encode, EncodeArguments};
+
+use super::{ffi, Block};
+use crate::BlockArguments;
+
+#[doc(hidden)]
+pub const __GLOBAL_DESCRIPTOR: ffi::Block_descriptor_header = ffi::Block_descriptor_header {
+    reserved: 0,
+    size: mem::size_of::<ffi::Block_layout>() as c_ulong,
+};
+
+/// An Objective-C block that does not capture it's environment.
+///
+/// This is effectively just a glorified function pointer, and can created and
+/// stored in static memory using the [`global_block`][`global_block!`] macro.
+///
+/// If [`ConcreteBlock`] is the [`Fn`]-block equivalent, this is likewise the
+/// [`fn`]-block equivalent.
+#[repr(C)]
+pub struct GlobalBlock<A, R = ()> {
+    layout: ffi::Block_layout,
+    p: PhantomData<(A, R)>,
+}
+
+unsafe impl<A, R> Sync for GlobalBlock<A, R>
+where
+    A: BlockArguments + EncodeArguments,
+    R: Encode,
+{
+}
+unsafe impl<A, R> Send for GlobalBlock<A, R>
+where
+    A: BlockArguments + EncodeArguments,
+    R: Encode,
+{
+}
+
+// Note: We can't put correct bounds on A and R because we have a const fn!
+//
+// Fortunately, we don't need them, since they're present on `Sync`, so
+// constructing the static in `global_block!` with an invalid `GlobalBlock`
+// triggers an error.
+impl<A, R> GlobalBlock<A, R> {
+    /// Use the [`global_block`] macro instead.
+    #[doc(hidden)]
+    pub const unsafe fn from_layout(layout: ffi::Block_layout) -> Self {
+        Self {
+            layout,
+            p: PhantomData,
+        }
+    }
+}
+
+impl<A, R> Deref for GlobalBlock<A, R>
+where
+    A: BlockArguments + EncodeArguments,
+    R: Encode,
+{
+    type Target = Block<A, R>;
+
+    fn deref(&self) -> &Block<A, R> {
+        // TODO: SAFETY
+        unsafe { &*(self as *const Self as *const Block<A, R>) }
+    }
+}
+
+/// Construct a static [`GlobalBlock`].
+///
+/// The syntax is similar to a static closure. Note that the block cannot
+/// capture it's environment, and it's argument types and return type must be
+/// [`Encode`].
+///
+/// # Examples
+///
+/// ```
+/// use block2::global_block;
+/// global_block! {
+///     static MY_BLOCK = || -> i32 {
+///         42
+///     }
+/// };
+/// assert_eq!(unsafe { MY_BLOCK.call(()) }, 42);
+/// ```
+///
+/// ```
+/// use block2::global_block;
+/// global_block! {
+///     static ADDER_BLOCK = |x: i32, y: i32,| -> i32 {
+///         x + y
+///     }
+/// };
+/// assert_eq!(unsafe { ADDER_BLOCK.call((5, 7)) }, 12);
+/// ```
+///
+/// ```
+/// use block2::global_block;
+/// global_block! {
+///     pub static MUTATING_BLOCK = |x: &mut i32| {
+///         *x = *x + 42;
+///     }
+/// };
+/// let mut x = 5;
+/// unsafe { MUTATING_BLOCK.call((&mut x,)) };
+/// assert_eq!(x, 47);
+/// ```
+///
+/// The following does not compile because [`Box`] is not [`Encode`]:
+///
+/// ```compile_fail
+/// use block2::global_block;
+/// global_block! {
+///     pub static INVALID_BLOCK = |b: Box<i32>| {}
+/// };
+/// ```
+#[macro_export]
+macro_rules! global_block {
+    // `||` is parsed as one token
+    (
+        $(#[$m:meta])*
+        $vis:vis static $name:ident = || $(-> $r:ty)? $body:block
+    ) => {
+        $crate::global_block!($(#[$m])* $vis static $name = |,| $(-> $r)? $body);
+    };
+    (
+        $(#[$m:meta])*
+        $vis:vis static $name:ident = |$($a:ident: $t:ty),* $(,)?| $(-> $r:ty)? $body:block
+    ) => {
+        $(#[$m])*
+        #[allow(unused_unsafe)]
+        $vis static $name: $crate::GlobalBlock<($($t,)*) $(, $r)?> = unsafe {
+            $crate::GlobalBlock::from_layout($crate::ffi::Block_layout {
+                isa: &$crate::ffi::_NSConcreteGlobalBlock as *const _ as *mut _,
+                flags: $crate::ffi::BLOCK_IS_GLOBAL | $crate::ffi::BLOCK_USE_STRET,
+                reserved: 0,
+                invoke: {
+                    unsafe extern "C" fn inner(_: *mut $crate::ffi::Block_layout, $($a: $t),*) $(-> $r)? {
+                        $body
+                    }
+                    let inner: unsafe extern "C" fn(*mut $crate::ffi::Block_layout, $($a: $t),*) $(-> $r)? = inner;
+
+                    // TODO: SAFETY
+                    ::core::mem::transmute(inner)
+                },
+                descriptor: &$crate::__GLOBAL_DESCRIPTOR as *const _ as *mut _,
+            })
+        };
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    global_block! {
+        /// Test comments and visibility
+        pub(super) static NOOP_BLOCK = || {}
+    }
+
+    global_block! {
+        /// Multiple arguments + trailing comma
+        #[allow(unused)]
+        static BLOCK = |x: i32, y: i32, z: i32, w: i32,| -> i32 {
+            x + y + z + w
+        }
+    }
+
+    #[test]
+    fn test_noop_block() {
+        unsafe { NOOP_BLOCK.call(()) };
+    }
+
+    #[test]
+    fn test_defined_in_function() {
+        global_block!(
+            static MY_BLOCK = || -> i32 {
+                42
+            }
+        );
+        assert_eq!(unsafe { MY_BLOCK.call(()) }, 42);
+    }
+}

--- a/block2/src/global.rs
+++ b/block2/src/global.rs
@@ -22,6 +22,8 @@ const GLOBAL_DESCRIPTOR: ffi::Block_descriptor_header = ffi::Block_descriptor_he
 ///
 /// If [`ConcreteBlock`] is the [`Fn`]-block equivalent, this is likewise the
 /// [`fn`]-block equivalent.
+///
+/// [`ConcreteBlock`]: crate::ConcreteBlock
 #[repr(C)]
 pub struct GlobalBlock<A, R = ()> {
     layout: ffi::Block_layout,
@@ -105,7 +107,7 @@ where
 /// ```
 /// use block2::global_block;
 /// global_block! {
-///     static ADDER_BLOCK = |x: i32, y: i32,| -> i32 {
+///     static ADDER_BLOCK = |x: i32, y: i32| -> i32 {
 ///         x + y
 ///     }
 /// };
@@ -132,6 +134,8 @@ where
 ///     pub static INVALID_BLOCK = |b: Box<i32>| {}
 /// };
 /// ```
+///
+/// [`Box`]: std::boxed::Box
 #[macro_export]
 macro_rules! global_block {
     // `||` is parsed as one token

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -43,6 +43,19 @@ It is important to copy your block to the heap (with the `copy` method) before
 passing it to Objective-C; this is because our `ConcreteBlock` is only meant
 to be copied once, and we can enforce this in Rust, but if Objective-C code
 were to copy it twice we could have a double free.
+
+As an optimization if your block doesn't capture any variables, you can use
+the [`global_block!`] macro to create a static block:
+
+```
+use block2::global_block;
+global_block! {
+    static MY_BLOCK = || -> f32 {
+        10.0
+    }
+};
+assert_eq!(unsafe { MY_BLOCK.call(()) }, 10.0);
+```
 */
 
 #![no_std]

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -69,7 +69,7 @@ use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 #[macro_use]
 mod global;
 
-pub use global::{GlobalBlock, __GLOBAL_DESCRIPTOR};
+pub use global::GlobalBlock;
 
 /// Types that may be used as the arguments to an Objective-C block.
 pub trait BlockArguments: Sized {

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -66,6 +66,11 @@ use std::os::raw::{c_int, c_ulong};
 pub use block_sys as ffi;
 use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
+#[macro_use]
+mod global;
+
+pub use global::{GlobalBlock, __GLOBAL_DESCRIPTOR};
+
 /// Types that may be used as the arguments to an Objective-C block.
 pub trait BlockArguments: Sized {
     /// Calls the given `Block` with self as the arguments.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 [dependencies]
 block2 = { path = "../block2" }
 block-sys = { path = "../block-sys" }
+objc2-encode = { path = "../objc2-encode" }
 
 [build-dependencies]
 cc = "1.0"

--- a/tests/extern/block_utils.c
+++ b/tests/extern/block_utils.c
@@ -1,8 +1,14 @@
 #include <stdint.h>
 #include <Block.h>
 
+typedef struct {
+    float x;
+    uint8_t y[100];
+} LargeStruct;
+
 typedef int32_t (^IntBlock)();
 typedef int32_t (^AddBlock)(int32_t);
+typedef LargeStruct (^LargeStructBlock)(LargeStruct);
 
 IntBlock get_int_block() {
     return ^{ return (int32_t)7; };
@@ -26,4 +32,24 @@ int32_t invoke_int_block(IntBlock block) {
 
 int32_t invoke_add_block(AddBlock block, int32_t a) {
     return block(a);
+}
+
+LargeStructBlock get_large_struct_block() {
+    return ^(LargeStruct s) {
+        s.x -= 1.0;
+        s.y[12] += 1;
+        s.y[99] = 123;
+        return s;
+    };
+}
+
+LargeStructBlock get_large_struct_block_with(LargeStruct a) {
+    return Block_copy(^(LargeStruct s) {
+        (void)s; // Unused
+        return a;
+    });
+}
+
+LargeStruct invoke_large_struct_block(LargeStructBlock block, LargeStruct s) {
+    return block(s);
 }

--- a/tests/src/ffi.rs
+++ b/tests/src/ffi.rs
@@ -1,3 +1,5 @@
+use objc2_encode::{Encode, Encoding};
+
 /// A block that takes no arguments and returns an integer: `int32_t (^)()`.
 #[repr(C)]
 pub struct IntBlock {
@@ -8,6 +10,37 @@ pub struct IntBlock {
 /// `int32_t (^)(int32_t)`.
 #[repr(C)]
 pub struct AddBlock {
+    _priv: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LargeStruct {
+    pub x: f32,
+    pub y: [u8; 100],
+}
+
+impl LargeStruct {
+    pub fn get() -> Self {
+        let mut y = [10; 100];
+        y[42] = 123;
+        Self { x: 5.0, y }
+    }
+
+    pub fn mutate(&mut self) {
+        self.x -= 1.0;
+        self.y[12] += 1;
+        self.y[99] = 123;
+    }
+}
+
+unsafe impl Encode for LargeStruct {
+    const ENCODING: Encoding<'static> =
+        Encoding::Struct("LargeStruct", &[f32::ENCODING, <[u8; 100]>::ENCODING]);
+}
+
+#[repr(C)]
+pub struct LargeStructBlock {
     _priv: [u8; 0],
 }
 
@@ -24,6 +57,10 @@ extern "C" {
     pub fn invoke_int_block(block: *mut IntBlock) -> i32;
     /// Invokes an `AddBlock` with `a` and returns the result.
     pub fn invoke_add_block(block: *mut AddBlock, a: i32) -> i32;
+
+    pub fn get_large_struct_block() -> *mut LargeStructBlock;
+    pub fn get_large_struct_block_with(i: LargeStruct) -> *mut LargeStructBlock;
+    pub fn invoke_large_struct_block(block: *mut LargeStructBlock, s: LargeStruct) -> LargeStruct;
 }
 
 #[cfg(test)]
@@ -44,5 +81,21 @@ mod tests {
             assert_eq!(invoke_add_block(get_add_block(), 5), 12);
             assert_eq!(invoke_add_block(get_add_block_with(3), 5), 8);
         }
+    }
+
+    #[test]
+    fn test_large_struct_block() {
+        let data = LargeStruct::get();
+        let mut expected = data.clone();
+        expected.mutate();
+
+        assert_eq!(
+            unsafe { invoke_large_struct_block(get_large_struct_block(), data) },
+            expected
+        );
+        assert_eq!(
+            unsafe { invoke_large_struct_block(get_large_struct_block_with(expected), data) },
+            expected
+        );
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,6 +8,7 @@ use block2::{Block, RcBlock};
 extern crate alloc;
 
 pub mod ffi;
+use crate::ffi::LargeStruct;
 
 pub fn get_int_block_with(i: i32) -> RcBlock<(), i32> {
     unsafe {
@@ -31,6 +32,14 @@ pub fn invoke_int_block(block: &Block<(), i32>) -> i32 {
 pub fn invoke_add_block(block: &Block<(i32,), i32>, a: i32) -> i32 {
     let ptr = block as *const _;
     unsafe { ffi::invoke_add_block(ptr as *mut _, a) }
+}
+
+pub fn invoke_large_struct_block(
+    block: &Block<(LargeStruct,), LargeStruct>,
+    x: LargeStruct,
+) -> LargeStruct {
+    let ptr = block as *const _;
+    unsafe { ffi::invoke_large_struct_block(ptr as *mut _, x) }
 }
 
 #[cfg(test)]
@@ -102,5 +111,31 @@ mod tests {
 
         let block = make_block();
         assert_eq!(invoke_int_block(&block), 7);
+    }
+
+    #[test]
+    fn test_large_struct_block() {
+        global_block! {
+            static BLOCK = |data: LargeStruct| -> LargeStruct {
+                let mut data = data;
+                data.mutate();
+                data
+            }
+        }
+
+        let data = LargeStruct::get();
+        let mut new_data = data.clone();
+        new_data.mutate();
+
+        assert_eq!(unsafe { BLOCK.call((data,)) }, new_data);
+        assert_eq!(invoke_large_struct_block(&BLOCK, data), new_data);
+
+        let block = ConcreteBlock::new(|mut x: LargeStruct| {
+            x.mutate();
+            x
+        });
+        assert_eq!(invoke_large_struct_block(&block, data), new_data);
+        let block = block.copy();
+        assert_eq!(invoke_large_struct_block(&block, data), new_data);
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -37,7 +37,19 @@ pub fn invoke_add_block(block: &Block<(i32,), i32>, a: i32) -> i32 {
 mod tests {
     use super::*;
     use alloc::string::ToString;
-    use block2::{ConcreteBlock, RcBlock};
+    use block2::{global_block, ConcreteBlock, RcBlock};
+
+    global_block! {
+        /// Test `global_block` in an external crate
+        static MY_BLOCK = || -> i32 {
+            42
+        }
+    }
+
+    #[test]
+    fn test_global_block() {
+        assert_eq!(invoke_int_block(&MY_BLOCK), 42);
+    }
 
     #[test]
     fn test_call_block() {


### PR DESCRIPTION
Defines a `static` containing a `GlobalBlock`. This can be used directly in Objective-C (without the need for `_Block_copy`) and so can be quite convenient. (And is also more efficient).

TODO: ~Figure out whether the naming is proper (`fn` snake_case to `static` UPPER_CASE). See [C-CASE](https://rust-lang.github.io/api-guidelines/naming.html#c-case)~ Done.