### PR TITLE
Remove `INSObject::Ownership`

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* **BREAKING**: Added associated `Ownership` type to `NSCopying`.
+* **BREAKING**: Added associated `Ownership` type to `INSData`.
+* **BREAKING**: Added associated `Ownership` type to `INSArray`.
+
+### Changed
+* **BREAKING**: Made some creation methods a bit less generic (e.g.
+  `INSDictionary::from_keys_and_objects` now always returns `Id<_, Shared>`).
+
+### Removed
+* **BREAKING**: Removed associated `Ownership` type from `INSObject`; instead,
+  it is present on the types that actually need it (for example `NSCopying`).
+
 ## 0.2.0-alpha.2 - 2021-11-22
 
 ### Added

--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -53,8 +53,6 @@ impl<'a> MyObject<'a> {
 static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 
 unsafe impl INSObject for MyObject<'_> {
-    type Ownership = Owned;
-
     fn class() -> &'static Class {
         MYOBJECT_REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -23,7 +23,7 @@ unsafe impl RefEncode for MYObject {
 }
 
 impl MYObject {
-    fn new() -> Id<Self, <Self as INSObject>::Ownership> {
+    fn new() -> Id<Self, Owned> {
         let cls = Self::class();
         unsafe { Id::new(NonNull::new_unchecked(msg_send![cls, new])) }
     }
@@ -48,8 +48,6 @@ unsafe impl Message for MYObject {}
 static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 
 unsafe impl INSObject for MYObject {
-    type Ownership = Owned;
-
     fn class() -> &'static Class {
         MYOBJECT_REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();

--- a/objc2-foundation/src/copying.rs
+++ b/objc2-foundation/src/copying.rs
@@ -1,23 +1,40 @@
 use core::ptr::NonNull;
 
 use objc2::msg_send;
-use objc2::rc::{Id, Owned};
+use objc2::rc::{Id, Owned, Ownership};
 
 use super::INSObject;
 
 pub unsafe trait INSCopying: INSObject {
-    /// This can be an [`Owned`] [`INSObject`] if and only if `copy` creates a
-    /// new instance, see the following example:
+    /// Indicates whether the type is mutable or immutable.
+    ///
+    /// This can be [`Owned`] if and only if `copy` creates a new instance,
+    /// see the following example:
     ///
     /// ```ignore
-    /// let x: Id<MyObject, Owned> = MyObject::new();
+    /// let x: Id<MyObject, _> = MyObject::new();
     /// // This is valid only if `y` is a new instance. Otherwise `x` and `y`
     /// // would be able to create aliasing mutable references!
     /// let y: Id<MyObject, Owned> = x.copy();
     /// ```
+    ///
+    /// Note that for the same reason, you should be careful when defining
+    /// `new` methods on your object; e.g. immutable types like [`NSString`]
+    /// don't return `Id<NSString, Owned>`, because that would allow this
+    /// trait to create an aliasing `Id<NSString, Shared>` (since sending the
+    /// `copy` message (and others) does not create a new instance, but
+    /// instead just retains the instance).
+    ///
+    /// [`NSString`]: crate::NSString
+    type Ownership: Ownership;
+
+    /// The output type.
+    ///
+    /// This is usually `Self`, but e.g. `NSMutableString` returns `NSString`.
+    /// TODO: Verify???
     type Output: INSObject;
 
-    fn copy(&self) -> Id<Self::Output, <Self::Output as INSObject>::Ownership> {
+    fn copy(&self) -> Id<Self::Output, Self::Ownership> {
         unsafe {
             let obj: *mut Self::Output = msg_send![self, copy];
             Id::new(NonNull::new_unchecked(obj))
@@ -25,10 +42,12 @@ pub unsafe trait INSCopying: INSObject {
     }
 }
 
+/// TODO
+///
+/// Note that the `mutableCopy` selector must return an owned object!
 pub unsafe trait INSMutableCopying: INSObject {
-    /// An [`Owned`] [`INSObject`] is required to be able to return an owned
-    /// [`Id`].
-    type Output: INSObject<Ownership = Owned>;
+    /// TODO
+    type Output: INSObject;
 
     fn mutable_copy(&self) -> Id<Self::Output, Owned> {
         unsafe {

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -6,10 +6,12 @@ use core::{ffi::c_void, ptr::NonNull};
 
 use super::{INSCopying, INSMutableCopying, INSObject, NSRange};
 use objc2::msg_send;
-use objc2::rc::{Id, Owned, Shared};
+use objc2::rc::{Id, Owned, Ownership, Shared};
 
 pub unsafe trait INSData: INSObject {
-    unsafe_def_fn!(fn new);
+    type Ownership: Ownership;
+
+    unsafe_def_fn!(fn new -> Self::Ownership);
 
     fn len(&self) -> usize {
         unsafe { msg_send![self, length] }
@@ -90,11 +92,14 @@ pub unsafe trait INSData: INSObject {
     }
 }
 
-object_struct!(unsafe NSData, Shared);
+object_struct!(unsafe NSData);
 
-unsafe impl INSData for NSData {}
+unsafe impl INSData for NSData {
+    type Ownership = Shared;
+}
 
 unsafe impl INSCopying for NSData {
+    type Ownership = Shared;
     type Output = NSData;
 }
 
@@ -150,13 +155,16 @@ pub unsafe trait INSMutableData: INSData {
     }
 }
 
-object_struct!(unsafe NSMutableData, Owned);
+object_struct!(unsafe NSMutableData);
 
-unsafe impl INSData for NSMutableData {}
+unsafe impl INSData for NSMutableData {
+    type Ownership = Owned;
+}
 
 unsafe impl INSMutableData for NSMutableData {}
 
 unsafe impl INSCopying for NSMutableData {
+    type Ownership = Shared;
     type Output = NSData;
 }
 

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -10,7 +10,7 @@ use objc2::{class, msg_send};
 
 use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator};
 
-unsafe fn from_refs<D, T>(keys: &[&T], vals: &[&D::Value]) -> Id<D, D::Ownership>
+unsafe fn from_refs<D, T>(keys: &[&T], vals: &[&D::Value]) -> Id<D, Shared>
 where
     D: INSDictionary,
     T: INSCopying<Output = D::Key>,
@@ -34,8 +34,6 @@ pub unsafe trait INSDictionary: INSObject {
     type Key: INSObject;
     type Value: INSObject;
     type ValueOwnership: Ownership;
-
-    unsafe_def_fn!(fn new);
 
     #[doc(alias = "count")]
     fn len(&self) -> usize {
@@ -124,7 +122,7 @@ pub unsafe trait INSDictionary: INSObject {
     fn from_keys_and_objects<T>(
         keys: &[&T],
         vals: Vec<Id<Self::Value, Self::ValueOwnership>>,
-    ) -> Id<Self, Self::Ownership>
+    ) -> Id<Self, Shared>
     where
         T: INSCopying<Output = Self::Key>,
     {
@@ -148,9 +146,11 @@ pub struct NSDictionary<K, V> {
 
 object_impl!(unsafe NSDictionary<K, V>);
 
-unsafe impl<K: INSObject, V: INSObject> INSObject for NSDictionary<K, V> {
-    type Ownership = Shared;
+impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
+    unsafe_def_fn!(pub fn new -> Shared);
+}
 
+unsafe impl<K: INSObject, V: INSObject> INSObject for NSDictionary<K, V> {
     fn class() -> &'static Class {
         class!(NSDictionary)
     }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -7,7 +7,7 @@
 /// example: `NSAutoreleasePool` does not have this). Finally the ownership
 /// must be correct for this class.
 macro_rules! object_struct {
-    (unsafe $name:ident, $ownership:ty) => {
+    (unsafe $name:ident) => {
         // TODO: `extern type`
         #[repr(C)]
         pub struct $name {
@@ -21,8 +21,6 @@ macro_rules! object_struct {
         }
 
         unsafe impl $crate::INSObject for $name {
-            type Ownership = $ownership;
-
             fn class() -> &'static ::objc2::runtime::Class {
                 ::objc2::class!($name)
             }
@@ -77,8 +75,8 @@ macro_rules! object_impl {
 }
 
 macro_rules! unsafe_def_fn {
-    ($v:vis fn new) => {
-        $v fn new() -> Id<Self, <Self as INSObject>::Ownership> {
+    ($v:vis fn new -> $o:ty) => {
+        $v fn new() -> Id<Self, $o> {
             let cls = <Self as INSObject>::class();
             unsafe { Id::new(NonNull::new_unchecked(msg_send![cls, new])) }
         }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -1,7 +1,7 @@
 use core::ptr::NonNull;
 
 use objc2::msg_send;
-use objc2::rc::{Id, Owned, Ownership, Shared};
+use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::{Bool, Class};
 use objc2::Message;
 
@@ -12,16 +12,6 @@ use super::NSString;
 // type pointer to an Object pointer, because dynamically-sized types can have
 // fat pointers (two words) instead of real pointers.
 pub unsafe trait INSObject: Sized + Message {
-    /// Indicates whether the type is mutable or immutable.
-    ///
-    /// [`Shared`] means that only a shared [`Id`] can ever be held to this
-    /// object. This is important for immutable types like `NSString`, because
-    /// sending the `copy` message (and others) does not create a new
-    /// instance, but instead just retains the instance.
-    ///
-    /// Most objects are mutable and hence can return [`Owned`] [`Id`]s.
-    type Ownership: Ownership;
-
     fn class() -> &'static Class;
 
     fn hash_code(&self) -> usize {
@@ -47,10 +37,10 @@ pub unsafe trait INSObject: Sized + Message {
     }
 }
 
-object_struct!(unsafe NSObject, Owned);
+object_struct!(unsafe NSObject);
 
 impl NSObject {
-    unsafe_def_fn!(pub fn new);
+    unsafe_def_fn!(pub fn new -> Owned);
 }
 
 #[cfg(test)]

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -22,8 +22,6 @@ const UTF8_ENCODING: i32 = 4;
 const NSNotFound: ffi::NSInteger = ffi::NSIntegerMax;
 
 pub unsafe trait INSString: INSObject {
-    unsafe_def_fn!(fn new);
-
     fn len(&self) -> usize {
         unsafe { msg_send![self, lengthOfBytesUsingEncoding: UTF8_ENCODING] }
     }
@@ -86,7 +84,7 @@ pub unsafe trait INSString: INSObject {
         str::from_utf8(bytes).unwrap()
     }
 
-    fn from_str(string: &str) -> Id<Self, Self::Ownership> {
+    fn from_str(string: &str) -> Id<Self, Shared> {
         let cls = Self::class();
         let bytes = string.as_ptr() as *const c_void;
         unsafe {
@@ -102,11 +100,16 @@ pub unsafe trait INSString: INSObject {
     }
 }
 
-object_struct!(unsafe NSString, Shared);
+object_struct!(unsafe NSString);
+
+impl NSString {
+    unsafe_def_fn!(pub fn new -> Shared);
+}
 
 unsafe impl INSString for NSString {}
 
 unsafe impl INSCopying for NSString {
+    type Ownership = Shared;
     type Output = NSString;
 }
 

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -54,7 +54,7 @@ pub unsafe trait INSValue: INSObject {
         result.map(|s| unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap())
     }
 
-    fn new(value: Self::Value) -> Id<Self, Self::Ownership> {
+    fn new(value: Self::Value) -> Id<Self, Shared> {
         let cls = Self::class();
         let bytes = &value as *const Self::Value as *const c_void;
         let encoding = CString::new(Self::Value::ENCODING.to_string()).unwrap();
@@ -77,8 +77,6 @@ pub struct NSValue<T> {
 object_impl!(unsafe NSValue<T>);
 
 unsafe impl<T: 'static> INSObject for NSValue<T> {
-    type Ownership = Shared;
-
     fn class() -> &'static Class {
         class!(NSValue)
     }
@@ -89,6 +87,7 @@ unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {
 }
 
 unsafe impl<T: 'static> INSCopying for NSValue<T> {
+    type Ownership = Shared;
     type Output = NSValue<T>;
 }
 


### PR DESCRIPTION
Instead, it is present on the types that actually need it. This is in preparation for bigger changes to `objc2-foundation`, see https://github.com/madsmtm/objc2/issues/58.