### PR TITLE
WIP: Allow `bool` as the return type from `msg_send!`

### DIFF
--- a/objc2-encode/src/encode.rs
+++ b/objc2-encode/src/encode.rs
@@ -183,13 +183,13 @@ unsafe impl Encode for () {
     const ENCODING: Encoding<'static> = Encoding::Void;
 }
 
-/// Using this directly is heavily discouraged, since the type of BOOL differs
-/// across platforms.
-///
-/// Use `objc2::runtime::Bool::ENCODING` instead.
-unsafe impl Encode for bool {
-    const ENCODING: Encoding<'static> = Encoding::Bool;
-}
+// /// Using this directly is heavily discouraged, since the type of BOOL differs
+// /// across platforms.
+// ///
+// /// Use `objc2::runtime::Bool::ENCODING` instead.
+// unsafe impl Encode for bool {
+//     const ENCODING: Encoding<'static> = Encoding::Bool;
+// }
 
 macro_rules! encode_impls_size {
     ($($t:ty => ($t16:ty, $t32:ty, $t64:ty),)*) => ($(
@@ -219,7 +219,7 @@ macro_rules! pointer_refencode_impl {
     )*);
 }
 
-pointer_refencode_impl!(bool, i16, i32, i64, isize, u16, u32, u64, usize, f32, f64);
+pointer_refencode_impl!(i16, i32, i64, isize, u16, u32, u64, usize, f32, f64);
 
 /// Pointers to [`i8`] use the special [`Encoding::String`] encoding.
 unsafe impl RefEncode for i8 {

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -90,3 +90,25 @@ mod parse;
 
 pub use self::encode::{Encode, EncodeArguments, RefEncode};
 pub use self::encoding::Encoding;
+
+/// TODO
+pub trait ReturnType {
+    /// TODO
+    type From: Encode;
+    /// TODO
+    fn from_return_type(from: Self::From) -> Self;
+}
+
+impl<T: Encode> ReturnType for T {
+    type From = T;
+    fn from_return_type(from: Self::From) -> Self {
+        from
+    }
+}
+
+impl ReturnType for bool {
+    type From = i8; // BOOL - Varies between runtimes
+    fn from_return_type(from: Self::From) -> Self {
+        from != 0
+    }
+}

--- a/objc2/examples/into_bool.rs
+++ b/objc2/examples/into_bool.rs
@@ -1,0 +1,12 @@
+use objc2::runtime::Object;
+use objc2::{class, msg_send};
+
+fn main() {
+    // Get a class
+    let cls = class!(NSObject);
+
+    let obj: *mut Object = unsafe { msg_send![cls, new] };
+
+    let x = unsafe { msg_send![obj, isEqual: obj] };
+    if x {}
+}

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -143,7 +143,7 @@ extern "C" {}
 
 pub use objc_sys as ffi;
 
-pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
+pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode, ReturnType};
 
 pub use crate::message::{Message, MessageArguments, MessageError, MessageReceiver};
 

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -140,7 +140,7 @@ macro_rules! msg_send {
         let result;
         match $crate::MessageReceiver::send_super_message(&$obj, $superclass, sel, ()) {
             Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
+            Ok(r) => result = $crate::ReturnType::from_return_type(r),
         }
         result
     });
@@ -149,7 +149,7 @@ macro_rules! msg_send {
         let result;
         match $crate::MessageReceiver::send_super_message(&$obj, $superclass, sel, ($($arg,)+)) {
             Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
+            Ok(r) => result = $crate::ReturnType::from_return_type(r),
         }
         result
     });
@@ -158,7 +158,7 @@ macro_rules! msg_send {
         let result;
         match $crate::MessageReceiver::send_message(&$obj, sel, ()) {
             Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
+            Ok(r) => result = $crate::ReturnType::from_return_type(r),
         }
         result
     });
@@ -167,7 +167,7 @@ macro_rules! msg_send {
         let result;
         match $crate::MessageReceiver::send_message(&$obj, sel, ($($arg,)+)) {
             Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
+            Ok(r) => result = $crate::ReturnType::from_return_type(r),
         }
         result
     });


### PR DESCRIPTION
A proof of concept for https://github.com/madsmtm/objc2/issues/125.

There's an issue with `objc2-encode` being its own crate, which means we can't write the `impl<T: Encode> ReturnType for T` in any other crate, but that's solvable (by merging `objc2` and `objc2-encode`, though not very nice).

Instead of the `impl<T: Encode> ReturnType for T` impl, what we really want is specialization :/