### PR TITLE
Properly test that encodings match the Objective-C `@encode` output

### DIFF
--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `Encoding::LONG` and `Encoding::U_LONG` to help with platform
+  compatibility; use these instead of `c_long::ENCODING` and
+  `c_ulong::ENCODING`.
+
 
 ## 2.0.0-beta.2 - 2022-01-03
 

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -78,6 +78,9 @@
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
+#[cfg(doc)]
+extern crate std;
+
 #[cfg(any(test, doc))]
 extern crate alloc;
 

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 use core::mem;
-use core::mem::size_of;
 use core::ptr;
 use core::ptr::NonNull;
 use core::slice;
@@ -57,35 +56,14 @@ struct NSFastEnumerationState<T: INSObject> {
     extra: [c_ulong; 5],
 }
 
-/// Ideally the encoding of `long` would just be the same as `int` when it's
-/// 32 bits wide and the same as `long long` when it's 64 bits wide; then
-/// `c_long::ENCODING` would just work.
-///
-/// Unfortunately, `long` and `unsigned long` have a different encoding than
-/// `int` when it's 32 bits wide; the 'l'/'L' encoding.
-const U_LONG_ENCODING: Encoding<'static> = {
-    // We could also just have used:
-    // #[cfg(any(target_pointer_width = "32", windows))]
-    //
-    // But this way we exactly match what `clang` does:
-    // https://github.com/llvm/llvm-project/blob/release/13.x/clang/lib/AST/ASTContext.cpp#L7245
-    if size_of::<c_ulong>() == 4 {
-        // @encode(unsigned long) = 'L'
-        Encoding::ULong
-    } else {
-        // @encode(unsigned long) = 'Q'
-        Encoding::ULongLong
-    }
-};
-
 unsafe impl<T: INSObject> Encode for NSFastEnumerationState<T> {
     const ENCODING: Encoding<'static> = Encoding::Struct(
         "?",
         &[
-            U_LONG_ENCODING,
+            Encoding::U_LONG,
             Encoding::Pointer(&Encoding::Object), // <*const *const T>::ENCODING
-            Encoding::Pointer(&U_LONG_ENCODING),
-            Encoding::Array(5, &U_LONG_ENCODING),
+            Encoding::Pointer(&Encoding::U_LONG),
+            Encoding::Array(5, &Encoding::U_LONG),
         ],
     );
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,12 @@ build = "build.rs"
 [dependencies]
 block2 = { path = "../block2" }
 block-sys = { path = "../block-sys" }
+objc-sys = { path = "../objc-sys" }
+objc2 = { path = "../objc2" }
 objc2-encode = { path = "../objc2-encode" }
 
 [build-dependencies]
 cc = "1.0"
+
+[dev-dependencies]
+paste = "1.0"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -2,6 +2,7 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=extern/block_utils.c");
+    println!("cargo:rerun-if-changed=extern/encode_utils.m");
 
     let mut builder = cc::Build::new();
     builder.compiler("clang");
@@ -12,4 +13,14 @@ fn main() {
     }
 
     builder.compile("libblock_utils.a");
+
+    let mut builder = cc::Build::new();
+    builder.compiler("clang");
+    builder.file("extern/encode_utils.m");
+
+    for flag in env::var("DEP_OBJC_CC_ARGS").unwrap().split(' ') {
+        builder.flag(flag);
+    }
+
+    builder.compile("libencode_utils.a");
 }

--- a/tests/extern/encode_utils.m
+++ b/tests/extern/encode_utils.m
@@ -1,0 +1,89 @@
+#include <objc/objc.h>
+#include <stdint.h>
+#include <stddef.h>
+// For NSInteger / NSUInteger. Linking is not required.
+#include <Foundation/NSObject.h>
+
+#define ENCODING_INNER(name, type) char* ENCODING_ ## name = @encode(type);
+
+#define ENCODING(name, type) \
+    ENCODING_INNER(name, type); \
+    ENCODING_INNER(name ## _POINTER, type*); \
+    ENCODING_INNER(name ## _ATOMIC, _Atomic type);
+
+// C types
+
+ENCODING(C99_BOOL, _Bool);
+ENCODING(CHAR, char);
+ENCODING(SIGNED_CHAR, signed char);
+ENCODING(UNSIGNED_CHAR, unsigned char);
+ENCODING(SHORT, short);
+ENCODING(UNSIGNED_SHORT, unsigned short);
+ENCODING(INT, int);
+ENCODING(UNSIGNED_INT, unsigned int);
+ENCODING(LONG, long);
+ENCODING(UNSIGNED_LONG, unsigned long);
+ENCODING(LONG_LONG, long long);
+ENCODING(UNSIGNED_LONG_LONG, unsigned long long);
+ENCODING(FLOAT, float);
+ENCODING(DOUBLE, double);
+ENCODING(LONG_DOUBLE, long double);
+
+ENCODING(FLOAT_COMPLEX, float _Complex);
+ENCODING(DOUBLE_COMPLEX, double _Complex);
+ENCODING(LONG_DOUBLE_COMPLEX, long double _Complex);
+// TODO: Enable these:
+// ENCODING(FLOAT_IMAGINARY, float _Imaginary);
+// ENCODING(DOUBLE_IMAGINARY, double _Imaginary);
+// ENCODING(LONG_DOUBLE_IMAGINARY, long double _Imaginary);
+
+ENCODING_INNER(VOID, void);
+ENCODING_INNER(VOID_POINTER, void*);
+ENCODING_INNER(VOID_POINTER_CONST, const void*);
+ENCODING_INNER(VOID_POINTER_POINTER, void**);
+
+// Array
+
+ENCODING_INNER(INT_ARRAY, int[10]);
+ENCODING_INNER(INT_ARRAY_POINTER, int*[10]);
+ENCODING_INNER(INT_ARRAY_ATOMIC, _Atomic int[10]);
+
+// Struct
+
+// TODO: Structs and such
+
+// Objective-C
+
+ENCODING(OBJC_BOOL, BOOL);
+ENCODING_INNER(ID, id);
+ENCODING_INNER(ID_POINTER, const id*);
+ENCODING_INNER(ID_ATOMIC, _Atomic id);
+ENCODING(CLASS, Class);
+ENCODING(SEL, SEL);
+ENCODING(NS_INTEGER, NSInteger);
+ENCODING(NS_UINTEGER, NSUInteger);
+
+// stdint.h
+
+ENCODING(INT8, int8_t);
+ENCODING(INT16, int16_t);
+ENCODING(INT32, int32_t);
+ENCODING(INT64, int64_t);
+ENCODING(INTPTR, intptr_t);
+ENCODING(UINT8, uint8_t);
+ENCODING(UINT16, uint16_t);
+ENCODING(UINT32, uint32_t);
+ENCODING(UINT64, uint64_t);
+ENCODING(UINTPTR, uintptr_t);
+
+// stddef.h
+
+ENCODING(SIZE_T, size_t);
+ENCODING(PTRDIFF_T, ptrdiff_t);
+
+// Possible extras
+
+#if __has_builtin(__int128_t)
+ENCODING(SIGNED_INT_128, __int128_t);
+ENCODING(UNSIGNED_INT_128, __uint128_t);
+#endif

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,10 +4,12 @@
 #![no_std]
 use block2::{Block, RcBlock};
 
-#[cfg(test)]
 extern crate alloc;
+extern crate std;
 
 pub mod ffi;
+#[cfg(test)]
+mod test_encode_utils;
 use crate::ffi::LargeStruct;
 
 pub fn get_int_block_with(i: i32) -> RcBlock<(), i32> {

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -1,0 +1,159 @@
+#![allow(non_snake_case)]
+use alloc::format;
+use core::fmt::Display;
+use objc2::ffi::{NSInteger, NSUInteger};
+use objc2::runtime::{Bool, Class, Object, Sel};
+use objc2_encode::Encoding;
+use paste::paste;
+use std::ffi::CStr;
+use std::os::raw::*;
+use std::string::ToString;
+
+unsafe fn assert_encoding(s: *const c_char, e: Encoding) {
+    let s = CStr::from_ptr(s).to_str().unwrap();
+    if !e.equivalent_to_str(s) {
+        panic!("{} were not equivalent to {}", e, s);
+    }
+    // To ensure `equivalent_to_str` is implemented correctly:
+    assert_eq!(e.to_string(), s.trim_start_matches('r'));
+}
+
+unsafe fn assert_str<T: Display>(s: *const c_char, expected: T) {
+    let s = CStr::from_ptr(s).to_str().unwrap();
+    // Exact comparison to ensure we catch regressions (and that they are not
+    // just masked by ).
+    assert_eq!(s, expected.to_string());
+}
+
+macro_rules! assert_inner {
+    (enc $stat:ident => $expected:expr) => {
+        #[test]
+        fn $stat() {
+            extern "C" {
+                static $stat: *const c_char;
+            }
+            unsafe { assert_encoding($stat, $expected) };
+        }
+    };
+    (str $stat:ident => $expected:expr) => {
+        #[test]
+        fn $stat() {
+            extern "C" {
+                static $stat: *const c_char;
+            }
+            unsafe { assert_str($stat, $expected) };
+        }
+    };
+}
+
+macro_rules! assert_types {
+    ($($stat:ident => $type:ty,)+) => {$(
+        paste! {
+            assert_inner!(enc [<ENCODING_ $stat>] => <$type>::ENCODING);
+            assert_inner!(enc [<ENCODING_ $stat _POINTER>] => <*const $type>::ENCODING);
+            assert_inner!(str [<ENCODING_ $stat _ATOMIC>] => format!("A{}", <$type>::ENCODING));
+        }
+    )+};
+}
+
+use super::*;
+use objc2_encode::Encode;
+
+assert_types! {
+    // C types
+
+    C99_BOOL => bool,
+    CHAR => c_char,
+    SIGNED_CHAR => c_schar,
+    UNSIGNED_CHAR => c_uchar,
+    SHORT => c_short,
+    UNSIGNED_SHORT => c_ushort,
+    INT => c_int,
+    UNSIGNED_INT => c_uint,
+    LONG => c_long,
+    UNSIGNED_LONG => c_ulong,
+    LONG_LONG => c_longlong,
+    UNSIGNED_LONG_LONG => c_ulonglong,
+    FLOAT => c_float,
+    DOUBLE => c_double,
+    // LONG_DOUBLE => c_longdouble,
+
+    // FLOAT_COMPLEX => float _Complex,
+    // DOUBLE_COMPLEX => double _Complex,
+    // LONG_DOUBLE_COMPLEX => long double _Complex,
+    // TODO:
+    // FLOAT_IMAGINARY => float _Imaginary,
+    // DOUBLE_IMAGINARY => double _Imaginary,
+    // LONG_DOUBLE_IMAGINARY => long double _Imaginary,
+
+    // VOID => void,
+
+    // Array
+
+    // TODO: INT_ARRAY => [c_int; 10],
+
+    // Struct
+
+    // TODO: Structs and such
+
+    // // Objective-C
+
+    OBJC_BOOL => Bool,
+    ID => *mut Object,
+    CLASS => &Class,
+    // SEL => Sel,
+    NS_INTEGER => NSInteger,
+    NS_UINTEGER => NSUInteger,
+
+    // stdint.h
+
+    INT8 => i8,
+    INT16 => i16,
+    INT32 => i32,
+    INT64 => i64,
+    INTPTR => isize,
+    UINT8 => u8,
+    UINT16 => u16,
+    UINT32 => u32,
+    UINT64 => u64,
+    UINTPTR => usize,
+
+    // stddef.h
+
+    SIZE_T => usize,
+    PTRDIFF_T => isize,
+
+    // Possible extras; need to be #[cfg]-ed somehow
+
+    // SIGNED_INT_128 => i128,
+    // UNSIGNED_INT_128 => u128,
+}
+
+// Sel is (intentionally) not RefEncode
+assert_inner!(enc ENCODING_SEL => Sel::ENCODING);
+assert_inner!(enc ENCODING_SEL_POINTER => Encoding::Pointer(&Sel::ENCODING));
+assert_inner!(str ENCODING_SEL_ATOMIC => format!("A{}", Sel::ENCODING));
+
+// _Atomic void* is not available
+assert_inner!(enc ENCODING_VOID => <()>::ENCODING);
+assert_inner!(enc ENCODING_VOID_POINTER => <*const c_void>::ENCODING);
+assert_inner!(str ENCODING_VOID_POINTER_CONST => format!("r{}", <*const c_void>::ENCODING));
+assert_inner!(enc ENCODING_VOID_POINTER_POINTER => <*const *const c_void>::ENCODING);
+
+// No appropriate Rust types for these:
+
+assert_inner!(enc ENCODING_LONG_DOUBLE => Encoding::LongDouble);
+assert_inner!(enc ENCODING_LONG_DOUBLE_POINTER => Encoding::Pointer(&Encoding::LongDouble));
+assert_inner!(str ENCODING_LONG_DOUBLE_ATOMIC => format!("A{}", Encoding::LongDouble));
+
+assert_inner!(enc ENCODING_FLOAT_COMPLEX => Encoding::FloatComplex);
+assert_inner!(enc ENCODING_FLOAT_COMPLEX_POINTER => Encoding::Pointer(&Encoding::FloatComplex));
+assert_inner!(str ENCODING_FLOAT_COMPLEX_ATOMIC => format!("A{}", Encoding::FloatComplex));
+
+assert_inner!(enc ENCODING_DOUBLE_COMPLEX => Encoding::DoubleComplex);
+assert_inner!(enc ENCODING_DOUBLE_COMPLEX_POINTER => Encoding::Pointer(&Encoding::DoubleComplex));
+assert_inner!(str ENCODING_DOUBLE_COMPLEX_ATOMIC => format!("A{}", Encoding::DoubleComplex));
+
+assert_inner!(enc ENCODING_LONG_DOUBLE_COMPLEX => Encoding::LongDoubleComplex);
+assert_inner!(enc ENCODING_LONG_DOUBLE_COMPLEX_POINTER => Encoding::Pointer(&Encoding::LongDoubleComplex));
+assert_inner!(str ENCODING_LONG_DOUBLE_COMPLEX_ATOMIC => format!("A{}", Encoding::LongDoubleComplex));

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -70,8 +70,8 @@ assert_types! {
     UNSIGNED_SHORT => c_ushort,
     INT => c_int,
     UNSIGNED_INT => c_uint,
-    LONG => c_long,
-    UNSIGNED_LONG => c_ulong,
+    // LONG => c_long,
+    // UNSIGNED_LONG => c_ulong,
     LONG_LONG => c_longlong,
     UNSIGNED_LONG_LONG => c_ulonglong,
     FLOAT => c_float,
@@ -139,6 +139,16 @@ assert_inner!(enc ENCODING_VOID => <()>::ENCODING);
 assert_inner!(enc ENCODING_VOID_POINTER => <*const c_void>::ENCODING);
 assert_inner!(str ENCODING_VOID_POINTER_CONST => format!("r{}", <*const c_void>::ENCODING));
 assert_inner!(enc ENCODING_VOID_POINTER_POINTER => <*const *const c_void>::ENCODING);
+
+// `[unsigned] long`s are weird:
+
+assert_inner!(enc ENCODING_LONG => Encoding::LONG);
+assert_inner!(enc ENCODING_LONG_POINTER => Encoding::Pointer(&Encoding::LONG));
+assert_inner!(str ENCODING_LONG_ATOMIC => format!("A{}", Encoding::LONG));
+
+assert_inner!(enc ENCODING_UNSIGNED_LONG => Encoding::U_LONG);
+assert_inner!(enc ENCODING_UNSIGNED_LONG_POINTER => Encoding::Pointer(&Encoding::U_LONG));
+assert_inner!(str ENCODING_UNSIGNED_LONG_ATOMIC => format!("A{}", Encoding::U_LONG));
 
 // No appropriate Rust types for these:
 


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/68

These currently fail on macOS 32bit ~because of weird differences in `long` encodings~ (tested with `cargo +nightly test --target=i686-apple-darwin -Zbuild-std`) (**won't fix**):
```rust
test_encode_utils::ENCODING_INTPTR
test_encode_utils::ENCODING_INTPTR_ATOMIC
// test_encode_utils::ENCODING_LONG
// test_encode_utils::ENCODING_LONG_ATOMIC
// test_encode_utils::ENCODING_LONG_POINTER
test_encode_utils::ENCODING_SIZE_T
test_encode_utils::ENCODING_SIZE_T_ATOMIC
test_encode_utils::ENCODING_UINTPTR
test_encode_utils::ENCODING_UINTPTR_ATOMIC
// test_encode_utils::ENCODING_UNSIGNED_LONG
// test_encode_utils::ENCODING_UNSIGNED_LONG_ATOMIC
// test_encode_utils::ENCODING_UNSIGNED_LONG_POINTER
```

~Though on GNUStep 32bit, only these fail:~
```rust
// test_encode_utils::ENCODING_LONG
// test_encode_utils::ENCODING_LONG_ATOMIC
// test_encode_utils::ENCODING_LONG_POINTER
// test_encode_utils::ENCODING_UNSIGNED_LONG
// test_encode_utils::ENCODING_UNSIGNED_LONG_ATOMIC
// test_encode_utils::ENCODING_UNSIGNED_LONG_POINTER
```