### PR TITLE
Move `Encode` types to exported module

### DIFF
--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -3,10 +3,10 @@ use std::ptr::NonNull;
 use std::sync::Once;
 
 use objc2::declare::ClassDecl;
+use objc2::encode::{Encoding, RefEncode};
 use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::{Class, Object, Sel};
-use objc2::{msg_send, sel};
-use objc2::{Encoding, Message, RefEncode};
+use objc2::{msg_send, sel, Message};
 use objc2_foundation::{INSObject, NSObject};
 
 #[repr(C)]

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -2,10 +2,10 @@ use std::ptr::NonNull;
 use std::sync::Once;
 
 use objc2::declare::ClassDecl;
+use objc2::encode::{Encoding, RefEncode};
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object, Sel};
-use objc2::{msg_send, sel};
-use objc2::{Encoding, Message, RefEncode};
+use objc2::{msg_send, sel, Message};
 use objc2_foundation::{INSObject, NSObject};
 
 /// In the future this should be an `extern type`, if that gets stabilized,

--- a/objc2-foundation/src/comparison_result.rs
+++ b/objc2-foundation/src/comparison_result.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use objc2::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 #[repr(isize)] // NSInteger
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -6,9 +6,10 @@ use core::ptr::NonNull;
 use core::slice;
 use std::os::raw::c_ulong;
 
+use objc2::encode::{Encode, Encoding, RefEncode};
+use objc2::msg_send;
 use objc2::rc::{Id, Owned};
 use objc2::runtime::Object;
-use objc2::{msg_send, Encode, Encoding, RefEncode};
 
 use super::INSObject;
 

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -29,8 +29,8 @@ macro_rules! object {
 
         unsafe impl<$($t $(: $b)?),*> ::objc2::Message for $name<$($t),*> { }
 
-        unsafe impl<$($t $(: $b)?),*> ::objc2::RefEncode for $name<$($t),*> {
-            const ENCODING_REF: ::objc2::Encoding<'static> = ::objc2::Encoding::Object;
+        unsafe impl<$($t $(: $b)?),*> ::objc2::encode::RefEncode for $name<$($t),*> {
+            const ENCODING_REF: ::objc2::encode::Encoding<'static> = ::objc2::encode::Encoding::Object;
         }
 
         unsafe impl<$($t $(: $b)?),*> $crate::INSObject for $name<$($t),*> {

--- a/objc2-foundation/src/range.rs
+++ b/objc2-foundation/src/range.rs
@@ -1,6 +1,6 @@
 use core::ops::Range;
 
-use objc2::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 #[repr(C)]
 // PartialEq is same as NSEqualRanges

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -8,9 +8,9 @@ use core::{fmt, str};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
+use objc2::encode::Encode;
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
-use objc2::Encode;
 
 use super::{INSCopying, INSObject};
 
@@ -131,9 +131,8 @@ pub struct NSValueFloatNotEq;
 mod tests {
     use alloc::format;
 
-    use crate::{INSValue, NSRange, NSValue};
-    use objc2::rc::{Id, Shared};
-    use objc2::Encode;
+    use super::*;
+    use crate::NSRange;
 
     #[test]
     fn test_value() {

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -4,7 +4,7 @@ use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
 use objc2::{class, msg_send};
 #[cfg(feature = "malloc")]
-use objc2::{sel, Encode};
+use objc2::{encode::Encode, sel};
 
 fn main() {
     // Get a class

--- a/objc2/src/bool.rs
+++ b/objc2/src/bool.rs
@@ -1,4 +1,5 @@
-use crate::{ffi, Encode, Encoding, RefEncode};
+use crate::encode::{Encode, Encoding, RefEncode};
+use crate::ffi;
 use core::fmt;
 
 /// The Objective-C `BOOL` type.

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -41,8 +41,9 @@ use core::mem::ManuallyDrop;
 use core::ptr;
 use std::ffi::CString;
 
+use crate::encode::{Encode, EncodeArguments, Encoding};
 use crate::runtime::{Bool, Class, Imp, Object, Protocol, Sel};
-use crate::{ffi, Encode, EncodeArguments, Encoding, Message};
+use crate::{ffi, Message};
 
 /// Types that can be used as the implementation of an Objective-C method.
 pub trait MethodImplementation {

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -141,9 +141,8 @@ extern crate std;
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
+pub use objc2_encode as encode;
 pub use objc_sys as ffi;
-
-pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
 pub use crate::message::{Message, MessageArguments, MessageError, MessageReceiver};
 

--- a/objc2/src/message/apple/arm.rs
+++ b/objc2/src/message/apple/arm.rs
@@ -1,9 +1,9 @@
 use core::mem;
 
 use super::MsgSendFn;
+use crate::encode::{Encode, Encoding};
 use crate::ffi;
 use crate::runtime::Imp;
-use crate::{Encode, Encoding};
 
 /// Double-word sized fundamental data types don't use stret, but any
 /// composite type larger than 4 bytes does.

--- a/objc2/src/message/apple/arm64.rs
+++ b/objc2/src/message/apple/arm64.rs
@@ -1,7 +1,7 @@
 use super::MsgSendFn;
+use crate::encode::Encode;
 use crate::ffi;
 use crate::runtime::Imp;
-use crate::Encode;
 
 /// `objc_msgSend_stret` is not even available in arm64.
 ///

--- a/objc2/src/message/apple/mod.rs
+++ b/objc2/src/message/apple/mod.rs
@@ -1,4 +1,5 @@
-use super::{conditional_try, Encode, MessageArguments, MessageError};
+use super::{conditional_try, MessageArguments, MessageError};
+use crate::encode::Encode;
 use crate::ffi;
 use crate::runtime::{Class, Imp, Object, Sel};
 

--- a/objc2/src/message/apple/x86.rs
+++ b/objc2/src/message/apple/x86.rs
@@ -1,9 +1,9 @@
 use core::mem;
 
 use super::MsgSendFn;
+use crate::encode::{Encode, Encoding};
 use crate::ffi;
 use crate::runtime::Imp;
-use crate::{Encode, Encoding};
 
 /// Structures 1 or 2 bytes in size are placed in EAX.
 /// Structures 4 or 8 bytes in size are placed in: EAX and EDX.

--- a/objc2/src/message/apple/x86_64.rs
+++ b/objc2/src/message/apple/x86_64.rs
@@ -1,9 +1,9 @@
 use core::mem;
 
 use super::MsgSendFn;
+use crate::encode::{Encode, Encoding};
 use crate::ffi;
 use crate::runtime::Imp;
-use crate::{Encode, Encoding};
 
 /// If the size of an object is larger than two eightbytes, it has class
 /// MEMORY. If the type has class MEMORY, then the caller provides space for

--- a/objc2/src/message/gnustep.rs
+++ b/objc2/src/message/gnustep.rs
@@ -1,6 +1,7 @@
 use core::mem;
 
-use super::{conditional_try, Encode, MessageArguments, MessageError};
+use super::{conditional_try, MessageArguments, MessageError};
+use crate::encode::Encode;
 use crate::ffi;
 use crate::runtime::{Class, Object, Sel};
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -5,9 +5,9 @@ use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 use std::error::Error;
 
+use crate::encode::{Encode, EncodeArguments, RefEncode};
 use crate::rc::{Id, Ownership};
 use crate::runtime::{Class, Imp, Object, Sel};
-use crate::{Encode, EncodeArguments, RefEncode};
 
 #[cfg(feature = "catch_all")]
 unsafe fn conditional_try<R: Encode>(f: impl FnOnce() -> R) -> Result<R, MessageError> {

--- a/objc2/src/message/verify.rs
+++ b/objc2/src/message/verify.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
+use crate::encode::{Encode, EncodeArguments, Encoding};
 use crate::runtime::{Class, Method, Object, Sel};
-use crate::{Encode, EncodeArguments, Encoding};
 
 pub enum VerificationError<'a> {
     NilReceiver(Sel),

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -16,7 +16,8 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_uint;
 
 pub use super::bool::Bool;
-use crate::{ffi, Encode, Encoding, RefEncode};
+use crate::encode::{Encode, Encoding, RefEncode};
+use crate::ffi;
 
 /// Use [`Bool`] or [`ffi::BOOL`] instead.
 #[deprecated = "Use `Bool` or `ffi::BOOL` instead"]
@@ -631,9 +632,8 @@ impl fmt::Debug for Object {
 mod tests {
     use alloc::string::ToString;
 
-    use super::{Bool, Class, Imp, Ivar, Method, Object, Protocol, Sel};
+    use super::*;
     use crate::test_utils;
-    use crate::Encode;
 
     #[test]
     fn test_ivar() {

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -3,8 +3,9 @@ use std::os::raw::c_char;
 use std::sync::Once;
 
 use crate::declare::{ClassDecl, ProtocolDecl};
+use crate::encode::{Encode, Encoding};
 use crate::runtime::{Class, Object, Protocol, Sel};
-use crate::{ffi, Encode, Encoding, MessageReceiver};
+use crate::{ffi, MessageReceiver};
 
 #[derive(Debug)]
 pub(crate) struct CustomObject {


### PR DESCRIPTION
In similar vein to the `ffi` module.

This is a rather large breaking change, we'd probably want to hold off on doing this