### PR TITLE
Ensure that `objc-sys` symbols have the correct `#[cfg]` guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
           - name: Test macOS 11
             os: macos-11
             target: x86_64-apple-darwin
+          - name: Build macOS AArch64
+            os: macos-11
+            target: aarch64-apple-darwin
+            test-args: --no-run
+          - name: Test macOS old SDK
+            os: macos-11
+            target: x86_64-apple-darwin
+            # Oldest macOS version we support
+            sdk: 10.7
           - name: Test macOS nightly
             os: macos-latest
             target: x86_64-apple-darwin
@@ -61,6 +70,8 @@ jobs:
             # 32-bit support was removed in 10.15, so we can't test the
             # binary, only build it
             test-args: --no-run
+            # Newest SDK that supports 32-bit
+            sdk: 10.13
           - name: Test GNUStep
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -133,12 +144,12 @@ jobs:
           libc6-dev:i386 libstdc++-10-dev:i386 libffi-dev:i386 \
           libxml2-dev:i386 libicu-dev:i386
 
-    - name: Download macOS 10.13 SDK (supports 32-bit)
-      if: matrix.target == 'i686-apple-darwin'
+    - name: Download different macOS SDK
+      if: matrix.sdk
       run: |
-        wget https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.13/MacOSX10.13.tar.bz2
-        tar -xyf MacOSX10.13.tar.bz2
-        echo "SDKROOT=$(pwd)/MacOSX10.13.sdk" >> $GITHUB_ENV
+        wget https://github.com/alexey-lysiuk/macos-sdk/releases/download/${{ matrix.sdk }}/MacOSX${{ matrix.sdk }}.tar.bz2
+        tar -xyf MacOSX${{ matrix.sdk }}.tar.bz2
+        echo "SDKROOT=$(pwd)/MacOSX${{ matrix.sdk }}.sdk" >> $GITHUB_ENV
 
     - name: Cache GNUStep
       if: contains(matrix.os, 'ubuntu')

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `objc_exception_try_enter` and `objc_exception_try_exit` on macOS x86.
+
+### Changed
+* **BREAKING**: Correctly `cfg`-guarded the following types and methods to not
+  be available on macOS x86:
+  - `objc_exception_matcher`
+  - `objc_exception_preprocessor`
+  - `objc_uncaught_exception_handler`
+  - `objc_exception_handler`
+  - `objc_begin_catch`
+  - `objc_end_catch`
+  - `objc_exception_rethrow`
+  - `objc_setExceptionMatcher`
+  - `objc_setExceptionPreprocessor`
+  - `objc_setUncaughtExceptionHandler`
+  - `objc_addExceptionHandler`
+  - `objc_removeExceptionHandler`
+
+### Removed
+* **BREAKING**: Removed`objc_set_apple_compatible_objcxx_exceptions` since it
+  is only available when `libobjc2` is compiled with the correct flags.
+* **BREAKING**: Removed `object_setInstanceVariableWithStrongDefault` since it
+  is only available since macOS 10.12.
+* **BREAKING**: Removed `objc_setHook_getClass` since it is only available
+  since macOS 10.14.4.
+* **BREAKING**: Removed `objc_setHook_lazyClassNamer` since it is only
+  available since macOS 11.
+
 
 ## 0.2.0-alpha.0 - 2021-12-22
 

--- a/objc-sys/src/class.rs
+++ b/objc-sys/src/class.rs
@@ -23,7 +23,7 @@ pub struct objc_class {
 /// difference.
 type ivar_layout_type = u8;
 
-extern "C" {
+extern_c! {
     pub fn objc_getClass(name: *const c_char) -> *const objc_class;
     pub fn objc_getRequiredClass(name: *const c_char) -> *const objc_class;
     pub fn objc_lookUpClass(name: *const c_char) -> *const objc_class;

--- a/objc-sys/src/exception-macos-x86.rs
+++ b/objc-sys/src/exception-macos-x86.rs
@@ -1,0 +1,18 @@
+//! `objc-exception.h` is conditional on __OBJC2__, which is set for all
+//! platforms except 32-bit macOS; these are the functions that are defined
+//! when !__OBJC2__.
+use core::ffi::c_void;
+
+use crate::objc_object;
+
+// objc_exception_functions_t
+
+extern_c! {
+    pub fn objc_exception_throw(exception: *mut objc_object) -> !;
+    pub fn objc_exception_try_enter(exception_data: *const c_void);
+    pub fn objc_exception_try_exit(exception_data: *const c_void);
+    // objc_exception_extract
+    // objc_exception_match
+    // objc_exception_get_functions
+    // objc_exception_set_functions
+}

--- a/objc-sys/src/exception.rs
+++ b/objc-sys/src/exception.rs
@@ -3,7 +3,7 @@
 //! GNUStep: `eh_personality.c`, which is a bit brittle to rely on, but I
 //!   think it's fine...
 use core::ffi::c_void;
-#[cfg(any(apple, gnustep))]
+#[cfg(apple)]
 use std::os::raw::c_int;
 
 #[cfg(apple)]
@@ -61,6 +61,9 @@ extern_c! {
     #[cfg(all(apple, target_os = "macos"))]
     pub fn objc_removeExceptionHandler(token: usize);
 
-    #[cfg(gnustep)]
-    pub fn objc_set_apple_compatible_objcxx_exceptions(newValue: c_int) -> c_int;
+    // Only available when ENABLE_OBJCXX is set, and a useable C++ runtime is
+    // present when building libobjc2.
+    //
+    // #[cfg(gnustep)]
+    // pub fn objc_set_apple_compatible_objcxx_exceptions(newValue: c_int) -> c_int;
 }

--- a/objc-sys/src/exception.rs
+++ b/objc-sys/src/exception.rs
@@ -31,7 +31,7 @@ pub type objc_uncaught_exception_handler = unsafe extern "C" fn(exception: *mut 
 pub type objc_exception_handler =
     unsafe extern "C" fn(unused: *mut objc_object, context: *mut c_void);
 
-extern "C" {
+extern_c! {
     pub fn objc_begin_catch(exc_buf: *mut c_void) -> *mut objc_object;
     pub fn objc_end_catch();
     /// See [`objc-exception.h`].

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -92,7 +92,13 @@ macro_rules! extern_c {
 
 mod class;
 mod constants;
+
+#[cfg(not(all(apple, target_os = "macos", target_arch = "x86")))]
 mod exception;
+#[cfg(all(apple, target_os = "macos", target_arch = "x86"))]
+#[path = "exception-macos-x86.rs"]
+mod exception;
+
 mod message;
 mod method;
 mod object;

--- a/objc-sys/src/message.rs
+++ b/objc-sys/src/message.rs
@@ -20,16 +20,15 @@ pub struct objc_super {
     pub super_class: *const objc_class,
 }
 
-#[cfg(gnustep)]
-extern "C" {
+extern_c! {
+    #[cfg(gnustep)]
     pub fn objc_msg_lookup(receiver: *mut objc_object, sel: *const objc_selector) -> IMP;
+    #[cfg(gnustep)]
     pub fn objc_msg_lookup_super(sup: *const objc_super, sel: *const objc_selector) -> IMP;
+    // #[cfg(gnustep)]
     // objc_msg_lookup_sender
-
     // objc_msgLookup family available in macOS >= 10.12
-}
 
-extern "C" {
     // objc_msgSend_noarg
 
     pub fn objc_msgSend();
@@ -45,41 +44,41 @@ extern "C" {
     #[cfg(apple)]
     pub fn _objc_msgForward();
     pub fn class_getMethodImplementation();
-}
 
-#[cfg(not(target_arch = "aarch64"))] // __arm64__
-extern "C" {
+    // Struct return. Not available on __arm64__:
+
     /// Not available on `target_arch = "aarch64"`
+    #[cfg(not(target_arch = "aarch64"))]
     pub fn objc_msgSend_stret();
     // objc_msgSend_stret_debug
 
     /// Not available on `target_arch = "aarch64"`
-    #[cfg(apple)]
+    #[cfg(all(apple, not(target_arch = "aarch64")))]
     pub fn objc_msgSendSuper_stret();
     // objc_msgSendSuper2_stret
     // objc_msgSendSuper2_stret_debug
 
     /// Not available on `target_arch = "aarch64"`
-    #[cfg(apple)]
+    #[cfg(all(apple, not(target_arch = "aarch64")))]
     pub fn method_invoke_stret();
     /// Not available on `target_arch = "aarch64"`
-    #[cfg(apple)]
+    #[cfg(all(apple, not(target_arch = "aarch64")))]
     pub fn _objc_msgForward_stret();
     /// Not available on `target_arch = "aarch64"`
+    #[cfg(not(target_arch = "aarch64"))]
     pub fn class_getMethodImplementation_stret();
-}
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))] // __x86_64__ and __i386__
-extern "C" {
+    // __x86_64__ and __i386__
+
     /// Only available on `target_arch = "x86_64"` or `target_arch = "x86"`
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     pub fn objc_msgSend_fpret();
     // objc_msgSend_fpret_debug
-}
 
-#[cfg(target_arch = "x86_64")] // __x86_64__
-extern "C" {
+    // __x86_64__
+
     /// Only available on `target_arch = "x86_64"`
-    #[cfg(apple)]
+    #[cfg(all(apple, target_arch = "x86_64"))]
     pub fn objc_msgSend_fp2ret();
     // objc_msgSend_fp2ret_debug
 }

--- a/objc-sys/src/method.rs
+++ b/objc-sys/src/method.rs
@@ -19,7 +19,7 @@ pub struct objc_method_description {
     pub types: *const c_char,
 }
 
-extern "C" {
+extern_c! {
     pub fn method_copyArgumentType(method: *const objc_method, index: c_uint) -> *mut c_char;
     pub fn method_copyReturnType(method: *const objc_method) -> *mut c_char;
     pub fn method_exchangeImplementations(method1: *mut objc_method, method2: *mut objc_method);

--- a/objc-sys/src/object.rs
+++ b/objc-sys/src/object.rs
@@ -32,13 +32,14 @@ extern_c! {
         name: *const c_char,
         value: *mut c_void,
     ) -> *const objc_ivar;
-    #[deprecated = "Not needed since ARC"]
-    #[cfg(apple)]
-    pub fn object_setInstanceVariableWithStrongDefault(
-        obj: *mut objc_object,
-        name: *const c_char,
-        value: *mut c_void,
-    ) -> *const objc_ivar;
+    // Available in macOS 10.12
+    // #[deprecated = "Not needed since ARC"]
+    // #[cfg(apple)]
+    // pub fn object_setInstanceVariableWithStrongDefault(
+    //     obj: *mut objc_object,
+    //     name: *const c_char,
+    //     value: *mut c_void,
+    // ) -> *const objc_ivar;
     #[deprecated = "Not needed since ARC"]
     pub fn object_getInstanceVariable(
         obj: *const objc_object,

--- a/objc-sys/src/object.rs
+++ b/objc-sys/src/object.rs
@@ -12,7 +12,7 @@ pub struct objc_object {
     _p: OpaqueData,
 }
 
-extern "C" {
+extern_c! {
     pub fn object_getClass(obj: *const objc_object) -> *const objc_class;
     pub fn object_getClassName(obj: *const objc_object) -> *const c_char;
     pub fn object_getIndexedIvars(obj: *const objc_object) -> *const c_void;

--- a/objc-sys/src/property.rs
+++ b/objc-sys/src/property.rs
@@ -21,7 +21,7 @@ pub struct objc_property_attribute_t {
     pub value: *const c_char,
 }
 
-extern "C" {
+extern_c! {
     pub fn property_copyAttributeList(
         property: *const objc_property,
         out_len: *mut c_uint,

--- a/objc-sys/src/protocol.rs
+++ b/objc-sys/src/protocol.rs
@@ -18,7 +18,7 @@ pub struct objc_protocol {
     _p: OpaqueData,
 }
 
-extern "C" {
+extern_c! {
     pub fn objc_getProtocol(name: *const c_char) -> *const objc_protocol;
     pub fn objc_copyProtocolList(out_len: *mut c_uint) -> *mut *const objc_protocol;
 

--- a/objc-sys/src/rc.rs
+++ b/objc-sys/src/rc.rs
@@ -12,7 +12,7 @@ use core::ffi::c_void;
 
 use crate::objc_object;
 
-extern "C" {
+extern_c! {
     // Autorelease
 
     pub fn objc_autorelease(value: *mut objc_object) -> *mut objc_object;

--- a/objc-sys/src/selector.rs
+++ b/objc-sys/src/selector.rs
@@ -11,7 +11,7 @@ pub struct objc_selector {
     _p: OpaqueData,
 }
 
-extern "C" {
+extern_c! {
     pub fn sel_getName(sel: *const objc_selector) -> *const c_char;
     pub fn sel_getUid(name: *const c_char) -> *const objc_selector;
     pub fn sel_isEqual(lhs: *const objc_selector, rhs: *const objc_selector) -> BOOL;

--- a/objc-sys/src/various.rs
+++ b/objc-sys/src/various.rs
@@ -31,7 +31,7 @@ pub type objc_hook_getClass =
 pub type objc_hook_lazyClassNamer =
     unsafe extern "C" fn(cls: *const crate::objc_class) -> *const c_char;
 
-extern "C" {
+extern_c! {
     pub fn imp_getBlock(imp: IMP) -> *mut objc_object;
     pub fn imp_implementationWithBlock(block: *mut objc_object) -> IMP;
     pub fn imp_removeBlock(imp: IMP) -> BOOL;

--- a/objc-sys/src/various.rs
+++ b/objc-sys/src/various.rs
@@ -76,22 +76,24 @@ extern_c! {
     pub fn objc_sync_enter(obj: *mut objc_object) -> c_int;
     pub fn objc_sync_exit(obj: *mut objc_object) -> c_int;
 
-    /// Not available on macOS x86.
-    ///
-    /// Remember that this is non-null!
-    #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
-    pub fn objc_setHook_getClass(
-        new_value: objc_hook_getClass,
-        out_old_value: *mut objc_hook_getClass,
-    );
-    /// Not available on macOS x86.
-    ///
-    /// Remember that this is non-null!
-    #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
-    pub fn objc_setHook_lazyClassNamer(
-        new_value: objc_hook_lazyClassNamer,
-        out_old_value: *mut objc_hook_lazyClassNamer,
-    );
+    // Available in macOS 10.14.4
+    // /// Not available on macOS x86.
+    // ///
+    // /// Remember that this is non-null!
+    // #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
+    // pub fn objc_setHook_getClass(
+    //     new_value: objc_hook_getClass,
+    //     out_old_value: *mut objc_hook_getClass,
+    // );
+    // Available in macOS 11
+    // /// Not available on macOS x86.
+    // ///
+    // /// Remember that this is non-null!
+    // #[cfg(all(apple, not(all(target_os = "macos", target_arch = "x86"))))]
+    // pub fn objc_setHook_lazyClassNamer(
+    //     new_value: objc_hook_lazyClassNamer,
+    //     out_old_value: *mut objc_hook_lazyClassNamer,
+    // );
 
     // #[deprecated = "not recommended"]
     // #[cfg(apple)]


### PR DESCRIPTION
And test it in CI!

In reality, it doesn't _really_ matter that they are correctly `cfg`-guarded, because they're just not gonna be available on the platforms anyhow, but I think it's a good idea to ensure, so that you get compile-time errors instead of obscure linker errors.