### PR TITLE
Add `autoreleasepool_leaking`

### DIFF
--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -62,7 +62,9 @@ mod id_traits;
 mod ownership;
 mod weak_id;
 
-pub use self::autorelease::{autoreleasepool, AutoreleasePool, AutoreleaseSafe};
+pub use self::autorelease::{
+    autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
+};
 pub use self::id::Id;
 pub use self::id_traits::{DefaultId, SliceId, SliceIdMut};
 pub use self::ownership::{Owned, Ownership, Shared};


### PR DESCRIPTION
Idea for https://github.com/madsmtm/objc2/issues/86 and/or https://github.com/madsmtm/objc2/issues/30.

Another idea for this:

```rust
impl AutoreleasePool {
    const LEAKING: &'static Self = {
        &*ManuallyDrop::new(unsafe { Self::new_leaking() })
    };
}
```

But that would always yield a static lifetime, which would mean it had to be `unsafe` somehow!