### PR TITLE
Add a few more encoding impls

### DIFF
--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * `Encoding::equivalent_to`, `Encoding::equivalent_to_str` and
   `Encoding::equivalent_to_start_of_str` methods for more precise comparison
   semantics.
+* Added `Encode` and `RefEncode` implementations for `Option` function
+  pointers.
 
 ### Changed
 * Discourage comparing `str` with `Encoding` using `PartialEq`. This trait

--- a/objc2-encode/src/encode.rs
+++ b/objc2-encode/src/encode.rs
@@ -408,8 +408,14 @@ macro_rules! encode_fn_pointer_impl {
         unsafe impl<Ret: Encode, $($Arg: Encode),*> Encode for $FnTy {
             const ENCODING: Encoding<'static> = Encoding::Pointer(&Encoding::Unknown);
         }
-
         unsafe impl<Ret: Encode, $($Arg: Encode),*> RefEncode for $FnTy {
+            const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+        }
+
+        unsafe impl<Ret: Encode, $($Arg: Encode),*> Encode for Option<$FnTy> {
+            const ENCODING: Encoding<'static> = Encoding::Pointer(&Encoding::Unknown);
+        }
+        unsafe impl<Ret: Encode, $($Arg: Encode),*> RefEncode for Option<$FnTy> {
             const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
         }
     };
@@ -541,6 +547,10 @@ mod tests {
         );
         assert_eq!(
             <extern "C" fn(x: ()) -> ()>::ENCODING,
+            Encoding::Pointer(&Encoding::Unknown)
+        );
+        assert_eq!(
+            <Option<unsafe extern "C" fn()>>::ENCODING,
             Encoding::Pointer(&Encoding::Unknown)
         );
     }

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Export `objc-sys` as `ffi` module.
 * Added common trait impls on `rc::Owned` and `rc::Shared` (useful in generic
   contexts).
+* Implement `RefEncode` for `runtime::Protocol`.
 
 ### Changed
 * Deprecated `runtime::BOOL`, `runtime::YES` and `runtime::NO`. Use the

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -595,7 +595,7 @@ impl fmt::Debug for Object {
 mod tests {
     use alloc::string::ToString;
 
-    use super::{Bool, Class, Ivar, Method, Object, Protocol, Sel};
+    use super::{Bool, Class, Imp, Ivar, Method, Object, Protocol, Sel};
     use crate::test_utils;
     use crate::Encode;
 
@@ -701,6 +701,8 @@ mod tests {
         assert_eq!(<*mut Object>::ENCODING.to_string(), "@");
         assert_eq!(<&Class>::ENCODING.to_string(), "#");
         assert_eq!(Sel::ENCODING.to_string(), ":");
+        assert_eq!(Imp::ENCODING.to_string(), "^?");
+        assert_eq!(<Option<Imp>>::ENCODING.to_string(), "^?");
     }
 
     #[test]

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -472,6 +472,11 @@ impl PartialEq for Protocol {
     }
 }
 
+unsafe impl RefEncode for Protocol {
+    // Protocol is an object internally
+    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+}
+
 impl Eq for Protocol {}
 
 impl fmt::Debug for Protocol {
@@ -697,12 +702,16 @@ mod tests {
 
     #[test]
     fn test_encode() {
-        assert_eq!(<&Object>::ENCODING.to_string(), "@");
-        assert_eq!(<*mut Object>::ENCODING.to_string(), "@");
-        assert_eq!(<&Class>::ENCODING.to_string(), "#");
-        assert_eq!(Sel::ENCODING.to_string(), ":");
-        assert_eq!(Imp::ENCODING.to_string(), "^?");
-        assert_eq!(<Option<Imp>>::ENCODING.to_string(), "^?");
+        fn assert_enc<T: Encode>(expected: &str) {
+            assert_eq!(&T::ENCODING.to_string(), expected);
+        }
+        assert_enc::<&Object>("@");
+        assert_enc::<*mut Object>("@");
+        assert_enc::<&Class>("#");
+        assert_enc::<Sel>(":");
+        assert_enc::<Imp>("^?");
+        assert_enc::<Option<Imp>>("^?");
+        assert_enc::<&Protocol>("@");
     }
 
     #[test]


### PR DESCRIPTION
- `impl RefEncode for runtime::Protocol`
- `impl Encode for Option<fn-pointers>`
- `impl RefEncode for Option<fn-pointers>`
