### PR TITLE
Refactor `objc2-foundation` macros

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * **BREAKING**: Made some creation methods a bit less generic (e.g.
   `INSDictionary::from_keys_and_objects` now always returns `Id<_, Shared>`).
+* Relax bounds on generic `INSObject` impls.
 
 ### Removed
 * **BREAKING**: Removed associated `Ownership` type from `INSObject`; instead,

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Added associated `Ownership` type to `NSCopying`.
 * **BREAKING**: Added associated `Ownership` type to `INSData`.
 * **BREAKING**: Added associated `Ownership` type to `INSArray`.
+* Added common trait impls (`PartialEq`, `Eq`, `Hash` and `Debug`) to
+  `NSValue`, `NSDictionary`, `NSArray` and `NSMutableArray`.
 
 ### Changed
 * **BREAKING**: Made some creation methods a bit less generic (e.g.
@@ -18,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 * **BREAKING**: Removed associated `Ownership` type from `INSObject`; instead,
   it is present on the types that actually need it (for example `NSCopying`).
+
+### Fixed
+* Soundness issue with `NSValue`, `NSDictionary`, `NSArray` and
+  `NSMutableArray` not being `#[repr(C)]`.
 
 ## 0.2.0-alpha.2 - 2021-11-22
 

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -5,9 +5,9 @@ use core::marker::PhantomData;
 use core::ops::{Index, Range};
 use core::ptr::NonNull;
 
+use objc2::msg_send;
 use objc2::rc::{Id, Owned, Ownership, Shared, SliceId};
-use objc2::runtime::{Class, Object};
-use objc2::{class, msg_send};
+use objc2::runtime::Object;
 
 use super::{
     INSCopying, INSFastEnumeration, INSMutableCopying, INSObject, NSComparisonResult, NSEnumerator,
@@ -158,27 +158,21 @@ pub unsafe trait INSArray: INSObject {
     }
 }
 
-/// TODO
-///
-/// You can have a `Id<NSArray<T, Owned>, Owned>`, which allows mutable access
-/// to the elements (without modifying the array itself), and
-/// `Id<NSArray<T, Shared>, Shared>` which allows sharing the array.
-///
-/// `Id<NSArray<T, Owned>, Shared>` is possible, but pretty useless.
-/// TODO: Can we make it impossible? Should we?
-///
-/// What about `Id<NSArray<T, Shared>, Owned>`?
-pub struct NSArray<T, O: Ownership> {
-    item: PhantomData<Id<T, O>>,
-}
-
-object_impl!(unsafe NSArray<T, O: Ownership>);
-
-unsafe impl<T: INSObject, O: Ownership> INSObject for NSArray<T, O> {
-    fn class() -> &'static Class {
-        class!(NSArray)
+object!(
+    /// TODO
+    ///
+    /// You can have a `Id<NSArray<T, Owned>, Owned>`, which allows mutable access
+    /// to the elements (without modifying the array itself), and
+    /// `Id<NSArray<T, Shared>, Shared>` which allows sharing the array.
+    ///
+    /// `Id<NSArray<T, Owned>, Shared>` is possible, but pretty useless.
+    /// TODO: Can we make it impossible? Should we?
+    ///
+    /// What about `Id<NSArray<T, Shared>, Owned>`?
+    unsafe pub struct<T: INSObject, O: Ownership> NSArray<T, O: Ownership> {
+        item: PhantomData<Id<T, O>>,
     }
-}
+);
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSArray<T, O> {
     /// The `NSArray` itself (length and number of items) is always immutable,
@@ -319,17 +313,11 @@ pub unsafe trait INSMutableArray: INSArray {
     }
 }
 
-pub struct NSMutableArray<T, O: Ownership> {
-    item: PhantomData<Id<T, O>>,
-}
-
-object_impl!(unsafe NSMutableArray<T, O: Ownership>);
-
-unsafe impl<T: INSObject, O: Ownership> INSObject for NSMutableArray<T, O> {
-    fn class() -> &'static Class {
-        class!(NSMutableArray)
+object!(
+    unsafe pub struct<T: INSObject, O: Ownership> NSMutableArray<T, O: Ownership> {
+        item: PhantomData<Id<T, O>>,
     }
-}
+);
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSMutableArray<T, O> {
     type Ownership = Owned;

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -352,6 +352,7 @@ impl<T: INSObject, O: Ownership> Index<usize> for NSMutableArray<T, O> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
     use alloc::vec;
     use alloc::vec::Vec;
 
@@ -403,6 +404,18 @@ mod tests {
         let array1 = sample_number_array(3);
         let array2 = sample_number_array(4);
         assert_ne!(array1, array2);
+    }
+
+    #[test]
+    #[ignore = "Output is different depending on OS version and runtime"]
+    fn test_debug() {
+        let obj = sample_number_array(3);
+        let expected = r#"(
+    "<00>",
+    "<01>",
+    "<02>"
+)"#;
+        assert_eq!(format!("{:?}", obj), format!("{:?}", expected));
     }
 
     #[test]

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -359,12 +359,20 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Owned, Shared};
 
     use super::{INSArray, INSMutableArray, NSArray, NSMutableArray};
-    use crate::{INSObject, INSString, NSObject, NSString};
+    use crate::{INSObject, INSString, INSValue, NSObject, NSString, NSValue};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);
         for _ in 0..len {
             vec.push(NSObject::new());
+        }
+        NSArray::from_vec(vec)
+    }
+
+    fn sample_number_array(len: u8) -> Id<NSArray<NSValue<u8>, Shared>, Shared> {
+        let mut vec = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            vec.push(NSValue::new(i));
         }
         NSArray::from_vec(vec)
     }
@@ -380,6 +388,21 @@ mod tests {
 
         let array = sample_array(4);
         assert_eq!(array.len(), 4);
+    }
+
+    #[test]
+    fn test_equality() {
+        let array1 = sample_array(3);
+        let array2 = sample_array(3);
+        assert_ne!(array1, array2);
+
+        let array1 = sample_number_array(3);
+        let array2 = sample_number_array(3);
+        assert_eq!(array1, array2);
+
+        let array1 = sample_number_array(3);
+        let array2 = sample_number_array(4);
+        assert_ne!(array1, array2);
     }
 
     #[test]

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -172,7 +172,6 @@ object!(
     unsafe pub struct NSArray<T, O: Ownership> {
         item: PhantomData<Id<T, O>>,
     }
-    impl where T: INSObject
 );
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSArray<T, O> {
@@ -318,7 +317,6 @@ object!(
     unsafe pub struct NSMutableArray<T, O: Ownership> {
         item: PhantomData<Id<T, O>>,
     }
-    impl where T: INSObject
 );
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSMutableArray<T, O> {

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -169,9 +169,10 @@ object!(
     /// TODO: Can we make it impossible? Should we?
     ///
     /// What about `Id<NSArray<T, Shared>, Owned>`?
-    unsafe pub struct<T: INSObject, O: Ownership> NSArray<T, O: Ownership> {
+    unsafe pub struct NSArray<T, O: Ownership> {
         item: PhantomData<Id<T, O>>,
     }
+    impl where T: INSObject
 );
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSArray<T, O> {
@@ -314,9 +315,10 @@ pub unsafe trait INSMutableArray: INSArray {
 }
 
 object!(
-    unsafe pub struct<T: INSObject, O: Ownership> NSMutableArray<T, O: Ownership> {
+    unsafe pub struct NSMutableArray<T, O: Ownership> {
         item: PhantomData<Id<T, O>>,
     }
+    impl where T: INSObject
 );
 
 unsafe impl<T: INSObject, O: Ownership> INSArray for NSMutableArray<T, O> {

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -92,7 +92,7 @@ pub unsafe trait INSData: INSObject {
     }
 }
 
-object_struct!(unsafe NSData);
+object!(unsafe pub struct NSData);
 
 unsafe impl INSData for NSData {
     type Ownership = Shared;
@@ -155,7 +155,7 @@ pub unsafe trait INSMutableData: INSData {
     }
 }
 
-object_struct!(unsafe NSMutableData);
+object!(unsafe pub struct NSMutableData);
 
 unsafe impl INSData for NSMutableData {
     type Ownership = Owned;

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -139,10 +139,13 @@ pub unsafe trait INSDictionary: INSObject {
 }
 
 object!(
-    unsafe pub struct<K: INSObject, V: INSObject> NSDictionary<K, V> {
+    unsafe pub struct NSDictionary<K, V> {
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
+    impl where
+        K: INSObject,
+        V: INSObject,
 );
 
 impl<K: INSObject, V: INSObject> NSDictionary<K, V> {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -4,9 +4,8 @@ use core::marker::PhantomData;
 use core::ops::Index;
 use core::ptr::{self, NonNull};
 
+use objc2::msg_send;
 use objc2::rc::{Id, Owned, Ownership, Shared, SliceId};
-use objc2::runtime::Class;
-use objc2::{class, msg_send};
 
 use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator};
 
@@ -139,21 +138,15 @@ pub unsafe trait INSDictionary: INSObject {
     }
 }
 
-pub struct NSDictionary<K, V> {
-    key: PhantomData<Id<K, Shared>>,
-    obj: PhantomData<Id<V, Owned>>,
-}
-
-object_impl!(unsafe NSDictionary<K, V>);
+object!(
+    unsafe pub struct<K: INSObject, V: INSObject> NSDictionary<K, V> {
+        key: PhantomData<Id<K, Shared>>,
+        obj: PhantomData<Id<V, Owned>>,
+    }
+);
 
 impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
     unsafe_def_fn!(pub fn new -> Shared);
-}
-
-unsafe impl<K: INSObject, V: INSObject> INSObject for NSDictionary<K, V> {
-    fn class() -> &'static Class {
-        class!(NSDictionary)
-    }
 }
 
 unsafe impl<K: INSObject, V: INSObject> INSDictionary for NSDictionary<K, V> {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -143,9 +143,6 @@ object!(
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
-    impl where
-        K: INSObject,
-        V: INSObject,
 );
 
 impl<K: INSObject, V: INSObject> NSDictionary<K, V> {

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -18,7 +18,6 @@ macro_rules! object {
         unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident)?),*> {
             $($p:ident: $pty:ty,)*
         }
-        $(impl where $($w:tt)+)?
     ) => {
         // TODO: `extern type`
         $(#[$m])*

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -39,22 +39,45 @@ macro_rules! object {
             }
         }
 
-        impl<$($t $(: $b)?),*> ::core::cmp::PartialEq for $name<$($t),*> {
+        // Objective-C equality has approximately the same semantics as Rust
+        // equality (although less aptly specified).
+        //
+        // At the very least, equality is _expected_ to be symmetric and
+        // transitive, and that's about the best we can do.
+        //
+        // `T: PartialEq` bound added because e.g. `NSArray` does deep
+        // (instead of shallow) equality comparisons.
+        //
+        // See also https://nshipster.com/equality/
+        impl<$($t: ::core::cmp::PartialEq $(+ $b)?),*> ::core::cmp::PartialEq for $name<$($t),*> {
+            #[inline]
             fn eq(&self, other: &Self) -> bool {
                 use $crate::INSObject;
                 self.is_equal(other)
             }
         }
 
-        impl<$($t $(: $b)?),*> ::core::cmp::Eq for $name<$($t),*> {}
+        // Most types' equality is reflexive.
+        //
+        // `T: Eq` bound added to prevent e.g. `NSValue<f32>` from being `Eq`
+        // (even though `[NAN isEqual: NAN]` is true in Objective-C).
+        impl<$($t: ::core::cmp::Eq $(+ $b)?),*> ::core::cmp::Eq for $name<$($t),*> {}
 
-        impl<$($t $(: $b)?),*> ::core::hash::Hash for $name<$($t),*> {
+        // Hashing in Objective-C has the exact same requirement as in Rust:
+        //
+        // > If two objects are equal (as determined by the isEqual: method),
+        // > they must have the same hash value.
+        //
+        // See https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418859-hash
+        impl<$($t: ::core::hash::Hash $(+ $b)?),*> ::core::hash::Hash for $name<$($t),*> {
+            #[inline]
             fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                 use $crate::INSObject;
                 self.hash_code().hash(state);
             }
         }
 
+        // TODO: Consider T: Debug bound
         impl<$($t $(: $b)?),*> ::core::fmt::Debug for $name<$($t),*> {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 use $crate::{INSObject, INSString};

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -7,56 +7,56 @@
 /// example: `NSAutoreleasePool` does not have this). Finally the ownership
 /// must be correct for this class.
 macro_rules! object {
-    ($(#[$m:meta])* unsafe $v:vis struct $name:ident) => {
-        object!($(#[$m])* unsafe $v struct<()> $name<> {});
+    (
+        $(#[$m:meta])*
+        unsafe $v:vis struct $name:ident
+    ) => {
+        object!($(#[$m])* unsafe $v struct $name<> {});
     };
-    ($(#[$m:meta])* unsafe $v:vis struct<$($t:ident $(: $b:ident)?),+> $name:ident<$($t2:ident $(: $b2:ident)?),+> {
-        $($p:ident: $pty:ty,)*
-    }) => {
-        object!($(#[$m])* unsafe $v struct<($($t $(: $b)?),+)> $name<$($t2 $(: $b2)?),+> {
-            $($p: $pty,)*
-        });
-    };
-    ($(#[$m:meta])* unsafe $v:vis struct<($($t:tt)*)> $name:ident<$($t2:ident $(: $b2:ident)?),*> {
-        $($p:ident: $pty:ty,)*
-    }) => {
+    (
+        $(#[$m:meta])*
+        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident)?),*> {
+            $($p:ident: $pty:ty,)*
+        }
+        $(impl where $($w:tt)+)?
+    ) => {
         // TODO: `extern type`
         $(#[$m])*
         #[repr(C)]
-        $v struct $name<$($t2 $(: $b2)?),*> {
+        $v struct $name<$($t $(: $b)?),*> {
             _private: [u8; 0],
             $($p: $pty),*
         }
 
-        unsafe impl<$($t)*> ::objc2::Message for $name<$($t2),*> { }
+        unsafe impl<$($t $(: $b)?),*> ::objc2::Message for $name<$($t),*> { }
 
-        unsafe impl<$($t)*> ::objc2::RefEncode for $name<$($t2),*> {
+        unsafe impl<$($t $(: $b)?),*> ::objc2::RefEncode for $name<$($t),*> {
             const ENCODING_REF: ::objc2::Encoding<'static> = ::objc2::Encoding::Object;
         }
 
-        unsafe impl<$($t)*> $crate::INSObject for $name<$($t2),*> {
+        unsafe impl<$($t $(: $b)?),*> $crate::INSObject for $name<$($t),*> {
             fn class() -> &'static ::objc2::runtime::Class {
                 ::objc2::class!($name)
             }
         }
 
-        impl<$($t)*> ::core::cmp::PartialEq for $name<$($t2),*> {
+        impl<$($t $(: $b)?),*> ::core::cmp::PartialEq for $name<$($t),*> {
             fn eq(&self, other: &Self) -> bool {
                 use $crate::INSObject;
                 self.is_equal(other)
             }
         }
 
-        impl<$($t)*> ::core::cmp::Eq for $name<$($t2),*> {}
+        impl<$($t $(: $b)?),*> ::core::cmp::Eq for $name<$($t),*> {}
 
-        impl<$($t)*> ::core::hash::Hash for $name<$($t2),*> {
+        impl<$($t $(: $b)?),*> ::core::hash::Hash for $name<$($t),*> {
             fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                 use $crate::INSObject;
                 self.hash_code().hash(state);
             }
         }
 
-        impl<$($t)*> ::core::fmt::Debug for $name<$($t2),*> {
+        impl<$($t $(: $b)?),*> ::core::fmt::Debug for $name<$($t),*> {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 use $crate::{INSObject, INSString};
                 ::objc2::rc::autoreleasepool(|pool| {

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -37,7 +37,7 @@ pub unsafe trait INSObject: Sized + Message {
     }
 }
 
-object_struct!(unsafe NSObject);
+object!(unsafe pub struct NSObject);
 
 impl NSObject {
     unsafe_def_fn!(pub fn new -> Owned);

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -46,9 +46,8 @@ impl NSObject {
 #[cfg(test)]
 mod tests {
     use super::{INSObject, NSObject};
-    use crate::{INSString, NSString};
+    use crate::NSString;
     use alloc::format;
-    use objc2::rc::autoreleasepool;
 
     #[test]
     fn test_equality() {
@@ -66,16 +65,10 @@ mod tests {
     }
 
     #[test]
-    fn test_description() {
+    fn test_debug() {
         let obj = NSObject::new();
-        let description = obj.description();
         let expected = format!("<NSObject: {:p}>", &*obj);
-        autoreleasepool(|pool| {
-            assert_eq!(description.as_str(pool), &*expected);
-        });
-
-        let expected = format!("\"<NSObject: {:p}>\"", &*obj);
-        assert_eq!(format!("{:?}", obj), expected);
+        assert_eq!(format!("{:?}", obj), format!("{:?}", expected));
     }
 
     #[test]

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -51,13 +51,11 @@ mod tests {
     use objc2::rc::autoreleasepool;
 
     #[test]
-    fn test_is_equal() {
+    fn test_equality() {
         let obj1 = NSObject::new();
-        assert!(obj1.is_equal(&*obj1));
-        assert_eq!(obj1, obj1); // Using forwarding impl on Id
+        assert_eq!(obj1, obj1);
 
         let obj2 = NSObject::new();
-        assert!(!obj1.is_equal(&*obj2));
         assert_ne!(obj1, obj2);
     }
 

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -130,6 +130,17 @@ mod tests {
     }
 
     #[test]
+    fn test_equality() {
+        let s1 = NSString::from_str("abc");
+        let s2 = NSString::from_str("abc");
+        assert_eq!(s1, s1);
+        assert_eq!(s1, s2);
+
+        let s3 = NSString::from_str("def");
+        assert_ne!(s1, s3);
+    }
+
+    #[test]
     fn test_empty() {
         let s1 = NSString::from_str("");
         let s2 = NSString::new();

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -100,7 +100,7 @@ pub unsafe trait INSString: INSObject {
     }
 }
 
-object_struct!(unsafe NSString);
+object!(unsafe pub struct NSString);
 
 impl NSString {
     unsafe_def_fn!(pub fn new -> Shared);

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -122,6 +122,7 @@ impl fmt::Display for NSString {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
 
     #[cfg(gnustep)]
     #[test]
@@ -138,6 +139,14 @@ mod tests {
 
         let s3 = NSString::from_str("def");
         assert_ne!(s1, s3);
+    }
+
+    #[test]
+    fn test_debug_display() {
+        let s = "xyz123";
+        let obj = NSString::from_str(s);
+        assert_eq!(format!("{:?}", obj), format!("{:?}", s));
+        assert_eq!(format!("{}", obj), format!("{}", s));
     }
 
     #[test]

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -94,6 +94,8 @@ pub struct NSValueFloatNotEq;
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use crate::{INSValue, NSRange, NSValue};
     use objc2::rc::{Id, Shared};
     use objc2::Encode;
@@ -124,6 +126,33 @@ mod tests {
 
         // Test that `objCType` is checked when comparing equality
         assert_ne!(val1, val2);
+    }
+
+    #[test]
+    #[ignore = "Output is different depending on OS version and runtime"]
+    fn test_debug() {
+        fn assert_debug(val: impl core::fmt::Debug, expected: &str) {
+            assert_eq!(format!("{:?}", val), format!("{:?}", expected));
+        }
+        let val = NSValue::new(0xabu8);
+        let expected = "<ab>";
+        assert_debug(val, expected);
+
+        let val = NSValue::new(0x12i8);
+        let expected = "<12>";
+        assert_debug(val, expected);
+
+        let val = NSValue::new(0xdeadbeefu32);
+        let expected = "<efbeadde>";
+        assert_debug(val, expected);
+
+        // Very brittle
+        let val = NSValue::new(1.0f32);
+        let expected = &format!(
+            "<{:08x}>",
+            u32::from_le_bytes(1.0f32.to_le_bytes()).reverse_bits()
+        );
+        assert_debug(val, expected);
     }
 
     #[test]

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -7,10 +7,9 @@ use core::str;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
+use objc2::msg_send;
 use objc2::rc::{Id, Shared};
-use objc2::runtime::Class;
 use objc2::Encode;
-use objc2::{class, msg_send};
 
 use super::{INSCopying, INSObject};
 
@@ -70,17 +69,11 @@ pub unsafe trait INSValue: INSObject {
     }
 }
 
-pub struct NSValue<T> {
-    value: PhantomData<T>,
-}
-
-object_impl!(unsafe NSValue<T>);
-
-unsafe impl<T: 'static> INSObject for NSValue<T> {
-    fn class() -> &'static Class {
-        class!(NSValue)
+object!(
+    unsafe pub struct<(T: 'static)> NSValue<T> {
+        value: PhantomData<T>,
     }
-}
+);
 
 unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {
     type Value = T;

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -73,7 +73,6 @@ object!(
     unsafe pub struct NSValue<T> {
         value: PhantomData<T>,
     }
-    impl where T: 'static
 );
 
 unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -70,9 +70,10 @@ pub unsafe trait INSValue: INSObject {
 }
 
 object!(
-    unsafe pub struct<(T: 'static)> NSValue<T> {
+    unsafe pub struct NSValue<T> {
         value: PhantomData<T>,
     }
+    impl where T: 'static
 );
 
 unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Export `objc-sys` as `ffi` module.
+* Added common trait impls on `rc::Owned` and `rc::Shared` (useful in generic
+  contexts).
 
 ### Changed
 * Deprecated `runtime::BOOL`, `runtime::YES` and `runtime::NO`. Use the

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -1,9 +1,11 @@
 /// A type used to mark that a struct owns the object(s) it contains,
 /// so it has the sole references to them.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Owned {}
 
 /// A type used to mark that the object(s) a struct contains are shared,
 /// so there may be other references to them.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Shared {}
 
 mod private {


### PR DESCRIPTION
Make the `object_struct` macro support generics