### PR TITLE
Relax `Sized` bounds where easily possible

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 * **BREAKING**: Removed associated `Ownership` type from `INSObject`; instead,
   it is present on the types that actually need it (for example `NSCopying`).
+* **BREAKING**: Removed `Sized` bound on `INSObject`.
 
 ### Fixed
 * Soundness issue with `NSValue`, `NSDictionary`, `NSArray` and

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -14,7 +14,7 @@ use super::{
     NSRange,
 };
 
-unsafe fn from_refs<A: INSArray>(refs: &[&A::Item]) -> Id<A, A::Ownership> {
+unsafe fn from_refs<A: INSArray + ?Sized>(refs: &[&A::Item]) -> Id<A, A::Ownership> {
     let cls = A::class();
     let obj: *mut A = unsafe { msg_send![cls, alloc] };
     let obj: *mut A = unsafe {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -11,8 +11,8 @@ use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator};
 
 unsafe fn from_refs<D, T>(keys: &[&T], vals: &[&D::Value]) -> Id<D, Shared>
 where
-    D: INSDictionary,
-    T: INSCopying<Output = D::Key>,
+    D: INSDictionary + ?Sized,
+    T: INSCopying<Output = D::Key> + ?Sized,
 {
     let cls = D::class();
     let count = min(keys.len(), vals.len());

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -94,7 +94,7 @@ unsafe impl<T: INSObject> RefEncode for NSFastEnumerationState<T> {
     const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
 }
 
-fn enumerate<'a, 'b: 'a, C: INSFastEnumeration>(
+fn enumerate<'a, 'b: 'a, C: INSFastEnumeration + ?Sized>(
     object: &'b C,
     state: &mut NSFastEnumerationState<C::Item>,
     buf: &'a mut [*const C::Item],
@@ -119,7 +119,7 @@ fn enumerate<'a, 'b: 'a, C: INSFastEnumeration>(
 
 const FAST_ENUM_BUF_SIZE: usize = 16;
 
-pub struct NSFastEnumerator<'a, C: 'a + INSFastEnumeration> {
+pub struct NSFastEnumerator<'a, C: 'a + INSFastEnumeration + ?Sized> {
     object: &'a C,
 
     ptr: *const *const C::Item,
@@ -129,7 +129,7 @@ pub struct NSFastEnumerator<'a, C: 'a + INSFastEnumeration> {
     buf: [*const C::Item; FAST_ENUM_BUF_SIZE],
 }
 
-impl<'a, C: INSFastEnumeration> NSFastEnumerator<'a, C> {
+impl<'a, C: INSFastEnumeration + ?Sized> NSFastEnumerator<'a, C> {
     fn new(object: &'a C) -> Self {
         Self {
             object,
@@ -174,7 +174,7 @@ impl<'a, C: INSFastEnumeration> NSFastEnumerator<'a, C> {
     }
 }
 
-impl<'a, C: INSFastEnumeration> Iterator for NSFastEnumerator<'a, C> {
+impl<'a, C: INSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
     type Item = &'a C::Item;
 
     fn next(&mut self) -> Option<&'a C::Item> {

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -8,11 +8,7 @@ use objc2::Message;
 
 use super::NSString;
 
-// The Sized bound is unfortunate; ideally, Objective-C objects would not be
-// treated as Sized. However, rust won't allow casting a dynamically-sized
-// type pointer to an Object pointer, because dynamically-sized types can have
-// fat pointers (two words) instead of real pointers.
-pub unsafe trait INSObject: Sized + Message {
+pub unsafe trait INSObject: Message {
     fn class() -> &'static Class;
 
     fn hash_code(&self) -> usize {

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -36,6 +36,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `Class::instance_variables`
   - `Protocol::protocols`
   - `Protocol::adopted_protocols`
+* Relaxed `Sized` bound on `rc::Id` and `rc::WeakId` to prepare for
+  `extern type` support.
+* **BREAKING**: Relaxed `Sized` bound on `rc::SliceId` and `rc::DefaultId`.
 
 ### Removed
 * **BREAKING**: Removed the raw FFI functions from the `runtime` module. These

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -45,7 +45,7 @@ use crate::{ffi, Encode, EncodeArguments, Encoding, Message};
 /// Types that can be used as the implementation of an Objective-C method.
 pub trait MethodImplementation {
     /// The callee type of the method.
-    type Callee: Message;
+    type Callee: Message + ?Sized;
     /// The return type of the method.
     type Ret: Encode;
     /// The argument types of the method.
@@ -59,7 +59,7 @@ macro_rules! method_decl_impl {
     (-$s:ident, $r:ident, $f:ty, $($t:ident),*) => (
         impl<$s, $r, $($t),*> MethodImplementation for $f
         where
-            $s: Message,
+            $s: Message + ?Sized,
             $r: Encode,
             $($t: Encode,)*
         {

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -79,7 +79,7 @@ pub(crate) mod private {
     impl<'a, T: Message + ?Sized> Sealed for &'a T {}
     impl<'a, T: Message + ?Sized> Sealed for &'a mut T {}
     impl<T: Message + ?Sized> Sealed for NonNull<T> {}
-    impl<T: Message, O: Ownership> Sealed for Id<T, O> {}
+    impl<T: Message + ?Sized, O: Ownership> Sealed for Id<T, O> {}
 
     impl<T: MessageReceiver + ?Sized> Sealed for ManuallyDrop<T> {}
 }
@@ -248,7 +248,7 @@ unsafe impl<T: Message + ?Sized> MessageReceiver for NonNull<T> {
     }
 }
 
-unsafe impl<T: Message, O: Ownership> MessageReceiver for Id<T, O> {
+unsafe impl<T: Message + ?Sized, O: Ownership> MessageReceiver for Id<T, O> {
     #[inline]
     fn as_raw_receiver(&self) -> *mut Object {
         // TODO: Maybe don't dereference here, just to be safe?

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -202,7 +202,7 @@ auto_trait! {
 }
 
 #[cfg(not(feature = "unstable_autoreleasesafe"))]
-unsafe impl<T> AutoreleaseSafe for T {}
+unsafe impl<T: ?Sized> AutoreleaseSafe for T {}
 
 #[cfg(feature = "unstable_autoreleasesafe")]
 impl !AutoreleaseSafe for AutoreleasePool {}

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -101,7 +101,7 @@ impl AutoreleasePool {
     /// the lifetime is bound to the pool instead of being unbounded.
     #[inline]
     #[allow(clippy::needless_lifetimes)]
-    pub unsafe fn ptr_as_ref<'p, T>(&'p self, ptr: *const T) -> &'p T {
+    pub unsafe fn ptr_as_ref<'p, T: ?Sized>(&'p self, ptr: *const T) -> &'p T {
         self.__verify_is_inner();
         // SAFETY: Checked by the caller
         unsafe { &*ptr }
@@ -122,7 +122,7 @@ impl AutoreleasePool {
     #[inline]
     #[allow(clippy::needless_lifetimes)]
     #[allow(clippy::mut_from_ref)]
-    pub unsafe fn ptr_as_mut<'p, T>(&'p self, ptr: *mut T) -> &'p mut T {
+    pub unsafe fn ptr_as_mut<'p, T: ?Sized>(&'p self, ptr: *mut T) -> &'p mut T {
         self.__verify_is_inner();
         // SAFETY: Checked by the caller
         unsafe { &mut *ptr }

--- a/objc2/src/rc/id_forwarding_impls.rs
+++ b/objc2/src/rc/id_forwarding_impls.rs
@@ -21,7 +21,7 @@ use std::io;
 
 use super::{Id, Owned, Ownership};
 
-impl<T: PartialEq, O: Ownership> PartialEq for Id<T, O> {
+impl<T: PartialEq + ?Sized, O: Ownership> PartialEq for Id<T, O> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         (**self).eq(&**other)
@@ -34,9 +34,9 @@ impl<T: PartialEq, O: Ownership> PartialEq for Id<T, O> {
     }
 }
 
-impl<T: Eq, O: Ownership> Eq for Id<T, O> {}
+impl<T: Eq + ?Sized, O: Ownership> Eq for Id<T, O> {}
 
-impl<T: PartialOrd, O: Ownership> PartialOrd for Id<T, O> {
+impl<T: PartialOrd + ?Sized, O: Ownership> PartialOrd for Id<T, O> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (**self).partial_cmp(&**other)
@@ -59,20 +59,20 @@ impl<T: PartialOrd, O: Ownership> PartialOrd for Id<T, O> {
     }
 }
 
-impl<T: Ord, O: Ownership> Ord for Id<T, O> {
+impl<T: Ord + ?Sized, O: Ownership> Ord for Id<T, O> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         (**self).cmp(&**other)
     }
 }
 
-impl<T: hash::Hash, O: Ownership> hash::Hash for Id<T, O> {
+impl<T: hash::Hash + ?Sized, O: Ownership> hash::Hash for Id<T, O> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
 }
 
-impl<T: hash::Hasher> hash::Hasher for Id<T, Owned> {
+impl<T: hash::Hasher + ?Sized> hash::Hasher for Id<T, Owned> {
     fn finish(&self) -> u64 {
         (**self).finish()
     }
@@ -117,19 +117,19 @@ impl<T: hash::Hasher> hash::Hasher for Id<T, Owned> {
     }
 }
 
-impl<T: fmt::Display, O: Ownership> fmt::Display for Id<T, O> {
+impl<T: fmt::Display + ?Sized, O: Ownership> fmt::Display for Id<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
-impl<T: fmt::Debug, O: Ownership> fmt::Debug for Id<T, O> {
+impl<T: fmt::Debug + ?Sized, O: Ownership> fmt::Debug for Id<T, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
 
-impl<I: Iterator> Iterator for Id<I, Owned> {
+impl<I: Iterator + ?Sized> Iterator for Id<I, Owned> {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
@@ -142,7 +142,7 @@ impl<I: Iterator> Iterator for Id<I, Owned> {
     }
 }
 
-impl<I: DoubleEndedIterator> DoubleEndedIterator for Id<I, Owned> {
+impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Id<I, Owned> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
@@ -151,13 +151,13 @@ impl<I: DoubleEndedIterator> DoubleEndedIterator for Id<I, Owned> {
     }
 }
 
-impl<I: ExactSizeIterator> ExactSizeIterator for Id<I, Owned> {
+impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Id<I, Owned> {
     fn len(&self) -> usize {
         (**self).len()
     }
 }
 
-impl<I: FusedIterator> FusedIterator for Id<I, Owned> {}
+impl<I: FusedIterator + ?Sized> FusedIterator for Id<I, Owned> {}
 
 impl<T, O: Ownership> borrow::Borrow<T> for Id<T, O> {
     fn borrow(&self) -> &T {
@@ -171,25 +171,25 @@ impl<T> borrow::BorrowMut<T> for Id<T, Owned> {
     }
 }
 
-impl<T, O: Ownership> AsRef<T> for Id<T, O> {
+impl<T: ?Sized, O: Ownership> AsRef<T> for Id<T, O> {
     fn as_ref(&self) -> &T {
         &**self
     }
 }
 
-impl<T> AsMut<T> for Id<T, Owned> {
+impl<T: ?Sized> AsMut<T> for Id<T, Owned> {
     fn as_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
-impl<T: Error, O: Ownership> Error for Id<T, O> {
+impl<T: Error + ?Sized, O: Ownership> Error for Id<T, O> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         (**self).source()
     }
 }
 
-impl<T: io::Read> io::Read for Id<T, Owned> {
+impl<T: io::Read + ?Sized> io::Read for Id<T, Owned> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
@@ -216,7 +216,7 @@ impl<T: io::Read> io::Read for Id<T, Owned> {
     }
 }
 
-impl<T: io::Write> io::Write for Id<T, Owned> {
+impl<T: io::Write + ?Sized> io::Write for Id<T, Owned> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (**self).write(buf)
@@ -243,7 +243,7 @@ impl<T: io::Write> io::Write for Id<T, Owned> {
     }
 }
 
-impl<T: io::Seek> io::Seek for Id<T, Owned> {
+impl<T: io::Seek + ?Sized> io::Seek for Id<T, Owned> {
     #[inline]
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         (**self).seek(pos)
@@ -255,7 +255,7 @@ impl<T: io::Seek> io::Seek for Id<T, Owned> {
     }
 }
 
-impl<T: io::BufRead> io::BufRead for Id<T, Owned> {
+impl<T: io::BufRead + ?Sized> io::BufRead for Id<T, Owned> {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         (**self).fill_buf()
@@ -277,7 +277,7 @@ impl<T: io::BufRead> io::BufRead for Id<T, Owned> {
     }
 }
 
-impl<T: Future + Unpin> Future for Id<T, Owned> {
+impl<T: Future + Unpin + ?Sized> Future for Id<T, Owned> {
     type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/objc2/src/rc/weak_id.rs
+++ b/objc2/src/rc/weak_id.rs
@@ -16,7 +16,7 @@ use crate::Message;
 /// Allows breaking reference cycles and safely checking whether the object
 /// has been deallocated.
 #[repr(transparent)]
-pub struct WeakId<T> {
+pub struct WeakId<T: ?Sized> {
     /// We give the runtime the address to this box, so that it can modify it
     /// even if the `WeakId` is moved.
     ///
@@ -69,7 +69,7 @@ impl<T: Message> WeakId<T> {
     }
 }
 
-impl<T> Drop for WeakId<T> {
+impl<T: ?Sized> Drop for WeakId<T> {
     /// Drops the `WeakId` pointer.
     #[doc(alias = "objc_destroyWeak")]
     fn drop(&mut self) {
@@ -77,6 +77,7 @@ impl<T> Drop for WeakId<T> {
     }
 }
 
+// TODO: Add ?Sized
 impl<T> Clone for WeakId<T> {
     /// Makes a clone of the `WeakId` that points to the same object.
     #[doc(alias = "objc_copyWeak")]
@@ -90,6 +91,7 @@ impl<T> Clone for WeakId<T> {
     }
 }
 
+// TODO: Add ?Sized
 impl<T: Message> Default for WeakId<T> {
     /// Constructs a new `WeakId<T>` that doesn't reference any object.
     ///
@@ -101,26 +103,26 @@ impl<T: Message> Default for WeakId<T> {
 }
 
 /// This implementation follows the same reasoning as `Id<T, Shared>`.
-unsafe impl<T: Sync + Send> Sync for WeakId<T> {}
+unsafe impl<T: Sync + Send + ?Sized> Sync for WeakId<T> {}
 
 /// This implementation follows the same reasoning as `Id<T, Shared>`.
-unsafe impl<T: Sync + Send> Send for WeakId<T> {}
+unsafe impl<T: Sync + Send + ?Sized> Send for WeakId<T> {}
 
 // Unsure about the Debug bound on T, see std::sync::Weak
-impl<T: fmt::Debug> fmt::Debug for WeakId<T> {
+impl<T: fmt::Debug + ?Sized> fmt::Debug for WeakId<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(WeakId)")
     }
 }
 
 // Underneath this is just a `Box`
-impl<T> Unpin for WeakId<T> {}
+impl<T: ?Sized> Unpin for WeakId<T> {}
 
 // Same as `Id<T, Shared>`.
-impl<T: RefUnwindSafe> RefUnwindSafe for WeakId<T> {}
+impl<T: RefUnwindSafe + ?Sized> RefUnwindSafe for WeakId<T> {}
 
 // Same as `Id<T, Shared>`.
-impl<T: RefUnwindSafe> UnwindSafe for WeakId<T> {}
+impl<T: RefUnwindSafe + ?Sized> UnwindSafe for WeakId<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -580,17 +580,17 @@ impl Object {
 
 /// ```
 /// use objc2::runtime::Object;
-/// fn needs_nothing<T>() {}
+/// fn needs_nothing<T: ?Sized>() {}
 /// needs_nothing::<Object>();
 /// ```
 /// ```compile_fail
 /// use objc2::runtime::Object;
-/// fn needs_sync<T: Sync>() {}
+/// fn needs_sync<T: ?Sized + Sync>() {}
 /// needs_sync::<Object>();
 /// ```
 /// ```compile_fail
 /// use objc2::runtime::Object;
-/// fn needs_send<T: Send>() {}
+/// fn needs_send<T: ?Sized + Send>() {}
 /// needs_send::<Object>();
 /// ```
 #[cfg(doctest)]
@@ -734,7 +734,7 @@ mod tests {
 
     #[test]
     fn test_send_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_send_sync<T: Send + Sync + ?Sized>() {}
         assert_send_sync::<Bool>();
         assert_send_sync::<Class>();
         assert_send_sync::<Ivar>();


### PR DESCRIPTION
To prepare for `extern type`s, precursor to #73.