### PR TITLE
Fix `docs.rs` configuration

### DIFF
--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -53,7 +53,7 @@ default-target = "x86_64-apple-darwin"
 targets = [
     # MacOS
     "x86_64-apple-darwin",
-    "i686-apple-darwin",
+    # "i686-apple-darwin",
     # iOS
     "aarch64-apple-ios",
     "x86_64-apple-ios",
@@ -61,5 +61,3 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
 ]
-
-cargo-args = ["-Z", "build-std"]

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -54,7 +54,7 @@ features = ["exception", "malloc"]
 targets = [
     # MacOS
     "x86_64-apple-darwin",
-    "i686-apple-darwin",
+    # "i686-apple-darwin",
     # iOS
     "aarch64-apple-ios",
     "x86_64-apple-ios",
@@ -62,5 +62,3 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
 ]
-
-cargo-args = ["-Z", "build-std"]


### PR DESCRIPTION
This _probably_ fixes it, see the [build log](https://docs.rs/crate/objc-sys/0.2.0-alpha.0/builds/480939).

Previous attempt: #89.