### PR TITLE
(Re)add deprecated ivar methods

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added deprecated `Object::get_ivar` and `Object::get_mut_ivar` to make
+  upgrading easier.
+
 
 ## 0.3.0-alpha.6 - 2022-01-03
 

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -557,6 +557,13 @@ impl Object {
         unsafe { &*ptr }
     }
 
+    /// Use [`ivar`](`Self::ivar`) instead.
+    #[deprecated = "Use `Object::ivar` instead."]
+    pub unsafe fn get_ivar<T: Encode>(&self, name: &str) -> &T {
+        // SAFETY: Upheld by caller
+        unsafe { self.ivar(name) }
+    }
+
     /// Returns a mutable reference to the ivar with the given name.
     ///
     /// # Panics
@@ -575,6 +582,13 @@ impl Object {
         let ptr = self as *mut Self as *mut u8;
         let ptr = unsafe { ptr.offset(offset) } as *mut T;
         unsafe { &mut *ptr }
+    }
+
+    /// Use [`ivar_mut`](`Self::ivar_mut`) instead.
+    #[deprecated = "Use `Object::ivar_mut` instead."]
+    pub unsafe fn get_mut_ivar<T: Encode>(&mut self, name: &str) -> &mut T {
+        // SAFETY: Upheld by caller
+        unsafe { self.ivar_mut(name) }
     }
 
     /// Sets the value of the ivar with the given name.


### PR DESCRIPTION
While I still think it was correct to rename them in https://github.com/madsmtm/objc2/pull/102, having these makes migration from `objc` much easier; we can always remove the deprecations again at a later stage.