### PR TITLE
Add `Id::retain_autoreleased`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,13 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
+        args: --no-default-features ${{ env.TESTARGS }} --release
+
+    - name: Test in release mode with features
+      if: ${{ !matrix.dinghy }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
         args: --features ${{ env.FEATURES }} ${{ env.TESTARGS }} --release
 
     - name: Run benchmarks
@@ -346,10 +353,12 @@ jobs:
         xcrun simctl boot $SIM_ID
 
         # Build
-        cargo dinghy build
+        cargo dinghy --device=$SIM_ID build
 
         # Run tests
         cargo dinghy --device=$SIM_ID test --no-default-features
+        cargo dinghy --device=$SIM_ID test --release
+
         # Enable a few features. We're doing it this way because cargo dingy
         # doesn't support specifying features from a workspace.
         sed -i -e '/\[features\]/a\

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -140,7 +140,7 @@ impl<T: Message> NSArray<T, Shared> {
     pub fn get_retained(&self, index: usize) -> Id<T, Shared> {
         let obj = self.get(index).unwrap();
         // SAFETY: The object is originally shared (see `where` bound).
-        unsafe { Id::retain(obj as *const T as *mut T).unwrap_unchecked() }
+        unsafe { Id::retain_autoreleased(obj as *const T as *mut T).unwrap_unchecked() }
     }
 
     pub fn to_shared_vec(&self) -> Vec<Id<T, Shared>> {
@@ -247,7 +247,7 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     pub fn replace(&mut self, index: usize, obj: Id<T, O>) -> Id<T, O> {
         let old_obj = unsafe {
             let obj = self.get(index).unwrap();
-            Id::retain(obj as *const T as *mut T).unwrap_unchecked()
+            Id::retain_autoreleased(obj as *const T as *mut T).unwrap_unchecked()
         };
         unsafe {
             let _: () = msg_send![
@@ -262,7 +262,7 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     #[doc(alias = "removeObjectAtIndex:")]
     pub fn remove(&mut self, index: usize) -> Id<T, O> {
         let obj = if let Some(obj) = self.get(index) {
-            unsafe { Id::retain(obj as *const T as *mut T).unwrap_unchecked() }
+            unsafe { Id::retain_autoreleased(obj as *const T as *mut T).unwrap_unchecked() }
         } else {
             panic!("removal index should be < len");
         };

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -103,7 +103,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     pub fn keys_array(&self) -> Id<NSArray<K, Shared>, Shared> {
         unsafe {
             let keys = msg_send![self, allKeys];
-            Id::retain(keys).unwrap()
+            Id::retain_autoreleased(keys).unwrap()
         }
     }
 
@@ -130,7 +130,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     pub fn into_values_array(dict: Id<Self, Owned>) -> Id<NSArray<V, Owned>, Shared> {
         unsafe {
             let vals = msg_send![dict, allValues];
-            Id::retain(vals).unwrap()
+            Id::retain_autoreleased(vals).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -23,7 +23,7 @@ impl<'a, T: Message> NSEnumerator<'a, T> {
     /// ownership.
     pub unsafe fn from_ptr(ptr: *mut Object) -> Self {
         Self {
-            id: unsafe { Id::retain(ptr) }.unwrap(),
+            id: unsafe { Id::retain_autoreleased(ptr) }.unwrap(),
             item: PhantomData,
         }
     }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -24,7 +24,7 @@ impl NSObject {
         unsafe {
             let result: *mut NSString = msg_send![self, description];
             // TODO: Verify that description always returns a non-null string
-            Id::retain(result).unwrap()
+            Id::retain_autoreleased(result).unwrap()
         }
     }
 

--- a/objc2-foundation/src/process_info.rs
+++ b/objc2-foundation/src/process_info.rs
@@ -22,11 +22,11 @@ impl NSProcessInfo {
         // currentThread is @property(strong), what does that mean?
         let obj: *mut Self = unsafe { msg_send![Self::class(), processInfo] };
         // TODO: Always available?
-        unsafe { Id::retain(obj).unwrap() }
+        unsafe { Id::retain_autoreleased(obj).unwrap() }
     }
 
     pub fn process_name(&self) -> Id<NSString, Shared> {
         let obj: *mut NSString = unsafe { msg_send![Self::class(), processName] };
-        unsafe { Id::retain(obj).unwrap() }
+        unsafe { Id::retain_autoreleased(obj).unwrap() }
     }
 }

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -20,7 +20,7 @@ impl NSThread {
         // TODO: currentThread is @property(strong), what does that mean?
         let obj: *mut Self = unsafe { msg_send![Self::class(), currentThread] };
         // TODO: Always available?
-        unsafe { Id::retain(obj).unwrap() }
+        unsafe { Id::retain_autoreleased(obj).unwrap() }
     }
 
     /// Returns the [`NSThread`] object representing the main thread.
@@ -29,7 +29,7 @@ impl NSThread {
         let obj: *mut Self = unsafe { msg_send![Self::class(), mainThread] };
         // The main thread static may not have been initialized
         // This can at least fail in GNUStep!
-        unsafe { Id::retain(obj).expect("Could not retrieve main thread.") }
+        unsafe { Id::retain_autoreleased(obj).expect("Could not retrieve main thread.") }
     }
 
     /// Returns `true` if the thread is the main thread.
@@ -41,7 +41,7 @@ impl NSThread {
     /// The name of the thread.
     pub fn name(&self) -> Option<Id<NSString, Shared>> {
         let obj: *mut NSString = unsafe { msg_send![self, name] };
-        unsafe { Id::retain(obj) }
+        unsafe { Id::retain_autoreleased(obj) }
     }
 }
 

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `Bool::as_bool` (more descriptive name than `Bool::is_true`).
 * Added convenience method `Id::as_ptr`.
 * The `objc2-encode` dependency is now exposed as `objc2::encode`.
+* Added `Id::retain_autoreleased` to allow following Cocoas memory management
+  rules more efficiently.
 
 ### Changed
 * **BREAKING**: Changed signature of `Id::new` and `Id::retain` from

--- a/objc2/benches/autorelease.rs
+++ b/objc2/benches/autorelease.rs
@@ -1,7 +1,6 @@
 use core::ffi::c_void;
 use std::mem::ManuallyDrop;
 
-use objc2::ffi;
 use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{class, msg_send, sel};
@@ -94,8 +93,7 @@ fn autoreleased_nsstring() -> *mut Object {
 }
 
 fn retain_autoreleased(obj: *mut Object) -> Id<Object, Shared> {
-    let obj = unsafe { ffi::objc_retainAutoreleasedReturnValue(obj.cast()) };
-    unsafe { Id::new(obj.cast()).unwrap_unchecked() }
+    unsafe { Id::retain_autoreleased(obj.cast()).unwrap_unchecked() }
 }
 
 fn autoreleased_nsdata_pool_cleanup() -> *mut Object {
@@ -133,6 +131,7 @@ macro_rules! main_with_warmup {
             )+
         }
 
+        // Required to get DYLD to resolve the stubs on x86_64
         fn warmup() {
             $(
                 warmup_fns::$f();

--- a/objc2/tests/id_retain_autoreleased.rs
+++ b/objc2/tests/id_retain_autoreleased.rs
@@ -1,0 +1,60 @@
+use std::ffi::c_void;
+
+use objc2::rc::{autoreleasepool, Id, Shared};
+use objc2::runtime::Object;
+use objc2::{class, msg_send};
+
+fn retain_count(obj: &Object) -> usize {
+    unsafe { msg_send![obj, retainCount] }
+}
+
+fn create_data(bytes: &[u8]) -> Id<Object, Shared> {
+    let bytes_ptr = bytes.as_ptr() as *const c_void;
+    unsafe {
+        // All code between the `msg_send!` and the `retain_autoreleased` must
+        // be able to be optimized away for this to work.
+        let obj: *mut Object = msg_send![
+            class!(NSData),
+            dataWithBytes: bytes_ptr,
+            length: bytes.len(),
+        ];
+        Id::retain_autoreleased(obj).unwrap()
+    }
+}
+
+#[test]
+fn test_retain_autoreleased() {
+    #[cfg(gnustep)]
+    unsafe {
+        objc2::__gnustep_hack::get_class_to_force_linkage()
+    };
+
+    #[cfg(apple)]
+    #[link(name = "Foundation", kind = "framework")]
+    extern "C" {}
+
+    autoreleasepool(|_| {
+        // Run once to allow DYLD to resolve the symbol stubs.
+        // Required for making `retain_autoreleased` work on x86_64.
+        let _data = create_data(b"12");
+
+        // When compiled in release mode / with optimizations enabled,
+        // subsequent usage of `retain_autoreleased` will succeed in retaining
+        // the autoreleased value!
+        let expected = if cfg!(all(debug_assertions, not(gnustep))) {
+            2
+        } else {
+            1
+        };
+
+        let data = create_data(b"34");
+        assert_eq!(retain_count(&data), expected);
+
+        let data = create_data(b"56");
+        assert_eq!(retain_count(&data), expected);
+
+        // Here we manually clean up the autorelease, so it will always be 1.
+        let data = autoreleasepool(|_| create_data(b"78"));
+        assert_eq!(retain_count(&data), 1);
+    });
+}

--- a/objc2/tests/id_retain_autoreleased.rs
+++ b/objc2/tests/id_retain_autoreleased.rs
@@ -54,7 +54,13 @@ fn test_retain_autoreleased() {
         // When compiled in release mode / with optimizations enabled,
         // subsequent usage of `retain_autoreleased` will succeed in retaining
         // the autoreleased value!
-        let expected = if cfg!(all(debug_assertions, not(gnustep))) {
+        let expected = if cfg!(gnustep) {
+            1
+        } else if cfg!(any(
+            debug_assertions,
+            feature = "exception",
+            feature = "verify_message"
+        )) {
             2
         } else {
             1

--- a/tests/assembly/test_retain_autoreleased/Cargo.toml
+++ b/tests/assembly/test_retain_autoreleased/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_retain_autoreleased"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+objc2 = { path = "../../../objc2" }
+objc-sys = { path = "../../../objc-sys" }
+block-sys = { path = "../../../block-sys" }

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-darwin.s
@@ -1,0 +1,11 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_handle
+	.p2align	2
+_handle:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	ldp	x29, x30, [sp], #16
+	b	_objc_retainAutoreleasedReturnValue
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-darwin.s
@@ -5,6 +5,9 @@ _handle:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_msgSend
+	; InlineAsm Start
+	mov	x29, x29
+	; InlineAsm End
 	ldp	x29, x30, [sp], #16
 	b	_objc_retainAutoreleasedReturnValue
 

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios-sim.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios-sim.s
@@ -5,6 +5,9 @@ _handle:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_msgSend
+	; InlineAsm Start
+	mov	x29, x29
+	; InlineAsm End
 	ldp	x29, x30, [sp], #16
 	b	_objc_retainAutoreleasedReturnValue
 

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios-sim.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios-sim.s
@@ -1,0 +1,15 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_handle
+	.p2align	2
+_handle:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	ldp	x29, x30, [sp], #16
+	b	_objc_retainAutoreleasedReturnValue
+
+; Stripped __LLVM section
+
+; Stripped __LLVM section
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios.s
@@ -5,6 +5,9 @@ _handle:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_msgSend
+	; InlineAsm Start
+	mov	x29, x29
+	; InlineAsm End
 	ldp	x29, x30, [sp], #16
 	b	_objc_retainAutoreleasedReturnValue
 

--- a/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/aarch64-apple-ios.s
@@ -1,0 +1,15 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_handle
+	.p2align	2
+_handle:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	ldp	x29, x30, [sp], #16
+	b	_objc_retainAutoreleasedReturnValue
+
+; Stripped __LLVM section
+
+; Stripped __LLVM section
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/armv7-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/armv7-apple-ios.s
@@ -7,6 +7,9 @@ _handle:
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_msgSend
+	@ InlineAsm Start
+	mov	r7, r7
+	@ InlineAsm End
 	pop	{r7, lr}
 	b	_objc_retainAutoreleasedReturnValue
 

--- a/tests/assembly/test_retain_autoreleased/expected/armv7-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/armv7-apple-ios.s
@@ -4,6 +4,10 @@
 	.p2align	2
 	.code	32
 _handle:
-	b	_objc_msgSend
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	pop	{r7, lr}
+	b	_objc_retainAutoreleasedReturnValue
 
 .subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/armv7s-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/armv7s-apple-ios.s
@@ -4,6 +4,10 @@
 	.p2align	2
 	.code	32
 _handle:
-	b	_objc_msgSend
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	bl	_objc_retainAutoreleasedReturnValue
+	pop	{r7, pc}
 
 .subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/armv7s-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/armv7s-apple-ios.s
@@ -7,6 +7,9 @@ _handle:
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_msgSend
+	@ InlineAsm Start
+	mov	r7, r7
+	@ InlineAsm End
 	bl	_objc_retainAutoreleasedReturnValue
 	pop	{r7, pc}
 

--- a/tests/assembly/test_retain_autoreleased/expected/i386-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/i386-apple-ios.s
@@ -1,0 +1,20 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle
+	.p2align	4, 0x90
+_handle:
+	push	ebp
+	mov	ebp, esp
+	sub	esp, 8
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [esp + 4], ecx
+	mov	dword ptr [esp], eax
+	call	_objc_msgSend
+	mov	dword ptr [esp], eax
+	call	_objc_retainAutoreleasedReturnValue
+	add	esp, 8
+	pop	ebp
+	ret
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/i386-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/i386-apple-ios.s
@@ -11,6 +11,11 @@ _handle:
 	mov	dword ptr [esp + 4], ecx
 	mov	dword ptr [esp], eax
 	call	_objc_msgSend
+	## InlineAsm Start
+
+	mov	ebp, ebp
+
+	## InlineAsm End
 	mov	dword ptr [esp], eax
 	call	_objc_retainAutoreleasedReturnValue
 	add	esp, 8

--- a/tests/assembly/test_retain_autoreleased/expected/i686-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/i686-apple-darwin.s
@@ -1,0 +1,20 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle
+	.p2align	4, 0x90
+_handle:
+	push	ebp
+	mov	ebp, esp
+	sub	esp, 8
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [esp + 4], ecx
+	mov	dword ptr [esp], eax
+	call	_objc_msgSend
+	mov	dword ptr [esp], eax
+	call	_objc_retainAutoreleasedReturnValue
+	add	esp, 8
+	pop	ebp
+	ret
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/i686-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/i686-apple-darwin.s
@@ -11,6 +11,11 @@ _handle:
 	mov	dword ptr [esp + 4], ecx
 	mov	dword ptr [esp], eax
 	call	_objc_msgSend
+	## InlineAsm Start
+
+	mov	ebp, ebp
+
+	## InlineAsm End
 	mov	dword ptr [esp], eax
 	call	_objc_retainAutoreleasedReturnValue
 	add	esp, 8

--- a/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-darwin.s
@@ -1,0 +1,13 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle
+	.p2align	4, 0x90
+_handle:
+	push	rbp
+	mov	rbp, rsp
+	call	_objc_msgSend
+	mov	rdi, rax
+	pop	rbp
+	jmp	_objc_retainAutoreleasedReturnValue
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-darwin.s
+++ b/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-darwin.s
@@ -7,7 +7,13 @@ _handle:
 	mov	rbp, rsp
 	call	_objc_msgSend
 	mov	rdi, rax
+	call	_objc_retainAutoreleasedReturnValue
+	## InlineAsm Start
+
+	nop
+
+	## InlineAsm End
 	pop	rbp
-	jmp	_objc_retainAutoreleasedReturnValue
+	ret
 
 .subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-ios.s
@@ -1,0 +1,13 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle
+	.p2align	4, 0x90
+_handle:
+	push	rbp
+	mov	rbp, rsp
+	call	_objc_msgSend
+	mov	rdi, rax
+	pop	rbp
+	jmp	_objc_retainAutoreleasedReturnValue
+
+.subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-ios.s
+++ b/tests/assembly/test_retain_autoreleased/expected/x86_64-apple-ios.s
@@ -7,7 +7,13 @@ _handle:
 	mov	rbp, rsp
 	call	_objc_msgSend
 	mov	rdi, rax
+	call	_objc_retainAutoreleasedReturnValue
+	## InlineAsm Start
+
+	nop
+
+	## InlineAsm End
 	pop	rbp
-	jmp	_objc_retainAutoreleasedReturnValue
+	ret
 
 .subsections_via_symbols

--- a/tests/assembly/test_retain_autoreleased/lib.rs
+++ b/tests/assembly/test_retain_autoreleased/lib.rs
@@ -1,0 +1,11 @@
+//! Test that `Id::retain_autoreleased` is inlined properly.
+
+use objc2::rc::{Id, Shared};
+use objc2::runtime::{Object, Sel};
+use objc2::MessageReceiver;
+
+#[no_mangle]
+pub fn handle(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
+    let ptr: *mut Object = unsafe { MessageReceiver::send_message(&obj, sel, ()).unwrap() };
+    unsafe { Id::retain_autoreleased(ptr) }
+}

--- a/tests/src/bin/test_assembly.rs
+++ b/tests/src/bin/test_assembly.rs
@@ -68,7 +68,11 @@ fn main() {
     let host = env!("TARGET");
 
     for entry in manifest_dir.join("assembly").read_dir().unwrap() {
-        let package_path = entry.unwrap().path();
+        let entry = entry.unwrap();
+        if !entry.file_type().unwrap().is_dir() {
+            continue;
+        }
+        let package_path = entry.path();
         let package = package_path.file_name().unwrap().to_str().unwrap();
 
         println!("Testing {package}.");
@@ -125,7 +129,7 @@ fn main() {
         let actual = read_assembly(&artifact).unwrap();
         if should_overwrite {
             fs::write(expected_file, actual).unwrap();
-        } else if let Ok(expected) = read_assembly(expected_file) {
+        } else if let Ok(expected) = fs::read_to_string(expected_file) {
             if expected != actual {
                 eprintln!("\n===Expected===\n{}\n===Actual===\n{}", expected, actual);
                 panic!("Expected and actual did not match.");


### PR DESCRIPTION
An optimized version of `Id::retain` that uses `objc_retainAutoreleasedReturnValue` for when the previous caller returns an autoreleased value with `objc_autoreleaseReturnValue`. This is a common thing in ARC code to avoid unnecessary `autorelease/retain` pairs, but it is (apart from changing the retain count) purely an optimization.

This uses the [newly stabilized](https://github.com/rust-lang/rust/pull/91728) inline assembly, which can easily cause _very_ undefined behaviour if used incorrectly. Luckily, the instructions are exceedingly simple (essentially just a special `nop`), so there's almost no room for error - so fingers crossed I got this right (at least enough that it doesn't cause UB)!

I've tested this on my local machine (both x86 and x86_64), and I've also added assembly tests to ensure that enough optimizations actually happen to make it work. At some point I would really like a helper like Apple's [`TestRoot`](https://github.com/apple-oss-distributions/objc4/blob/main/test/testroot.i) instead of the brittle checking of `retainCount` that we do now, but I'll defer that to later.

Related: https://github.com/gfx-rs/metal-rs/issues/222