### PR TITLE
Unstable: `extern type` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
       SOME_FEATURES: ${{ matrix.features || 'malloc,block,exception,foundation' }}
       FEATURES: ${{ matrix.features || 'malloc,block,exception,foundation,catch-all,verify_message,uuid' }}
-      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind' }}
+      UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind,unstable-extern-types' }}
       CMD: cargo
 
     runs-on: ${{ matrix.os }}

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -33,26 +33,29 @@ default = ["std", "apple"]
 std = ["alloc"]
 alloc = []
 
-# Link to Apple's objc4
+# Link to Apple's objc4.
 apple = []
 
-# Link to GNUStep's libobjc2
+# Link to GNUStep's libobjc2.
 gnustep-1-7 = []
 gnustep-1-8 = ["gnustep-1-7"]
 gnustep-1-9 = ["gnustep-1-8"]
 gnustep-2-0 = ["gnustep-1-9"]
 gnustep-2-1 = ["gnustep-2-0"]
 
-# Link to Microsoft's libobjc2
+# Link to Microsoft's libobjc2.
 unstable-winobjc = ["gnustep-1-8"]
 
-# Link to ObjFW
+# Link to ObjFW.
 unstable-objfw = []
 
-# Use nightly c_unwind feature
+# Use nightly c_unwind feature.
 unstable-c-unwind = []
 
-# Private
+# Use nightly extern_types feature to mark opaque types as !Sized.
+unstable-extern-types = []
+
+# Private.
 unstable-exception = ["cc"]
 unstable-docsrs = []
 

--- a/objc2-encode/src/encode.rs
+++ b/objc2-encode/src/encode.rs
@@ -496,8 +496,8 @@ encode_pointer_impls!(
 /// well. So trying to do it quickly requires generating a polynomial amount of
 /// implementations, which IMO is overkill for such a small issue.
 ///
-/// Using `?Sized` is probably not safe here because C functions can only take
-/// and return items with a known size.
+/// Using `?Sized` is not safe here because C functions can only take and
+/// return items with a known size.
 macro_rules! encode_fn_pointer_impl {
     (@ $FnTy: ty, $($Arg: ident),*) => {
         unsafe impl<Ret: Encode, $($Arg: Encode),*> Encode for $FnTy {

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Added required `ClassType::NAME` constant for statically
   determining the name of a specific class.
 * Allow directly specifying class name in declare_class! macro.
+* Added the `"unstable-extern-types"` feature flags to make relevant types
+  `!Sized`.
 
 ### Changed
 * **BREAKING**: Slightly changed when a type implements `?Sized` to support

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   determining the name of a specific class.
 * Allow directly specifying class name in declare_class! macro.
 
+### Changed
+* **BREAKING**: Slightly changed when a type implements `?Sized` to support
+  `extern type` in the future. In particular, `Message` now requires `Sized`.
+
 ### Removed
 * **BREAKING**: `MaybeUninit` no longer implements `IvarType` directly; use
   `Ivar::write` instead.

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -47,6 +47,14 @@ malloc = ["malloc_buf"]
 # Expose features that requires creating blocks.
 block = ["block2"]
 
+# Runtime selection. See `objc-sys` for details.
+apple = ["objc-sys/apple", "objc2-encode/apple", "block2?/apple"]
+gnustep-1-7 = ["objc-sys/gnustep-1-7", "objc2-encode/gnustep-1-7", "block2?/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8", "objc2-encode/gnustep-1-8", "block2?/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9", "objc2-encode/gnustep-1-9", "block2?/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0", "objc2-encode/gnustep-2-0", "block2?/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1", "objc2-encode/gnustep-2-1", "block2?/gnustep-2-1"]
+
 # Make the `sel!` macro look up the selector statically.
 #
 # The plan is to enable this by default, but right now we are uncertain of
@@ -69,16 +77,13 @@ unstable-autoreleasesafe = []
 # `objc2-encode/unstable-c-unwind` to use this.
 unstable-c-unwind = []
 
-# For better documentation on docs.rs
-unstable-docsrs = []
+# Use nightly features to make Object and other types !Sized.
+#
+# You must manually enable `objc-sys/unstable-extern-types` to use this.
+unstable-extern-types = []
 
-# Runtime selection. See `objc-sys` for details.
-apple = ["objc-sys/apple", "objc2-encode/apple", "block2?/apple"]
-gnustep-1-7 = ["objc-sys/gnustep-1-7", "objc2-encode/gnustep-1-7", "block2?/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8", "objc2-encode/gnustep-1-8", "block2?/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9", "objc2-encode/gnustep-1-9", "block2?/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0", "objc2-encode/gnustep-2-0", "block2?/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1", "objc2-encode/gnustep-2-1", "block2?/gnustep-2-1"]
+# Private.
+unstable-docsrs = []
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -1,7 +1,7 @@
 use crate::__sel_inner;
 use crate::rc::{Allocated, Id, Ownership};
 use crate::runtime::{Class, Object, Sel};
-use crate::{Message, MessageArguments, MessageReceiver};
+use crate::{Message, MessageArguments, MessageReceiver, Thin};
 
 pub use crate::cache::CachedClass;
 pub use crate::cache::CachedSel;
@@ -83,7 +83,7 @@ type Init = RetainSemantics<false, false, true, false>;
 type CopyOrMutCopy = RetainSemantics<false, false, false, true>;
 type Other = RetainSemantics<false, false, false, false>;
 
-pub trait MsgSendId<T, U: ?Sized, O: Ownership> {
+pub trait MsgSendId<T, U: ?Sized + Thin, O: Ownership> {
     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<U, O>>(
         obj: T,
         sel: Sel,
@@ -162,7 +162,7 @@ impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, U, O> f
     }
 }
 
-impl<T: MessageReceiver, U: Message, O: Ownership> MsgSendId<T, U, O> for Other {
+impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, U, O> for Other {
     #[inline]
     #[track_caller]
     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<U, O>>(
@@ -186,14 +186,14 @@ impl<T: MessageReceiver, U: Message, O: Ownership> MsgSendId<T, U, O> for Other 
     }
 }
 
-pub trait MaybeUnwrap<T: ?Sized, O: Ownership> {
+pub trait MaybeUnwrap<T: ?Sized + Thin, O: Ownership> {
     fn maybe_unwrap<'a, Failed: MsgSendIdFailed<'a>>(
         obj: Option<Id<T, O>>,
         args: Failed::Args,
     ) -> Self;
 }
 
-impl<T: ?Sized, O: Ownership> MaybeUnwrap<T, O> for Option<Id<T, O>> {
+impl<T: ?Sized + Thin, O: Ownership> MaybeUnwrap<T, O> for Option<Id<T, O>> {
     #[inline]
     #[track_caller]
     fn maybe_unwrap<'a, Failed: MsgSendIdFailed<'a>>(
@@ -204,7 +204,7 @@ impl<T: ?Sized, O: Ownership> MaybeUnwrap<T, O> for Option<Id<T, O>> {
     }
 }
 
-impl<T: ?Sized, O: Ownership> MaybeUnwrap<T, O> for Id<T, O> {
+impl<T: ?Sized + Thin, O: Ownership> MaybeUnwrap<T, O> for Id<T, O> {
     #[inline]
     #[track_caller]
     fn maybe_unwrap<'a, Failed: MsgSendIdFailed<'a>>(

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -107,7 +107,10 @@ impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, T, O> for New {
     }
 }
 
-impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Allocated<T>, O> for Alloc {
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Allocated<T>, O> for Alloc
+where
+    Allocated<T>: Thin,
+{
     #[inline]
     #[track_caller]
     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Allocated<T>, O>>(
@@ -123,7 +126,10 @@ impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Allocated<T>, O> fo
     }
 }
 
-impl<T: ?Sized + Message, O: Ownership> MsgSendId<Option<Id<Allocated<T>, O>>, T, O> for Init {
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<Option<Id<Allocated<T>, O>>, T, O> for Init
+where
+    Allocated<T>: Thin,
+{
     #[inline]
     #[track_caller]
     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<T, O>>(

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -67,7 +67,7 @@ pub unsafe trait ClassType: Message {
     /// [`Deref`]: std::ops::Deref
     /// [`Deref::Target`]: std::ops::Deref::Target
     /// [`runtime::Object`]: crate::runtime::Object
-    type Super: Message;
+    type Super: ?Sized + Message;
 
     /// The name of the Objective-C class that this type represents.
     const NAME: &'static str;

--- a/objc2/src/declare/ivar_drop.rs
+++ b/objc2/src/declare/ivar_drop.rs
@@ -98,7 +98,7 @@ unsafe impl<T: Sized> InnerIvarType for IvarDrop<Option<Box<T>>> {
     }
 }
 
-impl<T: Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Id<T, O>> {}
+impl<T: ?Sized + Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Id<T, O>> {}
 // SAFETY: `Id` is `NonNull<T>`, and hence safe to store as a pointer.
 //
 // The user ensures that the Id has been initialized in an `init` method
@@ -107,7 +107,7 @@ impl<T: Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Id<T, O
 // Note: We could technically do `impl InnerIvarType for Ivar<Id<T, O>>`
 // directly today, but since we can't do so for `Box` (because that is
 // `#[fundamental]`), I think it makes sense to handle them similarly.
-unsafe impl<T: Message, O: Ownership> InnerIvarType for IvarDrop<Id<T, O>> {
+unsafe impl<T: ?Sized + Message, O: Ownership> InnerIvarType for IvarDrop<Id<T, O>> {
     const __ENCODING: Encoding = <*const T as EncodeConvert>::__ENCODING;
 
     type __Inner = Option<Id<T, O>>;
@@ -137,12 +137,15 @@ unsafe impl<T: Message, O: Ownership> InnerIvarType for IvarDrop<Id<T, O>> {
     }
 }
 
-impl<T: Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Option<Id<T, O>>> {}
+impl<T: ?Sized + Message, O: Ownership> super::ivar::private::Sealed
+    for IvarDrop<Option<Id<T, O>>>
+{
+}
 // SAFETY: `Id<T, O>` guarantees the null-pointer optimization.
 //
 // This is valid to initialize as all-zeroes, so the user doesn't have to do
 // anything to initialize it.
-unsafe impl<T: Message, O: Ownership> InnerIvarType for IvarDrop<Option<Id<T, O>>> {
+unsafe impl<T: ?Sized + Message, O: Ownership> InnerIvarType for IvarDrop<Option<Id<T, O>>> {
     const __ENCODING: Encoding = <*const T as EncodeConvert>::__ENCODING;
 
     type __Inner = Option<Id<T, O>>;

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -8,9 +8,11 @@ use super::{
     NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableArray, NSMutableCopying,
     NSObject, NSRange,
 };
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use crate::rc::{Allocated, DefaultId, Id, Owned, Ownership, Shared, SliceId};
 use crate::runtime::{Class, Object};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
+use crate::{
+    ClassType, Message, Thin, __inner_extern_class, extern_methods, msg_send, msg_send_id,
+};
 
 __inner_extern_class!(
     /// An immutable ordered collection of objects.
@@ -79,7 +81,10 @@ impl<T: ?Sized + Message + UnwindSafe> UnwindSafe for NSArray<T, Owned> {}
 pub(crate) unsafe fn with_objects<T: ?Sized + Message, R: ?Sized + Message, O: Ownership>(
     cls: &Class,
     objects: &[&T],
-) -> Id<R, O> {
+) -> Id<R, O>
+where
+    Allocated<R>: Thin,
+{
     unsafe {
         msg_send_id![
             msg_send_id![cls, alloc],

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -63,6 +63,8 @@ __inner_extern_class!(
 );
 
 // SAFETY: Same as Id<T, O> (which is what NSArray effectively stores).
+//
+// Duplicated here, rustdoc doesn't show these otherwise.
 unsafe impl<T: ?Sized + Message + Sync + Send> Sync for NSArray<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync + Send> Send for NSArray<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync> Sync for NSArray<T, Owned> {}

--- a/objc2/src/foundation/copying.rs
+++ b/objc2/src/foundation/copying.rs
@@ -28,7 +28,7 @@ pub unsafe trait NSCopying: Message {
     ///
     /// This is usually `Self`, but e.g. `NSMutableString` returns `NSString`.
     /// TODO: Verify???
-    type Output: Message;
+    type Output: ?Sized + Message;
 
     fn copy(&self) -> Id<Self::Output, Self::Ownership> {
         unsafe { msg_send_id![self, copy] }
@@ -40,7 +40,7 @@ pub unsafe trait NSCopying: Message {
 /// Note that the `mutableCopy` selector must return an owned object!
 pub unsafe trait NSMutableCopying: Message {
     /// TODO
-    type Output: Message;
+    type Output: ?Sized + Message;
 
     fn mutable_copy(&self) -> Id<Self::Output, Owned> {
         unsafe { msg_send_id![self, mutableCopy] }

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -12,26 +12,38 @@ use crate::{ClassType, __inner_extern_class, extern_methods, msg_send, msg_send_
 
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
-    pub struct NSDictionary<K: Message, V: Message> {
+    pub struct NSDictionary<K: ?Sized + Message, V: ?Sized + Message> {
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
 
-    unsafe impl<K: Message, V: Message> ClassType for NSDictionary<K, V> {
+    unsafe impl<K: ?Sized + Message, V: ?Sized + Message> ClassType for NSDictionary<K, V> {
         type Super = NSObject;
     }
 );
 
 // TODO: SAFETY
 // Approximately same as `NSArray<T, Shared>`
-unsafe impl<K: Message + Sync + Send, V: Message + Sync> Sync for NSDictionary<K, V> {}
-unsafe impl<K: Message + Sync + Send, V: Message + Send> Send for NSDictionary<K, V> {}
+unsafe impl<K: ?Sized + Message + Sync + Send, V: ?Sized + Message + Sync> Sync
+    for NSDictionary<K, V>
+{
+}
+unsafe impl<K: ?Sized + Message + Sync + Send, V: ?Sized + Message + Send> Send
+    for NSDictionary<K, V>
+{
+}
 
 // Approximately same as `NSArray<T, Shared>`
-impl<K: Message + UnwindSafe, V: Message + UnwindSafe> UnwindSafe for NSDictionary<K, V> {}
-impl<K: Message + RefUnwindSafe, V: Message + RefUnwindSafe> RefUnwindSafe for NSDictionary<K, V> {}
+impl<K: ?Sized + Message + UnwindSafe, V: ?Sized + Message + UnwindSafe> UnwindSafe
+    for NSDictionary<K, V>
+{
+}
+impl<K: ?Sized + Message + RefUnwindSafe, V: ?Sized + Message + RefUnwindSafe> RefUnwindSafe
+    for NSDictionary<K, V>
+{
+}
 extern_methods!(
-    unsafe impl<K: Message, V: Message> NSDictionary<K, V> {
+    unsafe impl<K: ?Sized + Message, V: ?Sized + Message> NSDictionary<K, V> {
         pub fn new() -> Id<Self, Shared> {
             unsafe { msg_send_id![Self::class(), new] }
         }
@@ -131,7 +143,7 @@ extern_methods!(
     }
 );
 
-impl<K: Message, V: Message> DefaultId for NSDictionary<K, V> {
+impl<K: ?Sized + Message, V: ?Sized + Message> DefaultId for NSDictionary<K, V> {
     type Ownership = Shared;
 
     #[inline]
@@ -140,11 +152,11 @@ impl<K: Message, V: Message> DefaultId for NSDictionary<K, V> {
     }
 }
 
-unsafe impl<K: Message, V: Message> NSFastEnumeration for NSDictionary<K, V> {
+unsafe impl<K: ?Sized + Message, V: ?Sized + Message> NSFastEnumeration for NSDictionary<K, V> {
     type Item = K;
 }
 
-impl<'a, K: Message, V: Message> Index<&'a K> for NSDictionary<K, V> {
+impl<'a, K: ?Sized + Message, V: ?Sized + Message> Index<&'a K> for NSDictionary<K, V> {
     type Output = V;
 
     fn index<'s>(&'s self, index: &'a K) -> &'s V {
@@ -152,7 +164,9 @@ impl<'a, K: Message, V: Message> Index<&'a K> for NSDictionary<K, V> {
     }
 }
 
-impl<K: fmt::Debug + Message, V: fmt::Debug + Message> fmt::Debug for NSDictionary<K, V> {
+impl<K: ?Sized + fmt::Debug + Message, V: ?Sized + fmt::Debug + Message> fmt::Debug
+    for NSDictionary<K, V>
+{
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self.iter_keys().zip(self.iter_values());

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -35,7 +35,7 @@ __inner_extern_class!(
 
 // SAFETY: Same as NSArray<T, O>
 //
-// Put here because rustdoc doesn't show these otherwise
+// Duplicated here, rustdoc doesn't show these otherwise.
 unsafe impl<T: ?Sized + Message + Sync + Send> Sync for NSMutableArray<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync + Send> Send for NSMutableArray<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync> Sync for NSMutableArray<T, Owned> {}

--- a/objc2/src/foundation/mutable_dictionary.rs
+++ b/objc2/src/foundation/mutable_dictionary.rs
@@ -17,30 +17,39 @@ __inner_extern_class!(
     ///
     /// [apple-doc]: https://developer.apple.com/documentation/foundation/nsmutabledictionary?language=objc
     #[derive(PartialEq, Eq, Hash)]
-    pub struct NSMutableDictionary<K: Message, V: Message> {
+    pub struct NSMutableDictionary<K: ?Sized + Message, V: ?Sized + Message> {
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
 
-    unsafe impl<K: Message, V: Message> ClassType for NSMutableDictionary<K, V> {
+    unsafe impl<K: ?Sized + Message, V: ?Sized + Message> ClassType for NSMutableDictionary<K, V> {
         #[inherits(NSObject)]
         type Super = NSDictionary<K, V>;
     }
 );
 
 // Same as `NSDictionary<K, V>`
-unsafe impl<K: Message + Sync + Send, V: Message + Sync> Sync for NSMutableDictionary<K, V> {}
-unsafe impl<K: Message + Sync + Send, V: Message + Send> Send for NSMutableDictionary<K, V> {}
+unsafe impl<K: ?Sized + Message + Sync + Send, V: ?Sized + Message + Sync> Sync
+    for NSMutableDictionary<K, V>
+{
+}
+unsafe impl<K: ?Sized + Message + Sync + Send, V: ?Sized + Message + Send> Send
+    for NSMutableDictionary<K, V>
+{
+}
 
 // Same as `NSDictionary<K, V>`
-impl<K: Message + UnwindSafe, V: Message + UnwindSafe> UnwindSafe for NSMutableDictionary<K, V> {}
-impl<K: Message + RefUnwindSafe, V: Message + RefUnwindSafe> RefUnwindSafe
+impl<K: ?Sized + Message + UnwindSafe, V: ?Sized + Message + UnwindSafe> UnwindSafe
+    for NSMutableDictionary<K, V>
+{
+}
+impl<K: ?Sized + Message + RefUnwindSafe, V: ?Sized + Message + RefUnwindSafe> RefUnwindSafe
     for NSMutableDictionary<K, V>
 {
 }
 
 extern_methods!(
-    unsafe impl<K: Message, V: Message> NSMutableDictionary<K, V> {
+    unsafe impl<K: ?Sized + Message, V: ?Sized + Message> NSMutableDictionary<K, V> {
         /// Creates an empty [`NSMutableDictionary`].
         ///
         /// # Examples
@@ -238,11 +247,13 @@ extern_methods!(
     }
 );
 
-unsafe impl<K: Message, V: Message> NSFastEnumeration for NSMutableDictionary<K, V> {
+unsafe impl<K: ?Sized + Message, V: ?Sized + Message> NSFastEnumeration
+    for NSMutableDictionary<K, V>
+{
     type Item = K;
 }
 
-impl<'a, K: Message, V: Message> Index<&'a K> for NSMutableDictionary<K, V> {
+impl<'a, K: ?Sized + Message, V: ?Sized + Message> Index<&'a K> for NSMutableDictionary<K, V> {
     type Output = V;
 
     fn index<'s>(&'s self, index: &'a K) -> &'s V {
@@ -250,13 +261,13 @@ impl<'a, K: Message, V: Message> Index<&'a K> for NSMutableDictionary<K, V> {
     }
 }
 
-impl<'a, K: Message, V: Message> IndexMut<&'a K> for NSMutableDictionary<K, V> {
+impl<'a, K: ?Sized + Message, V: ?Sized + Message> IndexMut<&'a K> for NSMutableDictionary<K, V> {
     fn index_mut<'s>(&'s mut self, index: &'a K) -> &'s mut V {
         self.get_mut(index).unwrap()
     }
 }
 
-impl<K: Message, V: Message> DefaultId for NSMutableDictionary<K, V> {
+impl<K: ?Sized + Message, V: ?Sized + Message> DefaultId for NSMutableDictionary<K, V> {
     type Ownership = Owned;
 
     #[inline]
@@ -265,7 +276,9 @@ impl<K: Message, V: Message> DefaultId for NSMutableDictionary<K, V> {
     }
 }
 
-impl<K: fmt::Debug + Message, V: fmt::Debug + Message> fmt::Debug for NSMutableDictionary<K, V> {
+impl<K: ?Sized + fmt::Debug + Message, V: ?Sized + fmt::Debug + Message> fmt::Debug
+    for NSMutableDictionary<K, V>
+{
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)

--- a/objc2/src/foundation/mutable_set.rs
+++ b/objc2/src/foundation/mutable_set.rs
@@ -15,24 +15,24 @@ __inner_extern_class!(
     ///
     /// [apple-doc]: https://developer.apple.com/documentation/foundation/nsmutableset?language=objc
     #[derive(PartialEq, Eq, Hash)]
-    pub struct NSMutableSet<T: Message, O: Ownership = Owned> {
+    pub struct NSMutableSet<T: ?Sized + Message, O: Ownership = Owned> {
         p: PhantomData<*mut ()>,
     }
 
-    unsafe impl<T: Message, O: Ownership> ClassType for NSMutableSet<T, O> {
+    unsafe impl<T: ?Sized + Message, O: Ownership> ClassType for NSMutableSet<T, O> {
         #[inherits(NSObject)]
         type Super = NSSet<T, O>;
     }
 );
 
 // SAFETY: Same as NSSet<T, O>
-unsafe impl<T: Message + Sync + Send> Sync for NSMutableSet<T, Shared> {}
-unsafe impl<T: Message + Sync + Send> Send for NSMutableSet<T, Shared> {}
-unsafe impl<T: Message + Sync> Sync for NSMutableSet<T, Owned> {}
-unsafe impl<T: Message + Send> Send for NSMutableSet<T, Owned> {}
+unsafe impl<T: ?Sized + Message + Sync + Send> Sync for NSMutableSet<T, Shared> {}
+unsafe impl<T: ?Sized + Message + Sync + Send> Send for NSMutableSet<T, Shared> {}
+unsafe impl<T: ?Sized + Message + Sync> Sync for NSMutableSet<T, Owned> {}
+unsafe impl<T: ?Sized + Message + Send> Send for NSMutableSet<T, Owned> {}
 
 extern_methods!(
-    unsafe impl<T: Message, O: Ownership> NSMutableSet<T, O> {
+    unsafe impl<T: ?Sized + Message, O: Ownership> NSMutableSet<T, O> {
         /// Creates an empty [`NSMutableSet`].
         ///
         /// # Examples
@@ -112,7 +112,7 @@ extern_methods!(
         }
     }
 
-    unsafe impl<T: Message> NSMutableSet<T, Shared> {
+    unsafe impl<T: ?Sized + Message> NSMutableSet<T, Shared> {
         /// Creates an [`NSMutableSet`] from a slice.
         ///
         /// # Examples
@@ -139,7 +139,7 @@ extern_methods!(
     // We're explicit about `T` being `PartialEq` for these methods because the
     // set compares the input value with elements in the set
     // For comparison: Rust's HashSet requires similar methods to be `Hash` + `Eq`
-    unsafe impl<T: Message + PartialEq, O: Ownership> NSMutableSet<T, O> {
+    unsafe impl<T: ?Sized + Message + PartialEq, O: Ownership> NSMutableSet<T, O> {
         #[sel(addObject:)]
         fn add_object(&mut self, value: &T);
 
@@ -201,27 +201,27 @@ extern_methods!(
     }
 );
 
-unsafe impl<T: Message> NSCopying for NSMutableSet<T, Shared> {
+unsafe impl<T: ?Sized + Message> NSCopying for NSMutableSet<T, Shared> {
     type Ownership = Shared;
     type Output = NSSet<T, Shared>;
 }
 
-unsafe impl<T: Message> NSMutableCopying for NSMutableSet<T, Shared> {
+unsafe impl<T: ?Sized + Message> NSMutableCopying for NSMutableSet<T, Shared> {
     type Output = NSMutableSet<T, Shared>;
 }
 
-impl<T: Message> alloc::borrow::ToOwned for NSMutableSet<T, Shared> {
+impl<T: ?Sized + Message> alloc::borrow::ToOwned for NSMutableSet<T, Shared> {
     type Owned = Id<NSMutableSet<T, Shared>, Owned>;
     fn to_owned(&self) -> Self::Owned {
         self.mutable_copy()
     }
 }
 
-unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSMutableSet<T, O> {
+unsafe impl<T: ?Sized + Message, O: Ownership> NSFastEnumeration for NSMutableSet<T, O> {
     type Item = T;
 }
 
-impl<'a, T: Message, O: Ownership> IntoIterator for &'a NSMutableSet<T, O> {
+impl<'a, T: ?Sized + Message, O: Ownership> IntoIterator for &'a NSMutableSet<T, O> {
     type Item = &'a T;
     type IntoIter = NSFastEnumerator<'a, NSMutableSet<T, O>>;
 
@@ -230,7 +230,7 @@ impl<'a, T: Message, O: Ownership> IntoIterator for &'a NSMutableSet<T, O> {
     }
 }
 
-impl<T: Message + PartialEq, O: Ownership> Extend<Id<T, O>> for NSMutableSet<T, O> {
+impl<T: ?Sized + Message + PartialEq, O: Ownership> Extend<Id<T, O>> for NSMutableSet<T, O> {
     fn extend<I: IntoIterator<Item = Id<T, O>>>(&mut self, iter: I) {
         for item in iter {
             self.insert(item);
@@ -238,7 +238,7 @@ impl<T: Message + PartialEq, O: Ownership> Extend<Id<T, O>> for NSMutableSet<T, 
     }
 }
 
-impl<T: Message, O: Ownership> DefaultId for NSMutableSet<T, O> {
+impl<T: ?Sized + Message, O: Ownership> DefaultId for NSMutableSet<T, O> {
     type Ownership = Owned;
 
     #[inline]
@@ -247,7 +247,7 @@ impl<T: Message, O: Ownership> DefaultId for NSMutableSet<T, O> {
     }
 }
 
-impl<T: fmt::Debug + Message, O: Ownership> fmt::Debug for NSMutableSet<T, O> {
+impl<T: ?Sized + fmt::Debug + Message, O: Ownership> fmt::Debug for NSMutableSet<T, O> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)

--- a/objc2/src/foundation/set.rs
+++ b/objc2/src/foundation/set.rs
@@ -18,29 +18,29 @@ __inner_extern_class!(
     ///
     /// [apple-doc]: https://developer.apple.com/documentation/foundation/nsset?language=objc
     #[derive(PartialEq, Eq, Hash)]
-    pub struct NSSet<T: Message, O: Ownership = Shared> {
+    pub struct NSSet<T: ?Sized + Message, O: Ownership = Shared> {
         item: PhantomData<Id<T, O>>,
         notunwindsafe: PhantomData<&'static mut ()>,
     }
 
-    unsafe impl<T: Message, O: Ownership> ClassType for NSSet<T, O> {
+    unsafe impl<T: ?Sized + Message, O: Ownership> ClassType for NSSet<T, O> {
         type Super = NSObject;
     }
 );
 
 // SAFETY: Same as NSArray<T, O>
-unsafe impl<T: Message + Sync + Send> Sync for NSSet<T, Shared> {}
-unsafe impl<T: Message + Sync + Send> Send for NSSet<T, Shared> {}
-unsafe impl<T: Message + Sync> Sync for NSSet<T, Owned> {}
-unsafe impl<T: Message + Send> Send for NSSet<T, Owned> {}
+unsafe impl<T: ?Sized + Message + Sync + Send> Sync for NSSet<T, Shared> {}
+unsafe impl<T: ?Sized + Message + Sync + Send> Send for NSSet<T, Shared> {}
+unsafe impl<T: ?Sized + Message + Sync> Sync for NSSet<T, Owned> {}
+unsafe impl<T: ?Sized + Message + Send> Send for NSSet<T, Owned> {}
 
 // SAFETY: Same as NSArray<T, O>
-impl<T: Message + RefUnwindSafe, O: Ownership> RefUnwindSafe for NSSet<T, O> {}
-impl<T: Message + RefUnwindSafe> UnwindSafe for NSSet<T, Shared> {}
-impl<T: Message + UnwindSafe> UnwindSafe for NSSet<T, Owned> {}
+impl<T: ?Sized + Message + RefUnwindSafe, O: Ownership> RefUnwindSafe for NSSet<T, O> {}
+impl<T: ?Sized + Message + RefUnwindSafe> UnwindSafe for NSSet<T, Shared> {}
+impl<T: ?Sized + Message + UnwindSafe> UnwindSafe for NSSet<T, Owned> {}
 
 #[track_caller]
-pub(crate) unsafe fn with_objects<T: Message + ?Sized, R: Message, O: Ownership>(
+pub(crate) unsafe fn with_objects<T: ?Sized + Message, R: ?Sized + Message, O: Ownership>(
     cls: &Class,
     objects: &[&T],
 ) -> Id<R, O> {
@@ -54,7 +54,7 @@ pub(crate) unsafe fn with_objects<T: Message + ?Sized, R: Message, O: Ownership>
 }
 
 extern_methods!(
-    unsafe impl<T: Message, O: Ownership> NSSet<T, O> {
+    unsafe impl<T: ?Sized + Message, O: Ownership> NSSet<T, O> {
         /// Creates an empty [`NSSet`].
         ///
         /// # Examples
@@ -197,7 +197,7 @@ extern_methods!(
         }
     }
 
-    unsafe impl<T: Message> NSSet<T, Shared> {
+    unsafe impl<T: ?Sized + Message> NSSet<T, Shared> {
         /// Creates an [`NSSet`] from a slice.
         ///
         /// # Examples
@@ -248,7 +248,7 @@ extern_methods!(
     // We're explicit about `T` being `PartialEq` for these methods because the
     // set compares the input value(s) with elements in the set
     // For comparison: Rust's HashSet requires similar methods to be `Hash` + `Eq`
-    unsafe impl<T: Message + PartialEq, O: Ownership> NSSet<T, O> {
+    unsafe impl<T: ?Sized + Message + PartialEq, O: Ownership> NSSet<T, O> {
         /// Returns `true` if the set contains a value.
         ///
         /// # Examples
@@ -353,27 +353,27 @@ extern_methods!(
     }
 );
 
-unsafe impl<T: Message> NSCopying for NSSet<T, Shared> {
+unsafe impl<T: ?Sized + Message> NSCopying for NSSet<T, Shared> {
     type Ownership = Shared;
     type Output = NSSet<T, Shared>;
 }
 
-unsafe impl<T: Message> NSMutableCopying for NSSet<T, Shared> {
+unsafe impl<T: ?Sized + Message> NSMutableCopying for NSSet<T, Shared> {
     type Output = NSMutableSet<T, Shared>;
 }
 
-impl<T: Message> alloc::borrow::ToOwned for NSSet<T, Shared> {
+impl<T: ?Sized + Message> alloc::borrow::ToOwned for NSSet<T, Shared> {
     type Owned = Id<NSSet<T, Shared>, Shared>;
     fn to_owned(&self) -> Self::Owned {
         self.copy()
     }
 }
 
-unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSSet<T, O> {
+unsafe impl<T: ?Sized + Message, O: Ownership> NSFastEnumeration for NSSet<T, O> {
     type Item = T;
 }
 
-impl<'a, T: Message, O: Ownership> IntoIterator for &'a NSSet<T, O> {
+impl<'a, T: ?Sized + Message, O: Ownership> IntoIterator for &'a NSSet<T, O> {
     type Item = &'a T;
     type IntoIter = NSFastEnumerator<'a, NSSet<T, O>>;
 
@@ -382,7 +382,7 @@ impl<'a, T: Message, O: Ownership> IntoIterator for &'a NSSet<T, O> {
     }
 }
 
-impl<T: Message, O: Ownership> DefaultId for NSSet<T, O> {
+impl<T: ?Sized + Message, O: Ownership> DefaultId for NSSet<T, O> {
     type Ownership = Shared;
 
     #[inline]
@@ -391,7 +391,7 @@ impl<T: Message, O: Ownership> DefaultId for NSSet<T, O> {
     }
 }
 
-impl<T: fmt::Debug + Message, O: Ownership> fmt::Debug for NSSet<T, O> {
+impl<T: ?Sized + Message + fmt::Debug, O: Ownership> fmt::Debug for NSSet<T, O> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter_fast()).finish()

--- a/objc2/src/foundation/set.rs
+++ b/objc2/src/foundation/set.rs
@@ -7,9 +7,11 @@ use super::{
     NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableCopying,
     NSMutableSet, NSObject,
 };
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use crate::rc::{Allocated, DefaultId, Id, Owned, Ownership, Shared, SliceId};
 use crate::runtime::Class;
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
+use crate::{
+    ClassType, Message, Thin, __inner_extern_class, extern_methods, msg_send, msg_send_id,
+};
 
 __inner_extern_class!(
     /// An immutable unordered collection of unique objects.
@@ -45,7 +47,10 @@ impl<T: ?Sized + Message + UnwindSafe> UnwindSafe for NSSet<T, Owned> {}
 pub(crate) unsafe fn with_objects<T: ?Sized + Message, R: ?Sized + Message, O: Ownership>(
     cls: &Class,
     objects: &[&T],
-) -> Id<R, O> {
+) -> Id<R, O>
+where
+    Allocated<R>: Thin,
+{
     unsafe {
         msg_send_id![
             msg_send_id![cls, alloc],

--- a/objc2/src/foundation/set.rs
+++ b/objc2/src/foundation/set.rs
@@ -28,7 +28,9 @@ __inner_extern_class!(
     }
 );
 
-// SAFETY: Same as NSArray<T, O>
+// SAFETY: Same as Id<T, O>.
+//
+// Duplicated here, rustdoc doesn't show these otherwise.
 unsafe impl<T: ?Sized + Message + Sync + Send> Sync for NSSet<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync + Send> Send for NSSet<T, Shared> {}
 unsafe impl<T: ?Sized + Message + Sync> Sync for NSSet<T, Owned> {}

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -186,6 +186,8 @@ compile_error!("The `std` feature currently must be enabled.");
 extern crate alloc;
 extern crate std;
 
+pub(crate) use core::marker::Sized as Thin;
+
 // The example uses NSObject without doing the __gnustep_hack
 #[cfg(all(feature = "apple", doctest))]
 #[doc = include_str!("../README.md")]

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -167,6 +167,7 @@
 )]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg))]
+#![cfg_attr(feature = "unstable-extern-types", feature(extern_types, ptr_metadata))]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]
@@ -186,7 +187,10 @@ compile_error!("The `std` feature currently must be enabled.");
 extern crate alloc;
 extern crate std;
 
+#[cfg(not(feature = "unstable-extern-types"))]
 pub(crate) use core::marker::Sized as Thin;
+#[cfg(feature = "unstable-extern-types")]
+pub(crate) use core::ptr::Thin;
 
 // The example uses NSObject without doing the __gnustep_hack
 #[cfg(all(feature = "apple", doctest))]

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -231,11 +231,11 @@ macro_rules! __inner_extern_class {
     // TODO: Expose this variant in the `object` macro.
     (
         $(#[$m:meta])*
-        $v:vis struct $name:ident<$($t_struct:ident $(: $b_struct:ident $(= $default:ty)?)?),*> {
+        $v:vis struct $name:ident<$($t_struct:ident $(: $(?$s_struct:ident + )? $b_struct:ident $(= $default:ty)?)?),*> {
             $($field_vis:vis $field:ident: $field_ty:ty,)*
         }
 
-        unsafe impl<$($t_for:ident $(: $b_for:ident)?),*> ClassType for $for:ty {
+        unsafe impl<$($t_for:ident $(: $(?$s_for:ident + )? $b_for:ident)?),*> ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
             type Super = $superclass:ty;
         }
@@ -243,16 +243,16 @@ macro_rules! __inner_extern_class {
         $crate::__inner_extern_class! {
             @__inner
             $(#[$m])*
-            $v struct $name ($($t_struct $(: $b_struct $(= $default)?)?),*) {
+            $v struct $name ($($t_struct $(: $(?$s_struct + )? $b_struct $(= $default)?)?),*) {
                 $($field_vis $field: $field_ty,)*
             }
 
-            unsafe impl ($($t_for $(: $b_for)?),*) for $for {
+            unsafe impl ($($t_for $(: $(?$s_for + )? $b_for)?),*) for $for {
                 INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::Object];
             }
         }
 
-        unsafe impl<$($t_for $(: $b_for)?),*> ClassType for $for {
+        unsafe impl<$($t_for $(: $(?$s_for + )? $b_for)?),*> ClassType for $for {
             type Super = $superclass;
             const NAME: &'static str = stringify!($name);
 

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -181,14 +181,14 @@ macro_rules! extern_methods {
     (
         $(
             $(#[$impl_m:meta])*
-            unsafe impl<$($t:ident $(: $b:ident $(+ $rest:ident)*)?),*> $type:ty {
+            unsafe impl<$($t:ident $(: $(?$sized:ident +)? $b:ident $(+ $rest:ident)*)?),*> $type:ty {
                 $($methods:tt)*
             }
         )+
     ) => {
         $(
             $(#[$impl_m])*
-            impl<$($t $(: $b $(+ $rest)*)?),*> $type {
+            impl<$($t $(: $(?$sized +)? $b $(+ $rest)*)?),*> $type {
                 $crate::__inner_extern_methods! {
                     @rewrite_methods
                     $($methods)*

--- a/objc2/src/rc/allocated.rs
+++ b/objc2/src/rc/allocated.rs
@@ -1,3 +1,5 @@
+use crate::Thin;
+
 /// A marker type that can be used within [`Id`] to indicate that the object
 /// has been allocated but not initialized.
 ///
@@ -10,6 +12,6 @@
 /// [`Id`]: crate::rc::Id
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct Allocated<T: ?Sized>(T);
+pub struct Allocated<T: ?Sized + Thin>(T);
 
 // Explicitly don't implement `Deref`, `Message` nor `RefEncode`!

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -138,7 +138,10 @@ impl<T: ?Sized + Thin, O: Ownership> Id<T, O> {
     }
 }
 
-impl<T: ?Sized + Message, O: Ownership> Id<Allocated<T>, O> {
+impl<T: ?Sized + Message, O: Ownership> Id<Allocated<T>, O>
+where
+    Allocated<T>: Thin,
+{
     #[inline]
     pub(crate) unsafe fn new_allocated(ptr: *mut T) -> Option<Self> {
         // SAFETY: Upheld by the caller

--- a/objc2/src/rc/id_forwarding_impls.rs
+++ b/objc2/src/rc/id_forwarding_impls.rs
@@ -21,8 +21,9 @@ use std::error::Error;
 use std::io;
 
 use super::{Id, Owned, Ownership};
+use crate::Thin;
 
-impl<T: PartialEq + ?Sized, O: Ownership> PartialEq for Id<T, O> {
+impl<T: PartialEq + ?Sized + Thin, O: Ownership> PartialEq for Id<T, O> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         (**self).eq(&**other)
@@ -35,9 +36,9 @@ impl<T: PartialEq + ?Sized, O: Ownership> PartialEq for Id<T, O> {
     }
 }
 
-impl<T: Eq + ?Sized, O: Ownership> Eq for Id<T, O> {}
+impl<T: Eq + ?Sized + Thin, O: Ownership> Eq for Id<T, O> {}
 
-impl<T: PartialOrd + ?Sized, O: Ownership> PartialOrd for Id<T, O> {
+impl<T: PartialOrd + ?Sized + Thin, O: Ownership> PartialOrd for Id<T, O> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (**self).partial_cmp(&**other)
@@ -60,20 +61,20 @@ impl<T: PartialOrd + ?Sized, O: Ownership> PartialOrd for Id<T, O> {
     }
 }
 
-impl<T: Ord + ?Sized, O: Ownership> Ord for Id<T, O> {
+impl<T: Ord + ?Sized + Thin, O: Ownership> Ord for Id<T, O> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         (**self).cmp(&**other)
     }
 }
 
-impl<T: hash::Hash + ?Sized, O: Ownership> hash::Hash for Id<T, O> {
+impl<T: hash::Hash + ?Sized + Thin, O: Ownership> hash::Hash for Id<T, O> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
 }
 
-impl<T: hash::Hasher + ?Sized> hash::Hasher for Id<T, Owned> {
+impl<T: hash::Hasher + ?Sized + Thin> hash::Hasher for Id<T, Owned> {
     fn finish(&self) -> u64 {
         (**self).finish()
     }
@@ -118,19 +119,19 @@ impl<T: hash::Hasher + ?Sized> hash::Hasher for Id<T, Owned> {
     }
 }
 
-impl<T: fmt::Display + ?Sized, O: Ownership> fmt::Display for Id<T, O> {
+impl<T: fmt::Display + ?Sized + Thin, O: Ownership> fmt::Display for Id<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
-impl<T: fmt::Debug + ?Sized, O: Ownership> fmt::Debug for Id<T, O> {
+impl<T: fmt::Debug + ?Sized + Thin, O: Ownership> fmt::Debug for Id<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
-impl<I: Iterator + ?Sized> Iterator for Id<I, Owned> {
+impl<I: Iterator + ?Sized + Thin> Iterator for Id<I, Owned> {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
@@ -143,7 +144,7 @@ impl<I: Iterator + ?Sized> Iterator for Id<I, Owned> {
     }
 }
 
-impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Id<I, Owned> {
+impl<I: DoubleEndedIterator + ?Sized + Thin> DoubleEndedIterator for Id<I, Owned> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
@@ -152,13 +153,13 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Id<I, Owned> {
     }
 }
 
-impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Id<I, Owned> {
+impl<I: ExactSizeIterator + ?Sized + Thin> ExactSizeIterator for Id<I, Owned> {
     fn len(&self) -> usize {
         (**self).len()
     }
 }
 
-impl<I: FusedIterator + ?Sized> FusedIterator for Id<I, Owned> {}
+impl<I: FusedIterator + ?Sized + Thin> FusedIterator for Id<I, Owned> {}
 
 // TODO: Consider this impl
 // impl<'a, T, O: Ownership> IntoIterator for &'a Id<T, O>
@@ -173,37 +174,37 @@ impl<I: FusedIterator + ?Sized> FusedIterator for Id<I, Owned> {}
 //     }
 // }
 
-impl<T, O: Ownership> borrow::Borrow<T> for Id<T, O> {
+impl<T: ?Sized + Thin, O: Ownership> borrow::Borrow<T> for Id<T, O> {
     fn borrow(&self) -> &T {
         Deref::deref(self)
     }
 }
 
-impl<T> borrow::BorrowMut<T> for Id<T, Owned> {
+impl<T: ?Sized + Thin> borrow::BorrowMut<T> for Id<T, Owned> {
     fn borrow_mut(&mut self) -> &mut T {
         DerefMut::deref_mut(self)
     }
 }
 
-impl<T: ?Sized, O: Ownership> AsRef<T> for Id<T, O> {
+impl<T: ?Sized + Thin, O: Ownership> AsRef<T> for Id<T, O> {
     fn as_ref(&self) -> &T {
         Deref::deref(self)
     }
 }
 
-impl<T: ?Sized> AsMut<T> for Id<T, Owned> {
+impl<T: ?Sized + Thin> AsMut<T> for Id<T, Owned> {
     fn as_mut(&mut self) -> &mut T {
         DerefMut::deref_mut(self)
     }
 }
 
-impl<T: Error + ?Sized, O: Ownership> Error for Id<T, O> {
+impl<T: Error + ?Sized + Thin, O: Ownership> Error for Id<T, O> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         (**self).source()
     }
 }
 
-impl<T: io::Read + ?Sized> io::Read for Id<T, Owned> {
+impl<T: io::Read + ?Sized + Thin> io::Read for Id<T, Owned> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
@@ -230,7 +231,7 @@ impl<T: io::Read + ?Sized> io::Read for Id<T, Owned> {
     }
 }
 
-impl<T: io::Write + ?Sized> io::Write for Id<T, Owned> {
+impl<T: io::Write + ?Sized + Thin> io::Write for Id<T, Owned> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (**self).write(buf)
@@ -257,7 +258,7 @@ impl<T: io::Write + ?Sized> io::Write for Id<T, Owned> {
     }
 }
 
-impl<T: io::Seek + ?Sized> io::Seek for Id<T, Owned> {
+impl<T: io::Seek + ?Sized + Thin> io::Seek for Id<T, Owned> {
     #[inline]
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         (**self).seek(pos)
@@ -269,7 +270,7 @@ impl<T: io::Seek + ?Sized> io::Seek for Id<T, Owned> {
     }
 }
 
-impl<T: io::BufRead + ?Sized> io::BufRead for Id<T, Owned> {
+impl<T: io::BufRead + ?Sized + Thin> io::BufRead for Id<T, Owned> {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         (**self).fill_buf()
@@ -291,7 +292,7 @@ impl<T: io::BufRead + ?Sized> io::BufRead for Id<T, Owned> {
     }
 }
 
-impl<T: Future + Unpin + ?Sized> Future for Id<T, Owned> {
+impl<T: Future + Unpin + ?Sized + Thin> Future for Id<T, Owned> {
     type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/objc2/src/rc/id_traits.rs
+++ b/objc2/src/rc/id_traits.rs
@@ -1,12 +1,12 @@
 //! Helper traits for Id.
 
 use super::{Id, Owned, Ownership};
-use crate::Message;
+use crate::{Message, Thin};
 
 /// Helper trait for functionality on slices containing [`Id`]s.
 pub trait SliceId {
     /// The type of the items in the slice.
-    type Item: ?Sized;
+    type Item: ?Sized + Thin;
 
     /// Convert a slice of [`Id`]s into a slice of references.
     fn as_slice_ref(&self) -> &[&Self::Item];
@@ -22,7 +22,7 @@ pub trait SliceIdMut: SliceId {
     fn as_mut_slice_mut(&mut self) -> &mut [&mut Self::Item];
 }
 
-impl<T: Message + ?Sized, O: Ownership> SliceId for [Id<T, O>] {
+impl<T: ?Sized + Message, O: Ownership> SliceId for [Id<T, O>] {
     type Item = T;
 
     fn as_slice_ref(&self) -> &[&T] {
@@ -40,7 +40,7 @@ impl<T: Message + ?Sized, O: Ownership> SliceId for [Id<T, O>] {
     }
 }
 
-impl<T: Message + ?Sized> SliceIdMut for [Id<T, Owned>] {
+impl<T: ?Sized + Message> SliceIdMut for [Id<T, Owned>] {
     fn as_mut_slice_mut(&mut self) -> &mut [&mut T] {
         let ptr = self as *mut Self as *mut [&mut T];
         // SAFETY: Id<T, O> and &mut T have the same memory layout, and the
@@ -53,7 +53,7 @@ impl<T: Message + ?Sized> SliceIdMut for [Id<T, Owned>] {
 /// Helper trait to implement [`Default`] on types whoose default value is an
 /// [`Id`].
 // TODO: Maybe make this `unsafe` and provide a default implementation?
-pub trait DefaultId {
+pub trait DefaultId: Thin {
     /// Indicates whether the default value is mutable or immutable.
     type Ownership: Ownership;
 


### PR DESCRIPTION
Requires `extern_types` feature from [RFC-1861](https://rust-lang.github.io/rfcs/1861-extern-types.html) and `ptr_metadata` feature.

I think I'm gonna wait with merging any of this until Rust progresses further in the design space.