### PR TITLE
Link official `git` sources

### DIFF
--- a/block-sys/README.md
+++ b/block-sys/README.md
@@ -25,7 +25,7 @@ present in the module tree, this should have the same feature flag enabled as
 that.
 
 
-### Apple's [`libclosure`](https://opensource.apple.com/source/libclosure/)
+### Apple's [`libclosure`](https://github.com/apple-oss-distributions/libclosure)
 
 - Feature flag: `apple`.
 
@@ -40,8 +40,6 @@ The minimum required operating system versions are as follows:
 - watchOS: Unknown
 
 Though in practice Rust itself requires higher versions than this.
-
-A git mirror of the sources is available [here](https://github.com/madsmtm/libclosure).
 
 
 ### LLVM `compiler-rt`'s [`libBlocksRuntime`](https://github.com/llvm/llvm-project/tree/release/13.x/compiler-rt/lib/BlocksRuntime)

--- a/block-sys/src/lib.rs
+++ b/block-sys/src/lib.rs
@@ -338,7 +338,7 @@ pub struct Block_descriptor_with_signature {
 //     pub Block_copy: Option<unsafe extern "C" fn(dst: *mut c_void, src: *mut c_void)>,
 //     pub Block_dispose: Option<unsafe extern "C" fn(block: *mut c_void)>,
 // }
-// Example usage: https://opensource.apple.com/source/libdispatch/libdispatch-84.5/src/once.c.auto.html
+// Example usage: https://github.com/apple-oss-distributions/libdispatch/blob/libdispatch-84.5/src/once.c
 
 /// Structure used for on-stack variables that are referenced by blocks.
 #[repr(C)]

--- a/objc-sys/README.md
+++ b/objc-sys/README.md
@@ -19,7 +19,7 @@ Apple's runtime, but if you're using another runtime you must tell it to this
 library using feature flags.
 
 
-### Apple's [`objc4`](https://opensource.apple.com/source/objc4/)
+### Apple's [`objc4`](https://github.com/apple-oss-distributions/objc4)
 
 - Feature flag: `apple`.
 
@@ -41,8 +41,6 @@ chosen using the standard `X_DEPLOYMENT_TARGET` environment variables:
 - watchOS: `WATCHOS_DEPLOYMENT_TARGET`
   - Default: TODO
   - Minimum: `1.0` (theoretically)
-
-A git mirror of the sources is available [here](https://github.com/madsmtm/objc4-mirror).
 
 
 ### GNUStep's [`libobjc2`](https://github.com/gnustep/libobjc2)

--- a/objc-sys/helper-scripts/gen-git.fish
+++ b/objc-sys/helper-scripts/gen-git.fish
@@ -2,7 +2,7 @@
 
 # Yup, this is terrible, but was a great help in creating the correct implementations
 
-# Source repo should be a path to https://github.com/madsmtm/objc4-mirror.git
+# Source repo should be a path to https://github.com/apple-oss-distributions/objc4.git
 set source_repo $argv[1]
 set to_repo $argv[2]
 

--- a/objc-sys/src/exception.rs
+++ b/objc-sys/src/exception.rs
@@ -34,9 +34,9 @@ pub type objc_exception_handler =
 extern "C" {
     pub fn objc_begin_catch(exc_buf: *mut c_void) -> *mut objc_object;
     pub fn objc_end_catch();
-    /// See [`objc-exception.h`][objc-exception].
+    /// See [`objc-exception.h`].
     ///
-    /// [objc-exception]: https://opensource.apple.com/source/objc4/objc4-818.2/runtime/objc-exception.h.auto.html
+    /// [`objc-exception.h`]: https://github.com/apple-oss-distributions/objc4/blob/objc4-818.2/runtime/objc-exception.h
     pub fn objc_exception_throw(exception: *mut objc_object) -> !;
     #[cfg(apple)]
     pub fn objc_exception_rethrow() -> !;

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -3,8 +3,7 @@
 //! These bindings contain almost no documentation, so it is highly
 //! recommended to read the documentation of the original libraries:
 //! - Apple's [official documentation][apple].
-//! - Apple's `objc4` [source code][objc4] ([`git` mirror][objc4-mirror]), in
-//!   particular `runtime.h`.
+//! - Apple's `objc4` [source code][objc4], in particular `runtime.h`.
 //! - GNUStep's `libobjc2` [source code][libobjc2], in particular `runtime.h`.
 //!
 //! See also the [`README.md`](https://crates.io/crates/objc-sys) for more
@@ -12,8 +11,7 @@
 //!
 //! [apple]: https://developer.apple.com/documentation/objectivec/objective-c_runtime?language=objc
 //! [libobjc2]: https://github.com/gnustep/libobjc2/tree/v2.1/objc
-//! [objc4]: https://opensource.apple.com/source/objc4/objc4-818.2/runtime/
-//! [objc4-mirror]: https://github.com/madsmtm/objc4-mirror.git
+//! [objc4]: https://github.com/apple-oss-distributions/objc4
 
 #![no_std]
 #![allow(clippy::upper_case_acronyms)]

--- a/objc2/src/message/apple/x86.rs
+++ b/objc2/src/message/apple/x86.rs
@@ -12,8 +12,7 @@ use crate::{Encode, Encoding};
 /// <https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/LowLevelABI/130-IA-32_Function_Calling_Conventions/IA32.html>
 unsafe impl<T: Encode> MsgSendFn for T {
     const MSG_SEND: Imp = {
-        // See lines 156 to 172 in:
-        // https://opensource.apple.com/source/objc4/objc4-818.2/runtime/message.h.auto.html
+        // See https://github.com/apple-oss-distributions/objc4/blob/objc4-818.2/runtime/message.h#L156-L172
         if let Encoding::Float | Encoding::Double | Encoding::LongDouble = T::ENCODING {
             ffi::objc_msgSend_fpret
         } else if let 0 | 1 | 2 | 4 | 8 = mem::size_of::<T>() {

--- a/objc2/src/message/apple/x86_64.rs
+++ b/objc2/src/message/apple/x86_64.rs
@@ -11,10 +11,8 @@ use crate::{Encode, Encoding};
 ///
 /// <http://people.freebsd.org/~obrien/amd64-elf-abi.pdf>
 unsafe impl<T: Encode> MsgSendFn for T {
-    // TODO: Should we use objc_msgSend_fpret and objc_msgSend_fp2ret ?
     const MSG_SEND: Imp = {
-        // See lines 156 to 172 in:
-        // https://opensource.apple.com/source/objc4/objc4-818.2/runtime/message.h.auto.html
+        // See https://github.com/apple-oss-distributions/objc4/blob/objc4-818.2/runtime/message.h#L156-L172
         if let Encoding::LongDouble = T::ENCODING {
             ffi::objc_msgSend_fpret
         } else if let Encoding::LongDoubleComplex = T::ENCODING {

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -140,14 +140,16 @@ impl Drop for AutoreleasePool {
     /// > Not draining the pool during an unwind is apparently required by the
     /// > Objective-C exceptions implementation.
     ///
-    /// This was true in the past, but since [revision `371`] of
-    /// `objc-exception.m` (ships with MacOS 10.5) the exception is now
-    /// retained when `@throw` is encountered.
+    /// This was true in the past, but since [revision `371`] of objc4 (ships
+    /// with MacOS 10.5) the exception is now retained when `@throw` is
+    /// encountered.
     ///
     /// Hence it is safe to drain the pool when unwinding.
     ///
+    /// TODO: Verify this claim on 32bit!
+    ///
     /// [clang documentation]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#autoreleasepool
-    /// [revision `371`]: https://opensource.apple.com/source/objc4/objc4-371/runtime/objc-exception.m.auto.html
+    /// [revision `371`]: https://github.com/apple-oss-distributions/objc4/blob/objc4-371/runtime/objc-exception.m#L479-L482
     #[doc(alias = "objc_autoreleasePoolPop")]
     fn drop(&mut self) {
         unsafe { ffi::objc_autoreleasePoolPop(self.context) }


### PR DESCRIPTION
Apple's https://opensource.apple.com/ page recently changed their links; they now provide stuff on GitHub (yet still without change history or reasoning beyond what exists in the code), so my unofficial mirrors are obsolete.