### PR TITLE
Add `msg_send_id!`

### DIFF
--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -5,7 +5,7 @@ use std::sync::Once;
 use objc2::declare::ClassBuilder;
 use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::{Class, Object, Sel};
-use objc2::{msg_send, sel};
+use objc2::{msg_send, msg_send_id, sel};
 use objc2::{Encoding, Message, RefEncode};
 use objc2_foundation::NSObject;
 
@@ -28,9 +28,8 @@ static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 impl<'a> MyObject<'a> {
     fn new(number_ptr: &'a mut u8) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithPtr: number_ptr];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithPtr: number_ptr].unwrap()
         }
     }
 

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -3,7 +3,7 @@ use std::sync::Once;
 use objc2::declare::ClassBuilder;
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object, Sel};
-use objc2::{msg_send, sel};
+use objc2::{msg_send, msg_send_id, sel};
 use objc2::{Encoding, Message, RefEncode};
 use objc2_foundation::NSObject;
 
@@ -25,7 +25,7 @@ static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 impl MYObject {
     fn new() -> Id<Self, Owned> {
         let cls = Self::class();
-        unsafe { Id::new(msg_send![cls, new]).unwrap() }
+        unsafe { msg_send_id![cls, new].unwrap() }
     }
 
     fn number(&self) -> u32 {

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -1,6 +1,6 @@
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::runtime::Object;
+use objc2::{msg_send, msg_send_id};
 
 use crate::{
     NSCopying, NSDictionary, NSMutableAttributedString, NSMutableCopying, NSObject, NSString,
@@ -47,9 +47,8 @@ impl NSAttributedString {
         attributes: &NSDictionary<NSAttributedStringKey, Object>,
     ) -> Id<Self, Shared> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithString: string, attributes: attributes];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithString: string, attributes: attributes].unwrap()
         }
     }
 
@@ -57,9 +56,8 @@ impl NSAttributedString {
     #[doc(alias = "initWithString:")]
     pub fn from_nsstring(string: &NSString) -> Id<Self, Shared> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithString: string].unwrap()
         }
     }
 }
@@ -67,8 +65,8 @@ impl NSAttributedString {
 /// Querying.
 impl NSAttributedString {
     // TODO: Lifetimes?
-    pub fn string(&self) -> &NSString {
-        unsafe { msg_send![self, string] }
+    pub fn string(&self) -> Id<NSString, Shared> {
+        unsafe { msg_send_id![self, string].unwrap() }
     }
 
     /// Alias for `self.string().len_utf16()`.

--- a/objc2-foundation/src/copying.rs
+++ b/objc2-foundation/src/copying.rs
@@ -1,5 +1,5 @@
 use objc2::rc::{Id, Owned, Ownership};
-use objc2::{msg_send, Message};
+use objc2::{msg_send_id, Message};
 
 pub unsafe trait NSCopying: Message {
     /// Indicates whether the type is mutable or immutable.
@@ -31,10 +31,7 @@ pub unsafe trait NSCopying: Message {
     type Output: Message;
 
     fn copy(&self) -> Id<Self::Output, Self::Ownership> {
-        unsafe {
-            let obj: *mut Self::Output = msg_send![self, copy];
-            Id::new(obj).unwrap()
-        }
+        unsafe { msg_send_id![self, copy].unwrap() }
     }
 }
 
@@ -46,9 +43,6 @@ pub unsafe trait NSMutableCopying: Message {
     type Output: Message;
 
     fn mutable_copy(&self) -> Id<Self::Output, Owned> {
-        unsafe {
-            let obj: *mut Self::Output = msg_send![self, mutableCopy];
-            Id::new(obj).unwrap()
-        }
+        unsafe { msg_send_id![self, mutableCopy].unwrap() }
     }
 }

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -5,9 +5,9 @@ use core::ops::{Index, IndexMut, Range};
 use core::slice::{self, SliceIndex};
 use std::io;
 
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
+use objc2::{msg_send, msg_send_id};
 
 use super::{NSCopying, NSMutableCopying, NSObject, NSRange};
 
@@ -147,18 +147,16 @@ impl NSMutableData {
     pub fn from_data(data: &NSData) -> Id<Self, Owned> {
         // Not provided on NSData, one should just use NSData::copy or similar
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithData: data];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithData: data].unwrap()
         }
     }
 
     #[doc(alias = "initWithCapacity:")]
     pub fn with_capacity(capacity: usize) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithCapacity: capacity];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithCapacity: capacity].unwrap()
         }
     }
 }

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -5,7 +5,7 @@ use core::ops::Index;
 use core::ptr;
 
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
-use objc2::{msg_send, Message};
+use objc2::{msg_send, msg_send_id, Message};
 
 use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
 
@@ -101,10 +101,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     }
 
     pub fn keys_array(&self) -> Id<NSArray<K, Shared>, Shared> {
-        unsafe {
-            let keys = msg_send![self, allKeys];
-            Id::retain_autoreleased(keys).unwrap()
-        }
+        unsafe { msg_send_id![self, allKeys] }.unwrap()
     }
 
     pub fn from_keys_and_objects<T>(keys: &[&T], vals: Vec<Id<V, Owned>>) -> Id<Self, Shared>
@@ -115,23 +112,20 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
 
         let cls = Self::class();
         let count = min(keys.len(), vals.len());
-        let obj: *mut Self = unsafe { msg_send![cls, alloc] };
-        let obj: *mut Self = unsafe {
-            msg_send![
+        let obj = unsafe { msg_send_id![cls, alloc] };
+        unsafe {
+            msg_send_id![
                 obj,
                 initWithObjects: vals.as_ptr(),
                 forKeys: keys.as_ptr(),
                 count: count,
             ]
-        };
-        unsafe { Id::new(obj).unwrap() }
+        }
+        .unwrap()
     }
 
     pub fn into_values_array(dict: Id<Self, Owned>) -> Id<NSArray<V, Owned>, Shared> {
-        unsafe {
-            let vals = msg_send![&dict, allValues];
-            Id::retain_autoreleased(vals).unwrap()
-        }
+        unsafe { msg_send_id![&dict, allValues] }.unwrap()
     }
 }
 

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -227,7 +227,7 @@ macro_rules! unsafe_def_fn {
         $(#[$m])*
         $v fn new() -> Id<Self, $o> {
             let cls = Self::class();
-            unsafe { Id::new(msg_send![cls, new]).unwrap() }
+            unsafe { ::objc2::msg_send_id![cls, new].unwrap() }
         }
     };
 }

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -1,5 +1,5 @@
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{msg_send, msg_send_id};
 
 use crate::{NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
 
@@ -26,18 +26,16 @@ impl NSMutableAttributedString {
     #[doc(alias = "initWithString:")]
     pub fn from_nsstring(string: &NSString) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithString: string].unwrap()
         }
     }
 
     #[doc(alias = "initWithAttributedString:")]
     pub fn from_attributed_nsstring(attributed_string: &NSAttributedString) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithAttributedString: attributed_string];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithAttributedString: attributed_string].unwrap()
         }
     }
 }

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -3,8 +3,8 @@ use core::fmt;
 use core::ops::AddAssign;
 use core::str;
 
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{msg_send, msg_send_id};
 
 use crate::{NSCopying, NSMutableCopying, NSObject, NSString};
 
@@ -39,18 +39,16 @@ impl NSMutableString {
     #[doc(alias = "initWithString:")]
     pub fn from_nsstring(string: &NSString) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithString: string].unwrap()
         }
     }
 
     #[doc(alias = "initWithCapacity:")]
     pub fn with_capacity(capacity: usize) -> Id<Self, Owned> {
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithCapacity: capacity];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithCapacity: capacity].unwrap()
         }
     }
 }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -1,6 +1,6 @@
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
-use objc2::{msg_send, msg_send_bool};
+use objc2::{msg_send, msg_send_bool, msg_send_id};
 
 use super::NSString;
 
@@ -21,11 +21,8 @@ impl NSObject {
     }
 
     pub fn description(&self) -> Id<NSString, Shared> {
-        unsafe {
-            let result: *mut NSString = msg_send![self, description];
-            // TODO: Verify that description always returns a non-null string
-            Id::retain_autoreleased(result).unwrap()
-        }
+        // TODO: Verify that description always returns a non-null string
+        unsafe { msg_send_id![self, description].unwrap() }
     }
 
     pub fn is_kind_of(&self, cls: &Class) -> bool {

--- a/objc2-foundation/src/process_info.rs
+++ b/objc2-foundation/src/process_info.rs
@@ -1,4 +1,4 @@
-use objc2::msg_send;
+use objc2::msg_send_id;
 use objc2::rc::{Id, Shared};
 
 use crate::{NSObject, NSString};
@@ -20,13 +20,11 @@ unsafe impl Sync for NSProcessInfo {}
 impl NSProcessInfo {
     pub fn process_info() -> Id<NSProcessInfo, Shared> {
         // currentThread is @property(strong), what does that mean?
-        let obj: *mut Self = unsafe { msg_send![Self::class(), processInfo] };
         // TODO: Always available?
-        unsafe { Id::retain_autoreleased(obj).unwrap() }
+        unsafe { msg_send_id![Self::class(), processInfo].unwrap() }
     }
 
     pub fn process_name(&self) -> Id<NSString, Shared> {
-        let obj: *mut NSString = unsafe { msg_send![Self::class(), processName] };
-        unsafe { Id::retain_autoreleased(obj).unwrap() }
+        unsafe { msg_send_id![self, processName].unwrap() }
     }
 }

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -1,5 +1,5 @@
 use objc2::rc::{Id, Shared};
-use objc2::{msg_send, msg_send_bool};
+use objc2::{msg_send, msg_send_bool, msg_send_id};
 
 use crate::{NSObject, NSString};
 
@@ -15,20 +15,18 @@ unsafe impl Sync for NSThread {}
 
 impl NSThread {
     /// Returns the [`NSThread`] object representing the current thread.
-    pub fn current() -> Id<NSThread, Shared> {
+    pub fn current() -> Id<Self, Shared> {
         // TODO: currentThread is @property(strong), what does that mean?
-        let obj: *mut Self = unsafe { msg_send![Self::class(), currentThread] };
         // TODO: Always available?
-        unsafe { Id::retain_autoreleased(obj).unwrap() }
+        unsafe { msg_send_id![Self::class(), currentThread].unwrap() }
     }
 
     /// Returns the [`NSThread`] object representing the main thread.
     pub fn main() -> Id<NSThread, Shared> {
         // TODO: mainThread is @property(strong), what does that mean?
-        let obj: *mut Self = unsafe { msg_send![Self::class(), mainThread] };
         // The main thread static may not have been initialized
         // This can at least fail in GNUStep!
-        unsafe { Id::retain_autoreleased(obj).expect("Could not retrieve main thread.") }
+        unsafe { msg_send_id![Self::class(), mainThread] }.expect("Could not retrieve main thread.")
     }
 
     /// Returns `true` if the thread is the main thread.
@@ -38,13 +36,11 @@ impl NSThread {
 
     /// The name of the thread.
     pub fn name(&self) -> Option<Id<NSString, Shared>> {
-        let obj: *mut NSString = unsafe { msg_send![self, name] };
-        unsafe { Id::retain_autoreleased(obj) }
+        unsafe { msg_send_id![self, name] }
     }
 
     fn new() -> Id<Self, Shared> {
-        let obj: *mut Self = unsafe { msg_send![Self::class(), new] };
-        unsafe { Id::new(obj) }.unwrap()
+        unsafe { msg_send_id![Self::class(), new] }.unwrap()
     }
 
     fn start(&self) {

--- a/objc2-foundation/src/uuid.rs
+++ b/objc2-foundation/src/uuid.rs
@@ -1,5 +1,5 @@
 use objc2::rc::{Id, Shared};
-use objc2::{msg_send, Encode, Encoding, RefEncode};
+use objc2::{msg_send, msg_send_id, Encode, Encoding, RefEncode};
 
 use super::{NSCopying, NSObject};
 
@@ -32,19 +32,14 @@ impl NSUUID {
     // TODO: `nil` method?
 
     pub fn new_v4() -> Id<Self, Shared> {
-        unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, init];
-            Id::new(obj).unwrap()
-        }
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
     pub fn from_bytes(bytes: [u8; 16]) -> Id<Self, Shared> {
         let bytes = UuidBytes(bytes);
         unsafe {
-            let obj: *mut Self = msg_send![Self::class(), alloc];
-            let obj: *mut Self = msg_send![obj, initWithUUIDBytes: &bytes];
-            Id::new(obj).unwrap()
+            let obj = msg_send_id![Self::class(), alloc];
+            msg_send_id![obj, initWithUUIDBytes: &bytes].unwrap()
         }
     }
 

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -8,9 +8,9 @@ use core::{fmt, str};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
+use objc2::{msg_send, msg_send_id};
 
 use super::{NSCopying, NSObject};
 
@@ -68,13 +68,13 @@ impl<T: 'static + Copy + Encode> NSValue<T> {
         let bytes: *const c_void = bytes.cast();
         let encoding = CString::new(T::ENCODING.to_string()).unwrap();
         unsafe {
-            let obj: *mut Self = msg_send![cls, alloc];
-            let obj: *mut Self = msg_send![
+            let obj = msg_send_id![cls, alloc];
+            msg_send_id![
                 obj,
                 initWithBytes: bytes,
                 objCType: encoding.as_ptr(),
-            ];
-            Id::new(obj).unwrap()
+            ]
+            .unwrap()
         }
     }
 }

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `msg_send_id!` to help with following Objective-C's memory management
+  rules. **It is highly recommended that you use this instead of doing memory
+  management yourself!**
+
+  Example:
+  ```rust
+  // Before
+  let obj: Id<Object, Shared> = unsafe {
+      let obj: *mut Self = msg_send![Self::class(), alloc];
+      let obj: *mut Self = msg_send![obj, init];
+      Id::new(obj).unwrap()
+  };
+
+  // After
+  let obj: Id<Object, Shared> = unsafe {
+      msg_send_id![msg_send_id![Self::class(), alloc], new].unwrap()
+  };
+  ```
+
 
 ## 0.3.0-beta.0 - 2022-06-13
 

--- a/objc2/README.md
+++ b/objc2/README.md
@@ -13,16 +13,16 @@ written in Objective-C; this crate enables you to interract with those.
 ## Example
 
 ```rust
-use objc2::{class, msg_send_id};
+use objc2::{class, msg_send, msg_send_id};
+use objc2::ffi::NSUInteger;
 use objc2::rc::{Id, Owned};
-use objc2::runtime::{Class, Object};
+use objc2::runtime::Object;
 
 let cls = class!(NSObject);
 let obj: Id<Object, Owned> = unsafe { msg_send_id![cls, new] }.unwrap();
 
-// TODO
-// let isa = unsafe { obj.ivar::<Class>("isa") };
-// assert_eq!(cls, isa);
+let hash: NSUInteger = unsafe { msg_send![&obj, hash] };
+println!("NSObject hash: {}", hash);
 ```
 
 See [the docs](https://docs.rs/objc2/) for a more thorough overview, or jump

--- a/objc2/README.md
+++ b/objc2/README.md
@@ -13,13 +13,12 @@ written in Objective-C; this crate enables you to interract with those.
 ## Example
 
 ```rust
-use objc2::{class, msg_send};
+use objc2::{class, msg_send_id};
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
 
 let cls = class!(NSObject);
-let obj: *mut Object = unsafe { msg_send![cls, new] };
-let obj: Id<Object, Owned> = unsafe { Id::new(obj).unwrap() };
+let obj: Id<Object, Owned> = unsafe { msg_send_id![cls, new] }.unwrap();
 
 // TODO
 // let isa = unsafe { obj.ivar::<Class>("isa") };

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -1,6 +1,6 @@
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
-use objc2::{class, msg_send};
+use objc2::{class, msg_send, msg_send_id};
 #[cfg(feature = "malloc")]
 use objc2::{sel, Encode};
 
@@ -20,9 +20,8 @@ fn main() {
 
     // Allocate an instance
     let obj: Id<Object, Owned> = unsafe {
-        let obj: *mut Object = msg_send![cls, alloc];
-        let obj: *mut Object = msg_send![obj, init];
-        Id::new(obj).unwrap()
+        let obj = msg_send_id![cls, alloc];
+        msg_send_id![obj, init].unwrap()
     };
     println!("NSObject address: {:p}", obj);
 

--- a/objc2/examples/talk_to_me.rs
+++ b/objc2/examples/talk_to_me.rs
@@ -1,7 +1,7 @@
 use objc2::ffi::NSUInteger;
 use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::Object;
-use objc2::{class, msg_send};
+use objc2::{class, msg_send, msg_send_id};
 use std::ffi::c_void;
 
 #[cfg(feature = "apple")] // Does not work on GNUStep
@@ -13,24 +13,24 @@ fn main() {
     let text = "Hello from Rust!";
     const UTF8_ENCODING: NSUInteger = 4;
 
-    let string: *const Object = unsafe { msg_send![class!(NSString), alloc] };
+    let string = unsafe { msg_send_id![class!(NSString), alloc] };
     let text_ptr: *const c_void = text.as_ptr().cast();
-    let string = unsafe {
-        msg_send![
+    let string: Id<Object, Shared> = unsafe {
+        msg_send_id![
             string,
             initWithBytes: text_ptr,
             length: text.len(),
             encoding: UTF8_ENCODING,
         ]
-    };
-    let string: Id<Object, Shared> = unsafe { Id::new(string).unwrap() };
+    }
+    .unwrap();
 
-    let synthesizer: *mut Object = unsafe { msg_send![class!(AVSpeechSynthesizer), new] };
-    let synthesizer: Id<Object, Owned> = unsafe { Id::new(synthesizer).unwrap() };
+    let synthesizer: Id<Object, Owned> =
+        unsafe { msg_send_id![class!(AVSpeechSynthesizer), new] }.unwrap();
 
-    let utterance: *mut Object = unsafe { msg_send![class!(AVSpeechUtterance), alloc] };
-    let utterance: *mut Object = unsafe { msg_send![utterance, initWithString: &*string] };
-    let utterance: Id<Object, Owned> = unsafe { Id::new(utterance).unwrap() };
+    let utterance = unsafe { msg_send_id![class!(AVSpeechUtterance), alloc] };
+    let utterance: Id<Object, Owned> =
+        unsafe { msg_send_id![utterance, initWithString: &*string] }.unwrap();
 
     // let _: () = unsafe { msg_send![&utterance, setVolume: 90.0f32 };
     // let _: () = unsafe { msg_send![&utterance, setRate: 0.50f32 };

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -20,11 +20,11 @@ pub trait MsgSendId<T, U> {
         obj: T,
         sel: Sel,
         args: A,
-    ) -> Result<U, MessageError>;
+    ) -> Result<Option<U>, MessageError>;
 }
 
 // `new`
-impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Option<Id<T, O>>>
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Id<T, O>>
     for Assert<true, false, false, false>
 {
     #[inline(always)]
@@ -38,7 +38,7 @@ impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Option<Id<T, O>>>
 }
 
 // `alloc`, should mark the return value as "allocated, not initialized" somehow
-impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Option<Id<T, O>>>
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Id<T, O>>
     for Assert<false, true, false, false>
 {
     #[inline(always)]
@@ -54,7 +54,7 @@ impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Option<Id<T, O>>>
 // `init`, should mark the input value as "allocated, not initialized" somehow
 //
 // The generic bound allows `init` to take both `Option<Id>` and `Id`.
-impl<X: Into<Option<Id<T, O>>>, T: ?Sized + Message, O: Ownership> MsgSendId<X, Option<Id<T, O>>>
+impl<X: Into<Option<Id<T, O>>>, T: ?Sized + Message, O: Ownership> MsgSendId<X, Id<T, O>>
     for Assert<false, false, true, false>
 {
     #[inline(always)]
@@ -75,7 +75,7 @@ impl<X: Into<Option<Id<T, O>>>, T: ?Sized + Message, O: Ownership> MsgSendId<X, 
 }
 
 // `copy` and `mutableCopy`
-impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, Option<Id<U, O>>>
+impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, Id<U, O>>
     for Assert<false, false, false, true>
 {
     #[inline(always)]
@@ -89,7 +89,7 @@ impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, Option<
 }
 
 // All other selectors
-impl<T: MessageReceiver, U: Message, O: Ownership> MsgSendId<T, Option<Id<U, O>>>
+impl<T: MessageReceiver, U: Message, O: Ownership> MsgSendId<T, Id<U, O>>
     for Assert<false, false, false, false>
 {
     #[inline(always)]

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -78,18 +78,16 @@ impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Id<T, O>>
 }
 
 // `init`, should mark the input value as "allocated, not initialized" somehow
-//
-// The generic bound allows `init` to take both `Option<Id>` and `Id`.
-impl<X: Into<Option<Id<T, O>>>, T: ?Sized + Message, O: Ownership> MsgSendId<X, Id<T, O>>
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<Option<Id<T, O>>, Id<T, O>>
     for RetainSemantics<false, false, true, false>
 {
     #[inline(always)]
     unsafe fn send_message_id<A: MessageArguments>(
-        obj: X,
+        obj: Option<Id<T, O>>,
         sel: Sel,
         args: A,
     ) -> Result<Option<Id<T, O>>, MessageError> {
-        let ptr = Id::option_into_ptr(obj.into());
+        let ptr = Id::option_into_ptr(obj);
         // SAFETY: `ptr` may be null here, but that's fine since the return
         // is `*mut T`, which is one of the few types where messages to nil is
         // allowed.
@@ -242,7 +240,7 @@ mod tests {
         expected.alloc += 1;
         // Check allocation error before init
         let obj = obj.unwrap();
-        let _obj: Id<RcTestObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+        let _obj: Id<RcTestObject, Shared> = unsafe { msg_send_id![Some(obj), init].unwrap() };
         expected.init += 1;
         expected.assert_current();
     }

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -3,6 +3,9 @@ use crate::runtime::{Class, Sel};
 use crate::{Message, MessageArguments, MessageError, MessageReceiver};
 
 #[doc(hidden)]
+pub use core::compile_error;
+
+#[doc(hidden)]
 pub struct Assert<const ALLOC: bool, const INIT: bool, const RETAINED: bool> {}
 
 #[doc(hidden)]

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -1,0 +1,129 @@
+use core::mem::ManuallyDrop;
+
+use crate::rc::{Id, Ownership};
+use crate::runtime::{Class, Sel};
+use crate::{Message, MessageArguments, MessageError, MessageReceiver};
+
+#[doc(hidden)]
+pub struct Assert<const ALLOC: bool, const INIT: bool, const RETAINED: bool> {}
+
+#[doc(hidden)]
+pub trait MsgSendId<T, U> {
+    unsafe fn send_message_id<A: MessageArguments>(
+        obj: T,
+        sel: Sel,
+        args: A,
+    ) -> Result<U, MessageError>;
+}
+
+// `alloc`, should mark the return value as "allocated, not initialized" somehow
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<&'_ Class, Id<T, O>>
+    for Assert<true, false, true>
+{
+    #[inline(always)]
+    unsafe fn send_message_id<A: MessageArguments>(
+        cls: &Class,
+        sel: Sel,
+        args: A,
+    ) -> Result<Id<T, O>, MessageError> {
+        unsafe {
+            MessageReceiver::send_message(cls, sel, args)
+                .map(|r| Id::new(r).expect("Failed allocating"))
+        }
+    }
+}
+
+// `init`, should mark the input value as "allocated, not initialized" somehow
+impl<T: ?Sized + Message, O: Ownership> MsgSendId<Id<T, O>, Option<Id<T, O>>>
+    for Assert<false, true, true>
+{
+    #[inline(always)]
+    unsafe fn send_message_id<A: MessageArguments>(
+        obj: Id<T, O>,
+        sel: Sel,
+        args: A,
+    ) -> Result<Option<Id<T, O>>, MessageError> {
+        let obj = ManuallyDrop::new(obj);
+        unsafe { MessageReceiver::send_message(obj, sel, args).map(|r| Id::new(r)) }
+    }
+}
+
+// `copy`, `mutableCopy` and `new`
+impl<T: MessageReceiver, U: ?Sized + Message, O: Ownership> MsgSendId<T, Option<Id<U, O>>>
+    for Assert<false, false, true>
+{
+    #[inline(always)]
+    unsafe fn send_message_id<A: MessageArguments>(
+        obj: T,
+        sel: Sel,
+        args: A,
+    ) -> Result<Option<Id<U, O>>, MessageError> {
+        unsafe { MessageReceiver::send_message(obj, sel, args).map(|r| Id::new(r)) }
+    }
+}
+
+// All other selectors
+impl<T: MessageReceiver, U: Message, O: Ownership> MsgSendId<T, Option<Id<U, O>>>
+    for Assert<false, false, false>
+{
+    #[inline(always)]
+    unsafe fn send_message_id<A: MessageArguments>(
+        obj: T,
+        sel: Sel,
+        args: A,
+    ) -> Result<Option<Id<U, O>>, MessageError> {
+        // All code between the message send and the `retain_autoreleased`
+        // must be able to be optimized away for this to work.
+        unsafe { MessageReceiver::send_message(obj, sel, args).map(|r| Id::retain_autoreleased(r)) }
+    }
+}
+
+#[doc(hidden)]
+pub const fn starts_with_str(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < needle.len() {
+        if needle[i] != haystack[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rc::{Id, Owned, Shared};
+    use crate::runtime::Object;
+
+    #[test]
+    fn test_macro() {
+        let cls = class!(NSObject);
+
+        let _obj: Id<Object, Owned> = unsafe { msg_send_id![cls, new].unwrap() };
+
+        let obj = unsafe { msg_send_id![cls, alloc] };
+
+        let obj: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
+
+        // TODO:
+        // let copy: Id<Object, Shared> = unsafe { msg_send_id![&obj, copy].unwrap() };
+        // let mutable_copy: Id<Object, Shared> = unsafe { msg_send_id![&obj, mutableCopy].unwrap() };
+
+        let _desc: Option<Id<Object, Shared>> = unsafe { msg_send_id![&obj, description] };
+    }
+
+    #[test]
+    fn test_starts_with_str() {
+        assert!(starts_with_str(b"abcdef", b"abc"));
+        assert!(starts_with_str(b"a", b""));
+        assert!(starts_with_str(b"", b""));
+
+        assert!(!starts_with_str(b"abcdef", b"def"));
+        assert!(!starts_with_str(b"abcdef", b"abb"));
+        assert!(!starts_with_str(b"", b"a"));
+    }
+}

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -126,4 +126,20 @@ mod tests {
         assert!(!starts_with_str(b"abcdef", b"abb"));
         assert!(!starts_with_str(b"", b"a"));
     }
+
+    mod test_trait_disambugated {
+        use super::*;
+
+        trait Abc {
+            fn send_message_id() {}
+        }
+
+        impl<T> Abc for T {}
+
+        #[test]
+        fn test_macro_still_works() {
+            let cls = class!(NSObject);
+            let _obj: Id<Object, Owned> = unsafe { msg_send_id![cls, new].unwrap() };
+        }
+    }
 }

--- a/objc2/src/bool.rs
+++ b/objc2/src/bool.rs
@@ -16,10 +16,13 @@ use core::fmt;
 /// # Example
 ///
 /// ```no_run
-/// use objc2::{class, msg_send, msg_send_bool};
+/// use objc2::{class, msg_send_bool, msg_send_id};
+/// use objc2::rc::{Id, Shared};
 /// use objc2::runtime::{Object, Bool};
-/// let ns_value: *mut Object = unsafe { msg_send![class!(NSValue), initWithBool: Bool::YES] };
-/// assert!(unsafe { msg_send_bool![ns_value, boolValue] });
+/// let ns_value: Id<Object, Shared> = unsafe {
+///     msg_send_id![class!(NSNumber), numberWithBool: Bool::YES].unwrap()
+/// };
+/// assert!(unsafe { msg_send_bool![&ns_value, boolValue] });
 /// ```
 #[repr(transparent)]
 // We don't implement comparison traits because they could be implemented with

--- a/objc2/src/exception.rs
+++ b/objc2/src/exception.rs
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_throw_catch_object() {
-        let obj: Id<Object, Shared> = unsafe { Id::new(msg_send![class!(NSObject), new]).unwrap() };
+        let obj: Id<Object, Shared> = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
 
         let result = unsafe { catch(|| throw(Some(&obj))) };
         let exception = result.unwrap_err().unwrap();

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -1,9 +1,9 @@
 //! # Objective-C interface and runtime bindings
 //!
 //! Objective-C is<sup>1</sup> the standard programming language on Apple
-//! platforms like macOS, iOS, tvOS and watchOS. It is an object-oriented
-//! language centered around sending messages to it's instances, which is for
-//! the most part equivalent to a function call.
+//! platforms like macOS, iOS, iPadOS, tvOS and watchOS. It is an
+//! object-oriented language centered around sending messages to it's
+//! instances - can for the most part be viewed as a simple method call.
 //!
 //! Most of the core libraries and frameworks that are in use on Apple systems
 //! are written in Objective-C, and hence we would like the ability to
@@ -20,30 +20,51 @@
 //!
 //! First, we get a reference to the `NSObject`'s [`runtime::Class`] using the
 //! [`class!`] macro.
-//! Next, we creates a new [`runtime::Object`] pointer, and ensures it is
+//! Next, we creates a new [`runtime::Object`] pointer, and ensure it is
 //! deallocated after we've used it by putting it into an [`rc::Owned`]
 //! [`rc::Id`].
-//! Now we send messages to the object to our hearts desire using
-//! the [`msg_send!`] macro, and lastly, the `Id<Object, _>` goes out of
-//! scope, and the object is deallocated.
+//! Now we're free to send messages to the object to our hearts desire using
+//! the [`msg_send!`], [`msg_send_bool!`] or [`msg_send_id!`] macros
+//! (depending on the return type of the method).
+//! Finally, the `Id<Object, _>` goes out of scope, and the object is released
+//! and deallocated.
 //!
 #![cfg_attr(feature = "apple", doc = "```")]
 #![cfg_attr(not(feature = "apple"), doc = "```no_run")]
 //! use objc2::{class, msg_send, msg_send_bool, msg_send_id};
 //! use objc2::ffi::NSUInteger;
-//! use objc2::rc::{Id, Owned};
+//! use objc2::rc::{Id, Owned, Shared};
 //! use objc2::runtime::Object;
 //!
-//! // Creation
 //! let cls = class!(NSObject);
-//! let obj: Id<Object, Owned> = unsafe {
-//!     msg_send_id![cls, new].expect("Failed allocating object")
+//!
+//! // Creation
+//!
+//! let obj1: Id<Object, Owned> = unsafe {
+//!     msg_send_id![cls, new].expect("Failed allocating")
+//! };
+//! let obj2: Id<Object, Owned> = unsafe {
+//!     // Equivalent to using `new`
+//!     msg_send_id![msg_send_id![cls, alloc], init].expect("Failed allocating")
 //! };
 //!
 //! // Usage
-//! let hash: NSUInteger = unsafe { msg_send![&obj, hash] };
-//! let is_kind = unsafe { msg_send_bool![&obj, isKindOfClass: cls] };
+//!
+//! let hash1: NSUInteger = unsafe { msg_send![&obj1, hash] };
+//! let hash2: NSUInteger = unsafe { msg_send![&obj2, hash] };
+//! assert_ne!(hash1, hash2);
+//!
+//! let is_kind = unsafe { msg_send_bool![&obj1, isKindOfClass: cls] };
 //! assert!(is_kind);
+//!
+//! // We're going to create a new reference to the first object, so
+//! // relinquish mutable ownership.
+//! let obj1: Id<Object, Shared> = obj1.into();
+//! let obj1_self: Id<Object, Shared> = unsafe { msg_send_id![&obj1, self].unwrap() };
+//! let is_equal = unsafe { msg_send_bool![&obj1, isEqual: &*obj1_self] };
+//! assert!(is_equal);
+//!
+//! // Deallocation on drop
 //! ```
 //!
 //! Note that this very simple example contains **a lot** of `unsafe` (which
@@ -55,9 +76,10 @@
 //!
 //! Making the ergonomics better is something that is currently being worked
 //! on, see e.g. the [`objc2-foundation`] crate for more ergonomic usage of at
-//! least the `Foundation` framework.
+//! least parts of the `Foundation` framework.
 //!
-//! Anyhow, this nicely leads us to another feature that this crate has:
+//! Anyhow, all of this `unsafe` nicely leads us to another feature that this
+//! crate has:
 //!
 //! [`runtime::Class`]: crate::runtime::Class
 //! [`runtime::Object`]: crate::runtime::Object
@@ -70,23 +92,45 @@
 //!
 //! The Objective-C runtime includes encodings for each method that describe
 //! the argument and return types. See the [`objc2-encode`] crate for the
-//! full overview of what this is.
+//! full overview of what this is (its types are re-exported in this crate).
 //!
-//! The important part is, to make message sending _safer_ (not fully safe),
-//! all arguments and return values for messages must implement [`Encode`].
-//! This allows the Rust compiler to prevent you from passing e.g. a [`Box`]
-//! into Objective-C, which would both be UB and leak the box.
+//! The important part is: To make message sending safer, all arguments and
+//! return values for messages must implement [`Encode`]. This allows the Rust
+//! compiler to prevent you from passing e.g. a [`Box`] into Objective-C,
+//! which would both be UB and leak the box.
 //!
-//! Furthermore, this crate can take advantage of the encodings provided by
-//! the runtime to verify that the types used in Rust match the types encoded
-//! for the method. This is not a perfect solution for ensuring safety of
-//! message sends (some Rust types have the same encoding, but are not
+//! Furthermore, we can take advantage of the encodings provided by the
+//! runtime to verify that the types used in Rust actually match the types
+//! encoded for the method. This is not a perfect solution for ensuring safety
+//! (some Rust types have the same Objective-C encoding, but are not
 //! equivalent), but it gets us much closer to it!
 //!
 //! To use this functionality, enable the `"verify_message"` cargo feature
-//! while debugging. With this feature enabled, encoding types are checked
-//! every time your send a message, and the message send will panic if they
-//! are not equivalent.
+//! while debugging. With this feature enabled, encodings are checked every
+//! time your send a message, and the message send will panic if they are not
+//! equivalent.
+//!
+//! To take the example above, if we changed the `hash` method's return type
+//! as in the following example, it panics when the feature is enabled:
+//!
+#![cfg_attr(
+    all(feature = "apple", feature = "verify_message"),
+    doc = "```should_panic"
+)]
+#![cfg_attr(
+    not(all(feature = "apple", feature = "verify_message")),
+    doc = "```no_run"
+)]
+//! # use objc2::{class, msg_send, msg_send_id};
+//! # use objc2::rc::{Id, Owned};
+//! # use objc2::runtime::Object;
+//! #
+//! # let cls = class!(NSObject);
+//! # let obj1: Id<Object, Owned> = unsafe { msg_send_id![cls, new].unwrap() };
+//! #
+//! // Wrong return type - this is UB!
+//! let hash1: f32 = unsafe { msg_send![&obj1, hash] };
+//! ```
 //!
 //! [`objc2-encode`]: objc2_encode
 //! [`Box`]: std::boxed::Box
@@ -107,12 +151,12 @@
 //! see the [`objc-sys`][`objc_sys`] crate for how to configure this.
 //!
 //!
-//! ## Other features
+//! ## Other functionality
 //!
-//! Anyhow, that was a quick introduction, this library also has [support for
-//! handling exceptions][exc], [the ability to dynamically declare Objective-C
-//! classes][declare], [more advanced reference-counting utilities][rc] and
-//! more, peruse the documentation at will!
+//! That was a quick introduction, this library also has [support for handling
+//! exceptions][exc], [the ability to dynamically declare Objective-C
+//! classes][declare], [advanced reference-counting utilities][rc], and more -
+//! peruse the documentation at will!
 //!
 #![cfg_attr(feature = "exception", doc = "[exc]: crate::exception")]
 #![cfg_attr(not(feature = "exception"), doc = "[exc]: #exception-feature-disabled")]

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -107,7 +107,7 @@
 //!
 //! To use this functionality, enable the `"verify_message"` cargo feature
 //! while debugging. With this feature enabled, encodings are checked every
-//! time your send a message, and the message send will panic if they are not
+//! time you send a message, and the message send will panic if they are not
 //! equivalent.
 //!
 //! To take the example above, if we changed the `hash` method's return type

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -167,6 +167,9 @@ pub mod runtime;
 #[cfg(test)]
 mod test_utils;
 
+#[doc(hidden)]
+pub mod __macro_helpers;
+
 /// Hacky way to make GNUStep link properly to Foundation while testing.
 ///
 /// This is a temporary solution to make our CI work for now!

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -29,16 +29,15 @@
 //!
 #![cfg_attr(feature = "apple", doc = "```")]
 #![cfg_attr(not(feature = "apple"), doc = "```no_run")]
-//! use objc2::{class, msg_send, msg_send_bool};
+//! use objc2::{class, msg_send, msg_send_bool, msg_send_id};
 //! use objc2::ffi::NSUInteger;
 //! use objc2::rc::{Id, Owned};
 //! use objc2::runtime::Object;
 //!
 //! // Creation
 //! let cls = class!(NSObject);
-//! let obj: *mut Object = unsafe { msg_send![cls, new] };
 //! let obj: Id<Object, Owned> = unsafe {
-//!     Id::new(obj).expect("Failed allocating object")
+//!     msg_send_id![cls, new].expect("Failed allocating object")
 //! };
 //!
 //! // Usage

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -81,6 +81,9 @@ macro_rules! sel {
 /// methods that return respectively Objective-C's `BOOL` and `id` (or any
 /// object pointer). Use those whenever you want to call such a method!
 ///
+/// [`msg_send_bool!`]: crate::msg_send_bool
+/// [`msg_send_id!`]: crate::msg_send_id
+///
 ///
 /// # Specification
 ///
@@ -157,6 +160,7 @@ macro_rules! sel {
 /// 8. TODO: Maybe more?
 ///
 /// [`autoreleasepool`]: crate::rc::autoreleasepool
+/// [`msg_send_id!`]: crate::msg_send_id
 ///
 ///
 /// # Examples
@@ -298,6 +302,8 @@ macro_rules! msg_send_bool {
 ///
 /// [mmRules]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-SW1
 /// [arc-rel]: https://developer.apple.com/library/archive/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226
+///
+/// [`msg_send_id!`]: crate::msg_send_id
 ///
 ///
 /// # Specification

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -258,7 +258,7 @@ macro_rules! msg_send_id {
         let sel = $crate::sel!($selector);
         const NAME: &[u8] = stringify!($selector).as_bytes();
         $crate::msg_send_id!(@__get_assert_consts NAME);
-        let result;
+        let result: Option<$crate::rc::Id<_, _>>;
         match <X as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ()) {
             Err(s) => panic!("{}", s),
             Ok(r) => result = r,
@@ -269,7 +269,7 @@ macro_rules! msg_send_id {
         let sel = $crate::sel!($($selector:)+);
         const NAME: &[u8] = concat!($(stringify!($selector), ':'),+).as_bytes();
         $crate::msg_send_id!(@__get_assert_consts NAME);
-        let result;
+        let result: Option<$crate::rc::Id<_, _>>;
         match <X as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+)) {
             Err(s) => panic!("{}", s),
             Ok(r) => result = r,

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -230,8 +230,30 @@ macro_rules! msg_send_bool {
 }
 
 /// TODO
+///
+/// The `retain`, `release` and `autorelease` selectors are not supported, use
+/// [`Id::retain`], [`Id::drop`] and [`Id::autorelease`] for that.
+///
+/// [`Id::retain`]: crate::rc::Id::retain
+/// [`Id::drop`]: crate::rc::Id::drop
+/// [`Id::autorelease`]: crate::rc::Id::autorelease
 #[macro_export]
 macro_rules! msg_send_id {
+    [$obj:expr, retain $(,)?] => ({
+        $crate::__macro_helpers::compile_error!(
+            "msg_send_id![obj, retain] is not supported. Use `Id::retain` instead"
+        )
+    });
+    [$obj:expr, release $(,)?] => ({
+        $crate::__macro_helpers::compile_error!(
+            "msg_send_id![obj, release] is not supported. Drop an `Id` instead"
+        )
+    });
+    [$obj:expr, autorelease $(,)?] => ({
+        $crate::__macro_helpers::compile_error!(
+            "msg_send_id![obj, autorelease] is not supported. Use `Id::autorelease`"
+        )
+    });
     [$obj:expr, $selector:ident $(,)?] => ({
         let sel = $crate::sel!($selector);
         const NAME: &[u8] = stringify!($selector).as_bytes();

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -325,10 +325,9 @@ macro_rules! msg_send_bool {
 /// - The `alloc` family: The receiver must be `&Class`, and the return type
 ///   is a generic `Option<Id<T, O>>`. (This will change, see [#172]).
 ///
-/// - The `init` family: The receiver must be either `Id<T, O>` or
-///   `Option<Id<T, O>>` as returned from `alloc`. The receiver is consumed,
-///   and a the now-initialized `Option<Id<T, O>>` (with the same `T` and `O`)
-///   is returned.
+/// - The `init` family: The receiver must be `Option<Id<T, O>>` as returned
+///   from `alloc`. The receiver is consumed, and a the now-initialized
+///   `Option<Id<T, O>>` (with the same `T` and `O`) is returned.
 ///
 /// - The `copy` family: The receiver may be anything that implements
 ///   [`MessageReceiver`] and the return type is a generic `Option<Id<T, O>>`.

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -71,10 +71,10 @@ macro_rules! sel {
 /// ```
 ///
 /// This way we are clearly communicating to Rust that: The method
-/// `doSomething:` works on shared references to an object. It takes a C-style
-/// signed integer, and returns a pointer to what is probably a C-compatible
-/// string. Now it's much, _much_ easier to make a safe abstraction around
-/// this!
+/// `doSomething:` works with a shared reference to the object. It takes a
+/// C-style signed integer, and returns a pointer to what is probably a
+/// C-compatible string. Now it's much, _much_ easier to make a safe
+/// abstraction around this!
 ///
 /// There exists two variants of this macro, [`msg_send_bool!`] and
 /// [`msg_send_id!`], which can help with upholding certain requirements of
@@ -94,9 +94,12 @@ macro_rules! sel {
 ///
 /// All arguments, and the return type, must implement [`Encode`].
 ///
-/// This translates into a call to [`sel!`], and afterwards a fully qualified
-/// call to [`MessageReceiver::send_message`]. Note that this means that
-/// auto-dereferencing of the receiver is not supported.
+/// This macro translates into a call to [`sel!`], and afterwards a fully
+/// qualified call to [`MessageReceiver::send_message`]. Note that this means
+/// that auto-dereferencing of the receiver is not supported, and that the
+/// receiver is consumed. You may encounter a little trouble with `&mut`
+/// references, try refactoring into a separate method or reborrowing the
+/// reference.
 ///
 /// Variadic arguments are currently not supported.
 ///
@@ -127,10 +130,9 @@ macro_rules! sel {
 /// 1. The selector corresponds to a valid method that is available on the
 ///    receiver.
 ///
-/// 2. The argument types must match what the receiver excepts for this
-///    selector.
+/// 2. The argument types match what the receiver excepts for this selector.
 ///
-/// 3. The return type must match what the receiver returns for this selector.
+/// 3. The return type match what the receiver returns for this selector.
 ///
 /// 4. The call must not violate Rust's mutability rules, for example if
 ///    passing an `&T`, the Objective-C method must not mutate the variable
@@ -166,9 +168,9 @@ macro_rules! sel {
 /// # let obj: *mut Object = 0 as *mut Object;
 /// let description: *const Object = unsafe { msg_send![obj, description] };
 /// // Usually you'd use msg_send_id here ^
-/// let _: () = unsafe { msg_send![obj, setArg1: 1 arg2: 2] };
-/// // Or with an optional comma between arguments:
-/// let _: () = unsafe { msg_send![obj, setArg1: 1, arg2: 2] };
+/// let _: () = unsafe { msg_send![obj, setArg1: 1u32, arg2: 2i32] };
+/// let arg1: i32 = unsafe { msg_send![obj, getArg1] };
+/// let arg2: i32 = unsafe { msg_send![obj, getArg2] };
 /// ```
 #[macro_export]
 macro_rules! msg_send {
@@ -264,7 +266,7 @@ macro_rules! msg_send_bool {
 /// [`msg_send!`] for methods returning `id`, `NSObject*`, or similar object
 /// pointers.
 ///
-/// Objective-C's object pointers have certain rules for when they should be
+/// Object pointers in Objective-C have certain rules for when they should be
 /// retained and released across function calls. This macro helps doing that,
 /// and returns an [`Option`] (letting you handle failures) containing an
 /// [`rc::Id`] with the object.
@@ -334,10 +336,9 @@ macro_rules! msg_send_bool {
 ///   pools!
 ///
 /// See [the clang documentation][arc-retainable] for the precise
-/// specification.
+/// specification of Objective-C's ownership rules.
 ///
 /// This macro doesn't support super methods yet, see [#173].
-///
 /// The `retain`, `release` and `autorelease` selectors are not supported, use
 /// [`Id::retain`], [`Id::drop`] and [`Id::autorelease`] for that.
 ///
@@ -403,7 +404,7 @@ macro_rules! msg_send_id {
     });
 }
 
-/// Helper macro: To avoid exposing these in the docs for [`msg_send_id!`].
+/// Helper macro to avoid exposing these in the docs for [`msg_send_id!`].
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __msg_send_id_helper {

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -231,6 +231,8 @@ macro_rules! msg_send_bool {
 
 /// TODO
 ///
+/// TODO: Assumes that attributes like `objc_method_family`, `ns_returns_retained`, `ns_consumed` and so on are not present.
+///
 /// The `retain`, `release` and `autorelease` selectors are not supported, use
 /// [`Id::retain`], [`Id::drop`] and [`Id::autorelease`] for that.
 ///
@@ -245,7 +247,7 @@ macro_rules! msg_send_id {
         const NAME: &[u8] = stringify!($selector).as_bytes();
         $crate::__msg_send_id_helper!(@get_assert_consts NAME);
         let result: Option<$crate::rc::Id<_, _>>;
-        match <X as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ()) {
+        match <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ()) {
             Err(s) => panic!("{}", s),
             Ok(r) => result = r,
         }
@@ -256,7 +258,7 @@ macro_rules! msg_send_id {
         const NAME: &[u8] = concat!($(stringify!($selector), ':'),+).as_bytes();
         $crate::__msg_send_id_helper!(@get_assert_consts NAME);
         let result: Option<$crate::rc::Id<_, _>>;
-        match <X as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+)) {
+        match <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+)) {
             Err(s) => panic!("{}", s),
             Ok(r) => result = r,
         }
@@ -285,13 +287,13 @@ macro_rules! __msg_send_id_helper {
     }};
     (@verify $selector:ident) => {{}};
     (@get_assert_consts $selector:ident) => {
-        const NEW: bool = $crate::__macro_helpers::in_method_family($selector, b"new");
-        const ALLOC: bool = $crate::__macro_helpers::in_method_family($selector, b"alloc");
-        const INIT: bool = $crate::__macro_helpers::in_method_family($selector, b"init");
+        const NEW: bool = $crate::__macro_helpers::in_selector_family($selector, b"new");
+        const ALLOC: bool = $crate::__macro_helpers::in_selector_family($selector, b"alloc");
+        const INIT: bool = $crate::__macro_helpers::in_selector_family($selector, b"init");
         const COPY_OR_MUT_COPY: bool = {
-            $crate::__macro_helpers::in_method_family($selector, b"copy")
-                || $crate::__macro_helpers::in_method_family($selector, b"mutableCopy")
+            $crate::__macro_helpers::in_selector_family($selector, b"copy")
+                || $crate::__macro_helpers::in_selector_family($selector, b"mutableCopy")
         };
-        type X = $crate::__macro_helpers::Assert<NEW, ALLOC, INIT, COPY_OR_MUT_COPY>;
+        type RS = $crate::__macro_helpers::RetainSemantics<NEW, ALLOC, INIT, COPY_OR_MUT_COPY>;
     };
 }

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -257,14 +257,16 @@ macro_rules! msg_send_id {
         result
     });
     (@__get_assert_consts $name:ident) => {
-        const ALLOC: bool = $crate::__macro_helpers::starts_with_str($name, b"alloc");
-        const INIT: bool = $crate::__macro_helpers::starts_with_str($name, b"init");
+        const ALLOC: bool = $crate::__macro_helpers::in_method_family($name, b"alloc");
+        // https://clang.llvm.org/docs/AutomaticReferenceCounting.html#consumed-parameters
+        const INIT: bool = $crate::__macro_helpers::in_method_family($name, b"init");
+        // https://clang.llvm.org/docs/AutomaticReferenceCounting.html#retained-return-values
         const RETAINED: bool = {
-            $crate::__macro_helpers::starts_with_str($name, b"alloc")
-                || $crate::__macro_helpers::starts_with_str($name, b"new")
-                || $crate::__macro_helpers::starts_with_str($name, b"copy")
-                || $crate::__macro_helpers::starts_with_str($name, b"mutableCopy")
-                || $crate::__macro_helpers::starts_with_str($name, b"init")
+            $crate::__macro_helpers::in_method_family($name, b"alloc")
+                || $crate::__macro_helpers::in_method_family($name, b"new")
+                || $crate::__macro_helpers::in_method_family($name, b"copy")
+                || $crate::__macro_helpers::in_method_family($name, b"mutableCopy")
+                || $crate::__macro_helpers::in_method_family($name, b"init")
         };
     };
 }

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -452,10 +452,13 @@ mod tests {
     #[cfg(not(feature = "verify_message"))]
     #[test]
     fn test_send_message_nil() {
+        use crate::rc::Shared;
+
         let nil: *mut Object = ::core::ptr::null_mut();
 
-        let result: *mut Object = unsafe { msg_send![nil, description] };
-        assert!(result.is_null());
+        // This result should not be relied on
+        let result: Option<Id<Object, Shared>> = unsafe { msg_send_id![nil, description] };
+        assert!(result.is_none());
 
         // This result should not be relied on
         let result: usize = unsafe { msg_send![nil, hash] };
@@ -471,8 +474,9 @@ mod tests {
         assert_eq!(result, 0.0);
 
         // This result should not be relied on
-        let result: *mut Object = unsafe { msg_send![nil, multiple: 1u32, arguments: 2i8] };
-        assert!(result.is_null());
+        let result: Option<Id<Object, Shared>> =
+            unsafe { msg_send_id![nil, multiple: 1u32, arguments: 2i8] };
+        assert!(result.is_none());
     }
 
     #[test]

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -477,6 +477,10 @@ mod tests {
         let result: Option<Id<Object, Shared>> =
             unsafe { msg_send_id![nil, multiple: 1u32, arguments: 2i8] };
         assert!(result.is_none());
+
+        // This result should not be relied on
+        let result: Option<Id<Object, Shared>> = unsafe { msg_send_id![None, init] };
+        assert!(result.is_none());
     }
 
     #[test]

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -218,6 +218,13 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 /// error in a future release. You can test the compile error with the
 /// `unstable-autoreleasesafe` crate feature on nightly Rust.
 ///
+/// Note that this is mostly useful for preventing leaks (as any Objective-C
+/// method may leak internally). If implementing an interface to an object,
+/// you should try to return retained pointers with [`msg_send_id!`] wherever
+/// you can instead, since having to use this function can be quite cumbersome
+/// for your users!
+///
+///
 /// # Examples
 ///
 /// Basic usage:

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -223,15 +223,21 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 /// Basic usage:
 ///
 /// ```no_run
-/// use objc2::{class, msg_send};
-/// use objc2::rc::{autoreleasepool, AutoreleasePool};
+/// use core::mem::ManuallyDrop;
+/// use objc2::{class, msg_send, msg_send_id};
+/// use objc2::rc::{autoreleasepool, AutoreleasePool, Id, Owned};
 /// use objc2::runtime::Object;
 ///
 /// fn needs_lifetime_from_pool<'p>(pool: &'p AutoreleasePool) -> &'p mut Object {
-///     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+///     let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
+///     let obj = ManuallyDrop::new(obj);
 ///     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
 ///     // Lifetime of the returned reference is bounded by the pool
 ///     unsafe { pool.ptr_as_mut(obj) }
+///
+///     // Or simply
+///     // let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
+///     // obj.autorelease(pool)
 /// }
 ///
 /// autoreleasepool(|pool| {
@@ -246,14 +252,13 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 /// safely take it out of the pool:
 ///
 /// ```compile_fail
-/// # use objc2::{class, msg_send};
-/// # use objc2::rc::{autoreleasepool, AutoreleasePool};
+/// # use objc2::{class, msg_send_id, Id, Owned};
+/// # use objc2::rc::{autoreleasepool, AutoreleasePool, Id, Owned};
 /// # use objc2::runtime::Object;
 /// #
 /// # fn needs_lifetime_from_pool<'p>(pool: &'p AutoreleasePool) -> &'p mut Object {
-/// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
-/// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
-/// #     unsafe { pool.ptr_as_mut(obj) }
+/// #     let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
+/// #     obj.autorelease(pool)
 /// # }
 /// #
 /// let obj = autoreleasepool(|pool| {
@@ -268,14 +273,13 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 ///
 #[cfg_attr(feature = "unstable-autoreleasesafe", doc = "```compile_fail")]
 #[cfg_attr(not(feature = "unstable-autoreleasesafe"), doc = "```should_panic")]
-/// # use objc2::{class, msg_send};
-/// # use objc2::rc::{autoreleasepool, AutoreleasePool};
+/// # use objc2::{class, msg_send_id};
+/// # use objc2::rc::{autoreleasepool, AutoreleasePool, Id, Owned};
 /// # use objc2::runtime::Object;
 /// #
 /// # fn needs_lifetime_from_pool<'p>(pool: &'p AutoreleasePool) -> &'p mut Object {
-/// #     let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
-/// #     let obj: *mut Object = unsafe { msg_send![obj, autorelease] };
-/// #     unsafe { pool.ptr_as_mut(obj) }
+/// #     let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
+/// #     obj.autorelease(pool)
 /// # }
 /// #
 /// autoreleasepool(|outer_pool| {

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
+use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::NonNull;
@@ -206,6 +206,15 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     #[inline]
     pub(crate) fn consume_as_ptr(this: ManuallyDrop<Self>) -> *mut T {
         this.ptr.as_ptr()
+    }
+
+    #[inline]
+    pub(crate) fn option_into_ptr(obj: Option<Self>) -> *mut T {
+        // Difficult to write this in an ergonomic way with ?Sized
+        // So we just hack it with transmute!
+
+        // SAFETY: Option<Id<T, _>> has the same size as *mut T
+        unsafe { mem::transmute::<ManuallyDrop<Option<Self>>, *mut T>(ManuallyDrop::new(obj)) }
     }
 }
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -59,13 +59,13 @@ use crate::Message;
 /// # Examples
 ///
 /// ```no_run
-/// use objc2::msg_send;
+/// use objc2::msg_send_id;
 /// use objc2::runtime::{Class, Object};
 /// use objc2::rc::{Id, Owned, Shared, WeakId};
 ///
 /// let cls = Class::get("NSObject").unwrap();
 /// let obj: Id<Object, Owned> = unsafe {
-///     Id::new(msg_send![cls, new]).unwrap()
+///     msg_send_id![cls, new].unwrap()
 /// };
 /// // obj will be released when it goes out of scope
 ///
@@ -83,12 +83,12 @@ use crate::Message;
 /// ```
 ///
 /// ```no_run
-/// # use objc2::{class, msg_send};
+/// # use objc2::{class, msg_send_id};
 /// # use objc2::runtime::Object;
 /// # use objc2::rc::{Id, Owned, Shared};
 /// # type T = Object;
 /// let mut owned: Id<T, Owned>;
-/// # owned = unsafe { Id::new(msg_send![class!(NSObject), new]).unwrap() };
+/// # owned = unsafe { msg_send_id![class!(NSObject), new].unwrap() };
 /// let mut_ref: &mut T = &mut *owned;
 /// // Do something with `&mut T` here
 ///
@@ -149,25 +149,28 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     /// # Example
     ///
     /// ```no_run
-    /// # use objc2::{class, msg_send};
+    /// # use objc2::{class, msg_send, msg_send_id};
     /// # use objc2::runtime::{Class, Object};
     /// # use objc2::rc::{Id, Owned};
     /// let cls: &Class;
     /// # let cls = class!(NSObject);
     /// let obj: &mut Object = unsafe { msg_send![cls, alloc] };
     /// let obj: Id<Object, Owned> = unsafe { Id::new(msg_send![obj, init]).unwrap() };
+    /// // Or utilizing `msg_send_id`:
+    /// let obj = unsafe { msg_send_id![cls, alloc] };
+    /// let obj: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
     /// // Or in this case simply just:
-    /// let obj: Id<Object, Owned> = unsafe { Id::new(msg_send![cls, new]).unwrap() };
+    /// let obj: Id<Object, Owned> = unsafe { msg_send_id![cls, new].unwrap() };
     /// ```
     ///
     /// ```no_run
-    /// # use objc2::{class, msg_send};
+    /// # use objc2::{class, msg_send_id};
     /// # use objc2::runtime::Object;
     /// # use objc2::rc::{Id, Shared};
     /// # type NSString = Object;
     /// let cls = class!(NSString);
     /// // NSString is immutable, so don't create an owned reference to it
-    /// let obj: Id<NSString, Shared> = unsafe { Id::new(msg_send![cls, new]).unwrap() };
+    /// let obj: Id<NSString, Shared> = unsafe { msg_send_id![cls, new].unwrap() };
     /// ```
     #[inline]
     // Note: We don't take a reference as a parameter since it would be too

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -32,13 +32,13 @@
 //!
 #![cfg_attr(feature = "apple", doc = "```")]
 #![cfg_attr(not(feature = "apple"), doc = "```no_run")]
-//! use objc2::{class, msg_send};
+//! use objc2::{class, msg_send_id};
 //! use objc2::rc::{autoreleasepool, Id, Shared, WeakId};
 //! use objc2::runtime::Object;
 //!
 //! // Id will release the object when dropped
 //! let obj: Id<Object, Shared> = unsafe {
-//!     Id::new(msg_send![class!(NSObject), new]).unwrap()
+//!     msg_send_id![class!(NSObject), new].unwrap()
 //! };
 //!
 //! // Cloning retains the object an additional time

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -152,7 +152,7 @@ impl RcTestObject {
     }
 
     pub(crate) fn new() -> Id<Self, Owned> {
-        // Use msg_send! to test that; msg_send_id! is tested elsewhere!
+        // Use msg_send! - msg_send_id! is tested elsewhere!
         unsafe { Id::new(msg_send![Self::class(), new]) }.unwrap()
     }
 }

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -5,7 +5,7 @@ use std::sync::Once;
 use super::{Id, Owned};
 use crate::declare::ClassBuilder;
 use crate::runtime::{Bool, Class, Object, Sel};
-use crate::{msg_send, msg_send_bool};
+use crate::{msg_send, msg_send_bool, msg_send_id};
 use crate::{Encoding, Message, RefEncode};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -152,6 +152,6 @@ impl RcTestObject {
     }
 
     pub(crate) fn new() -> Id<Self, Owned> {
-        unsafe { Id::new(msg_send![Self::class(), new]) }.unwrap()
+        unsafe { msg_send_id![Self::class(), new] }.unwrap()
     }
 }

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -5,7 +5,7 @@ use std::sync::Once;
 use super::{Id, Owned};
 use crate::declare::ClassBuilder;
 use crate::runtime::{Bool, Class, Object, Sel};
-use crate::{msg_send, msg_send_bool, msg_send_id};
+use crate::{msg_send, msg_send_bool};
 use crate::{Encoding, Message, RefEncode};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -77,7 +77,7 @@ impl DerefMut for RcTestObject {
 }
 
 impl RcTestObject {
-    fn class() -> &'static Class {
+    pub(crate) fn class() -> &'static Class {
         static REGISTER_CLASS: Once = Once::new();
 
         REGISTER_CLASS.call_once(|| {
@@ -152,6 +152,7 @@ impl RcTestObject {
     }
 
     pub(crate) fn new() -> Id<Self, Owned> {
-        unsafe { msg_send_id![Self::class(), new] }.unwrap()
+        // Use msg_send! to test that; msg_send_id! is tested elsewhere!
+        unsafe { Id::new(msg_send![Self::class(), new]) }.unwrap()
     }
 }

--- a/tests/assembly/test_msg_send_id/Cargo.toml
+++ b/tests/assembly/test_msg_send_id/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test_msg_send_id"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+objc2 = { path = "../../../objc2", default-features = false }
+
+[features]
+default = ["apple"]
+# Runtime
+apple = ["objc2/apple"]
+gnustep-1-7 = ["objc2/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc2/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1"]

--- a/tests/assembly/test_msg_send_id/expected/apple-aarch64.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-aarch64.s
@@ -1,0 +1,138 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_handle_alloc
+	.p2align	2
+_handle_alloc:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	cbz	x0, LBB0_2
+	ldp	x29, x30, [sp], #16
+	ret
+LBB0_2:
+Lloh0:
+	adrp	x0, l___unnamed_1@PAGE
+Lloh1:
+	add	x0, x0, l___unnamed_1@PAGEOFF
+Lloh2:
+	adrp	x2, l___unnamed_2@PAGE
+Lloh3:
+	add	x2, x2, l___unnamed_2@PAGEOFF
+	mov	w1, #17
+	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
+	.loh AdrpAdd	Lloh2, Lloh3
+	.loh AdrpAdd	Lloh0, Lloh1
+
+	.globl	_handle_init
+	.p2align	2
+_handle_init:
+	b	_objc_msgSend
+
+	.globl	_handle_alloc_init
+	.p2align	2
+_handle_alloc_init:
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	add	x29, sp, #16
+	mov	x19, x2
+	bl	_objc_msgSend
+	cbz	x0, LBB2_2
+	mov	x1, x19
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
+	b	_objc_msgSend
+LBB2_2:
+Lloh4:
+	adrp	x0, l___unnamed_1@PAGE
+Lloh5:
+	add	x0, x0, l___unnamed_1@PAGEOFF
+Lloh6:
+	adrp	x2, l___unnamed_2@PAGE
+Lloh7:
+	add	x2, x2, l___unnamed_2@PAGEOFF
+	mov	w1, #17
+	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
+	.loh AdrpAdd	Lloh6, Lloh7
+	.loh AdrpAdd	Lloh4, Lloh5
+
+	.globl	_handle_alloc_release
+	.p2align	2
+_handle_alloc_release:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	cbz	x0, LBB3_2
+	ldp	x29, x30, [sp], #16
+	b	_objc_release
+LBB3_2:
+Lloh8:
+	adrp	x0, l___unnamed_1@PAGE
+Lloh9:
+	add	x0, x0, l___unnamed_1@PAGEOFF
+Lloh10:
+	adrp	x2, l___unnamed_2@PAGE
+Lloh11:
+	add	x2, x2, l___unnamed_2@PAGEOFF
+	mov	w1, #17
+	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
+	.loh AdrpAdd	Lloh10, Lloh11
+	.loh AdrpAdd	Lloh8, Lloh9
+
+	.globl	_handle_alloc_init_release
+	.p2align	2
+_handle_alloc_init_release:
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	add	x29, sp, #16
+	mov	x19, x2
+	bl	_objc_msgSend
+	cbz	x0, LBB4_2
+	mov	x1, x19
+	bl	_objc_msgSend
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
+	b	_objc_release
+LBB4_2:
+Lloh12:
+	adrp	x0, l___unnamed_1@PAGE
+Lloh13:
+	add	x0, x0, l___unnamed_1@PAGEOFF
+Lloh14:
+	adrp	x2, l___unnamed_2@PAGE
+Lloh15:
+	add	x2, x2, l___unnamed_2@PAGEOFF
+	mov	w1, #17
+	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
+	.loh AdrpAdd	Lloh14, Lloh15
+	.loh AdrpAdd	Lloh12, Lloh13
+
+	.globl	_handle_copy
+	.p2align	2
+_handle_copy:
+	b	_objc_msgSend
+
+	.globl	_handle_autoreleased
+	.p2align	2
+_handle_autoreleased:
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	bl	_objc_msgSend
+	; InlineAsm Start
+	mov	x29, x29
+	; InlineAsm End
+	ldp	x29, x30, [sp], #16
+	b	_objc_retainAutoreleasedReturnValue
+
+	.section	__TEXT,__const
+l___unnamed_1:
+	.ascii	"Failed allocating"
+
+l___unnamed_3:
+	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
+
+	.section	__DATA,__const
+	.p2align	3
+l___unnamed_2:
+	.quad	l___unnamed_3
+	.asciz	"B\000\000\000\000\000\000\000\037\000\000\000%\000\000"
+
+.subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-aarch64.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-aarch64.s
@@ -2,25 +2,7 @@
 	.globl	_handle_alloc
 	.p2align	2
 _handle_alloc:
-	stp	x29, x30, [sp, #-16]!
-	mov	x29, sp
-	bl	_objc_msgSend
-	cbz	x0, LBB0_2
-	ldp	x29, x30, [sp], #16
-	ret
-LBB0_2:
-Lloh0:
-	adrp	x0, l___unnamed_1@PAGE
-Lloh1:
-	add	x0, x0, l___unnamed_1@PAGEOFF
-Lloh2:
-	adrp	x2, l___unnamed_2@PAGE
-Lloh3:
-	add	x2, x2, l___unnamed_2@PAGEOFF
-	mov	w1, #17
-	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
-	.loh AdrpAdd	Lloh2, Lloh3
-	.loh AdrpAdd	Lloh0, Lloh1
+	b	_objc_msgSend
 
 	.globl	_handle_init
 	.p2align	2
@@ -35,24 +17,10 @@ _handle_alloc_init:
 	add	x29, sp, #16
 	mov	x19, x2
 	bl	_objc_msgSend
-	cbz	x0, LBB2_2
 	mov	x1, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_msgSend
-LBB2_2:
-Lloh4:
-	adrp	x0, l___unnamed_1@PAGE
-Lloh5:
-	add	x0, x0, l___unnamed_1@PAGEOFF
-Lloh6:
-	adrp	x2, l___unnamed_2@PAGE
-Lloh7:
-	add	x2, x2, l___unnamed_2@PAGEOFF
-	mov	w1, #17
-	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
-	.loh AdrpAdd	Lloh6, Lloh7
-	.loh AdrpAdd	Lloh4, Lloh5
 
 	.globl	_handle_alloc_release
 	.p2align	2
@@ -60,22 +28,8 @@ _handle_alloc_release:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_msgSend
-	cbz	x0, LBB3_2
 	ldp	x29, x30, [sp], #16
 	b	_objc_release
-LBB3_2:
-Lloh8:
-	adrp	x0, l___unnamed_1@PAGE
-Lloh9:
-	add	x0, x0, l___unnamed_1@PAGEOFF
-Lloh10:
-	adrp	x2, l___unnamed_2@PAGE
-Lloh11:
-	add	x2, x2, l___unnamed_2@PAGEOFF
-	mov	w1, #17
-	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
-	.loh AdrpAdd	Lloh10, Lloh11
-	.loh AdrpAdd	Lloh8, Lloh9
 
 	.globl	_handle_alloc_init_release
 	.p2align	2
@@ -85,25 +39,11 @@ _handle_alloc_init_release:
 	add	x29, sp, #16
 	mov	x19, x2
 	bl	_objc_msgSend
-	cbz	x0, LBB4_2
 	mov	x1, x19
 	bl	_objc_msgSend
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_release
-LBB4_2:
-Lloh12:
-	adrp	x0, l___unnamed_1@PAGE
-Lloh13:
-	add	x0, x0, l___unnamed_1@PAGEOFF
-Lloh14:
-	adrp	x2, l___unnamed_2@PAGE
-Lloh15:
-	add	x2, x2, l___unnamed_2@PAGEOFF
-	mov	w1, #17
-	bl	__ZN4core6option13expect_failed17h16e38b99483f925bE
-	.loh AdrpAdd	Lloh14, Lloh15
-	.loh AdrpAdd	Lloh12, Lloh13
 
 	.globl	_handle_copy
 	.p2align	2
@@ -121,18 +61,5 @@ _handle_autoreleased:
 	; InlineAsm End
 	ldp	x29, x30, [sp], #16
 	b	_objc_retainAutoreleasedReturnValue
-
-	.section	__TEXT,__const
-l___unnamed_1:
-	.ascii	"Failed allocating"
-
-l___unnamed_3:
-	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
-
-	.section	__DATA,__const
-	.p2align	3
-l___unnamed_2:
-	.quad	l___unnamed_3
-	.asciz	"B\000\000\000\000\000\000\000\037\000\000\000%\000\000"
 
 .subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-armv7.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-armv7.s
@@ -1,0 +1,140 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.syntax unified
+	.globl	_handle_alloc
+	.p2align	2
+	.code	32
+_handle_alloc:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	cmp	r0, #0
+	popne	{r7, pc}
+LBB0_1:
+	movw	r0, :lower16:(l___unnamed_1-(LPC0_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC0_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC0_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC0_1+8))
+LPC0_0:
+	add	r0, pc, r0
+LPC0_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
+
+	.globl	_handle_init
+	.p2align	2
+	.code	32
+_handle_init:
+	b	_objc_msgSend
+
+	.globl	_handle_alloc_init
+	.p2align	2
+	.code	32
+_handle_alloc_init:
+	push	{r4, r7, lr}
+	add	r7, sp, #4
+	mov	r4, r2
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB2_2
+	mov	r1, r4
+	pop	{r4, r7, lr}
+	b	_objc_msgSend
+LBB2_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC2_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC2_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC2_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC2_1+8))
+LPC2_0:
+	add	r0, pc, r0
+LPC2_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
+
+	.globl	_handle_alloc_release
+	.p2align	2
+	.code	32
+_handle_alloc_release:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB3_2
+	pop	{r7, lr}
+	b	_objc_release
+LBB3_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC3_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC3_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC3_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC3_1+8))
+LPC3_0:
+	add	r0, pc, r0
+LPC3_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
+
+	.globl	_handle_alloc_init_release
+	.p2align	2
+	.code	32
+_handle_alloc_init_release:
+	push	{r4, r7, lr}
+	add	r7, sp, #4
+	mov	r4, r2
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB4_2
+	mov	r1, r4
+	bl	_objc_msgSend
+	pop	{r4, r7, lr}
+	b	_objc_release
+LBB4_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC4_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC4_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC4_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC4_1+8))
+LPC4_0:
+	add	r0, pc, r0
+LPC4_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
+
+	.globl	_handle_copy
+	.p2align	2
+	.code	32
+_handle_copy:
+	b	_objc_msgSend
+
+	.globl	_handle_autoreleased
+	.p2align	2
+	.code	32
+_handle_autoreleased:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	@ InlineAsm Start
+	mov	r7, r7
+	@ InlineAsm End
+	pop	{r7, lr}
+	b	_objc_retainAutoreleasedReturnValue
+
+	.section	__TEXT,__const
+l___unnamed_1:
+	.ascii	"Failed allocating"
+
+l___unnamed_3:
+	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
+
+	.section	__DATA,__const
+	.p2align	2
+l___unnamed_2:
+	.long	l___unnamed_3
+	.asciz	"B\000\000\000\037\000\000\000%\000\000"
+
+.subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-armv7.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-armv7.s
@@ -4,23 +4,7 @@
 	.p2align	2
 	.code	32
 _handle_alloc:
-	push	{r7, lr}
-	mov	r7, sp
-	bl	_objc_msgSend
-	cmp	r0, #0
-	popne	{r7, pc}
-LBB0_1:
-	movw	r0, :lower16:(l___unnamed_1-(LPC0_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC0_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC0_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC0_1+8))
-LPC0_0:
-	add	r0, pc, r0
-LPC0_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
+	b	_objc_msgSend
 
 	.globl	_handle_init
 	.p2align	2
@@ -36,23 +20,9 @@ _handle_alloc_init:
 	add	r7, sp, #4
 	mov	r4, r2
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB2_2
 	mov	r1, r4
 	pop	{r4, r7, lr}
 	b	_objc_msgSend
-LBB2_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC2_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC2_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC2_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC2_1+8))
-LPC2_0:
-	add	r0, pc, r0
-LPC2_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
 
 	.globl	_handle_alloc_release
 	.p2align	2
@@ -61,22 +31,8 @@ _handle_alloc_release:
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB3_2
 	pop	{r7, lr}
 	b	_objc_release
-LBB3_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC3_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC3_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC3_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC3_1+8))
-LPC3_0:
-	add	r0, pc, r0
-LPC3_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
 
 	.globl	_handle_alloc_init_release
 	.p2align	2
@@ -86,24 +42,10 @@ _handle_alloc_init_release:
 	add	r7, sp, #4
 	mov	r4, r2
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB4_2
 	mov	r1, r4
 	bl	_objc_msgSend
 	pop	{r4, r7, lr}
 	b	_objc_release
-LBB4_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC4_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC4_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC4_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC4_1+8))
-LPC4_0:
-	add	r0, pc, r0
-LPC4_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9fa2fcc9b79e39c1E
 
 	.globl	_handle_copy
 	.p2align	2
@@ -123,18 +65,5 @@ _handle_autoreleased:
 	@ InlineAsm End
 	pop	{r7, lr}
 	b	_objc_retainAutoreleasedReturnValue
-
-	.section	__TEXT,__const
-l___unnamed_1:
-	.ascii	"Failed allocating"
-
-l___unnamed_3:
-	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
-
-	.section	__DATA,__const
-	.p2align	2
-l___unnamed_2:
-	.long	l___unnamed_3
-	.asciz	"B\000\000\000\037\000\000\000%\000\000"
 
 .subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-armv7s.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-armv7s.s
@@ -1,0 +1,146 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.syntax unified
+	.globl	_handle_alloc
+	.p2align	2
+	.code	32
+_handle_alloc:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	cmp	r0, #0
+	popne	{r7, pc}
+LBB0_1:
+	movw	r0, :lower16:(l___unnamed_1-(LPC0_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC0_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC0_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC0_1+8))
+LPC0_0:
+	add	r0, pc, r0
+LPC0_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
+
+	.globl	_handle_init
+	.p2align	2
+	.code	32
+_handle_init:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	pop	{r7, pc}
+
+	.globl	_handle_alloc_init
+	.p2align	2
+	.code	32
+_handle_alloc_init:
+	push	{r4, r7, lr}
+	add	r7, sp, #4
+	mov	r4, r2
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB2_2
+	mov	r1, r4
+	bl	_objc_msgSend
+	pop	{r4, r7, pc}
+LBB2_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC2_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC2_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC2_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC2_1+8))
+LPC2_0:
+	add	r0, pc, r0
+LPC2_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
+
+	.globl	_handle_alloc_release
+	.p2align	2
+	.code	32
+_handle_alloc_release:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB3_2
+	bl	_objc_release
+	pop	{r7, pc}
+LBB3_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC3_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC3_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC3_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC3_1+8))
+LPC3_0:
+	add	r0, pc, r0
+LPC3_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
+
+	.globl	_handle_alloc_init_release
+	.p2align	2
+	.code	32
+_handle_alloc_init_release:
+	push	{r4, r7, lr}
+	add	r7, sp, #4
+	mov	r4, r2
+	bl	_objc_msgSend
+	cmp	r0, #0
+	beq	LBB4_2
+	mov	r1, r4
+	bl	_objc_msgSend
+	bl	_objc_release
+	pop	{r4, r7, pc}
+LBB4_2:
+	movw	r0, :lower16:(l___unnamed_1-(LPC4_0+8))
+	mov	r1, #17
+	movt	r0, :upper16:(l___unnamed_1-(LPC4_0+8))
+	movw	r2, :lower16:(l___unnamed_2-(LPC4_1+8))
+	movt	r2, :upper16:(l___unnamed_2-(LPC4_1+8))
+LPC4_0:
+	add	r0, pc, r0
+LPC4_1:
+	add	r2, pc, r2
+	mov	lr, pc
+	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
+
+	.globl	_handle_copy
+	.p2align	2
+	.code	32
+_handle_copy:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	pop	{r7, pc}
+
+	.globl	_handle_autoreleased
+	.p2align	2
+	.code	32
+_handle_autoreleased:
+	push	{r7, lr}
+	mov	r7, sp
+	bl	_objc_msgSend
+	@ InlineAsm Start
+	mov	r7, r7
+	@ InlineAsm End
+	bl	_objc_retainAutoreleasedReturnValue
+	pop	{r7, pc}
+
+	.section	__TEXT,__const
+l___unnamed_1:
+	.ascii	"Failed allocating"
+
+l___unnamed_3:
+	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
+
+	.section	__DATA,__const
+	.p2align	2
+l___unnamed_2:
+	.long	l___unnamed_3
+	.asciz	"B\000\000\000\037\000\000\000%\000\000"
+
+.subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-armv7s.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-armv7s.s
@@ -7,20 +7,7 @@ _handle_alloc:
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_msgSend
-	cmp	r0, #0
-	popne	{r7, pc}
-LBB0_1:
-	movw	r0, :lower16:(l___unnamed_1-(LPC0_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC0_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC0_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC0_1+8))
-LPC0_0:
-	add	r0, pc, r0
-LPC0_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
+	pop	{r7, pc}
 
 	.globl	_handle_init
 	.p2align	2
@@ -39,23 +26,9 @@ _handle_alloc_init:
 	add	r7, sp, #4
 	mov	r4, r2
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB2_2
 	mov	r1, r4
 	bl	_objc_msgSend
 	pop	{r4, r7, pc}
-LBB2_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC2_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC2_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC2_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC2_1+8))
-LPC2_0:
-	add	r0, pc, r0
-LPC2_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
 
 	.globl	_handle_alloc_release
 	.p2align	2
@@ -64,22 +37,8 @@ _handle_alloc_release:
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB3_2
 	bl	_objc_release
 	pop	{r7, pc}
-LBB3_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC3_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC3_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC3_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC3_1+8))
-LPC3_0:
-	add	r0, pc, r0
-LPC3_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
 
 	.globl	_handle_alloc_init_release
 	.p2align	2
@@ -89,24 +48,10 @@ _handle_alloc_init_release:
 	add	r7, sp, #4
 	mov	r4, r2
 	bl	_objc_msgSend
-	cmp	r0, #0
-	beq	LBB4_2
 	mov	r1, r4
 	bl	_objc_msgSend
 	bl	_objc_release
 	pop	{r4, r7, pc}
-LBB4_2:
-	movw	r0, :lower16:(l___unnamed_1-(LPC4_0+8))
-	mov	r1, #17
-	movt	r0, :upper16:(l___unnamed_1-(LPC4_0+8))
-	movw	r2, :lower16:(l___unnamed_2-(LPC4_1+8))
-	movt	r2, :upper16:(l___unnamed_2-(LPC4_1+8))
-LPC4_0:
-	add	r0, pc, r0
-LPC4_1:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	__ZN4core6option13expect_failed17h9461c0e6a2661999E
 
 	.globl	_handle_copy
 	.p2align	2
@@ -129,18 +74,5 @@ _handle_autoreleased:
 	@ InlineAsm End
 	bl	_objc_retainAutoreleasedReturnValue
 	pop	{r7, pc}
-
-	.section	__TEXT,__const
-l___unnamed_1:
-	.ascii	"Failed allocating"
-
-l___unnamed_3:
-	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
-
-	.section	__DATA,__const
-	.p2align	2
-l___unnamed_2:
-	.long	l___unnamed_3
-	.asciz	"B\000\000\000\037\000\000\000%\000\000"
 
 .subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-x86.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-x86.s
@@ -5,30 +5,8 @@
 _handle_alloc:
 	push	ebp
 	mov	ebp, esp
-	push	esi
-	push	eax
-	call	L0$pb
-L0$pb:
-	pop	esi
-	sub	esp, 8
-	push	dword ptr [ebp + 12]
-	push	dword ptr [ebp + 8]
-	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB0_2
-	add	esp, 4
-	pop	esi
 	pop	ebp
-	ret
-LBB0_2:
-	sub	esp, 4
-	lea	eax, [esi + l___unnamed_1-L0$pb]
-	lea	ecx, [esi + l___unnamed_2-L0$pb]
-	push	eax
-	push	17
-	push	ecx
-	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
+	jmp	_objc_msgSend
 
 	.globl	_handle_init
 	.p2align	4, 0x90
@@ -45,65 +23,36 @@ _handle_alloc_init:
 	mov	ebp, esp
 	push	esi
 	push	eax
-	call	L2$pb
-L2$pb:
-	pop	esi
+	mov	esi, dword ptr [ebp + 16]
 	sub	esp, 8
 	push	dword ptr [ebp + 12]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB2_2
-	sub	esp, 8
-	push	dword ptr [ebp + 16]
+	add	esp, 8
+	push	esi
 	push	eax
 	call	_objc_msgSend
 	add	esp, 20
 	pop	esi
 	pop	ebp
 	ret
-LBB2_2:
-	sub	esp, 4
-	lea	eax, [esi + l___unnamed_1-L2$pb]
-	lea	ecx, [esi + l___unnamed_2-L2$pb]
-	push	eax
-	push	17
-	push	ecx
-	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
 
 	.globl	_handle_alloc_release
 	.p2align	4, 0x90
 _handle_alloc_release:
 	push	ebp
 	mov	ebp, esp
-	push	esi
-	push	eax
-	call	L3$pb
-L3$pb:
-	pop	esi
 	sub	esp, 8
-	push	dword ptr [ebp + 12]
-	push	dword ptr [ebp + 8]
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [esp + 4], ecx
+	mov	dword ptr [esp], eax
 	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB3_2
-	sub	esp, 12
-	push	eax
+	mov	dword ptr [esp], eax
 	call	_objc_release
-	add	esp, 20
-	pop	esi
+	add	esp, 8
 	pop	ebp
 	ret
-LBB3_2:
-	sub	esp, 4
-	lea	eax, [esi + l___unnamed_1-L3$pb]
-	lea	ecx, [esi + l___unnamed_2-L3$pb]
-	push	eax
-	push	17
-	push	ecx
-	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
 
 	.globl	_handle_alloc_init_release
 	.p2align	4, 0x90
@@ -111,36 +60,22 @@ _handle_alloc_init_release:
 	push	ebp
 	mov	ebp, esp
 	push	esi
-	push	eax
-	call	L4$pb
-L4$pb:
-	pop	esi
-	sub	esp, 8
-	push	dword ptr [ebp + 12]
-	push	dword ptr [ebp + 8]
+	sub	esp, 20
+	mov	esi, dword ptr [ebp + 16]
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [esp + 4], ecx
+	mov	dword ptr [esp], eax
 	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB4_2
-	sub	esp, 8
-	push	dword ptr [ebp + 16]
-	push	eax
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], eax
 	call	_objc_msgSend
-	add	esp, 4
-	push	eax
+	mov	dword ptr [esp], eax
 	call	_objc_release
 	add	esp, 20
 	pop	esi
 	pop	ebp
 	ret
-LBB4_2:
-	sub	esp, 4
-	lea	eax, [esi + l___unnamed_1-L4$pb]
-	lea	ecx, [esi + l___unnamed_2-L4$pb]
-	push	eax
-	push	17
-	push	ecx
-	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
 
 	.globl	_handle_copy
 	.p2align	4, 0x90
@@ -171,18 +106,5 @@ _handle_autoreleased:
 	add	esp, 8
 	pop	ebp
 	ret
-
-	.section	__TEXT,__const
-l___unnamed_2:
-	.ascii	"Failed allocating"
-
-l___unnamed_3:
-	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
-
-	.section	__DATA,__const
-	.p2align	2
-l___unnamed_1:
-	.long	l___unnamed_3
-	.asciz	"B\000\000\000\037\000\000\000%\000\000"
 
 .subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-x86.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-x86.s
@@ -1,0 +1,188 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle_alloc
+	.p2align	4, 0x90
+_handle_alloc:
+	push	ebp
+	mov	ebp, esp
+	push	esi
+	push	eax
+	call	L0$pb
+L0$pb:
+	pop	esi
+	sub	esp, 8
+	push	dword ptr [ebp + 12]
+	push	dword ptr [ebp + 8]
+	call	_objc_msgSend
+	add	esp, 16
+	test	eax, eax
+	je	LBB0_2
+	add	esp, 4
+	pop	esi
+	pop	ebp
+	ret
+LBB0_2:
+	sub	esp, 4
+	lea	eax, [esi + l___unnamed_1-L0$pb]
+	lea	ecx, [esi + l___unnamed_2-L0$pb]
+	push	eax
+	push	17
+	push	ecx
+	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
+
+	.globl	_handle_init
+	.p2align	4, 0x90
+_handle_init:
+	push	ebp
+	mov	ebp, esp
+	pop	ebp
+	jmp	_objc_msgSend
+
+	.globl	_handle_alloc_init
+	.p2align	4, 0x90
+_handle_alloc_init:
+	push	ebp
+	mov	ebp, esp
+	push	esi
+	push	eax
+	call	L2$pb
+L2$pb:
+	pop	esi
+	sub	esp, 8
+	push	dword ptr [ebp + 12]
+	push	dword ptr [ebp + 8]
+	call	_objc_msgSend
+	add	esp, 16
+	test	eax, eax
+	je	LBB2_2
+	sub	esp, 8
+	push	dword ptr [ebp + 16]
+	push	eax
+	call	_objc_msgSend
+	add	esp, 20
+	pop	esi
+	pop	ebp
+	ret
+LBB2_2:
+	sub	esp, 4
+	lea	eax, [esi + l___unnamed_1-L2$pb]
+	lea	ecx, [esi + l___unnamed_2-L2$pb]
+	push	eax
+	push	17
+	push	ecx
+	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
+
+	.globl	_handle_alloc_release
+	.p2align	4, 0x90
+_handle_alloc_release:
+	push	ebp
+	mov	ebp, esp
+	push	esi
+	push	eax
+	call	L3$pb
+L3$pb:
+	pop	esi
+	sub	esp, 8
+	push	dword ptr [ebp + 12]
+	push	dword ptr [ebp + 8]
+	call	_objc_msgSend
+	add	esp, 16
+	test	eax, eax
+	je	LBB3_2
+	sub	esp, 12
+	push	eax
+	call	_objc_release
+	add	esp, 20
+	pop	esi
+	pop	ebp
+	ret
+LBB3_2:
+	sub	esp, 4
+	lea	eax, [esi + l___unnamed_1-L3$pb]
+	lea	ecx, [esi + l___unnamed_2-L3$pb]
+	push	eax
+	push	17
+	push	ecx
+	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
+
+	.globl	_handle_alloc_init_release
+	.p2align	4, 0x90
+_handle_alloc_init_release:
+	push	ebp
+	mov	ebp, esp
+	push	esi
+	push	eax
+	call	L4$pb
+L4$pb:
+	pop	esi
+	sub	esp, 8
+	push	dword ptr [ebp + 12]
+	push	dword ptr [ebp + 8]
+	call	_objc_msgSend
+	add	esp, 16
+	test	eax, eax
+	je	LBB4_2
+	sub	esp, 8
+	push	dword ptr [ebp + 16]
+	push	eax
+	call	_objc_msgSend
+	add	esp, 4
+	push	eax
+	call	_objc_release
+	add	esp, 20
+	pop	esi
+	pop	ebp
+	ret
+LBB4_2:
+	sub	esp, 4
+	lea	eax, [esi + l___unnamed_1-L4$pb]
+	lea	ecx, [esi + l___unnamed_2-L4$pb]
+	push	eax
+	push	17
+	push	ecx
+	call	__ZN4core6option13expect_failed17hc70f05bfe703751eE
+
+	.globl	_handle_copy
+	.p2align	4, 0x90
+_handle_copy:
+	push	ebp
+	mov	ebp, esp
+	pop	ebp
+	jmp	_objc_msgSend
+
+	.globl	_handle_autoreleased
+	.p2align	4, 0x90
+_handle_autoreleased:
+	push	ebp
+	mov	ebp, esp
+	sub	esp, 8
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [esp + 4], ecx
+	mov	dword ptr [esp], eax
+	call	_objc_msgSend
+	## InlineAsm Start
+
+	mov	ebp, ebp
+
+	## InlineAsm End
+	mov	dword ptr [esp], eax
+	call	_objc_retainAutoreleasedReturnValue
+	add	esp, 8
+	pop	ebp
+	ret
+
+	.section	__TEXT,__const
+l___unnamed_2:
+	.ascii	"Failed allocating"
+
+l___unnamed_3:
+	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
+
+	.section	__DATA,__const
+	.p2align	2
+l___unnamed_1:
+	.long	l___unnamed_3
+	.asciz	"B\000\000\000\037\000\000\000%\000\000"
+
+.subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-x86_64.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-x86_64.s
@@ -5,16 +5,8 @@
 _handle_alloc:
 	push	rbp
 	mov	rbp, rsp
-	call	_objc_msgSend
-	test	rax, rax
-	je	LBB0_2
 	pop	rbp
-	ret
-LBB0_2:
-	lea	rdi, [rip + l___unnamed_1]
-	lea	rdx, [rip + l___unnamed_2]
-	mov	esi, 17
-	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
+	jmp	_objc_msgSend
 
 	.globl	_handle_init
 	.p2align	4, 0x90
@@ -33,19 +25,12 @@ _handle_alloc_init:
 	push	rax
 	mov	rbx, rdx
 	call	_objc_msgSend
-	test	rax, rax
-	je	LBB2_1
 	mov	rdi, rax
 	mov	rsi, rbx
 	add	rsp, 8
 	pop	rbx
 	pop	rbp
 	jmp	_objc_msgSend
-LBB2_1:
-	lea	rdi, [rip + l___unnamed_1]
-	lea	rdx, [rip + l___unnamed_2]
-	mov	esi, 17
-	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
 
 	.globl	_handle_alloc_release
 	.p2align	4, 0x90
@@ -53,16 +38,9 @@ _handle_alloc_release:
 	push	rbp
 	mov	rbp, rsp
 	call	_objc_msgSend
-	test	rax, rax
-	je	LBB3_1
 	mov	rdi, rax
 	pop	rbp
 	jmp	_objc_release
-LBB3_1:
-	lea	rdi, [rip + l___unnamed_1]
-	lea	rdx, [rip + l___unnamed_2]
-	mov	esi, 17
-	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
 
 	.globl	_handle_alloc_init_release
 	.p2align	4, 0x90
@@ -73,8 +51,6 @@ _handle_alloc_init_release:
 	push	rax
 	mov	rbx, rdx
 	call	_objc_msgSend
-	test	rax, rax
-	je	LBB4_1
 	mov	rdi, rax
 	mov	rsi, rbx
 	call	_objc_msgSend
@@ -83,11 +59,6 @@ _handle_alloc_init_release:
 	pop	rbx
 	pop	rbp
 	jmp	_objc_release
-LBB4_1:
-	lea	rdi, [rip + l___unnamed_1]
-	lea	rdx, [rip + l___unnamed_2]
-	mov	esi, 17
-	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
 
 	.globl	_handle_copy
 	.p2align	4, 0x90
@@ -112,18 +83,5 @@ _handle_autoreleased:
 	## InlineAsm End
 	pop	rbp
 	ret
-
-	.section	__TEXT,__const
-l___unnamed_1:
-	.ascii	"Failed allocating"
-
-l___unnamed_3:
-	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
-
-	.section	__DATA,__const
-	.p2align	3
-l___unnamed_2:
-	.quad	l___unnamed_3
-	.asciz	"B\000\000\000\000\000\000\000\037\000\000\000%\000\000"
 
 .subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/expected/apple-x86_64.s
+++ b/tests/assembly/test_msg_send_id/expected/apple-x86_64.s
@@ -1,0 +1,129 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_handle_alloc
+	.p2align	4, 0x90
+_handle_alloc:
+	push	rbp
+	mov	rbp, rsp
+	call	_objc_msgSend
+	test	rax, rax
+	je	LBB0_2
+	pop	rbp
+	ret
+LBB0_2:
+	lea	rdi, [rip + l___unnamed_1]
+	lea	rdx, [rip + l___unnamed_2]
+	mov	esi, 17
+	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
+
+	.globl	_handle_init
+	.p2align	4, 0x90
+_handle_init:
+	push	rbp
+	mov	rbp, rsp
+	pop	rbp
+	jmp	_objc_msgSend
+
+	.globl	_handle_alloc_init
+	.p2align	4, 0x90
+_handle_alloc_init:
+	push	rbp
+	mov	rbp, rsp
+	push	rbx
+	push	rax
+	mov	rbx, rdx
+	call	_objc_msgSend
+	test	rax, rax
+	je	LBB2_1
+	mov	rdi, rax
+	mov	rsi, rbx
+	add	rsp, 8
+	pop	rbx
+	pop	rbp
+	jmp	_objc_msgSend
+LBB2_1:
+	lea	rdi, [rip + l___unnamed_1]
+	lea	rdx, [rip + l___unnamed_2]
+	mov	esi, 17
+	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
+
+	.globl	_handle_alloc_release
+	.p2align	4, 0x90
+_handle_alloc_release:
+	push	rbp
+	mov	rbp, rsp
+	call	_objc_msgSend
+	test	rax, rax
+	je	LBB3_1
+	mov	rdi, rax
+	pop	rbp
+	jmp	_objc_release
+LBB3_1:
+	lea	rdi, [rip + l___unnamed_1]
+	lea	rdx, [rip + l___unnamed_2]
+	mov	esi, 17
+	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
+
+	.globl	_handle_alloc_init_release
+	.p2align	4, 0x90
+_handle_alloc_init_release:
+	push	rbp
+	mov	rbp, rsp
+	push	rbx
+	push	rax
+	mov	rbx, rdx
+	call	_objc_msgSend
+	test	rax, rax
+	je	LBB4_1
+	mov	rdi, rax
+	mov	rsi, rbx
+	call	_objc_msgSend
+	mov	rdi, rax
+	add	rsp, 8
+	pop	rbx
+	pop	rbp
+	jmp	_objc_release
+LBB4_1:
+	lea	rdi, [rip + l___unnamed_1]
+	lea	rdx, [rip + l___unnamed_2]
+	mov	esi, 17
+	call	__ZN4core6option13expect_failed17h5222b7f29d1fceaaE
+
+	.globl	_handle_copy
+	.p2align	4, 0x90
+_handle_copy:
+	push	rbp
+	mov	rbp, rsp
+	pop	rbp
+	jmp	_objc_msgSend
+
+	.globl	_handle_autoreleased
+	.p2align	4, 0x90
+_handle_autoreleased:
+	push	rbp
+	mov	rbp, rsp
+	call	_objc_msgSend
+	mov	rdi, rax
+	call	_objc_retainAutoreleasedReturnValue
+	## InlineAsm Start
+
+	nop
+
+	## InlineAsm End
+	pop	rbp
+	ret
+
+	.section	__TEXT,__const
+l___unnamed_1:
+	.ascii	"Failed allocating"
+
+l___unnamed_3:
+	.ascii	"$WORKSPACE/objc2/src/__macro_helpers.rs"
+
+	.section	__DATA,__const
+	.p2align	3
+l___unnamed_2:
+	.quad	l___unnamed_3
+	.asciz	"B\000\000\000\000\000\000\000\037\000\000\000%\000\000"
+
+.subsections_via_symbols

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -1,0 +1,44 @@
+//! Test assembly output of `msg_send_id!` internals.
+use objc2::__macro_helpers::{Assert, MsgSendId};
+use objc2::rc::{Id, Shared};
+use objc2::runtime::{Class, Object, Sel};
+
+#[no_mangle]
+unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Id<Object, Shared> {
+    <Assert<true, false, true>>::send_message_id(obj, sel, ()).unwrap()
+}
+
+#[no_mangle]
+unsafe fn handle_init(obj: Id<Object, Shared>, sel: Sel) -> Option<Id<Object, Shared>> {
+    <Assert<false, true, true>>::send_message_id(obj, sel, ()).unwrap()
+}
+
+#[no_mangle]
+unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object, Shared>> {
+    let obj = <Assert<true, false, true>>::send_message_id(obj, sel1, ()).unwrap();
+    <Assert<false, true, true>>::send_message_id(obj, sel2, ()).unwrap()
+}
+
+#[no_mangle]
+unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
+    let _obj: Id<Object, Shared> =
+        <Assert<true, false, true>>::send_message_id(cls, sel, ()).unwrap();
+}
+
+#[no_mangle]
+unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
+    let obj = <Assert<true, false, true>>::send_message_id(cls, sel1, ()).unwrap();
+    let _obj: Id<Object, Shared> = <Assert<false, true, true>>::send_message_id(obj, sel2, ())
+        .unwrap()
+        .unwrap_unchecked();
+}
+
+#[no_mangle]
+unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
+    <Assert<false, false, true>>::send_message_id(obj, sel, ()).unwrap()
+}
+
+#[no_mangle]
+unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
+    <Assert<false, false, false>>::send_message_id(obj, sel, ()).unwrap()
+}

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -1,47 +1,47 @@
 //! Test assembly output of `msg_send_id!` internals.
-use objc2::__macro_helpers::{Assert, MsgSendId};
+use objc2::__macro_helpers::{MsgSendId, RetainSemantics};
 use objc2::rc::{Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
 unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, true, false, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_init(obj: Option<Id<Object, Shared>>, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, false, true, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object, Shared>> {
-    let obj = <Assert<false, true, false, false>>::send_message_id(obj, sel1, ()).unwrap();
-    <Assert<false, false, true, false>>::send_message_id(obj, sel2, ()).unwrap()
+    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel1, ()).unwrap();
+    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
     let _obj: Id<Object, Shared> =
-        <Assert<false, true, false, false>>::send_message_id(cls, sel, ())
+        <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ())
             .unwrap()
             .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
-    let obj = <Assert<false, true, false, false>>::send_message_id(cls, sel1, ()).unwrap();
+    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel1, ()).unwrap();
     let _obj: Id<Object, Shared> =
-        <Assert<false, false, true, false>>::send_message_id(obj, sel2, ())
+        <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ())
             .unwrap()
             .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, false, false, true>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, false, true>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, false, false, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, false, false>>::send_message_id(obj, sel, ()).unwrap()
 }

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -4,12 +4,12 @@ use objc2::rc::{Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
-unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Id<Object, Shared> {
+unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
     <Assert<true, false, true>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
-unsafe fn handle_init(obj: Id<Object, Shared>, sel: Sel) -> Option<Id<Object, Shared>> {
+unsafe fn handle_init(obj: Option<Id<Object, Shared>>, sel: Sel) -> Option<Id<Object, Shared>> {
     <Assert<false, true, true>>::send_message_id(obj, sel, ()).unwrap()
 }
 
@@ -21,8 +21,9 @@ unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Obje
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
-    let _obj: Id<Object, Shared> =
-        <Assert<true, false, true>>::send_message_id(cls, sel, ()).unwrap();
+    let _obj: Id<Object, Shared> = <Assert<true, false, true>>::send_message_id(cls, sel, ())
+        .unwrap()
+        .unwrap_unchecked();
 }
 
 #[no_mangle]

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -5,41 +5,43 @@ use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
 unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<true, false, true>>::send_message_id(obj, sel, ()).unwrap()
+    <Assert<false, true, false, false>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_init(obj: Option<Id<Object, Shared>>, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, true, true>>::send_message_id(obj, sel, ()).unwrap()
+    <Assert<false, false, true, false>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object, Shared>> {
-    let obj = <Assert<true, false, true>>::send_message_id(obj, sel1, ()).unwrap();
-    <Assert<false, true, true>>::send_message_id(obj, sel2, ()).unwrap()
+    let obj = <Assert<false, true, false, false>>::send_message_id(obj, sel1, ()).unwrap();
+    <Assert<false, false, true, false>>::send_message_id(obj, sel2, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
-    let _obj: Id<Object, Shared> = <Assert<true, false, true>>::send_message_id(cls, sel, ())
-        .unwrap()
-        .unwrap_unchecked();
+    let _obj: Id<Object, Shared> =
+        <Assert<false, true, false, false>>::send_message_id(cls, sel, ())
+            .unwrap()
+            .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
-    let obj = <Assert<true, false, true>>::send_message_id(cls, sel1, ()).unwrap();
-    let _obj: Id<Object, Shared> = <Assert<false, true, true>>::send_message_id(obj, sel2, ())
-        .unwrap()
-        .unwrap_unchecked();
+    let obj = <Assert<false, true, false, false>>::send_message_id(cls, sel1, ()).unwrap();
+    let _obj: Id<Object, Shared> =
+        <Assert<false, false, true, false>>::send_message_id(obj, sel2, ())
+            .unwrap()
+            .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, false, true>>::send_message_id(obj, sel, ()).unwrap()
+    <Assert<false, false, false, true>>::send_message_id(obj, sel, ()).unwrap()
 }
 
 #[no_mangle]
 unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <Assert<false, false, false>>::send_message_id(obj, sel, ()).unwrap()
+    <Assert<false, false, false, false>>::send_message_id(obj, sel, ()).unwrap()
 }

--- a/tests/ui/msg_send_id_invalid_method.rs
+++ b/tests/ui/msg_send_id_invalid_method.rs
@@ -1,4 +1,8 @@
 //! Test invalid msg_send_id methods.
+//!
+//! The `__msg_send_id_helper!` macro is unfortunately leaked, but I think
+//! this is better than having it show up as part of the `msg_send_id!` macro
+//! itself!
 use objc2::msg_send_id;
 use objc2::runtime::Object;
 

--- a/tests/ui/msg_send_id_invalid_method.rs
+++ b/tests/ui/msg_send_id_invalid_method.rs
@@ -1,0 +1,16 @@
+//! Test invalid msg_send_id methods.
+use objc2::msg_send_id;
+use objc2::runtime::Object;
+
+fn main() {
+    let object: &Object;
+    unsafe { msg_send_id![object, retain] };
+    unsafe { msg_send_id![object, release] };
+    unsafe { msg_send_id![object, autorelease] };
+    unsafe {
+        msg_send_id![
+            object,
+            retain,
+        ]
+    };
+}

--- a/tests/ui/msg_send_id_invalid_method.stderr
+++ b/tests/ui/msg_send_id_invalid_method.stderr
@@ -1,34 +1,34 @@
 error: msg_send_id![obj, retain] is not supported. Use `Id::retain` instead
- --> ui/msg_send_id_invalid_method.rs:7:14
-  |
-7 |     unsafe { msg_send_id![object, retain] };
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> ui/msg_send_id_invalid_method.rs:11:14
+   |
+11 |     unsafe { msg_send_id![object, retain] };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `$crate::__msg_send_id_helper` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: msg_send_id![obj, release] is not supported. Drop an `Id` instead
- --> ui/msg_send_id_invalid_method.rs:8:14
-  |
-8 |     unsafe { msg_send_id![object, release] };
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> ui/msg_send_id_invalid_method.rs:12:14
+   |
+12 |     unsafe { msg_send_id![object, release] };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `$crate::__msg_send_id_helper` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: msg_send_id![obj, autorelease] is not supported. Use `Id::autorelease`
- --> ui/msg_send_id_invalid_method.rs:9:14
-  |
-9 |     unsafe { msg_send_id![object, autorelease] };
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> ui/msg_send_id_invalid_method.rs:13:14
+   |
+13 |     unsafe { msg_send_id![object, autorelease] };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `$crate::__msg_send_id_helper` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: msg_send_id![obj, retain] is not supported. Use `Id::retain` instead
-  --> ui/msg_send_id_invalid_method.rs:11:9
+  --> ui/msg_send_id_invalid_method.rs:15:9
    |
-11 | /         msg_send_id![
-12 | |             object,
-13 | |             retain,
-14 | |         ]
+15 | /         msg_send_id![
+16 | |             object,
+17 | |             retain,
+18 | |         ]
    | |_________^
    |
-   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__msg_send_id_helper` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_method.stderr
+++ b/tests/ui/msg_send_id_invalid_method.stderr
@@ -1,0 +1,34 @@
+error: msg_send_id![obj, retain] is not supported. Use `Id::retain` instead
+ --> ui/msg_send_id_invalid_method.rs:7:14
+  |
+7 |     unsafe { msg_send_id![object, retain] };
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: msg_send_id![obj, release] is not supported. Drop an `Id` instead
+ --> ui/msg_send_id_invalid_method.rs:8:14
+  |
+8 |     unsafe { msg_send_id![object, release] };
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: msg_send_id![obj, autorelease] is not supported. Use `Id::autorelease`
+ --> ui/msg_send_id_invalid_method.rs:9:14
+  |
+9 |     unsafe { msg_send_id![object, autorelease] };
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: msg_send_id![obj, retain] is not supported. Use `Id::retain` instead
+  --> ui/msg_send_id_invalid_method.rs:11:9
+   |
+11 | /         msg_send_id![
+12 | |             object,
+13 | |             retain,
+14 | |         ]
+   | |_________^
+   |
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_receiver.rs
+++ b/tests/ui/msg_send_id_invalid_receiver.rs
@@ -1,0 +1,16 @@
+//! Test compiler output with invalid msg_send_id receivers.
+use objc2::msg_send_id;
+use objc2::runtime::{Class, Object};
+use objc2::rc::{Id, Shared};
+
+fn main() {
+    let obj: &Object;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+
+    let cls: &Class;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
+
+    let obj: Id<Object, Shared>;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
+}

--- a/tests/ui/msg_send_id_invalid_receiver.rs
+++ b/tests/ui/msg_send_id_invalid_receiver.rs
@@ -5,6 +5,7 @@ use objc2::rc::{Id, Shared};
 
 fn main() {
     let obj: &Object;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new].unwrap() };
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
 

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Object>` 
              <Option<&'a mut T> as From<&'a mut Option<T>>>
              <Option<T> as From<T>>
    = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Option<Id<_, _>>>` for `Assert<false, false, true, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Id<_, _>>` for `Assert<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` is not satisfied
@@ -57,7 +57,7 @@ error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` i
              <Option<&'a mut T> as From<&'a mut Option<T>>>
              <Option<T> as From<T>>
    = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Class`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<_, _>>>` for `Assert<false, false, true, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<_, _>>` for `Assert<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
@@ -69,5 +69,5 @@ error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiv
    = help: the following other types implement trait `MessageReceiver`:
              &'a Id<T, O>
              &'a mut Id<T, objc2::rc::Owned>
-   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Option<Id<_, _>>>` for `Assert<false, false, false, true>`
+   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>` for `Assert<false, false, false, true>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -32,33 +32,39 @@ note: associated function defined here
    |     unsafe fn send_message_id<A: MessageArguments>(
    |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Object>` is not satisfied
-  --> ui/msg_send_id_invalid_receiver.rs:10:42
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:10:55
    |
 10 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&objc2::runtime::Object>` is not implemented for `Option<Id<_, _>>`
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected enum `Option`, found `&objc2::runtime::Object`
+   |                                          arguments to this function are incorrect
    |
-   = help: the following other types implement trait `From<T>`:
-             <Option<&'a T> as From<&'a Option<T>>>
-             <Option<&'a mut T> as From<&'a mut Option<T>>>
-             <Option<T> as From<T>>
-   = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Id<_, _>>` for `RetainSemantics<false, false, true, false>`
-   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note:   expected enum `Option<Id<_, _>>`
+           found reference `&objc2::runtime::Object`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` is not satisfied
-  --> ui/msg_send_id_invalid_receiver.rs:13:42
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:13:55
    |
 13 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&objc2::runtime::Class>` is not implemented for `Option<Id<_, _>>`
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected enum `Option`, found `&objc2::runtime::Class`
+   |                                          arguments to this function are incorrect
    |
-   = help: the following other types implement trait `From<T>`:
-             <Option<&'a T> as From<&'a Option<T>>>
-             <Option<&'a mut T> as From<&'a mut Option<T>>>
-             <Option<T> as From<T>>
-   = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Class`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<_, _>>` for `RetainSemantics<false, false, true, false>`
-   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note:   expected enum `Option<Id<_, _>>`
+           found reference `&objc2::runtime::Class`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
   --> ui/msg_send_id_invalid_receiver.rs:16:42

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -32,34 +32,32 @@ note: associated function defined here
    |     unsafe fn send_message_id<A: MessageArguments>(
    |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Assert<false, false, true, false>: MsgSendId<&objc2::runtime::Object, _>` is not satisfied
+error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Object>` is not satisfied
   --> ui/msg_send_id_invalid_receiver.rs:10:42
    |
 10 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Object, _>` is not implemented for `Assert<false, false, true, false>`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&objc2::runtime::Object>` is not implemented for `Option<Id<_, _>>`
    |
-   = help: the following other types implement trait `MsgSendId<T, U>`:
-             <Assert<false, false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, false, true, false> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
-             <Assert<false, false, true, false> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
-             <Assert<false, true, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
-             <Assert<true, false, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+   = help: the following other types implement trait `From<T>`:
+             <Option<&'a T> as From<&'a Option<T>>>
+             <Option<&'a mut T> as From<&'a mut Option<T>>>
+             <Option<T> as From<T>>
+   = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Object`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Option<Id<_, _>>>` for `Assert<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Assert<false, false, true, false>: MsgSendId<&objc2::runtime::Class, _>` is not satisfied
+error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` is not satisfied
   --> ui/msg_send_id_invalid_receiver.rs:13:42
    |
 13 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Class, _>` is not implemented for `Assert<false, false, true, false>`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&objc2::runtime::Class>` is not implemented for `Option<Id<_, _>>`
    |
-   = help: the following other types implement trait `MsgSendId<T, U>`:
-             <Assert<false, false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, false, true, false> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
-             <Assert<false, false, true, false> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
-             <Assert<false, true, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
-             <Assert<true, false, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+   = help: the following other types implement trait `From<T>`:
+             <Option<&'a T> as From<&'a Option<T>>>
+             <Option<&'a mut T> as From<&'a mut Option<T>>>
+             <Option<T> as From<T>>
+   = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Class`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<_, _>>>` for `Assert<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -1,7 +1,24 @@
 error[E0308]: mismatched types
   --> ui/msg_send_id_invalid_receiver.rs:8:55
    |
-8  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
+8  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new].unwrap() };
+   |                                          -------------^^^------
+   |                                          |            |
+   |                                          |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
+   |                                          arguments to this function are incorrect
+   |
+   = note: expected reference `&objc2::runtime::Class`
+              found reference `&objc2::runtime::Object`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:9:55
+   |
+9  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
    |                                          -------------^^^--------
    |                                          |            |
    |                                          |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
@@ -15,42 +32,44 @@ note: associated function defined here
    |     unsafe fn send_message_id<A: MessageArguments>(
    |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Assert<false, true, true>: MsgSendId<&objc2::runtime::Object, _>` is not satisfied
- --> ui/msg_send_id_invalid_receiver.rs:9:42
-  |
-9 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-  |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Object, _>` is not implemented for `Assert<false, true, true>`
-  |
-  = help: the following other types implement trait `MsgSendId<T, U>`:
-            <Assert<false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
-            <Assert<false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
-            <Assert<false, true, true> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
-            <Assert<false, true, true> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
-            <Assert<true, false, true> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `Assert<false, true, true>: MsgSendId<&objc2::runtime::Class, _>` is not satisfied
-  --> ui/msg_send_id_invalid_receiver.rs:12:42
+error[E0277]: the trait bound `Assert<false, false, true, false>: MsgSendId<&objc2::runtime::Object, _>` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs:10:42
    |
-12 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Class, _>` is not implemented for `Assert<false, true, true>`
+10 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Object, _>` is not implemented for `Assert<false, false, true, false>`
    |
    = help: the following other types implement trait `MsgSendId<T, U>`:
-             <Assert<false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
-             <Assert<false, true, true> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
-             <Assert<false, true, true> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
-             <Assert<true, false, true> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+             <Assert<false, false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, false, true, false> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
+             <Assert<false, false, true, false> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
+             <Assert<false, true, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+             <Assert<true, false, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Assert<false, false, true, false>: MsgSendId<&objc2::runtime::Class, _>` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs:13:42
+   |
+13 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Class, _>` is not implemented for `Assert<false, false, true, false>`
+   |
+   = help: the following other types implement trait `MsgSendId<T, U>`:
+             <Assert<false, false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, false, true, false> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
+             <Assert<false, false, true, false> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
+             <Assert<false, true, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+             <Assert<true, false, false, false> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
-  --> ui/msg_send_id_invalid_receiver.rs:15:42
+  --> ui/msg_send_id_invalid_receiver.rs:16:42
    |
-15 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
+16 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object, Shared>`
    |
    = help: the following other types implement trait `MessageReceiver`:
              &'a Id<T, O>
              &'a mut Id<T, objc2::rc::Owned>
-   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Option<Id<_, _>>>` for `Assert<false, false, true>`
+   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Option<Id<_, _>>>` for `Assert<false, false, false, true>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Object>` 
              <Option<&'a mut T> as From<&'a mut Option<T>>>
              <Option<T> as From<T>>
    = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Id<_, _>>` for `Assert<false, false, true, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Id<_, _>>` for `RetainSemantics<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` is not satisfied
@@ -57,7 +57,7 @@ error[E0277]: the trait bound `Option<Id<_, _>>: From<&objc2::runtime::Class>` i
              <Option<&'a mut T> as From<&'a mut Option<T>>>
              <Option<T> as From<T>>
    = note: required because of the requirements on the impl of `Into<Option<Id<_, _>>>` for `&objc2::runtime::Class`
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<_, _>>` for `Assert<false, false, true, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<_, _>>` for `RetainSemantics<false, false, true, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
@@ -69,5 +69,5 @@ error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiv
    = help: the following other types implement trait `MessageReceiver`:
              &'a Id<T, O>
              &'a mut Id<T, objc2::rc::Owned>
-   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>` for `Assert<false, false, false, true>`
+   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>` for `RetainSemantics<false, false, false, true>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -15,39 +15,33 @@ note: associated function defined here
    |     unsafe fn send_message_id<A: MessageArguments>(
    |               ^^^^^^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_receiver.rs:9:55
-   |
-9  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-   |                                          -------------^^^-------
-   |                                          |            |
-   |                                          |            expected enum `Option`, found `&objc2::runtime::Object`
-   |                                          arguments to this function are incorrect
-   |
-   = note:   expected enum `Option<Id<_, _>>`
-           found reference `&objc2::runtime::Object`
-note: associated function defined here
-  --> $WORKSPACE/objc2/src/__macro_helpers.rs
-   |
-   |     unsafe fn send_message_id<A: MessageArguments>(
-   |               ^^^^^^^^^^^^^^^
+error[E0277]: the trait bound `Assert<false, true, true>: MsgSendId<&objc2::runtime::Object, _>` is not satisfied
+ --> ui/msg_send_id_invalid_receiver.rs:9:42
+  |
+9 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Object, _>` is not implemented for `Assert<false, true, true>`
+  |
+  = help: the following other types implement trait `MsgSendId<T, U>`:
+            <Assert<false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
+            <Assert<false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
+            <Assert<false, true, true> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
+            <Assert<false, true, true> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
+            <Assert<true, false, true> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_receiver.rs:12:55
+error[E0277]: the trait bound `Assert<false, true, true>: MsgSendId<&objc2::runtime::Class, _>` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs:12:42
    |
 12 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
-   |                                          -------------^^^-------
-   |                                          |            |
-   |                                          |            expected enum `Option`, found `&objc2::runtime::Class`
-   |                                          arguments to this function are incorrect
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MsgSendId<&objc2::runtime::Class, _>` is not implemented for `Assert<false, true, true>`
    |
-   = note:   expected enum `Option<Id<_, _>>`
-           found reference `&objc2::runtime::Class`
-note: associated function defined here
-  --> $WORKSPACE/objc2/src/__macro_helpers.rs
-   |
-   |     unsafe fn send_message_id<A: MessageArguments>(
-   |               ^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `MsgSendId<T, U>`:
+             <Assert<false, false, false> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, false, true> as MsgSendId<T, Option<Id<U, O>>>>
+             <Assert<false, true, true> as MsgSendId<Id<T, O>, Option<Id<T, O>>>>
+             <Assert<false, true, true> as MsgSendId<Option<Id<T, O>>, Option<Id<T, O>>>>
+             <Assert<true, false, true> as MsgSendId<&objc2::runtime::Class, Option<Id<T, O>>>>
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
   --> ui/msg_send_id_invalid_receiver.rs:15:42

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -1,0 +1,62 @@
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:8:55
+   |
+8  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
+   |                                          -------------^^^--------
+   |                                          |            |
+   |                                          |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
+   |                                          arguments to this function are incorrect
+   |
+   = note: expected reference `&objc2::runtime::Class`
+              found reference `&objc2::runtime::Object`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:9:55
+   |
+9  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected enum `Option`, found `&objc2::runtime::Object`
+   |                                          arguments to this function are incorrect
+   |
+   = note:   expected enum `Option<Id<_, _>>`
+           found reference `&objc2::runtime::Object`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:12:55
+   |
+12 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected enum `Option`, found `&objc2::runtime::Class`
+   |                                          arguments to this function are incorrect
+   |
+   = note:   expected enum `Option<Id<_, _>>`
+           found reference `&objc2::runtime::Class`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(
+   |               ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs:15:42
+   |
+15 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object, Shared>`
+   |
+   = help: the following other types implement trait `MessageReceiver`:
+             &'a Id<T, O>
+             &'a mut Id<T, objc2::rc::Owned>
+   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, Option<Id<_, _>>>` for `Assert<false, false, true>`
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_id_invalid_return.rs
+++ b/tests/ui/msg_send_id_invalid_return.rs
@@ -1,0 +1,25 @@
+//! Test compiler output with invalid msg_send_id receivers.
+use objc2::msg_send_id;
+use objc2::runtime::{Class, Object};
+use objc2::rc::{Id, Owned, Shared};
+use objc2_foundation::NSObject;
+
+fn main() {
+    let cls: &Class;
+    let _: &Object = unsafe { msg_send_id![cls, new].unwrap() };
+    let _: Id<Class, Shared> = unsafe { msg_send_id![cls, new].unwrap() };
+    let _: &Object = unsafe { msg_send_id![cls, alloc].unwrap() };
+    let _: Id<Class, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+
+    let obj: Option<Id<Object, Shared>>;
+    let _: &Object = unsafe { msg_send_id![obj, init].unwrap() };
+    let obj: Option<Id<Object, Shared>>;
+    let _: Id<Class, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+    let obj: Option<Id<Object, Shared>>;
+    let _: Id<NSObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+    let obj: Option<Id<Object, Shared>>;
+    let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
+
+    let obj: Id<Object, Shared>;
+    let _: &Object = unsafe { msg_send_id![&obj, description].unwrap() };
+}

--- a/tests/ui/msg_send_id_invalid_return.stderr
+++ b/tests/ui/msg_send_id_invalid_return.stderr
@@ -1,0 +1,112 @@
+error[E0308]: mismatched types
+ --> ui/msg_send_id_invalid_return.rs:9:31
+  |
+9 |     let _: &Object = unsafe { msg_send_id![cls, new].unwrap() };
+  |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                               |
+  |                               expected `&objc2::runtime::Object`, found struct `Id`
+  |                               help: consider borrowing here: `&msg_send_id![cls, new].unwrap()`
+  |
+  = note: expected reference `&objc2::runtime::Object`
+                found struct `Id<_, _>`
+
+error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
+  --> ui/msg_send_id_invalid_return.rs:10:41
+   |
+10 |     let _: Id<Class, Shared> = unsafe { msg_send_id![cls, new].unwrap() };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `objc2::runtime::Class`
+   |
+   = help: the following other types implement trait `Message`:
+             NSArray<T, O>
+             NSAttributedString
+             NSData
+             NSDictionary<K, V>
+             NSMutableArray<T, O>
+             NSMutableAttributedString
+             NSMutableData
+             NSMutableString
+           and 7 others
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<false, false, true>`
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:11:31
+   |
+11 |     let _: &Object = unsafe { msg_send_id![cls, alloc].unwrap() };
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               expected `&objc2::runtime::Object`, found struct `Id`
+   |                               help: consider borrowing here: `&msg_send_id![cls, alloc].unwrap()`
+   |
+   = note: expected reference `&objc2::runtime::Object`
+                 found struct `Id<_, _>`
+
+error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
+  --> ui/msg_send_id_invalid_return.rs:12:41
+   |
+12 |     let _: Id<Class, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `objc2::runtime::Class`
+   |
+   = help: the following other types implement trait `Message`:
+             NSArray<T, O>
+             NSAttributedString
+             NSData
+             NSDictionary<K, V>
+             NSMutableArray<T, O>
+             NSMutableAttributedString
+             NSMutableData
+             NSMutableString
+           and 7 others
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<true, false, true>`
+   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:15:31
+   |
+15 |     let _: &Object = unsafe { msg_send_id![obj, init].unwrap() };
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               expected `&objc2::runtime::Object`, found struct `Id`
+   |                               help: consider borrowing here: `&msg_send_id![obj, init].unwrap()`
+   |
+   = note: expected reference `&objc2::runtime::Object`
+                 found struct `Id<objc2::runtime::Object, Shared>`
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:17:41
+   |
+17 |     let _: Id<Class, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
+   |
+   = note: expected struct `Id<objc2::runtime::Class, _>`
+              found struct `Id<objc2::runtime::Object, _>`
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:19:44
+   |
+19 |     let _: Id<NSObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `NSObject`, found struct `objc2::runtime::Object`
+   |
+   = note: expected struct `Id<NSObject, _>`
+              found struct `Id<objc2::runtime::Object, _>`
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:21:41
+   |
+21 |     let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `objc2::rc::Owned`, found enum `Shared`
+   |
+   = note: expected struct `Id<_, objc2::rc::Owned>`
+              found struct `Id<_, Shared>`
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:24:31
+   |
+24 |     let _: &Object = unsafe { msg_send_id![&obj, description].unwrap() };
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               expected `&objc2::runtime::Object`, found struct `Id`
+   |                               help: consider borrowing here: `&msg_send_id![&obj, description].unwrap()`
+   |
+   = note: expected reference `&objc2::runtime::Object`
+                 found struct `Id<_, _>`

--- a/tests/ui/msg_send_id_invalid_return.stderr
+++ b/tests/ui/msg_send_id_invalid_return.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<false, false, true>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<true, false, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -57,7 +57,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<true, false, true>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<false, true, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui/msg_send_id_invalid_return.stderr
+++ b/tests/ui/msg_send_id_invalid_return.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `Assert<true, false, false, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `RetainSemantics<true, false, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -57,7 +57,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `Assert<false, true, false, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `RetainSemantics<false, true, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui/msg_send_id_invalid_return.stderr
+++ b/tests/ui/msg_send_id_invalid_return.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<true, false, false, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `Assert<true, false, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -57,7 +57,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Option<Id<objc2::runtime::Class, Shared>>>` for `Assert<false, true, false, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `Assert<false, true, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui/msg_send_id_underspecified.rs
+++ b/tests/ui/msg_send_id_underspecified.rs
@@ -1,0 +1,10 @@
+//! Test compiler output of msg_send_id when ownership is not specified.
+//!
+//! Don't think it's really possible for us to improve this diagnostic?
+use objc2::msg_send_id;
+use objc2::runtime::Object;
+
+fn main() {
+    let obj: &Object;
+    let _: &Object = &*unsafe { msg_send_id![obj, description].unwrap() };
+}

--- a/tests/ui/msg_send_id_underspecified.rs
+++ b/tests/ui/msg_send_id_underspecified.rs
@@ -1,6 +1,4 @@
 //! Test compiler output of msg_send_id when ownership is not specified.
-//!
-//! Don't think it's really possible for us to improve this diagnostic?
 use objc2::msg_send_id;
 use objc2::runtime::Object;
 

--- a/tests/ui/msg_send_id_underspecified.stderr
+++ b/tests/ui/msg_send_id_underspecified.stderr
@@ -1,12 +1,7 @@
-error[E0282]: type annotations needed for `Option<Id<objc2::runtime::Object, O>>`
- --> ui/msg_send_id_underspecified.rs:9:33
+error[E0282]: type annotations needed
+ --> ui/msg_send_id_underspecified.rs:7:33
   |
-9 |     let _: &Object = &*unsafe { msg_send_id![obj, description].unwrap() };
-  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+7 |     let _: &Object = &*unsafe { msg_send_id![obj, description].unwrap() };
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
   |
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider giving `result` an explicit type, where the type for type parameter `O` is specified
- --> $WORKSPACE/objc2/src/macros.rs
-  |
-  |         let result: Option<Id<objc2::runtime::Object, O>>;
-  |                   +++++++++++++++++++++++++++++++++++++++

--- a/tests/ui/msg_send_id_underspecified.stderr
+++ b/tests/ui/msg_send_id_underspecified.stderr
@@ -1,0 +1,12 @@
+error[E0282]: type annotations needed for `Option<Id<objc2::runtime::Object, O>>`
+ --> ui/msg_send_id_underspecified.rs:9:33
+  |
+9 |     let _: &Object = &*unsafe { msg_send_id![obj, description].unwrap() };
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider giving `result` an explicit type, where the type for type parameter `O` is specified
+ --> $WORKSPACE/objc2/src/macros.rs
+  |
+  |         let result: Option<Id<objc2::runtime::Object, O>>;
+  |                   +++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Add `msg_send_id!` to help with following [memory management rules](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-BAJHFBGH) (see also [this](https://clang.llvm.org/docs/AutomaticReferenceCounting.html#retain-count-semantics)).

Closes https://github.com/madsmtm/objc2/issues/86.

TODO:
- [x] Figure out https://github.com/madsmtm/objc2/pull/81.
- [x] Figure out https://github.com/madsmtm/objc2/pull/150.
- [x] Better testing, ~blocked on https://github.com/madsmtm/objc2/pull/166~.
- [x] Proper initial implementation
- [x] Should `alloc` return `Option<Id<Allocated<T>, O>>`, and just allow passing that to `init`, or should we handle it?
  It should and now does.
- [x] Test whether diagnostics are better if we use associated types (means that `__MsgSendId`/`__MsgSuperSendId` can only be implemented for one type pr. `__Allocated<...>`, which may be better?)
  - I've tweaked things and tried a few different options, what we have now is pretty good!
- [x] ~Consider using `MaybeUninit` instead of `Allocated`?~
  Nope, see https://github.com/madsmtm/objc2/issues/87#issuecomment-1148099411
- [x] ~`super` calls~ Postponed, to https://github.com/madsmtm/objc2/pull/173
- [x] Moved `rc::Allocated<T>` to https://github.com/madsmtm/objc2/pull/172 to get this merged.
- [x] Consider whether `init` should take generic `Into<Option>`, or just `Option`.
- [x] Documentation
- [x] Cleanup