### PR TITLE
Unstable: Make calling `throw` no longer UB by using "C-unwind"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
       FEATURES: ${{ matrix.features || 'malloc,block,exception,catch_all,verify_message' }}
-      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe' }}
+      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind' }}
 
     runs-on: ${{ matrix.os }}
 

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `unstable-c-unwind` feature.
+
 
 ## 0.2.0-beta.0 - 2022-06-13
 

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -49,6 +49,9 @@ unstable-winobjc = ["gnustep-1-8"]
 # Link to ObjFW
 unstable-objfw = []
 
+# Use nightly c_unwind feature
+unstable-c-unwind = []
+
 # Private
 unstable-exception = ["cc"]
 unstable-docsrs = []

--- a/objc-sys/src/class.rs
+++ b/objc-sys/src/class.rs
@@ -23,6 +23,21 @@ pub struct objc_class {
 /// difference.
 type ivar_layout_type = u8;
 
+// May call `resolveClassMethod:` or `resolveInstanceMethod:`.
+extern_c_unwind! {
+    #[cfg(not(objfw))]
+    pub fn class_getClassMethod(
+        cls: *const objc_class,
+        name: *const objc_selector,
+    ) -> *const objc_method;
+    #[cfg(not(objfw))] // Available in newer versions
+    pub fn class_getInstanceMethod(
+        cls: *const objc_class,
+        name: *const objc_selector,
+    ) -> *const objc_method;
+}
+
+// TODO: Hooks registered with objc_setHook_getClass may be allowed to unwind?
 extern_c! {
     pub fn objc_getClass(name: *const c_char) -> *const objc_class;
     pub fn objc_getRequiredClass(name: *const c_char) -> *const objc_class;
@@ -97,19 +112,9 @@ extern_c! {
     #[cfg(not(objfw))]
     pub fn class_createInstance(cls: *const objc_class, extra_bytes: usize) -> *mut objc_object;
     #[cfg(not(objfw))]
-    pub fn class_getClassMethod(
-        cls: *const objc_class,
-        name: *const objc_selector,
-    ) -> *const objc_method;
-    #[cfg(not(objfw))]
     pub fn class_getClassVariable(cls: *const objc_class, name: *const c_char) -> *const objc_ivar;
     #[cfg(apple)]
     pub fn class_getImageName(cls: *const objc_class) -> *const c_char;
-    #[cfg(not(objfw))] // Available in newer versions
-    pub fn class_getInstanceMethod(
-        cls: *const objc_class,
-        name: *const objc_selector,
-    ) -> *const objc_method;
     pub fn class_getInstanceSize(cls: *const objc_class) -> usize;
     #[cfg(not(objfw))]
     pub fn class_getInstanceVariable(
@@ -140,6 +145,7 @@ extern_c! {
         attributes: *const objc_property_attribute_t,
         attributes_len: c_uint,
     );
+    // TODO: Verify unwinding
     pub fn class_respondsToSelector(cls: *const objc_class, sel: *const objc_selector) -> BOOL;
     #[cfg(not(objfw))]
     pub fn class_setIvarLayout(cls: *mut objc_class, layout: *const ivar_layout_type);

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -71,6 +71,10 @@ macro_rules! generate_linking_tests {
                     // Get function pointer to make the linker require the
                     // symbol to be available.
                     let f: unsafe extern $abi fn($($t),*) $(-> $r)? = crate::$name;
+                    // Workaround for https://github.com/rust-lang/rust/pull/92964
+                    #[cfg(feature = "unstable-c-unwind")]
+                    #[allow(clippy::useless_transmute)]
+                    let f: unsafe extern "C" fn() = unsafe { core::mem::transmute(f) };
                     // Execute side-effect to ensure it is not optimized away.
                     std::println!("{:p}", f);
                 }

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -25,9 +25,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-beta.0")]
-
-// TODO: Replace `extern "C"` with `extern "C-unwind"` where applicable.
-// See https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html.
+#![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 
 // TODO: Remove this and add "no-std" category to Cargo.toml
 // Requires a better solution for C-types in `no_std` crates.
@@ -51,6 +49,7 @@ macro_rules! generate_linking_tests {
             $(#[$m:meta])*
             $v:vis fn $name:ident($($a:ident: $t:ty),* $(,)?) $(-> $r:ty)?;
         )+}
+        mod $test_name:ident;
     } => {
         $(#[$extern_m])*
         extern $abi {$(
@@ -61,10 +60,9 @@ macro_rules! generate_linking_tests {
         $(#[$extern_m])*
         #[allow(deprecated)]
         #[cfg(test)]
-        mod test_linkable {
+        mod $test_name {
             #[allow(unused)]
             use super::*;
-            use std::println;
 
             $(
                 $(#[$m])*
@@ -74,7 +72,7 @@ macro_rules! generate_linking_tests {
                     // symbol to be available.
                     let f: unsafe extern $abi fn($($t),*) $(-> $r)? = crate::$name;
                     // Execute side-effect to ensure it is not optimized away.
-                    println!("{:p}", f);
+                    std::println!("{:p}", f);
                 }
             )+
         }
@@ -95,6 +93,40 @@ macro_rules! extern_c {
                 $(#[$m])*
                 $v fn $name($($a: $t),*) $(-> $r)?;
             )+}
+            mod test_linkable;
+        }
+    };
+}
+
+// A lot of places may call `+initialize`, but the runtime guards those calls
+// with `@try/@catch` blocks already, so we don't need to mark every function
+// "C-unwind", only certain ones!
+macro_rules! extern_c_unwind {
+    {
+        $(#![$extern_m:meta])*
+        $(
+            $(#[$m:meta])*
+            $v:vis fn $name:ident($($a:ident: $t:ty),* $(,)?) $(-> $r:ty)?;
+        )+
+    } => {
+        #[cfg(not(feature = "unstable-c-unwind"))]
+        generate_linking_tests! {
+            $(#[$extern_m])*
+            extern "C" {$(
+                $(#[$m])*
+                $v fn $name($($a: $t),*) $(-> $r)?;
+            )+}
+            mod test_linkable_unwind;
+        }
+
+        #[cfg(feature = "unstable-c-unwind")]
+        generate_linking_tests! {
+            $(#[$extern_m])*
+            extern "C-unwind" {$(
+                $(#[$m])*
+                $v fn $name($($a: $t),*) $(-> $r)?;
+            )+}
+            mod test_linkable_unwind;
         }
     };
 }

--- a/objc-sys/src/message.rs
+++ b/objc-sys/src/message.rs
@@ -20,7 +20,12 @@ pub struct objc_super {
     pub super_class: *const objc_class,
 }
 
-extern_c! {
+// All message sending functions should use "C-unwind"!
+//
+// Note that lookup functions won't throw exceptions themselves, but they can
+// call hooks, `resolveClassMethod:` and `resolveInstanceMethod:`, so we have
+// to make those "C-unwind" as well!
+extern_c_unwind! {
     #[cfg(any(gnustep, objfw))]
     pub fn objc_msg_lookup(receiver: *mut objc_object, sel: *const objc_selector) -> IMP;
     #[cfg(objfw)]

--- a/objc-sys/src/protocol.rs
+++ b/objc-sys/src/protocol.rs
@@ -30,10 +30,12 @@ extern_c! {
     #[cfg(not(objfw))]
     pub fn objc_registerProtocol(proto: *mut objc_protocol);
 
+    // TODO: Verify unwinding
     pub fn protocol_conformsToProtocol(
         proto: *const objc_protocol,
         other: *const objc_protocol,
     ) -> BOOL;
+    // TODO: Verify unwinding
     pub fn protocol_isEqual(proto: *const objc_protocol, other: *const objc_protocol) -> BOOL;
     pub fn protocol_getName(proto: *const objc_protocol) -> *const c_char;
 

--- a/objc-sys/src/rc.rs
+++ b/objc-sys/src/rc.rs
@@ -14,7 +14,9 @@ use core::ffi::c_void;
 
 use crate::objc_object;
 
-extern_c! {
+// All of these very rarely unwind, but may if the user defined methods
+// `retain`, `release`, `autorelease` or `dealloc` do.
+extern_c_unwind! {
     // Autoreleasepool
     // ObjFW: Defined in `autorelease.h`, not available with libobjfw-rt!
 

--- a/objc2-encode/Cargo.toml
+++ b/objc2-encode/Cargo.toml
@@ -26,6 +26,9 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 
+# Enables support for the nightly c_unwind feature
+unstable-c-unwind = []
+
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -94,6 +94,7 @@
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-pre.0")]
+#![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -302,6 +302,7 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
 
     #[doc(alias = "sortUsingFunction:context:")]
     pub fn sort_by<F: FnMut(&T, &T) -> Ordering>(&mut self, compare: F) {
+        // TODO: "C-unwind"
         extern "C" fn compare_with_closure<U, F: FnMut(&U, &U) -> Ordering>(
             obj1: &U,
             obj2: &U,

--- a/objc2-foundation/src/geometry.rs
+++ b/objc2-foundation/src/geometry.rs
@@ -315,6 +315,7 @@ mod tests {
     fn test_partial_eq() {
         use objc2::runtime::Bool;
 
+        // Note: No need to use "C-unwind"
         extern "C" {
             fn NSEqualPoints(a: NSPoint, b: NSPoint) -> Bool;
             fn NSEqualSizes(a: NSSize, b: NSSize) -> Bool;

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -34,6 +34,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING:** `Sel` is now required to be non-null, which means that you
   have to ensure that any selectors you receive from method calls are
   non-null before using them.
+* **BREAKING**: `ClassBuilder::root` is now generic over the function pointer,
+  meaning you will have to coerce initializer functions to pointers like in
+  `ClassBuilder::add_method` before you can use it.
 
 ### Removed
 * **BREAKING:** Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added the `"unstable-static-sel"` and `"unstable-static-sel-inlined"`
   feature flags to make the `sel!` macro (and by extension, the `msg_send!`
   macros) faster.
+* Added `"unstable-c-unwind"` feature.
 
 ### Changed
 * **BREAKING:** `Sel` is now required to be non-null, which means that you

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -55,6 +55,9 @@ unstable-static-sel-inlined = ["unstable-static-sel"]
 # Uses nightly features to make AutoreleasePool zero-cost even in debug mode
 unstable-autoreleasesafe = []
 
+# Uses the nightly c_unwind feature to make throwing safe
+unstable-c-unwind = ["objc-sys/unstable-c-unwind"]
+
 # Runtime selection. See `objc-sys` for details.
 apple = ["objc-sys/apple"]
 gnustep-1-7 = ["objc-sys/gnustep-1-7"]

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -110,17 +110,22 @@ macro_rules! method_decl_impl {
             }
         }
     };
-    ($($t:ident),*) => {
-        method_decl_impl!(-T, R, extern "C" fn(&T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(-T, R, extern "C" fn(&mut T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(-T, R, unsafe extern "C" fn(*const T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(-T, R, unsafe extern "C" fn(*mut T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(-T, R, unsafe extern "C" fn(&T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(-T, R, unsafe extern "C" fn(&mut T, Sel $(, $t)*) -> R, $($t),*);
+    (# $abi:literal; $($t:ident),*) => {
+        method_decl_impl!(-T, R, extern $abi fn(&T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(-T, R, extern $abi fn(&mut T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(-T, R, unsafe extern $abi fn(*const T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(-T, R, unsafe extern $abi fn(*mut T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(-T, R, unsafe extern $abi fn(&T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(-T, R, unsafe extern $abi fn(&mut T, Sel $(, $t)*) -> R, $($t),*);
 
-        method_decl_impl!(@Class, R, extern "C" fn(&Class, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(@Class, R, unsafe extern "C" fn(*const Class, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(@Class, R, unsafe extern "C" fn(&Class, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(@Class, R, extern $abi fn(&Class, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(@Class, R, unsafe extern $abi fn(*const Class, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(@Class, R, unsafe extern $abi fn(&Class, Sel $(, $t)*) -> R, $($t),*);
+    };
+    ($($t:ident),*) => {
+        method_decl_impl!(# "C"; $($t),*);
+        #[cfg(feature = "unstable-c-unwind")]
+        method_decl_impl!(# "C-unwind"; $($t),*);
     };
 }
 

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -226,7 +226,10 @@ impl ClassBuilder {
     /// the entire `NSObject` protocol is implemented.
     /// Functionality it expects, like implementations of `-retain` and
     /// `-release` used by ARC, will not be present otherwise.
-    pub fn root(name: &str, intitialize_fn: extern "C" fn(&Class, Sel)) -> Option<Self> {
+    pub fn root<F>(name: &str, intitialize_fn: F) -> Option<Self>
+    where
+        F: MethodImplementation<Callee = Class, Args = (), Ret = ()>,
+    {
         Self::with_superclass(name, None).map(|mut this| {
             unsafe { this.add_class_method(sel!(initialize), intitialize_fn) };
             this

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -168,6 +168,7 @@
     feature = "unstable-autoreleasesafe",
     feature(negative_impls, auto_traits)
 )]
+#![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -320,7 +320,12 @@ macro_rules! message_args_impl {
                 // type before being called; the msgSend functions are not
                 // parametric, but instead "trampolines" to the actual
                 // method implementations.
+                #[cfg(not(feature = "unstable-c-unwind"))]
                 let imp: unsafe extern "C" fn(*mut Object, Sel $(, $t)*) -> R = unsafe {
+                    mem::transmute(imp)
+                };
+                #[cfg(feature = "unstable-c-unwind")]
+                let imp: unsafe extern "C-unwind" fn(*mut Object, Sel $(, $t)*) -> R = unsafe {
                     mem::transmute(imp)
                 };
                 // TODO: On x86_64 it would be more efficient to use a GOT

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -103,13 +103,18 @@ standard_pointer_impls!(Ivar, Method, Class);
 #[repr(C)]
 pub struct Object(ffi::objc_object);
 
+#[cfg(not(feature = "unstable-c-unwind"))]
+type InnerImp = unsafe extern "C" fn();
+#[cfg(feature = "unstable-c-unwind")]
+type InnerImp = unsafe extern "C-unwind" fn();
+
 /// A pointer to the start of a method implementation.
 ///
 /// # Safety
 ///
 /// This is a "catch all" type; it must be transmuted to the correct type
 /// before being called!
-pub type Imp = unsafe extern "C" fn();
+pub type Imp = InnerImp;
 
 impl Sel {
     #[inline]

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -92,7 +92,11 @@ pub(crate) fn custom_class() -> &'static Class {
         // The runtime will call this method, so it has to be implemented
         extern "C" fn custom_obj_class_initialize(_this: &Class, _cmd: Sel) {}
 
-        let mut builder = ClassBuilder::root("CustomObject", custom_obj_class_initialize).unwrap();
+        let mut builder = ClassBuilder::root(
+            "CustomObject",
+            custom_obj_class_initialize as extern "C" fn(&Class, Sel),
+        )
+        .unwrap();
         let proto = custom_protocol();
 
         builder.add_protocol(proto);


### PR DESCRIPTION
Upstream: https://github.com/SSheldon/rust-objc-exception/pull/11

Requires https://github.com/rust-lang/rust/issues/74990