### PR TITLE
New versions

### DIFF
--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.0.3 - 2022-01-03
+
 ### Changed
 * **BREAKING**: Updated `objc-sys` to `v0.2.0-alpha.1`.
 

--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Updated `objc-sys` to `v0.2.0-alpha.1`.
+
 
 ## 0.0.2 - 2021-12-22
+
+### Changed
+* **BREAKING**: Updated `objc-sys` to `v0.2.0-alpha.0`.
 
 ### Fixed
 * **BREAKING**: `Class` is now `!UnwindSafe`.

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-sys"
-version = "0.0.2" # Remember to update html_root_url in lib.rs
+version = "0.0.3" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -47,7 +47,7 @@ winobjc = ["objc-sys/winobjc", "gnustep-1-8"]
 objfw = []
 
 [dependencies]
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.0", optional = true }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/block-sys/src/lib.rs
+++ b/block-sys/src/lib.rs
@@ -10,7 +10,7 @@
 //! [ABI]: https://clang.llvm.org/docs/Block-ABI-Apple.html
 
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block-sys/0.0.2")]
+#![doc(html_root_url = "https://docs.rs/block-sys/0.0.3")]
 
 // Ensure linkage actually happens
 #[cfg(feature = "gnustep-1-7")]

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Changed `global_block!` macro to take an optional semicolon at the end.
 * Improved documentation.
+* **BREAKING**: Updated `ffi` module to `block-sys v0.0.3`
 
 
 ## 0.2.0-alpha.2 - 2021-12-22
@@ -16,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 * `GlobalBlock` and corresponding `global_block!` macro, allowing statically
   creating blocks that don't reference their environment.
+
+### Changed
+* **BREAKING**: Updated `ffi` module to `block-sys v0.0.2`
 
 
 ## 0.2.0-alpha.1 - 2021-11-22

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.3 - 2022-01-03
+
 ### Changed
 * Changed `global_block!` macro to take an optional semicolon at the end.
 * Improved documentation.

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs and README.md
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 
 [dependencies]
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
-block-sys = { path = "../block-sys", version = "0.0.2" }
+block-sys = { path = "../block-sys", version = "0.0.3" }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://docs.rs/block2/"
 license = "MIT"
 
 [dependencies]
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.1" }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
 block-sys = { path = "../block-sys", version = "0.0.2" }
 
 [package.metadata.docs.rs]

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -81,7 +81,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.3")]
 
 extern crate std;
 

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.1 - 2022-01-03
+
 ### Added
 * Added `objc_exception_try_enter` and `objc_exception_try_exit` on macOS x86.
 
@@ -34,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   since macOS 10.14.4.
 * **BREAKING**: Removed `objc_setHook_lazyClassNamer` since it is only
   available since macOS 11.
+
+## Fixed
+* `docs.rs` configuration.
 
 
 ## 0.2.0-alpha.0 - 2021-12-22

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc-sys"
-version = "0.2.0-alpha.0" # Remember to update html_root_url in lib.rs
+version = "0.2.0-alpha.1" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -18,7 +18,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-alpha.0")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-alpha.1")]
 
 // TODO: Replace `extern "C"` with `extern "C-unwind"` where applicable.
 // See https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html.

--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 2.0.0-beta.2 - 2022-01-03
+
 ### Added
 * Implement `Hash` for `Encoding`.
 

--- a/objc2-encode/Cargo.toml
+++ b/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs and README.md
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -72,7 +72,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-beta.2")]
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.4 - 2022-01-03
+
 ### Added
 * Implement `PartialOrd` and `Ord` for `NSComparisonResult` and `NSValue`.
 * Implement `fmt::Display` for `NSValue`.

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -26,7 +26,7 @@ block = ["block2"]
 [dependencies]
 block2 = { path = "../block2", version = "=0.2.0-alpha.2", optional = true }
 objc2 = { path = "../objc2", version = "=0.3.0-alpha.5" }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.0" }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -24,7 +24,7 @@ default = ["block"]
 block = ["block2"]
 
 [dependencies]
-block2 = { path = "../block2", version = "=0.2.0-alpha.2", optional = true }
+block2 = { path = "../block2", version = "=0.2.0-alpha.3", optional = true }
 objc2 = { path = "../objc2", version = "=0.3.0-alpha.5" }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
 

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -25,7 +25,7 @@ block = ["block2"]
 
 [dependencies]
 block2 = { path = "../block2", version = "=0.2.0-alpha.3", optional = true }
-objc2 = { path = "../objc2", version = "=0.3.0-alpha.5" }
+objc2 = { path = "../objc2", version = "=0.3.0-alpha.6" }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
 
 [package.metadata.docs.rs]

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2-foundation"
-version = "0.2.0-alpha.3" # Remember to update html_root_url in lib.rs
+version = "0.2.0-alpha.4" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -12,7 +12,7 @@
 // TODO: #![warn(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.0-alpha.3")]
+#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.0-alpha.4")]
 
 extern crate alloc;
 extern crate std;

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `Object::get_ivar` -> `Object::ivar`
   - `Object::get_mut_ivar` -> `Object::ivar_mut`
 * Vastly improved documentation.
+* **BREAKING**: Updated `ffi` module to `objc-sys v0.2.0-alpha.1`.
 
 
 ## 0.3.0-alpha.5 - 2021-12-22
@@ -54,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Relaxed `Sized` bound on `rc::Id` and `rc::WeakId` to prepare for
   `extern type` support.
 * **BREAKING**: Relaxed `Sized` bound on `rc::SliceId` and `rc::DefaultId`.
+* **BREAKING**: Updated `objc-sys` to `v0.2.0-alpha.0`.
 
 ### Removed
 * **BREAKING**: Removed the raw FFI functions from the `runtime` module. These
@@ -81,13 +83,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: The `exception` feature now just enables the `exception`
   module for general use. Use the new `catch_all` feature to wrap all message
   sends in a `@try/@catch`.
+* **BREAKING**: Updated `objc-sys` to `v0.1.0`.
 
 
 ## 0.3.0-alpha.3 - 2021-09-05
 
 ### Added
-* Now uses the `objc-sys` crate for possibly better interoperability with
-  other crates that link to `libobjc`.
+* Now uses the `objc-sys` (`v0.0.1`) crate for possibly better
+  interoperability with other crates that link to `libobjc`.
 * Added newtype `runtime::Bool` to fix soundness issues with using
   `runtime::BOOL` or `bool`.
 * Moved `objc_id` crate into `rc` module. Notable changes:

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.0-alpha.6 - 2022-01-03
+
 ### Added
 * Implement `Hash` for `Sel`, `Ivar`, `Class`, `Method` and `MessageError`.
 * Implement `PartialEq` and `Eq` for `Ivar`, `Method` and `MessageError`.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `Object::get_mut_ivar` -> `Object::ivar_mut`
 * Vastly improved documentation.
 * **BREAKING**: Updated `ffi` module to `objc-sys v0.2.0-alpha.1`.
+* **BREAKING**: Updated `objc2-encode` (`Encoding`, `Encode`, `RefEncode` and
+  `EncodeArguments`) to `v2.0.0-beta.2`.
 
 
 ## 0.3.0-alpha.5 - 2021-12-22
@@ -56,6 +58,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `extern type` support.
 * **BREAKING**: Relaxed `Sized` bound on `rc::SliceId` and `rc::DefaultId`.
 * **BREAKING**: Updated `objc-sys` to `v0.2.0-alpha.0`.
+* Updated `objc2-encode` (`Encoding`, `Encode`, `RefEncode` and
+  `EncodeArguments`) to `v2.0.0-beta.1`.
 
 ### Removed
 * **BREAKING**: Removed the raw FFI functions from the `runtime` module. These
@@ -84,6 +88,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   module for general use. Use the new `catch_all` feature to wrap all message
   sends in a `@try/@catch`.
 * **BREAKING**: Updated `objc-sys` to `v0.1.0`.
+* **BREAKING**: Updated `objc2-encode` (`Encoding`, `Encode`, `RefEncode` and
+  `EncodeArguments`) to `v2.0.0-beta.0`.
 
 
 ## 0.3.0-alpha.3 - 2021-09-05

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.3.0-alpha.5" # Remember to update html_root_url in lib.rs
+version = "0.3.0-alpha.6" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2018"
 

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -43,7 +43,7 @@ unstable_autoreleasesafe = []
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.1" }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -42,7 +42,7 @@ unstable_autoreleasesafe = []
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.0" }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.1" }
 
 [build-dependencies]

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -131,7 +131,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-alpha.6")]
 
 extern crate alloc;
 extern crate std;


### PR DESCRIPTION
This is mostly to roll out the fix for the failing `objc-sys` docs (see #89).

I've also added entries to the changelogs for when a significant dependency has been updated; this will become less relevant as we get more stable versions of `objc-sys` and `objc2-encode`.