### PR TITLE
Add `NSInteger` and `NSUInteger` to `objc-sys`

### DIFF
--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+## Added
+* `NSInteger` and `NSUInteger` (type aliases of `isize`/`usize`).
+* `NSIntegerMax`, `NSIntegerMin` and `NSUIntegerMax`.
+
 
 ## 0.1.0 - 2021-11-22
 

--- a/objc-sys/src/types.rs
+++ b/objc-sys/src/types.rs
@@ -70,7 +70,110 @@ mod inner {
 /// `objc2_encode::RefEncode`, but the `RefEncode` implementation is wrong
 /// on some platforms! You should only use this on FFI boundaries, otherwise
 /// prefer `objc2::runtime::Bool`.
+///
+/// See also the [corresponding documentation entry][docs].
+///
+/// [docs]: https://developer.apple.com/documentation/objectivec/bool?language=objc
 pub type BOOL = inner::BOOL;
+
+// # Why isize/usize is correct for NSInteger/NSUInteger
+//
+// ## Apple
+// The documentation clearly states:
+//
+// > When building 32-bit applications, NSInteger is a 32-bit integer. A
+//   64-bit application treats NSInteger as a 64-bit integer.
+//
+// And the header file defines them like so:
+//
+//     #if __LP64__ || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
+//     typedef long NSInteger;
+//     typedef unsigned long NSUInteger;
+//     #else
+//     typedef int NSInteger;
+//     typedef unsigned int NSUInteger;
+//     #endif
+//
+// Rust (or at least `libc`) has no targets where c_int/c_uint are not 32-bit,
+// so that part is correct. By manual inspection it is found that the only
+// platform where c_long/c_ulong differs from isize/usize is on Windows.
+// However Apple's libraries are only designed to work on 32-bit Windows, so
+// this case should be fine as well.
+//
+// Likewise for NSUInteger.
+//
+// ## GNUStep / WinObjC
+//
+// Defined as intptr_t/uintptr_t, which is exactly the same as isize/usize.
+//
+// ## ObjFW
+//
+// Doesn't define these, but e.g. `OFString -length` returns size_t, so our
+// definitions are should be correct on effectively all targets.
+//
+// Things might change slightly in the future, see
+// <https://internals.rust-lang.org/t/pre-rfc-usize-is-not-size-t/15369>.
+
+/// A signed integer value type.
+///
+/// This is guaranteed to always be a type-alias to [`isize`]. That means it
+/// is valid to use `#[repr(isize)]` on enums and structs with size
+/// `NSInteger`.
+///
+/// See also the [corresponding documentation entry][docs].
+///
+/// [docs]: https://developer.apple.com/documentation/objectivec/nsinteger?language=objc
+///
+/// # Examples
+///
+/// ```
+/// #[repr(isize)] // NSInteger
+/// pub enum NSComparisonResult {
+///     NSOrderedAscending = -1,
+///     NSOrderedSame = 0,
+///     NSOrderedDescending = 1,
+/// }
+/// ```
+pub type NSInteger = isize;
+
+/// Describes an unsigned integer.
+///
+/// This is guaranteed to always be a type-alias to [`usize`]. That means it
+/// is valid to use `#[repr(usize)]` on enums and structs with size
+/// `NSUInteger`.
+///
+/// See also the [corresponding documentation entry][docs].
+///
+/// [docs]: https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc
+///
+/// # Examples
+///
+/// ```
+/// use objc_sys::NSUInteger;
+/// extern "C" {
+///     fn some_external_function() -> NSUInteger;
+/// }
+/// ```
+///
+/// ```
+/// #[repr(usize)] // NSUInteger
+/// enum NSRoundingMode {
+///     NSRoundPlain = 0,
+///     NSRoundDown = 1,
+///     NSRoundUp = 2,
+///     NSRoundBankers = 3,
+/// };
+/// ```
+pub type NSUInteger = usize;
+
+/// The maximum value for an NSInteger.
+pub const NSIntegerMax: NSInteger = NSInteger::MAX;
+
+/// The minimum value for an NSInteger.
+pub const NSIntegerMin: NSInteger = NSInteger::MIN;
+
+/// The maximum value for an NSUInteger.
+pub const NSUIntegerMax: NSUInteger = NSUInteger::MAX;
 
 /// An immutable pointer to a selector.
 ///

--- a/objc2-encode/examples/ns_uinteger.rs
+++ b/objc2-encode/examples/ns_uinteger.rs
@@ -1,7 +1,7 @@
 //! Implementing `Encode` and `RefEncode` for `NSUInteger`.
 //!
 //! Note that in this case `NSUInteger` could actually just be a type alias
-//! for `usize`.
+//! for `usize`, and that's already available under `objc2::ffi::NSUInteger`.
 use objc2_encode::{Encode, Encoding, RefEncode};
 
 #[repr(transparent)]

--- a/objc2-foundation/src/comparison_result.rs
+++ b/objc2-foundation/src/comparison_result.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 
 use objc2::{Encode, Encoding, RefEncode};
 
-#[repr(isize)]
+#[repr(isize)] // NSInteger
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum NSComparisonResult {
     Ascending = -1,


### PR DESCRIPTION
See code comment for why these can be `isize` and `usize` instead of [how `cocoa` defines them](https://github.com/servo/core-foundation-rs/blob/cocoa-foundation-v0.1.0/cocoa-foundation/src/foundation.rs#L19-L27).