### PR TITLE
Add `"malloc"` feature

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         command: test
         # Not using --all-features because some features are nightly-only
-        args: --no-fail-fast --features block,exception,catch_all,verify_message
+        args: --no-fail-fast --features malloc,block,exception,catch_all,verify_message
 
   build_32_bit:
     name: Build 32-bit
@@ -105,8 +105,14 @@ jobs:
         tar -xyf MacOSX10.13.tar.bz2
         echo "SDKROOT=$(pwd)/MacOSX10.13.sdk" >> $GITHUB_ENV
 
+    - name: Build without features
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: -Zbuild-std --tests --no-default-features
+
     - name: Build with features
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: -Zbuild-std --tests --features exception,catch_all,verify_message
+        args: -Zbuild-std --tests --features malloc,exception,catch_all,verify_message

--- a/.github/workflows/gnustep.yml
+++ b/.github/workflows/gnustep.yml
@@ -148,4 +148,4 @@ jobs:
       with:
         command: test
         # Not using --all-features because some features are nightly-only
-        args: --no-fail-fast --features gnustep-1-9,block,exception,catch_all,verify_message
+        args: --no-fail-fast --features gnustep-1-9,malloc,block,exception,catch_all,verify_message

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -19,10 +19,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   // `init` takes ownership and possibly returns a new object.
   let obj = Id::new(msg_send![obj, init]);
   ```
+* New cargo feature `"malloc"`, which allows cutting down on dependencies,
+  most crates don't need the introspection features that this provides.
 
 ### Changed
 * Deprecated `runtime::BOOL`, `runtime::YES` and `runtime::NO`. Use the
   newtype `Bool` instead, or low-level `ffi::BOOL`, `ffi::YES` and `ffi::NO`.
+* **BREAKING**: The following methods now require the new `"malloc"` feature
+  flag to be enabled:
+  - `MessageReceiver::verify_message` (temporarily)
+  - `Method::return_type`
+  - `Method::argument_type`
+  - `Class::classes`
+  - `Class::instance_methods`
+  - `Class::adopted_protocols`
+  - `Class::instance_variables`
+  - `Protocol::protocols`
+  - `Protocol::adopted_protocols`
 
 ### Removed
 * **BREAKING**: Removed the raw FFI functions from the `runtime` module. These

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -24,11 +24,22 @@ exception = ["cc"]
 
 # Wrap every `objc2::msg_send` call in a `@try/@catch` block
 catch_all = ["exception"]
-verify_message = []
+
+# Verify type encodings on every message send
+# Only intended to be used while debugging!
+verify_message = ["malloc"] # TODO: Remove malloc feature here
+
+# Expose features that require linking to `libc::free`.
+#
+# This is not enabled by default because most users won't need it, and it
+# increases compilation time.
+malloc = ["malloc_buf"]
+
+# Uses nightly features to make AutoreleasePool zero-cost even in debug mode
 unstable_autoreleasesafe = []
 
 [dependencies]
-malloc_buf = "1.0"
+malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.1.0" }
 # Loose dependency, because objc2-encode is not expected to change much more
 objc2-encode = { path = "../objc2-encode", version = "^2.0.0-beta.0" }
@@ -39,7 +50,7 @@ cc = { version = "1", optional = true }
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 
-features = ["exception"]
+features = ["exception", "malloc"]
 
 targets = [
     # MacOS

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -2,17 +2,22 @@ use core::ptr::NonNull;
 
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
-use objc2::{class, msg_send, sel, Encode};
+use objc2::{class, msg_send};
+#[cfg(feature = "malloc")]
+use objc2::{sel, Encode};
 
 fn main() {
     // Get a class
     let cls = class!(NSObject);
     println!("NSObject size: {}", cls.instance_size());
 
-    // Inspect its ivars
-    println!("NSObject ivars:");
-    for ivar in cls.instance_variables().iter() {
-        println!("{}", ivar.name());
+    #[cfg(feature = "malloc")]
+    {
+        // Inspect its ivars
+        println!("NSObject ivars:");
+        for ivar in cls.instance_variables().iter() {
+            println!("{}", ivar.name());
+        }
     }
 
     // Allocate an instance
@@ -27,12 +32,15 @@ fn main() {
     let isa: *const Class = unsafe { *obj.get_ivar("isa") };
     println!("NSObject isa: {:?}", isa);
 
-    // Inspect a method of the class
-    let hash_sel = sel!(hash);
-    let hash_method = cls.instance_method(hash_sel).unwrap();
-    let hash_return = hash_method.return_type();
-    println!("-[NSObject hash] return type: {:?}", hash_return);
-    assert!(usize::ENCODING.equivalent_to_str(&hash_return));
+    #[cfg(feature = "malloc")]
+    {
+        // Inspect a method of the class
+        let hash_sel = sel!(hash);
+        let hash_method = cls.instance_method(hash_sel).unwrap();
+        let hash_return = hash_method.return_type();
+        println!("-[NSObject hash] return type: {:?}", hash_return);
+        assert!(usize::ENCODING.equivalent_to_str(&hash_return));
+    }
 
     // Invoke a method on the object
     let hash: usize = unsafe { msg_send![obj, hash] };


### PR DESCRIPTION
Helps cutting down on dependencies.

`malloc` transitively enables the `libc` crate, which is rarely needed and adds to download and compile times.

With this PR a clean build of `objc2-foundation` goes from ~7 seconds to ~5.5 seconds.