### PR TITLE
Test 32-bit support in CI

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -10,6 +10,7 @@ env:
   RUST_BACKTRACE: 1
   # Faster compilation and error on warnings
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
+  CARGO_TERM_VERBOSE: true
 
 jobs:
   fmt:
@@ -61,28 +62,30 @@ jobs:
     - name: Check documentation
       uses: actions-rs/cargo@v1
       with:
-        # TODO: Disallow warnings here
         command: doc
-        args: --verbose --no-deps --document-private-items
+        args: --no-deps --document-private-items
 
     - name: Test without features
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --no-fail-fast --no-default-features
+        args: --no-fail-fast --no-default-features
 
     - name: Test with features
       uses: actions-rs/cargo@v1
       with:
         command: test
         # Not using --all-features because some features are nightly-only
-        args: --verbose --no-fail-fast --features block,exception,catch_all,verify_message
+        args: --no-fail-fast --features block,exception,catch_all,verify_message
 
   build_32_bit:
     name: Build 32-bit
 
     # 32-bit support was removed in 10.15, so we can't test the binary, only build it
     runs-on: macos-10.15
+
+    env:
+      CARGO_BUILD_TARGET: i686-apple-darwin
 
     steps:
     - uses: actions/checkout@v2
@@ -105,4 +108,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --verbose -Zbuild-std --tests --target i686-apple-darwin --features exception,catch_all,verify_message
+        args: -Zbuild-std --tests --features exception,catch_all,verify_message

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -10,6 +10,7 @@ env:
   RUST_BACKTRACE: 1
   # Faster compilation and error on warnings
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
+  RUSTDOCFLAGS: "-D warnings"
   CARGO_TERM_VERBOSE: true
 
 jobs:

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -77,3 +77,32 @@ jobs:
         command: test
         # Not using --all-features because some features are nightly-only
         args: --verbose --no-fail-fast --features block,exception,catch_all,verify_message
+
+  build_32_bit:
+    name: Build 32-bit
+
+    # 32-bit support was removed in 10.15, so we can't test the binary, only build it
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install nightly Rust # required for -Zbuild-std
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+        components: rust-src
+
+    - name: Download macOS 10.13 SDK (supports 32-bit)
+      run: |
+        wget https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.13/MacOSX10.13.tar.bz2
+        tar -xyf MacOSX10.13.tar.bz2
+        echo "SDKROOT=$(pwd)/MacOSX10.13.sdk" >> $GITHUB_ENV
+
+    - name: Build with features
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --verbose -Zbuild-std --tests --target i686-apple-darwin --features exception,catch_all,verify_message

--- a/.github/workflows/gnustep.yml
+++ b/.github/workflows/gnustep.yml
@@ -17,14 +17,38 @@ env:
 jobs:
   test:
     name: Test
-    # TODO: 32bit and gcc-multilib
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-unknown-linux-gnu
+
+          - target: i686-unknown-linux-gnu
+            cflags: -m32
+            configureflags: --target=x86-pc-linux-gnu
+
     runs-on: ubuntu-latest
+
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.platform.target }}
+      CFLAGS: ${{ matrix.platform.cflags }}
+      CXXFLAGS: ${{ matrix.platform.cflags }}
+      ASMFLAGS: ${{ matrix.platform.cflags }}
+      LDFLAGS: ${{ matrix.platform.cflags }}
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install Clang
       run: sudo apt-get -y install clang
+
+    - name: Install cross compilation tools
+      if: contains(matrix.platform.target, 'i686')
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get -y install gcc-multilib libgcc-10-dev:i386 \
+          libc6-dev:i386 libstdc++-10-dev:i386 libffi-dev:i386 \
+          libxml2-dev:i386 libicu-dev:i386
 
     - name: Cache GNUStep
       id: cache-gnustep
@@ -43,7 +67,7 @@ jobs:
         path: |
           ~/gnustep/lib
           ~/gnustep/include
-        key: gnustep-libobjc2_1.9-make_2.9.0-base_1.28.0
+        key: ${{ matrix.platform.target }}-gnustep-libobjc2_1.9-make_2.9.0-base_1.28.0
 
     - name: Setup environment
       run: |
@@ -84,7 +108,7 @@ jobs:
         wget https://github.com/gnustep/libs-base/archive/refs/tags/base-1_28_0.tar.gz
         tar -xzf base-1_28_0.tar.gz
         cd libs-base-base-1_28_0
-        ./configure --prefix=$HOME/gnustep --disable-tls --disable-xslt
+        ./configure --prefix=$HOME/gnustep --disable-tls --disable-xslt ${{ matrix.platform.configureflags }}
         make install
         ls -al $HOME/gnustep/*
 
@@ -94,9 +118,17 @@ jobs:
         path: |
           ~/.cargo/
           target/
-        key: gnustep-cargo-${{ hashFiles('**/Cargo.toml') }}
+        key: ${{ matrix.platform.target }}-gnustep-cargo-${{ hashFiles('**/Cargo.toml') }}
         restore-keys: |
-          gnustep-cargo-
+          ${{ matrix.platform.target }}-gnustep-cargo-
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.platform.target }}
+        profile: minimal
+        override: true
 
     - name: Run checks
       uses: actions-rs/cargo@v1

--- a/.github/workflows/gnustep.yml
+++ b/.github/workflows/gnustep.yml
@@ -10,6 +10,7 @@ env:
   RUST_BACKTRACE: 1
   # Faster compilation and error on warnings
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
+  RUSTDOCFLAGS: "-D warnings"
   CARGO_TERM_VERBOSE: true
   CC: clang
   CXX: clang++

--- a/.github/workflows/gnustep.yml
+++ b/.github/workflows/gnustep.yml
@@ -10,6 +10,7 @@ env:
   RUST_BACKTRACE: 1
   # Faster compilation and error on warnings
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
+  CARGO_TERM_VERBOSE: true
   CC: clang
   CXX: clang++
 
@@ -101,17 +102,17 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --verbose --no-default-features --features gnustep-1-9
+        args: --no-default-features --features gnustep-1-9
 
     - name: Test without features
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --no-fail-fast --no-default-features --features gnustep-1-9
+        args: --no-fail-fast --no-default-features --features gnustep-1-9
 
     - name: Test with features
       uses: actions-rs/cargo@v1
       with:
         command: test
         # Not using --all-features because some features are nightly-only
-        args: --verbose --no-fail-fast --features gnustep-1-9,block,exception,catch_all,verify_message
+        args: --no-fail-fast --features gnustep-1-9,block,exception,catch_all,verify_message

--- a/objc-sys/build.rs
+++ b/objc-sys/build.rs
@@ -164,11 +164,16 @@ fn main() {
 
     let clang_runtime = match &runtime {
         Apple(runtime) => {
-            let clang_runtime_str = match runtime {
-                MacOS(_) => "macosx",
-                IOS(_) => "ios",
-                WatchOS(_) => "watchos",
-                TvOS(_) => "ios", // ??
+            // The fragile runtime is expected on i686-apple-darwin, see:
+            // https://github.com/llvm/llvm-project/blob/release/13.x/clang/lib/Driver/ToolChains/Darwin.h#L228-L231
+            // https://github.com/llvm/llvm-project/blob/release/13.x/clang/lib/Driver/ToolChains/Clang.cpp#L3639-L3640
+            let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+            let clang_runtime_str = match (runtime, &*target_arch) {
+                (MacOS(_), "x86") => "macosx-fragile",
+                (MacOS(_), _) => "macosx",
+                (IOS(_), _) => "ios",
+                (WatchOS(_), _) => "watchos",
+                (TvOS(_), _) => "ios", // ??
             };
             match runtime {
                 MacOS(version) | IOS(version) | WatchOS(version) | TvOS(version) => {

--- a/objc-sys/src/various.rs
+++ b/objc-sys/src/various.rs
@@ -3,8 +3,6 @@ use core::ffi::c_void;
 use std::os::raw::c_uint;
 use std::os::raw::{c_char, c_int};
 
-#[cfg(apple)]
-use crate::objc_class;
 use crate::{objc_AssociationPolicy, objc_object, OpaqueData, BOOL};
 
 /// An opaque type that represents an instance variable.
@@ -24,13 +22,14 @@ pub type IMP = Option<unsafe extern "C" fn()>;
 /// Remember that this is non-null!
 #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
 pub type objc_hook_getClass =
-    unsafe extern "C" fn(name: *const c_char, out_cls: *mut *const objc_class) -> BOOL;
+    unsafe extern "C" fn(name: *const c_char, out_cls: *mut *const crate::objc_class) -> BOOL;
 
 /// Not available on macOS x86.
 ///
 /// Remember that this is non-null!
 #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
-pub type objc_hook_lazyClassNamer = unsafe extern "C" fn(cls: *const objc_class) -> *const c_char;
+pub type objc_hook_lazyClassNamer =
+    unsafe extern "C" fn(cls: *const crate::objc_class) -> *const c_char;
 
 extern "C" {
     pub fn imp_getBlock(imp: IMP) -> *mut objc_object;

--- a/objc2/src/exception.rs
+++ b/objc2/src/exception.rs
@@ -128,6 +128,8 @@ mod tests {
     }
 
     #[test]
+    // TODO: `NULL` exceptions are invalid on 32-bit / w. fragile runtime
+    #[cfg(not(all(target_os = "macos", target_arch = "x86")))]
     fn test_throw_catch_none() {
         let s = "Hello".to_string();
         let result = unsafe {


### PR DESCRIPTION
Added 32-bit support testing in CI, this revealed a few issues that I've also now fixed.

Unfortunately, GitHub Actions only support macOS 10.15 or above, which can't run 32-bit binaries, so they are only built on that platform; we'll have to rely on users with a macOS version of 10.14 or below (like me) to run the following to test it once in a while:
```sh
# Download older SDK from:
# - https://github.com/alexey-lysiuk/macos-sdk
# - https://github.com/phracker/MacOSX-SDKs
export SDKROOT=/path/to/downloaded/MacOSX10.13.sdk
cargo +nightly test -Z build-std --target i686-apple-darwin
cargo +nightly test -Z build-std --target i686-apple-darwin --features exception,catch_all,verify_message
```