### PR TITLE
Use `Deref` in `objc2-foundation` and remove "`INS`" helper traits

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   This allows more ergonomic usage.
 
+### Changed
+* **BREAKING**: Removed the following helper traits in favor of inherent
+  methods on the object itself:
+  - `INSMutableArray`
+
+  This is possible because objects now deref to their superclasses.
+
 
 ## 0.2.0-alpha.4 - 2022-01-03
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSMutableData`
   - `INSData`
   - `INSDictionary`
+  - `INSString`
 
   This is possible because objects now deref to their superclasses.
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Relaxed a lot of bounds from `INSObject` to `Message`. At some
   point in the future a new trait will be introduced which remedies this
   change.
+* **BREAKING**: Removed the `I` prefix from:
+  - `INSCopying` (now `NSCopying`)
+  - `INSMutableCopying` (now `NSMutableCopying`)
+  - `INSFastEnumeration` (now `NSFastEnumeration`)
 
 
 ## 0.2.0-alpha.4 - 2022-01-03

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSData`
   - `INSDictionary`
   - `INSString`
+  - `INSValue`
 
   This is possible because objects now deref to their superclasses.
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSArray`
   - `INSMutableData`
   - `INSData`
+  - `INSDictionary`
 
   This is possible because objects now deref to their superclasses.
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Removed the following helper traits in favor of inherent
   methods on the object itself:
   - `INSMutableArray`
+  - `INSArray`
   - `INSMutableData`
 
   This is possible because objects now deref to their superclasses.

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -22,8 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSDictionary`
   - `INSString`
   - `INSValue`
+  - `INSObject`
 
   This is possible because objects now deref to their superclasses.
+* **BREAKING**: Relaxed a lot of bounds from `INSObject` to `Message`. At some
+  point in the future a new trait will be introduced which remedies this
+  change.
 
 
 ## 0.2.0-alpha.4 - 2022-01-03

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Removed the following helper traits in favor of inherent
   methods on the object itself:
   - `INSMutableArray`
+  - `INSMutableData`
 
   This is possible because objects now deref to their superclasses.
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSMutableArray`
   - `INSArray`
   - `INSMutableData`
+  - `INSData`
 
   This is possible because objects now deref to their superclasses.
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Objects now `Deref` to their superclasses. E.g. `NSMutableArray` derefs to
+  `NSArray`, which derefs to `NSObject`, which derefs to `Object`.
+
+  This allows more ergonomic usage.
+
 
 ## 0.2.0-alpha.4 - 2022-01-03
 

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * **BREAKING**: Removed the following helper traits in favor of inherent
-  methods on the object itself:
+  methods on the objects themselves:
   - `INSMutableArray`
   - `INSArray`
   - `INSMutableData`
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `INSValue`
   - `INSObject`
 
-  This is possible because objects now deref to their superclasses.
+  This changed because objects now deref to their superclasses.
 * **BREAKING**: Relaxed a lot of bounds from `INSObject` to `Message`. At some
   point in the future a new trait will be introduced which remedies this
   change.

--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,7 +1,5 @@
 use objc2::rc::autoreleasepool;
-use objc2_foundation::{
-    INSCopying, INSDictionary, INSString, NSArray, NSDictionary, NSObject, NSString,
-};
+use objc2_foundation::{INSCopying, INSString, NSArray, NSDictionary, NSObject, NSString};
 
 fn main() {
     // Create and compare NSObjects

--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,6 +1,6 @@
 use objc2::rc::autoreleasepool;
 use objc2_foundation::{
-    INSArray, INSCopying, INSDictionary, INSString, NSArray, NSDictionary, NSObject, NSString,
+    INSCopying, INSDictionary, INSString, NSArray, NSDictionary, NSObject, NSString,
 };
 
 fn main() {

--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,5 +1,5 @@
 use objc2::rc::autoreleasepool;
-use objc2_foundation::{INSCopying, NSArray, NSDictionary, NSObject, NSString};
+use objc2_foundation::{NSArray, NSCopying, NSDictionary, NSObject, NSString};
 
 fn main() {
     // Create and compare NSObjects

--- a/objc2-foundation/examples/basic_usage.rs
+++ b/objc2-foundation/examples/basic_usage.rs
@@ -1,5 +1,5 @@
 use objc2::rc::autoreleasepool;
-use objc2_foundation::{INSCopying, INSString, NSArray, NSDictionary, NSObject, NSString};
+use objc2_foundation::{INSCopying, NSArray, NSDictionary, NSObject, NSString};
 
 fn main() {
     // Create and compare NSObjects

--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -7,7 +7,7 @@ use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{msg_send, sel};
 use objc2::{Encoding, Message, RefEncode};
-use objc2_foundation::{INSObject, NSObject};
+use objc2_foundation::NSObject;
 
 #[repr(C)]
 pub struct MyObject<'a> {
@@ -22,6 +22,8 @@ unsafe impl RefEncode for MyObject<'_> {
 }
 
 unsafe impl Message for MyObject<'_> {}
+
+static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 
 impl<'a> MyObject<'a> {
     fn new(number_ptr: &'a mut u8) -> Id<Self, Owned> {
@@ -48,11 +50,7 @@ impl<'a> MyObject<'a> {
             **ptr = number;
         }
     }
-}
 
-static MYOBJECT_REGISTER_CLASS: Once = Once::new();
-
-unsafe impl INSObject for MyObject<'_> {
     fn class() -> &'static Class {
         MYOBJECT_REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -6,7 +6,7 @@ use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{msg_send, sel};
 use objc2::{Encoding, Message, RefEncode};
-use objc2_foundation::{INSObject, NSObject};
+use objc2_foundation::NSObject;
 
 /// In the future this should be an `extern type`, if that gets stabilized,
 /// see [RFC-1861](https://rust-lang.github.io/rfcs/1861-extern-types.html).
@@ -21,6 +21,10 @@ pub struct MYObject {
 unsafe impl RefEncode for MYObject {
     const ENCODING_REF: Encoding<'static> = Encoding::Object;
 }
+
+unsafe impl Message for MYObject {}
+
+static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 
 impl MYObject {
     fn new() -> Id<Self, Owned> {
@@ -41,13 +45,7 @@ impl MYObject {
             obj.set_ivar("_number", number);
         }
     }
-}
 
-unsafe impl Message for MYObject {}
-
-static MYOBJECT_REGISTER_CLASS: Once = Once::new();
-
-unsafe impl INSObject for MYObject {
     fn class() -> &'static Class {
         MYOBJECT_REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -8,10 +8,11 @@ use core::ptr::NonNull;
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
 use objc2::runtime::{Class, Object};
+use objc2::Message;
 
 use super::{
-    INSCopying, INSFastEnumeration, INSMutableCopying, INSObject, NSComparisonResult, NSEnumerator,
-    NSObject, NSRange,
+    INSCopying, INSFastEnumeration, INSMutableCopying, NSComparisonResult, NSEnumerator, NSObject,
+    NSRange,
 };
 
 object! {
@@ -65,7 +66,7 @@ unsafe impl<T: Sync + Send> Send for NSMutableArray<T, Shared> {}
 unsafe impl<T: Sync> Sync for NSMutableArray<T, Owned> {}
 unsafe impl<T: Send> Send for NSMutableArray<T, Owned> {}
 
-unsafe fn from_refs<T: INSObject + ?Sized>(cls: &Class, refs: &[&T]) -> NonNull<Object> {
+unsafe fn from_refs<T: Message + ?Sized>(cls: &Class, refs: &[&T]) -> NonNull<Object> {
     let obj: *mut Object = unsafe { msg_send![cls, alloc] };
     let obj: *mut Object = unsafe {
         msg_send![
@@ -77,7 +78,7 @@ unsafe fn from_refs<T: INSObject + ?Sized>(cls: &Class, refs: &[&T]) -> NonNull<
     unsafe { NonNull::new_unchecked(obj) }
 }
 
-impl<T: INSObject, O: Ownership> NSArray<T, O> {
+impl<T: Message, O: Ownership> NSArray<T, O> {
     unsafe_def_fn! {
         /// The `NSArray` itself (length and number of items) is always immutable,
         /// but we would like to know when we're the only owner of the array, to
@@ -151,7 +152,7 @@ impl<T: INSObject, O: Ownership> NSArray<T, O> {
     }
 }
 
-impl<T: INSObject> NSArray<T, Shared> {
+impl<T: Message> NSArray<T, Shared> {
     pub fn from_slice(slice: &[Id<T, Shared>]) -> Id<Self, Shared> {
         unsafe { Id::new(from_refs(Self::class(), slice.as_slice_ref()).cast()) }
     }
@@ -171,7 +172,7 @@ impl<T: INSObject> NSArray<T, Shared> {
     }
 }
 
-impl<T: INSObject> NSArray<T, Owned> {
+impl<T: Message> NSArray<T, Owned> {
     #[doc(alias = "objectAtIndex:")]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         // TODO: Replace this check with catching the thrown NSRangeException
@@ -196,20 +197,20 @@ impl<T: INSObject> NSArray<T, Owned> {
 
 // Copying only possible when ItemOwnership = Shared
 
-unsafe impl<T: INSObject> INSCopying for NSArray<T, Shared> {
+unsafe impl<T: Message> INSCopying for NSArray<T, Shared> {
     type Ownership = Shared;
     type Output = NSArray<T, Shared>;
 }
 
-unsafe impl<T: INSObject> INSMutableCopying for NSArray<T, Shared> {
+unsafe impl<T: Message> INSMutableCopying for NSArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
 }
 
-unsafe impl<T: INSObject, O: Ownership> INSFastEnumeration for NSArray<T, O> {
+unsafe impl<T: Message, O: Ownership> INSFastEnumeration for NSArray<T, O> {
     type Item = T;
 }
 
-impl<T: INSObject, O: Ownership> Index<usize> for NSArray<T, O> {
+impl<T: Message, O: Ownership> Index<usize> for NSArray<T, O> {
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
@@ -217,7 +218,7 @@ impl<T: INSObject, O: Ownership> Index<usize> for NSArray<T, O> {
     }
 }
 
-impl<T: INSObject, O: Ownership> DefaultId for NSArray<T, O> {
+impl<T: Message, O: Ownership> DefaultId for NSArray<T, O> {
     type Ownership = O;
 
     #[inline]
@@ -226,7 +227,7 @@ impl<T: INSObject, O: Ownership> DefaultId for NSArray<T, O> {
     }
 }
 
-impl<T: INSObject, O: Ownership> NSMutableArray<T, O> {
+impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     unsafe_def_fn!(pub fn new -> Owned);
 
     pub fn from_vec(vec: Vec<Id<T, O>>) -> Id<Self, Owned> {
@@ -234,13 +235,13 @@ impl<T: INSObject, O: Ownership> NSMutableArray<T, O> {
     }
 }
 
-impl<T: INSObject> NSMutableArray<T, Shared> {
+impl<T: Message> NSMutableArray<T, Shared> {
     pub fn from_slice(slice: &[Id<T, Shared>]) -> Id<Self, Owned> {
         unsafe { Id::new(from_refs(Self::class(), slice.as_slice_ref()).cast()) }
     }
 }
 
-impl<T: INSObject, O: Ownership> NSMutableArray<T, O> {
+impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     #[doc(alias = "addObject:")]
     pub fn push(&mut self, obj: Id<T, O>) {
         // SAFETY: The object is not nil
@@ -339,20 +340,20 @@ impl<T: INSObject, O: Ownership> NSMutableArray<T, O> {
 
 // Copying only possible when ItemOwnership = Shared
 
-unsafe impl<T: INSObject> INSCopying for NSMutableArray<T, Shared> {
+unsafe impl<T: Message> INSCopying for NSMutableArray<T, Shared> {
     type Ownership = Shared;
     type Output = NSArray<T, Shared>;
 }
 
-unsafe impl<T: INSObject> INSMutableCopying for NSMutableArray<T, Shared> {
+unsafe impl<T: Message> INSMutableCopying for NSMutableArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
 }
 
-unsafe impl<T: INSObject, O: Ownership> INSFastEnumeration for NSMutableArray<T, O> {
+unsafe impl<T: Message, O: Ownership> INSFastEnumeration for NSMutableArray<T, O> {
     type Item = T;
 }
 
-impl<T: INSObject, O: Ownership> Index<usize> for NSMutableArray<T, O> {
+impl<T: Message, O: Ownership> Index<usize> for NSMutableArray<T, O> {
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
@@ -360,13 +361,13 @@ impl<T: INSObject, O: Ownership> Index<usize> for NSMutableArray<T, O> {
     }
 }
 
-impl<T: INSObject> IndexMut<usize> for NSMutableArray<T, Owned> {
+impl<T: Message> IndexMut<usize> for NSMutableArray<T, Owned> {
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index).unwrap()
     }
 }
 
-impl<T: INSObject, O: Ownership> DefaultId for NSMutableArray<T, O> {
+impl<T: Message, O: Ownership> DefaultId for NSMutableArray<T, O> {
     type Ownership = Owned;
 
     #[inline]
@@ -385,7 +386,7 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Owned, Shared};
 
     use super::{NSArray, NSMutableArray};
-    use crate::{INSObject, NSObject, NSString, NSValue};
+    use crate::{NSObject, NSString, NSValue};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);
@@ -403,7 +404,7 @@ mod tests {
         NSArray::from_vec(vec)
     }
 
-    fn retain_count<T: INSObject>(obj: &T) -> usize {
+    fn retain_count(obj: &NSObject) -> usize {
         unsafe { msg_send![obj, retainCount] }
     }
 

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -11,7 +11,7 @@ use objc2::runtime::{Class, Object};
 use objc2::Message;
 
 use super::{
-    INSCopying, INSFastEnumeration, INSMutableCopying, NSComparisonResult, NSEnumerator, NSObject,
+    NSComparisonResult, NSCopying, NSEnumerator, NSFastEnumeration, NSMutableCopying, NSObject,
     NSRange,
 };
 
@@ -197,16 +197,16 @@ impl<T: Message> NSArray<T, Owned> {
 
 // Copying only possible when ItemOwnership = Shared
 
-unsafe impl<T: Message> INSCopying for NSArray<T, Shared> {
+unsafe impl<T: Message> NSCopying for NSArray<T, Shared> {
     type Ownership = Shared;
     type Output = NSArray<T, Shared>;
 }
 
-unsafe impl<T: Message> INSMutableCopying for NSArray<T, Shared> {
+unsafe impl<T: Message> NSMutableCopying for NSArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
 }
 
-unsafe impl<T: Message, O: Ownership> INSFastEnumeration for NSArray<T, O> {
+unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSArray<T, O> {
     type Item = T;
 }
 
@@ -340,16 +340,16 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
 
 // Copying only possible when ItemOwnership = Shared
 
-unsafe impl<T: Message> INSCopying for NSMutableArray<T, Shared> {
+unsafe impl<T: Message> NSCopying for NSMutableArray<T, Shared> {
     type Ownership = Shared;
     type Output = NSArray<T, Shared>;
 }
 
-unsafe impl<T: Message> INSMutableCopying for NSMutableArray<T, Shared> {
+unsafe impl<T: Message> NSMutableCopying for NSMutableArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
 }
 
-unsafe impl<T: Message, O: Ownership> INSFastEnumeration for NSMutableArray<T, O> {
+unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSMutableArray<T, O> {
     type Item = T;
 }
 

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -11,7 +11,7 @@ use objc2::runtime::Object;
 
 use super::{
     INSCopying, INSFastEnumeration, INSMutableCopying, INSObject, NSComparisonResult, NSEnumerator,
-    NSRange,
+    NSObject, NSRange,
 };
 
 unsafe fn from_refs<A: INSArray + ?Sized>(refs: &[&A::Item]) -> Id<A, A::Ownership> {
@@ -158,7 +158,7 @@ pub unsafe trait INSArray: INSObject {
     }
 }
 
-object!(
+object! {
     /// TODO
     ///
     /// You can have a `Id<NSArray<T, Owned>, Owned>`, which allows mutable access
@@ -169,10 +169,10 @@ object!(
     /// TODO: Can we make it impossible? Should we?
     ///
     /// What about `Id<NSArray<T, Shared>, Owned>`?
-    unsafe pub struct NSArray<T, O: Ownership> {
+    unsafe pub struct NSArray<T, O: Ownership>: NSObject {
         item: PhantomData<Id<T, O>>,
     }
-);
+}
 
 // SAFETY: Same as Id<T, O> (which is what NSArray effectively stores).
 //
@@ -342,11 +342,12 @@ pub unsafe trait INSMutableArray: INSArray {
     }
 }
 
-object!(
-    unsafe pub struct NSMutableArray<T, O: Ownership> {
+object! {
+    // TODO: Ensure that this deref to NSArray is safe!
+    unsafe pub struct NSMutableArray<T, O: Ownership>: NSArray<T, O> {
         item: PhantomData<Id<T, O>>,
     }
-);
+}
 
 // SAFETY: Same as NSArray.
 //

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -385,7 +385,7 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Owned, Shared};
 
     use super::{NSArray, NSMutableArray};
-    use crate::{INSObject, INSValue, NSObject, NSString, NSValue};
+    use crate::{INSObject, NSObject, NSString, NSValue};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -385,7 +385,7 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Owned, Shared};
 
     use super::{NSArray, NSMutableArray};
-    use crate::{INSObject, INSString, INSValue, NSObject, NSString, NSValue};
+    use crate::{INSObject, INSValue, NSObject, NSString, NSValue};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);

--- a/objc2-foundation/src/copying.rs
+++ b/objc2-foundation/src/copying.rs
@@ -1,11 +1,9 @@
 use core::ptr::NonNull;
 
-use objc2::msg_send;
 use objc2::rc::{Id, Owned, Ownership};
+use objc2::{msg_send, Message};
 
-use super::INSObject;
-
-pub unsafe trait INSCopying: INSObject {
+pub unsafe trait INSCopying: Message {
     /// Indicates whether the type is mutable or immutable.
     ///
     /// This can be [`Owned`] if and only if `copy` creates a new instance,
@@ -32,7 +30,7 @@ pub unsafe trait INSCopying: INSObject {
     ///
     /// This is usually `Self`, but e.g. `NSMutableString` returns `NSString`.
     /// TODO: Verify???
-    type Output: INSObject;
+    type Output: Message;
 
     fn copy(&self) -> Id<Self::Output, Self::Ownership> {
         unsafe {
@@ -45,9 +43,9 @@ pub unsafe trait INSCopying: INSObject {
 /// TODO
 ///
 /// Note that the `mutableCopy` selector must return an owned object!
-pub unsafe trait INSMutableCopying: INSObject {
+pub unsafe trait INSMutableCopying: Message {
     /// TODO
-    type Output: INSObject;
+    type Output: Message;
 
     fn mutable_copy(&self) -> Id<Self::Output, Owned> {
         unsafe {

--- a/objc2-foundation/src/copying.rs
+++ b/objc2-foundation/src/copying.rs
@@ -3,7 +3,7 @@ use core::ptr::NonNull;
 use objc2::rc::{Id, Owned, Ownership};
 use objc2::{msg_send, Message};
 
-pub unsafe trait INSCopying: Message {
+pub unsafe trait NSCopying: Message {
     /// Indicates whether the type is mutable or immutable.
     ///
     /// This can be [`Owned`] if and only if `copy` creates a new instance,
@@ -43,7 +43,7 @@ pub unsafe trait INSCopying: Message {
 /// TODO
 ///
 /// Note that the `mutableCopy` selector must return an owned object!
-pub unsafe trait INSMutableCopying: Message {
+pub unsafe trait NSMutableCopying: Message {
     /// TODO
     type Output: Message;
 

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -146,8 +146,8 @@ impl DefaultId for NSData {
     }
 }
 
-pub unsafe trait INSMutableData: INSData {
-    fn bytes_mut(&mut self) -> &mut [u8] {
+impl NSMutableData {
+    pub fn bytes_mut(&mut self) -> &mut [u8] {
         let ptr: *mut c_void = unsafe { msg_send![self, mutableBytes] };
         // The bytes pointer may be null for length zero
         if ptr.is_null() {
@@ -158,16 +158,16 @@ pub unsafe trait INSMutableData: INSData {
     }
 
     /// Expands with zeroes, or truncates the buffer.
-    fn set_len(&mut self, len: usize) {
+    pub fn set_len(&mut self, len: usize) {
         unsafe { msg_send![self, setLength: len] }
     }
 
-    fn append(&mut self, bytes: &[u8]) {
+    pub fn append(&mut self, bytes: &[u8]) {
         let bytes_ptr = bytes.as_ptr() as *const c_void;
         unsafe { msg_send![self, appendBytes: bytes_ptr, length: bytes.len()] }
     }
 
-    fn replace_range(&mut self, range: Range<usize>, bytes: &[u8]) {
+    pub fn replace_range(&mut self, range: Range<usize>, bytes: &[u8]) {
         let range = NSRange::from(range);
         let ptr = bytes.as_ptr() as *const c_void;
         unsafe {
@@ -180,7 +180,7 @@ pub unsafe trait INSMutableData: INSData {
         }
     }
 
-    fn set_bytes(&mut self, bytes: &[u8]) {
+    pub fn set_bytes(&mut self, bytes: &[u8]) {
         let len = self.len();
         self.replace_range(0..len, bytes);
     }
@@ -189,8 +189,6 @@ pub unsafe trait INSMutableData: INSData {
 unsafe impl INSData for NSMutableData {
     type Ownership = Owned;
 }
-
-unsafe impl INSMutableData for NSMutableData {}
 
 unsafe impl INSCopying for NSMutableData {
     type Ownership = Shared;
@@ -240,7 +238,7 @@ impl DefaultId for NSMutableData {
 
 #[cfg(test)]
 mod tests {
-    use super::{INSData, INSMutableData, NSData, NSMutableData};
+    use super::{INSData, NSData, NSMutableData};
     #[cfg(feature = "block")]
     use alloc::vec;
 

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -9,6 +9,22 @@ use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared};
 
 use super::{INSCopying, INSMutableCopying, INSObject, NSObject, NSRange};
 
+object! {
+    unsafe pub struct NSData: NSObject;
+}
+
+// TODO: SAFETY
+unsafe impl Sync for NSData {}
+unsafe impl Send for NSData {}
+
+object! {
+    unsafe pub struct NSMutableData: NSData;
+}
+
+// TODO: SAFETY
+unsafe impl Sync for NSMutableData {}
+unsafe impl Send for NSMutableData {}
+
 pub unsafe trait INSData: INSObject {
     type Ownership: Ownership;
 
@@ -93,14 +109,6 @@ pub unsafe trait INSData: INSObject {
     }
 }
 
-object! {
-    unsafe pub struct NSData: NSObject;
-}
-
-// TODO: SAFETY
-unsafe impl Sync for NSData {}
-unsafe impl Send for NSData {}
-
 unsafe impl INSData for NSData {
     type Ownership = Shared;
 }
@@ -177,14 +185,6 @@ pub unsafe trait INSMutableData: INSData {
         self.replace_range(0..len, bytes);
     }
 }
-
-object! {
-    unsafe pub struct NSMutableData: NSData;
-}
-
-// TODO: SAFETY
-unsafe impl Sync for NSMutableData {}
-unsafe impl Send for NSMutableData {}
 
 unsafe impl INSData for NSMutableData {
     type Ownership = Owned;

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -8,7 +8,7 @@ use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
 
-use super::{INSCopying, INSMutableCopying, INSObject, NSObject, NSRange};
+use super::{INSCopying, INSMutableCopying, NSObject, NSRange};
 
 object! {
     unsafe pub struct NSData: NSObject;

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -8,7 +8,7 @@ use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
 
-use super::{INSCopying, INSMutableCopying, NSObject, NSRange};
+use super::{NSCopying, NSMutableCopying, NSObject, NSRange};
 
 object! {
     unsafe pub struct NSData: NSObject;
@@ -69,12 +69,12 @@ impl NSData {
     }
 }
 
-unsafe impl INSCopying for NSData {
+unsafe impl NSCopying for NSData {
     type Ownership = Shared;
     type Output = NSData;
 }
 
-unsafe impl INSMutableCopying for NSData {
+unsafe impl NSMutableCopying for NSData {
     type Output = NSMutableData;
 }
 
@@ -153,12 +153,12 @@ impl NSMutableData {
     }
 }
 
-unsafe impl INSCopying for NSMutableData {
+unsafe impl NSCopying for NSMutableData {
     type Ownership = Shared;
     type Output = NSData;
 }
 
-unsafe impl INSMutableCopying for NSMutableData {
+unsafe impl NSMutableCopying for NSMutableData {
     type Output = NSMutableData;
 }
 

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -5,7 +5,8 @@ use core::slice::{self, SliceIndex};
 use core::{ffi::c_void, ptr::NonNull};
 
 use objc2::msg_send;
-use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared};
+use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::runtime::{Class, Object};
 
 use super::{INSCopying, INSMutableCopying, INSObject, NSObject, NSRange};
 
@@ -25,20 +26,18 @@ object! {
 unsafe impl Sync for NSMutableData {}
 unsafe impl Send for NSMutableData {}
 
-pub unsafe trait INSData: INSObject {
-    type Ownership: Ownership;
+impl NSData {
+    unsafe_def_fn!(fn new -> Shared);
 
-    unsafe_def_fn!(fn new -> Self::Ownership);
-
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         unsafe { msg_send![self, length] }
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    fn bytes(&self) -> &[u8] {
+    pub fn bytes(&self) -> &[u8] {
         let ptr: *const c_void = unsafe { msg_send![self, bytes] };
         // The bytes pointer may be null for length zero
         if ptr.is_null() {
@@ -48,69 +47,26 @@ pub unsafe trait INSData: INSObject {
         }
     }
 
-    fn with_bytes(bytes: &[u8]) -> Id<Self, Self::Ownership> {
-        let cls = Self::class();
-        let bytes_ptr = bytes.as_ptr() as *const c_void;
-        unsafe {
-            let obj: *mut Self = msg_send![cls, alloc];
-            let obj: *mut Self = msg_send![
-                obj,
-                initWithBytes: bytes_ptr,
-                length: bytes.len(),
-            ];
-            Id::new(NonNull::new_unchecked(obj))
-        }
+    pub fn with_bytes(bytes: &[u8]) -> Id<Self, Shared> {
+        unsafe { Id::new(data_with_bytes(Self::class(), bytes).cast()) }
     }
 
     #[cfg(feature = "block")]
-    fn from_vec(bytes: Vec<u8>) -> Id<Self, Self::Ownership> {
-        use core::mem::ManuallyDrop;
-
-        use block2::{Block, ConcreteBlock};
-
-        let capacity = bytes.capacity();
-
-        let dealloc = ConcreteBlock::new(move |bytes: *mut c_void, len: usize| unsafe {
-            // Recreate the Vec and let it drop
-            let _ = Vec::from_raw_parts(bytes as *mut u8, len, capacity);
-        });
-        let dealloc = dealloc.copy();
-        let dealloc: &Block<(*mut c_void, usize), ()> = &dealloc;
-
+    pub fn from_vec(bytes: Vec<u8>) -> Id<Self, Shared> {
         // GNUStep's NSData `initWithBytesNoCopy:length:deallocator:` has a
         // bug; it forgets to assign the input buffer and length to the
         // instance before it swizzles to NSDataWithDeallocatorBlock.
         // See https://github.com/gnustep/libs-base/pull/213
         // So we just use NSDataWithDeallocatorBlock directly.
+        //
+        // NSMutableData does not have this problem.
         #[cfg(gnustep)]
-        let cls = {
-            let cls = Self::class();
-            if cls == objc2::class!(NSData) {
-                objc2::class!(NSDataWithDeallocatorBlock)
-            } else {
-                cls
-            }
-        };
+        let cls = objc2::class!(NSDataWithDeallocatorBlock);
         #[cfg(not(gnustep))]
         let cls = Self::class();
 
-        let mut bytes = ManuallyDrop::new(bytes);
-
-        unsafe {
-            let obj: *mut Self = msg_send![cls, alloc];
-            let obj: *mut Self = msg_send![
-                obj,
-                initWithBytesNoCopy: bytes.as_mut_ptr() as *mut c_void,
-                length: bytes.len(),
-                deallocator: dealloc,
-            ];
-            Id::new(NonNull::new_unchecked(obj))
-        }
+        unsafe { Id::new(data_from_vec(cls, bytes).cast()) }
     }
-}
-
-unsafe impl INSData for NSData {
-    type Ownership = Shared;
 }
 
 unsafe impl INSCopying for NSData {
@@ -147,6 +103,17 @@ impl DefaultId for NSData {
 }
 
 impl NSMutableData {
+    unsafe_def_fn!(fn new -> Owned);
+
+    pub fn with_bytes(bytes: &[u8]) -> Id<Self, Owned> {
+        unsafe { Id::new(data_with_bytes(Self::class(), bytes).cast()) }
+    }
+
+    #[cfg(feature = "block")]
+    pub fn from_vec(bytes: Vec<u8>) -> Id<Self, Owned> {
+        unsafe { Id::new(data_from_vec(Self::class(), bytes).cast()) }
+    }
+
     pub fn bytes_mut(&mut self) -> &mut [u8] {
         let ptr: *mut c_void = unsafe { msg_send![self, mutableBytes] };
         // The bytes pointer may be null for length zero
@@ -184,10 +151,6 @@ impl NSMutableData {
         let len = self.len();
         self.replace_range(0..len, bytes);
     }
-}
-
-unsafe impl INSData for NSMutableData {
-    type Ownership = Owned;
 }
 
 unsafe impl INSCopying for NSMutableData {
@@ -236,9 +199,51 @@ impl DefaultId for NSMutableData {
     }
 }
 
+unsafe fn data_with_bytes(cls: &Class, bytes: &[u8]) -> NonNull<Object> {
+    let bytes_ptr = bytes.as_ptr() as *const c_void;
+    unsafe {
+        let obj: *mut Object = msg_send![cls, alloc];
+        let obj: *mut Object = msg_send![
+            obj,
+            initWithBytes: bytes_ptr,
+            length: bytes.len(),
+        ];
+        NonNull::new_unchecked(obj)
+    }
+}
+
+#[cfg(feature = "block")]
+unsafe fn data_from_vec(cls: &Class, bytes: Vec<u8>) -> NonNull<Object> {
+    use core::mem::ManuallyDrop;
+
+    use block2::{Block, ConcreteBlock};
+
+    let capacity = bytes.capacity();
+
+    let dealloc = ConcreteBlock::new(move |bytes: *mut c_void, len: usize| unsafe {
+        // Recreate the Vec and let it drop
+        let _ = Vec::from_raw_parts(bytes as *mut u8, len, capacity);
+    });
+    let dealloc = dealloc.copy();
+    let dealloc: &Block<(*mut c_void, usize), ()> = &dealloc;
+
+    let mut bytes = ManuallyDrop::new(bytes);
+
+    unsafe {
+        let obj: *mut Object = msg_send![cls, alloc];
+        let obj: *mut Object = msg_send![
+            obj,
+            initWithBytesNoCopy: bytes.as_mut_ptr() as *mut c_void,
+            length: bytes.len(),
+            deallocator: dealloc,
+        ];
+        NonNull::new_unchecked(obj)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{INSData, NSData, NSMutableData};
+    use super::{NSData, NSMutableData};
     #[cfg(feature = "block")]
     use alloc::vec;
 

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -4,9 +4,10 @@ use core::ops::{Index, IndexMut, Range};
 use core::slice::{self, SliceIndex};
 use core::{ffi::c_void, ptr::NonNull};
 
-use super::{INSCopying, INSMutableCopying, INSObject, NSRange};
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared};
+
+use super::{INSCopying, INSMutableCopying, INSObject, NSObject, NSRange};
 
 pub unsafe trait INSData: INSObject {
     type Ownership: Ownership;
@@ -92,7 +93,9 @@ pub unsafe trait INSData: INSObject {
     }
 }
 
-object!(unsafe pub struct NSData);
+object! {
+    unsafe pub struct NSData: NSObject;
+}
 
 // TODO: SAFETY
 unsafe impl Sync for NSData {}
@@ -175,7 +178,9 @@ pub unsafe trait INSMutableData: INSData {
     }
 }
 
-object!(unsafe pub struct NSMutableData);
+object! {
+    unsafe pub struct NSMutableData: NSData;
+}
 
 // TODO: SAFETY
 unsafe impl Sync for NSMutableData {}

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -163,7 +163,7 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Shared};
 
     use super::NSDictionary;
-    use crate::{INSString, NSObject, NSString};
+    use crate::{NSObject, NSString};
 
     fn sample_dict(key: &str) -> Id<NSDictionary<NSString, NSObject>, Shared> {
         let string = NSString::from_str(key);

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -7,7 +7,7 @@ use core::ptr::{self, NonNull};
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
 
-use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator};
+use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator, NSObject};
 
 unsafe fn from_refs<D, T>(keys: &[&T], vals: &[&D::Value]) -> Id<D, Shared>
 where
@@ -138,12 +138,12 @@ pub unsafe trait INSDictionary: INSObject {
     }
 }
 
-object!(
-    unsafe pub struct NSDictionary<K, V> {
+object! {
+    unsafe pub struct NSDictionary<K, V>: NSObject {
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
-);
+}
 
 // TODO: SAFETY
 unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -4,10 +4,10 @@ use core::marker::PhantomData;
 use core::ops::Index;
 use core::ptr::{self, NonNull};
 
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
+use objc2::{msg_send, Message};
 
-use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator, NSObject};
+use super::{INSCopying, INSFastEnumeration, NSArray, NSEnumerator, NSObject};
 
 object! {
     unsafe pub struct NSDictionary<K, V>: NSObject {
@@ -20,7 +20,7 @@ object! {
 unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}
 unsafe impl<K: Sync + Send, V: Send> Send for NSDictionary<K, V> {}
 
-impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
+impl<K: Message, V: Message> NSDictionary<K, V> {
     unsafe_def_fn!(pub fn new -> Shared);
 
     #[doc(alias = "count")]
@@ -136,7 +136,7 @@ impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
     }
 }
 
-impl<K: INSObject, V: INSObject> DefaultId for NSDictionary<K, V> {
+impl<K: Message, V: Message> DefaultId for NSDictionary<K, V> {
     type Ownership = Shared;
 
     #[inline]
@@ -145,11 +145,11 @@ impl<K: INSObject, V: INSObject> DefaultId for NSDictionary<K, V> {
     }
 }
 
-unsafe impl<K: INSObject, V: INSObject> INSFastEnumeration for NSDictionary<K, V> {
+unsafe impl<K: Message, V: Message> INSFastEnumeration for NSDictionary<K, V> {
     type Item = K;
 }
 
-impl<'a, K: INSObject, V: INSObject> Index<&'a K> for NSDictionary<K, V> {
+impl<'a, K: Message, V: Message> Index<&'a K> for NSDictionary<K, V> {
     type Output = V;
 
     fn index<'s>(&'s self, index: &'a K) -> &'s V {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -9,6 +9,21 @@ use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
 
 use super::{INSCopying, INSFastEnumeration, INSObject, NSArray, NSEnumerator, NSObject};
 
+object! {
+    unsafe pub struct NSDictionary<K, V>: NSObject {
+        key: PhantomData<Id<K, Shared>>,
+        obj: PhantomData<Id<V, Owned>>,
+    }
+}
+
+// TODO: SAFETY
+unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}
+unsafe impl<K: Sync + Send, V: Send> Send for NSDictionary<K, V> {}
+
+impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
+    unsafe_def_fn!(pub fn new -> Shared);
+}
+
 unsafe fn from_refs<D, T>(keys: &[&T], vals: &[&D::Value]) -> Id<D, Shared>
 where
     D: INSDictionary + ?Sized,
@@ -136,21 +151,6 @@ pub unsafe trait INSDictionary: INSObject {
             Id::retain(NonNull::new_unchecked(vals))
         }
     }
-}
-
-object! {
-    unsafe pub struct NSDictionary<K, V>: NSObject {
-        key: PhantomData<Id<K, Shared>>,
-        obj: PhantomData<Id<V, Owned>>,
-    }
-}
-
-// TODO: SAFETY
-unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}
-unsafe impl<K: Sync + Send, V: Send> Send for NSDictionary<K, V> {}
-
-impl<K: INSObject, V: INSObject> NSDictionary<K, V> {
-    unsafe_def_fn!(pub fn new -> Shared);
 }
 
 impl<K: INSObject, V: INSObject> DefaultId for NSDictionary<K, V> {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -7,7 +7,7 @@ use core::ptr::{self, NonNull};
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
 use objc2::{msg_send, Message};
 
-use super::{INSCopying, INSFastEnumeration, NSArray, NSEnumerator, NSObject};
+use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
 
 object! {
     unsafe pub struct NSDictionary<K, V>: NSObject {
@@ -109,7 +109,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
 
     pub fn from_keys_and_objects<T>(keys: &[&T], vals: Vec<Id<V, Owned>>) -> Id<Self, Shared>
     where
-        T: INSCopying<Output = K>,
+        T: NSCopying<Output = K>,
     {
         let vals = vals.as_slice_ref();
 
@@ -145,7 +145,7 @@ impl<K: Message, V: Message> DefaultId for NSDictionary<K, V> {
     }
 }
 
-unsafe impl<K: Message, V: Message> INSFastEnumeration for NSDictionary<K, V> {
+unsafe impl<K: Message, V: Message> NSFastEnumeration for NSDictionary<K, V> {
     type Item = K;
 }
 

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -186,7 +186,7 @@ mod tests {
     use objc2::rc::{autoreleasepool, Id, Shared};
 
     use super::{INSDictionary, NSDictionary};
-    use crate::{INSArray, INSString, NSObject, NSString};
+    use crate::{INSString, NSObject, NSString};
 
     fn sample_dict(key: &str) -> Id<NSDictionary<NSString, NSObject>, Shared> {
         let string = NSString::from_str(key);

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -38,7 +38,7 @@ impl<'a, T: Message> Iterator for NSEnumerator<'a, T> {
     }
 }
 
-pub unsafe trait INSFastEnumeration: Message {
+pub unsafe trait NSFastEnumeration: Message {
     type Item: Message;
 
     fn iter_fast(&self) -> NSFastEnumerator<'_, Self> {
@@ -70,7 +70,7 @@ unsafe impl<T: Message> RefEncode for NSFastEnumerationState<T> {
     const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
 }
 
-fn enumerate<'a, 'b: 'a, C: INSFastEnumeration + ?Sized>(
+fn enumerate<'a, 'b: 'a, C: NSFastEnumeration + ?Sized>(
     object: &'b C,
     state: &mut NSFastEnumerationState<C::Item>,
     buf: &'a mut [*const C::Item],
@@ -95,7 +95,7 @@ fn enumerate<'a, 'b: 'a, C: INSFastEnumeration + ?Sized>(
 
 const FAST_ENUM_BUF_SIZE: usize = 16;
 
-pub struct NSFastEnumerator<'a, C: 'a + INSFastEnumeration + ?Sized> {
+pub struct NSFastEnumerator<'a, C: 'a + NSFastEnumeration + ?Sized> {
     object: &'a C,
 
     ptr: *const *const C::Item,
@@ -105,7 +105,7 @@ pub struct NSFastEnumerator<'a, C: 'a + INSFastEnumeration + ?Sized> {
     buf: [*const C::Item; FAST_ENUM_BUF_SIZE],
 }
 
-impl<'a, C: INSFastEnumeration + ?Sized> NSFastEnumerator<'a, C> {
+impl<'a, C: NSFastEnumeration + ?Sized> NSFastEnumerator<'a, C> {
     fn new(object: &'a C) -> Self {
         Self {
             object,
@@ -150,7 +150,7 @@ impl<'a, C: INSFastEnumeration + ?Sized> NSFastEnumerator<'a, C> {
     }
 }
 
-impl<'a, C: INSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
+impl<'a, C: NSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
     type Item = &'a C::Item;
 
     fn next(&mut self) -> Option<&'a C::Item> {
@@ -168,7 +168,7 @@ impl<'a, C: INSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
 
 #[cfg(test)]
 mod tests {
-    use super::INSFastEnumeration;
+    use super::NSFastEnumeration;
     use crate::{NSArray, NSValue};
 
     #[test]

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -171,7 +171,7 @@ impl<'a, C: INSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
 #[cfg(test)]
 mod tests {
     use super::INSFastEnumeration;
-    use crate::{INSArray, INSValue, NSArray, NSValue};
+    use crate::{INSValue, NSArray, NSValue};
 
     #[test]
     fn test_enumerator() {

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -171,7 +171,7 @@ impl<'a, C: INSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
 #[cfg(test)]
 mod tests {
     use super::INSFastEnumeration;
-    use crate::{INSValue, NSArray, NSValue};
+    use crate::{NSArray, NSValue};
 
     #[test]
     fn test_enumerator() {

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -21,7 +21,7 @@ extern crate std;
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
-pub use self::array::{INSArray, INSMutableArray, NSArray, NSMutableArray};
+pub use self::array::{INSArray, NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
 pub use self::copying::{INSCopying, INSMutableCopying};
 pub use self::data::{INSData, INSMutableData, NSData, NSMutableData};

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -27,7 +27,7 @@ pub use self::copying::{INSCopying, INSMutableCopying};
 pub use self::data::{NSData, NSMutableData};
 pub use self::dictionary::NSDictionary;
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
-pub use self::object::{INSObject, NSObject};
+pub use self::object::NSObject;
 pub use self::range::NSRange;
 pub use self::string::NSString;
 pub use self::value::NSValue;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -24,7 +24,7 @@ extern "C" {}
 pub use self::array::{NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
 pub use self::copying::{INSCopying, INSMutableCopying};
-pub use self::data::{INSData, NSData, NSMutableData};
+pub use self::data::{NSData, NSMutableData};
 pub use self::dictionary::{INSDictionary, NSDictionary};
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
 pub use self::object::{INSObject, NSObject};

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::dictionary::NSDictionary;
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
 pub use self::object::{INSObject, NSObject};
 pub use self::range::NSRange;
-pub use self::string::{INSString, NSString};
+pub use self::string::NSString;
 pub use self::value::{INSValue, NSValue};
 
 #[cfg(apple)]

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -21,7 +21,7 @@ extern crate std;
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
-pub use self::array::{INSArray, NSArray, NSMutableArray};
+pub use self::array::{NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
 pub use self::copying::{INSCopying, INSMutableCopying};
 pub use self::data::{INSData, NSData, NSMutableData};

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -24,7 +24,7 @@ extern "C" {}
 pub use self::array::{INSArray, NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
 pub use self::copying::{INSCopying, INSMutableCopying};
-pub use self::data::{INSData, INSMutableData, NSData, NSMutableData};
+pub use self::data::{INSData, NSData, NSMutableData};
 pub use self::dictionary::{INSDictionary, NSDictionary};
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
 pub use self::object::{INSObject, NSObject};

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -23,10 +23,10 @@ extern "C" {}
 
 pub use self::array::{NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
-pub use self::copying::{INSCopying, INSMutableCopying};
+pub use self::copying::{NSCopying, NSMutableCopying};
 pub use self::data::{NSData, NSMutableData};
 pub use self::dictionary::NSDictionary;
-pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
+pub use self::enumerator::{NSEnumerator, NSFastEnumeration, NSFastEnumerator};
 pub use self::object::NSObject;
 pub use self::range::NSRange;
 pub use self::string::NSString;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::array::{NSArray, NSMutableArray};
 pub use self::comparison_result::NSComparisonResult;
 pub use self::copying::{INSCopying, INSMutableCopying};
 pub use self::data::{NSData, NSMutableData};
-pub use self::dictionary::{INSDictionary, NSDictionary};
+pub use self::dictionary::NSDictionary;
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
 pub use self::object::{INSObject, NSObject};
 pub use self::range::NSRange;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
 pub use self::object::{INSObject, NSObject};
 pub use self::range::NSRange;
 pub use self::string::NSString;
-pub use self::value::{INSValue, NSValue};
+pub use self::value::NSValue;
 
 #[cfg(apple)]
 #[link(name = "Foundation", kind = "framework")]

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -115,7 +115,11 @@ macro_rules! object {
 }
 
 macro_rules! unsafe_def_fn {
-    ($v:vis fn new -> $o:ty) => {
+    (
+        $(#[$m:meta])*
+        $v:vis fn new -> $o:ty $(;)?
+    ) => {
+        $(#[$m])*
         $v fn new() -> Id<Self, $o> {
             let cls = <Self as INSObject>::class();
             unsafe { Id::new(NonNull::new_unchecked(msg_send![cls, new])) }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -100,7 +100,7 @@ macro_rules! object {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 use ::objc2::MessageReceiver;
                 use ::alloc::borrow::ToOwned;
-                use $crate::{INSObject, INSString, NSObject};
+                use $crate::{INSObject, NSObject};
                 // "downgrading" to  NSObject and calling `to_owned` to work
                 // around `f` and Self not being AutoreleaseSafe.
                 // TODO: Fix this!

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -7,6 +7,27 @@ use objc2::Message;
 
 use super::NSString;
 
+object! {
+    unsafe pub struct NSObject: Object;
+}
+
+/// ```compile_fail
+/// use objc2_foundation::NSObject;
+/// fn needs_sync<T: Sync>() {}
+/// needs_sync::<NSObject>();
+/// ```
+/// ```compile_fail
+/// use objc2_foundation::NSObject;
+/// fn needs_send<T: Send>() {}
+/// needs_send::<NSObject>();
+/// ```
+#[cfg(doctest)]
+pub struct NSObjectNotSendNorSync;
+
+impl NSObject {
+    unsafe_def_fn!(pub fn new -> Owned);
+}
+
 pub unsafe trait INSObject: Message {
     fn class() -> &'static Class;
 
@@ -31,27 +52,6 @@ pub unsafe trait INSObject: Message {
         let result: Bool = unsafe { msg_send![self, isKindOfClass: cls] };
         result.as_bool()
     }
-}
-
-object! {
-    unsafe pub struct NSObject: Object;
-}
-
-/// ```compile_fail
-/// use objc2_foundation::NSObject;
-/// fn needs_sync<T: Sync>() {}
-/// needs_sync::<NSObject>();
-/// ```
-/// ```compile_fail
-/// use objc2_foundation::NSObject;
-/// fn needs_send<T: Send>() {}
-/// needs_send::<NSObject>();
-/// ```
-#[cfg(doctest)]
-pub struct NSObjectNotSendNorSync;
-
-impl NSObject {
-    unsafe_def_fn!(pub fn new -> Owned);
 }
 
 impl DefaultId for NSObject {

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -3,7 +3,6 @@ use core::ptr::NonNull;
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Bool, Class, Object};
-use objc2::Message;
 
 use super::NSString;
 
@@ -26,21 +25,17 @@ pub struct NSObjectNotSendNorSync;
 
 impl NSObject {
     unsafe_def_fn!(pub fn new -> Owned);
-}
 
-pub unsafe trait INSObject: Message {
-    fn class() -> &'static Class;
-
-    fn hash_code(&self) -> usize {
+    pub fn hash_code(&self) -> usize {
         unsafe { msg_send![self, hash] }
     }
 
-    fn is_equal<T: INSObject>(&self, other: &T) -> bool {
+    pub fn is_equal(&self, other: &NSObject) -> bool {
         let result: Bool = unsafe { msg_send![self, isEqual: other] };
         result.as_bool()
     }
 
-    fn description(&self) -> Id<NSString, Shared> {
+    pub fn description(&self) -> Id<NSString, Shared> {
         unsafe {
             let result: *mut NSString = msg_send![self, description];
             // TODO: Verify that description always returns a non-null string
@@ -48,7 +43,7 @@ pub unsafe trait INSObject: Message {
         }
     }
 
-    fn is_kind_of(&self, cls: &Class) -> bool {
+    pub fn is_kind_of(&self, cls: &Class) -> bool {
         let result: Bool = unsafe { msg_send![self, isKindOfClass: cls] };
         result.as_bool()
     }
@@ -65,7 +60,7 @@ impl DefaultId for NSObject {
 
 #[cfg(test)]
 mod tests {
-    use super::{INSObject, NSObject};
+    use super::NSObject;
     use crate::NSString;
     use alloc::format;
 

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -1,4 +1,3 @@
-use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use objc2::msg_send;
@@ -34,9 +33,9 @@ pub unsafe trait INSObject: Message {
     }
 }
 
-object!(unsafe pub struct NSObject<> {
-    p: PhantomData<Object>, // Temporary
-});
+object! {
+    unsafe pub struct NSObject: Object;
+}
 
 /// ```compile_fail
 /// use objc2_foundation::NSObject;

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -12,7 +12,7 @@ use objc2::rc::DefaultId;
 use objc2::rc::{autoreleasepool, AutoreleasePool};
 use objc2::rc::{Id, Shared};
 
-use super::{INSCopying, NSObject};
+use super::{NSCopying, NSObject};
 
 #[cfg(apple)]
 const UTF8_ENCODING: usize = 4;
@@ -121,7 +121,7 @@ impl DefaultId for NSString {
     }
 }
 
-unsafe impl INSCopying for NSString {
+unsafe impl NSCopying for NSString {
     type Ownership = Shared;
     type Output = NSString;
 }

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -23,6 +23,18 @@ const UTF8_ENCODING: i32 = 4;
 #[allow(non_upper_case_globals)]
 const NSNotFound: ffi::NSInteger = ffi::NSIntegerMax;
 
+object! {
+    unsafe pub struct NSString: NSObject;
+}
+
+// TODO: SAFETY
+unsafe impl Sync for NSString {}
+unsafe impl Send for NSString {}
+
+impl NSString {
+    unsafe_def_fn!(pub fn new -> Shared);
+}
+
 pub unsafe trait INSString: INSObject {
     fn len(&self) -> usize {
         unsafe { msg_send![self, lengthOfBytesUsingEncoding: UTF8_ENCODING] }
@@ -100,18 +112,6 @@ pub unsafe trait INSString: INSObject {
             Id::new(NonNull::new_unchecked(obj))
         }
     }
-}
-
-object! {
-    unsafe pub struct NSString: NSObject;
-}
-
-// TODO: SAFETY
-unsafe impl Sync for NSString {}
-unsafe impl Send for NSString {}
-
-impl NSString {
-    unsafe_def_fn!(pub fn new -> Shared);
 }
 
 impl DefaultId for NSString {

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -33,14 +33,12 @@ unsafe impl Send for NSString {}
 
 impl NSString {
     unsafe_def_fn!(pub fn new -> Shared);
-}
 
-pub unsafe trait INSString: INSObject {
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         unsafe { msg_send![self, lengthOfBytesUsingEncoding: UTF8_ENCODING] }
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -48,7 +46,7 @@ pub unsafe trait INSString: INSObject {
     ///
     /// ```compile_fail
     /// # use objc2::rc::autoreleasepool;
-    /// # use objc2_foundation::{INSObject, INSString, NSString};
+    /// # use objc2_foundation::{INSObject, NSString};
     /// autoreleasepool(|pool| {
     ///     let ns_string = NSString::new();
     ///     let s = ns_string.as_str(pool);
@@ -59,11 +57,11 @@ pub unsafe trait INSString: INSObject {
     ///
     /// ```compile_fail
     /// # use objc2::rc::autoreleasepool;
-    /// # use objc2_foundation::{INSObject, INSString, NSString};
+    /// # use objc2_foundation::{INSObject, NSString};
     /// let ns_string = NSString::new();
     /// let s = autoreleasepool(|pool| ns_string.as_str(pool));
     /// ```
-    fn as_str<'r, 's: 'r, 'p: 'r>(&'s self, pool: &'p AutoreleasePool) -> &'r str {
+    pub fn as_str<'r, 's: 'r, 'p: 'r>(&'s self, pool: &'p AutoreleasePool) -> &'r str {
         // This is necessary until `auto` types stabilizes.
         pool.__verify_is_inner();
 
@@ -98,7 +96,7 @@ pub unsafe trait INSString: INSObject {
         str::from_utf8(bytes).unwrap()
     }
 
-    fn from_str(string: &str) -> Id<Self, Shared> {
+    pub fn from_str(string: &str) -> Id<Self, Shared> {
         let cls = Self::class();
         let bytes = string.as_ptr() as *const c_void;
         unsafe {
@@ -122,8 +120,6 @@ impl DefaultId for NSString {
         Self::new()
     }
 }
-
-unsafe impl INSString for NSString {}
 
 unsafe impl INSCopying for NSString {
     type Ownership = Shared;

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -12,7 +12,7 @@ use objc2::rc::DefaultId;
 use objc2::rc::{autoreleasepool, AutoreleasePool};
 use objc2::rc::{Id, Shared};
 
-use super::{INSCopying, INSObject, NSObject};
+use super::{INSCopying, NSObject};
 
 #[cfg(apple)]
 const UTF8_ENCODING: usize = 4;
@@ -46,7 +46,7 @@ impl NSString {
     ///
     /// ```compile_fail
     /// # use objc2::rc::autoreleasepool;
-    /// # use objc2_foundation::{INSObject, NSString};
+    /// # use objc2_foundation::NSString;
     /// autoreleasepool(|pool| {
     ///     let ns_string = NSString::new();
     ///     let s = ns_string.as_str(pool);
@@ -57,7 +57,7 @@ impl NSString {
     ///
     /// ```compile_fail
     /// # use objc2::rc::autoreleasepool;
-    /// # use objc2_foundation::{INSObject, NSString};
+    /// # use objc2_foundation::NSString;
     /// let ns_string = NSString::new();
     /// let s = autoreleasepool(|pool| ns_string.as_str(pool));
     /// ```

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -12,7 +12,7 @@ use objc2::rc::DefaultId;
 use objc2::rc::{autoreleasepool, AutoreleasePool};
 use objc2::rc::{Id, Shared};
 
-use super::{INSCopying, INSObject};
+use super::{INSCopying, INSObject, NSObject};
 
 #[cfg(apple)]
 const UTF8_ENCODING: usize = 4;
@@ -102,7 +102,9 @@ pub unsafe trait INSString: INSObject {
     }
 }
 
-object!(unsafe pub struct NSString);
+object! {
+    unsafe pub struct NSString: NSObject;
+}
 
 // TODO: SAFETY
 unsafe impl Sync for NSString {}

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -12,7 +12,7 @@ use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
 
-use super::{INSCopying, INSObject};
+use super::{INSCopying, INSObject, NSObject};
 
 pub unsafe trait INSValue: INSObject {
     type Value: 'static + Copy + Encode;
@@ -73,11 +73,11 @@ pub unsafe trait INSValue: INSObject {
     }
 }
 
-object!(
-    unsafe pub struct NSValue<T> {
+object! {
+    unsafe pub struct NSValue<T>: NSObject {
         value: PhantomData<T>,
     }
-);
+}
 
 // TODO: SAFETY
 unsafe impl<T: Sync> Sync for NSValue<T> {}

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -12,7 +12,7 @@ use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
 
-use super::{INSCopying, NSObject};
+use super::{NSCopying, NSObject};
 
 object! {
     unsafe pub struct NSValue<T>: NSObject {
@@ -78,7 +78,7 @@ impl<T: 'static + Copy + Encode> NSValue<T> {
     }
 }
 
-unsafe impl<T: 'static> INSCopying for NSValue<T> {
+unsafe impl<T: 'static> NSCopying for NSValue<T> {
     type Ownership = Shared;
     type Output = NSValue<T>;
 }

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -12,7 +12,7 @@ use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
 
-use super::{INSCopying, INSObject, NSObject};
+use super::{INSCopying, NSObject};
 
 object! {
     unsafe pub struct NSValue<T>: NSObject {

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -24,9 +24,7 @@ object! {
 unsafe impl<T: Sync> Sync for NSValue<T> {}
 unsafe impl<T: Send> Send for NSValue<T> {}
 
-pub unsafe trait INSValue: INSObject {
-    type Value: 'static + Copy + Encode;
-
+impl<T: 'static + Copy + Encode> NSValue<T> {
     // Default / empty new is not provided because `-init` returns `nil` on
     // Apple and GNUStep throws an exception on all other messages to this
     // invalid instance.
@@ -37,13 +35,10 @@ pub unsafe trait INSValue: INSObject {
     /// [gnustep/libs-base#216].
     ///
     /// [gnustep/libs-base#216]: https://github.com/gnustep/libs-base/pull/216
-    fn get(&self) -> Self::Value {
+    pub fn get(&self) -> T {
         if let Some(encoding) = self.encoding() {
             // TODO: This can be a debug assertion (?)
-            assert!(
-                Self::Value::ENCODING.equivalent_to_str(encoding),
-                "Wrong encoding"
-            );
+            assert!(T::ENCODING.equivalent_to_str(encoding), "Wrong encoding");
             unsafe { self.get_unchecked() }
         } else {
             panic!("Missing NSValue encoding");
@@ -55,22 +50,22 @@ pub unsafe trait INSValue: INSObject {
     /// # Safety
     ///
     /// The user must ensure that the inner value is properly initialized.
-    unsafe fn get_unchecked(&self) -> Self::Value {
-        let mut value = MaybeUninit::<Self::Value>::uninit();
+    pub unsafe fn get_unchecked(&self) -> T {
+        let mut value = MaybeUninit::<T>::uninit();
         let ptr = value.as_mut_ptr() as *mut c_void;
         let _: () = unsafe { msg_send![self, getValue: ptr] };
         unsafe { value.assume_init() }
     }
 
-    fn encoding(&self) -> Option<&str> {
+    pub fn encoding(&self) -> Option<&str> {
         let result: Option<NonNull<c_char>> = unsafe { msg_send![self, objCType] };
         result.map(|s| unsafe { CStr::from_ptr(s.as_ptr()) }.to_str().unwrap())
     }
 
-    fn new(value: Self::Value) -> Id<Self, Shared> {
+    pub fn new(value: T) -> Id<Self, Shared> {
         let cls = Self::class();
-        let bytes = &value as *const Self::Value as *const c_void;
-        let encoding = CString::new(Self::Value::ENCODING.to_string()).unwrap();
+        let bytes = &value as *const T as *const c_void;
+        let encoding = CString::new(T::ENCODING.to_string()).unwrap();
         unsafe {
             let obj: *mut Self = msg_send![cls, alloc];
             let obj: *mut Self = msg_send![
@@ -81,10 +76,6 @@ pub unsafe trait INSValue: INSObject {
             Id::new(NonNull::new_unchecked(obj))
         }
     }
-}
-
-unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {
-    type Value = T;
 }
 
 unsafe impl<T: 'static> INSCopying for NSValue<T> {
@@ -131,7 +122,7 @@ pub struct NSValueFloatNotEq;
 mod tests {
     use alloc::format;
 
-    use crate::{INSValue, NSRange, NSValue};
+    use crate::{NSRange, NSValue};
     use objc2::rc::{Id, Shared};
     use objc2::Encode;
 

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -14,6 +14,16 @@ use objc2::Encode;
 
 use super::{INSCopying, INSObject, NSObject};
 
+object! {
+    unsafe pub struct NSValue<T>: NSObject {
+        value: PhantomData<T>,
+    }
+}
+
+// TODO: SAFETY
+unsafe impl<T: Sync> Sync for NSValue<T> {}
+unsafe impl<T: Send> Send for NSValue<T> {}
+
 pub unsafe trait INSValue: INSObject {
     type Value: 'static + Copy + Encode;
 
@@ -72,16 +82,6 @@ pub unsafe trait INSValue: INSObject {
         }
     }
 }
-
-object! {
-    unsafe pub struct NSValue<T>: NSObject {
-        value: PhantomData<T>,
-    }
-}
-
-// TODO: SAFETY
-unsafe impl<T: Sync> Sync for NSValue<T> {}
-unsafe impl<T: Send> Send for NSValue<T> {}
 
 unsafe impl<T: 'static + Copy + Encode> INSValue for NSValue<T> {
     type Value = T;

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -499,6 +499,7 @@ mod tests {
         });
 
         // make sure that the autoreleased value has been released
+        // TODO: Investigate if this is flaky on GNUStep
         assert_eq!(retain_count(&*cloned), 1);
     }
 


### PR DESCRIPTION
Huge part of https://github.com/madsmtm/objc2/issues/58.

Also renamed protocols, now that the possible confusion from them is gone.

(Yes, there exists both the `NSObject` class and the `NSObject` protocol, but that is something we'll paper over).