### PR TITLE
Verify that an `Id`s' ownership is correct using associated objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       ARGS: --no-default-features --features std --features ${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
-      FEATURES: ${{ matrix.features || 'malloc,block,exception,catch_all,verify_message' }}
+      FEATURES: ${{ matrix.features || 'malloc,block,exception,catch_all,verify_message,unstable-verify-ownership' }}
       UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind' }}
 
     runs-on: ${{ matrix.os }}

--- a/objc-sys/src/constants.rs
+++ b/objc-sys/src/constants.rs
@@ -19,12 +19,32 @@ pub const nil: id = 0 as *mut _;
 /// A quick alias for a [`null_mut`][`core::ptr::null_mut`] class.
 pub const Nil: *mut objc_class = 0 as *mut _;
 
+/// Policies related to associative references.
+///
+/// These are options to [`objc_setAssociatedObject`].
+///
+/// [`objc_setAssociatedObject`]: crate::objc_setAssociatedObject
 pub type objc_AssociationPolicy = usize;
+/// Specifies a weak reference to the associated object.
+///
+/// This performs straight assignment, without message sends.
 pub const OBJC_ASSOCIATION_ASSIGN: objc_AssociationPolicy = 0;
+/// Specifies a strong reference to the associated object.
+///
+/// The association is not made atomically.
 pub const OBJC_ASSOCIATION_RETAIN_NONATOMIC: objc_AssociationPolicy = 1;
+/// Specifies that the associated object is copied.
+///
+/// The association is not made atomically.
 pub const OBJC_ASSOCIATION_COPY_NONATOMIC: objc_AssociationPolicy = 3;
-pub const OBJC_ASSOCIATION_RETAIN: objc_AssociationPolicy = 769;
-pub const OBJC_ASSOCIATION_COPY: objc_AssociationPolicy = 771;
+/// Specifies a strong reference to the associated object.
+///
+/// The association is made atomically.
+pub const OBJC_ASSOCIATION_RETAIN: objc_AssociationPolicy = 0o1401;
+/// Specifies that the associated object is copied.
+///
+/// The association is made atomically.
+pub const OBJC_ASSOCIATION_COPY: objc_AssociationPolicy = 0o1403;
 
 #[cfg(apple)]
 pub const OBJC_SYNC_SUCCESS: c_int = 0;
@@ -36,3 +56,17 @@ pub const OBJC_SYNC_TIMED_OUT: c_int = -2;
 /// Only relevant before macOS 10.13
 #[cfg(apple)]
 pub const OBJC_SYNC_NOT_INITIALIZED: c_int = -3;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_association_policy() {
+        assert_eq!(OBJC_ASSOCIATION_RETAIN, 769);
+        assert_eq!(OBJC_ASSOCIATION_COPY, 771);
+
+        // What the GNUStep headers define
+        assert_eq!(OBJC_ASSOCIATION_RETAIN, 0x301);
+        assert_eq!(OBJC_ASSOCIATION_COPY, 0x303);
+    }
+}

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -58,6 +58,10 @@ unstable-autoreleasesafe = []
 # Uses the nightly c_unwind feature to make throwing safe
 unstable-c-unwind = ["objc-sys/unstable-c-unwind"]
 
+# Uses associated types on every object to check whether Id's ownership rules
+# are being upheld.
+unstable-verify-ownership = []
+
 # Runtime selection. See `objc-sys` for details.
 apple = ["objc-sys/apple"]
 gnustep-1-7 = ["objc-sys/gnustep-1-7"]

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -272,6 +272,8 @@ mod tests {
             // let copy: Id<RcTestObject, Shared> = unsafe { msg_send_id![&obj, copy].unwrap() };
             // let mutable_copy: Id<RcTestObject, Shared> = unsafe { msg_send_id![&obj, mutableCopy].unwrap() };
 
+            let obj: Id<RcTestObject, Shared> = obj.into();
+            expected.assert_current();
             let _self: Id<RcTestObject, Shared> = unsafe { msg_send_id![&obj, self].unwrap() };
             expected.retain += 1;
             expected.assert_current();

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -218,7 +218,9 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
         // SAFETY: Option<Id<T, _>> has the same size as *mut T
         let obj = ManuallyDrop::new(obj);
         let ptr = unsafe { mem::transmute::<ManuallyDrop<Option<Self>>, *mut T>(obj) };
-        unsafe { O::__relinquish_ownership(ptr.cast()) };
+        if !ptr.is_null() {
+            unsafe { O::__relinquish_ownership(ptr.cast()) };
+        }
         ptr
     }
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -781,4 +781,14 @@ mod tests {
         };
         // Dropping fails
     }
+
+    #[test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "An `Id<T, Owned>` exists while trying to create `Id<T, Shared>`!"
+    )]
+    fn test_create_shared_when_owned_exists() {
+        let obj = new();
+        let _obj: Id<Object, Shared> = unsafe { Id::retain(obj.ptr) };
+    }
 }

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -750,10 +750,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        debug_assertions,
-        should_panic = "Another `Id<T, Owned>` has already been created from that object"
-    )]
+    #[cfg(feature = "unstable-verify-ownership")]
+    #[should_panic = "Another `Id<T, Owned>` has already been created from that object"]
     fn test_double_owned() {
         let mut obj = new();
         // Double-retain: This is unsound!
@@ -761,10 +759,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        debug_assertions,
-        should_panic = "Tried to give up ownership of `Id<T, Owned>` that wasn't owned"
-    )]
+    #[cfg(feature = "unstable-verify-ownership")]
+    #[should_panic = "Tried to give up ownership of `Id<T, Owned>` that wasn't owned"]
     fn test_double_forgotten() {
         let obj = new();
         let ptr = Id::forget(obj);
@@ -779,10 +775,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        debug_assertions,
-        should_panic = "An `Id<T, Owned>` exists while trying to create `Id<T, Shared>`!"
-    )]
+    #[cfg(feature = "unstable-verify-ownership")]
+    #[should_panic = "An `Id<T, Owned>` exists while trying to create `Id<T, Shared>`!"]
     fn test_create_shared_when_owned_exists() {
         let mut obj = new();
         let _obj: Id<Object, Shared> = unsafe { Id::retain(Id::as_mut_ptr(&mut obj)).unwrap() };

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -47,6 +47,10 @@ impl Ownership for Owned {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
         std::println!("\nOwned __ensure_unique_if_owned: {:?} / {:?}", obj, key());
+        if obj.is_null() {
+            panic!("Tried to take ownership of nil object!");
+        }
+
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
         std::println!("Owned associated: {:?}", associated);
         if associated.is_null() {
@@ -66,6 +70,10 @@ impl Ownership for Owned {
     #[track_caller]
     unsafe fn __relinquish_ownership(obj: *mut ffi::objc_object) {
         std::println!("\nOwned __relinquish_ownership: {:?} / {:?}", obj, key());
+        if obj.is_null() {
+            panic!("Tried to release ownership of nil object!");
+        }
+
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
         std::println!("Owned associated: {:?}", associated);
         if associated.is_null() {
@@ -89,6 +97,10 @@ impl Ownership for Shared {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
         std::println!("\nShared __ensure_unique_if_owned: {:?} / {:?}", obj, key());
+        if obj.is_null() {
+            panic!("Tried to take shared ownership of nil object!");
+        }
+
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
         std::println!("Shared associated: {:?}", associated);
         if !associated.is_null() {
@@ -98,6 +110,10 @@ impl Ownership for Shared {
     #[track_caller]
     unsafe fn __relinquish_ownership(obj: *mut ffi::objc_object) {
         std::println!("\nShared __relinquish_ownership: {:?} / {:?}", obj, key());
+        if obj.is_null() {
+            panic!("Tried to release shared ownership of nil object!");
+        }
+
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
         std::println!("Shared associated: {:?}", associated);
         if !associated.is_null() {

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -46,9 +46,9 @@ fn key() -> *const c_void {
 impl Ownership for Owned {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
-        std::println!("\n__ensure_unique_if_owned: {:?} / {:?}", obj, key());
+        std::println!("\nOwned __ensure_unique_if_owned: {:?} / {:?}", obj, key());
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Owned associated: {:?}", associated);
         if associated.is_null() {
             // Set the associated object to something (it can be anything, so
             // we just set it to the current object).
@@ -60,14 +60,14 @@ impl Ownership for Owned {
             panic!("Another `Id<T, Owned>` has already been created from that object!");
         }
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Owned associated: {:?}", associated);
     }
 
     #[track_caller]
     unsafe fn __relinquish_ownership(obj: *mut ffi::objc_object) {
-        std::println!("\n__relinquish_ownership: {:?} / {:?}", obj, key());
+        std::println!("\nOwned __relinquish_ownership: {:?} / {:?}", obj, key());
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Owned associated: {:?}", associated);
         if associated.is_null() {
             panic!("Tried to give up ownership of `Id<T, Owned>` that wasn't owned!");
         } else {
@@ -77,7 +77,7 @@ impl Ownership for Owned {
             };
         }
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Owned associated: {:?}", associated);
     }
 }
 
@@ -88,18 +88,18 @@ impl Ownership for Owned {}
 impl Ownership for Shared {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
-        std::println!("\n__ensure_unique_if_owned: {:?} / {:?}", obj, key());
+        std::println!("\nShared __ensure_unique_if_owned: {:?} / {:?}", obj, key());
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Shared associated: {:?}", associated);
         if !associated.is_null() {
             panic!("An `Id<T, Owned>` exists while trying to create `Id<T, Shared>`!");
         }
     }
     #[track_caller]
     unsafe fn __relinquish_ownership(obj: *mut ffi::objc_object) {
-        std::println!("\n__relinquish_ownership: {:?} / {:?}", obj, key());
+        std::println!("\nShared __relinquish_ownership: {:?} / {:?}", obj, key());
         let associated = unsafe { ffi::objc_getAssociatedObject(obj, key()) };
-        std::println!("associated: {:?}", associated);
+        std::println!("Shared associated: {:?}", associated);
         if !associated.is_null() {
             panic!("Tried to give up ownership of `Id<T, Shared>`!");
         }

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -26,18 +26,23 @@ mod private {
 /// crate.
 pub trait Ownership: private::Sealed + 'static {
     #[doc(hidden)]
-    unsafe fn __ensure_unique_if_owned(_: *mut ffi::objc_object);
+    #[inline]
+    unsafe fn __ensure_unique_if_owned(_: *mut ffi::objc_object) {}
     #[doc(hidden)]
-    unsafe fn __relinquish_ownership(_: *mut ffi::objc_object);
+    #[inline]
+    unsafe fn __relinquish_ownership(_: *mut ffi::objc_object) {}
 }
 
 /// The value of this doesn't matter, it's only the address that we use.
 static OBJC2_ID_OWNED_UNIQUE_KEY: i32 = 0;
-#[inline(always)]
+
+#[inline]
+#[allow(unused)]
 fn key() -> *const c_void {
     &OBJC2_ID_OWNED_UNIQUE_KEY as *const i32 as *const _
 }
 
+#[cfg(feature = "unstable-verify-ownership")]
 impl Ownership for Owned {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
@@ -76,6 +81,10 @@ impl Ownership for Owned {
     }
 }
 
+#[cfg(not(feature = "unstable-verify-ownership"))]
+impl Ownership for Owned {}
+
+#[cfg(feature = "unstable-verify-ownership")]
 impl Ownership for Shared {
     #[track_caller]
     unsafe fn __ensure_unique_if_owned(obj: *mut ffi::objc_object) {
@@ -96,3 +105,6 @@ impl Ownership for Shared {
         }
     }
 }
+
+#[cfg(not(feature = "unstable-verify-ownership"))]
+impl Ownership for Shared {}

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -39,7 +39,8 @@ static OBJC2_ID_OWNED_UNIQUE_KEY: i32 = 0;
 #[inline]
 #[allow(unused)]
 fn key() -> *const c_void {
-    &OBJC2_ID_OWNED_UNIQUE_KEY as *const i32 as *const _
+    let ptr: *const i32 = &OBJC2_ID_OWNED_UNIQUE_KEY;
+    ptr.cast()
 }
 
 #[cfg(feature = "unstable-verify-ownership")]

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -662,10 +662,19 @@ impl Object {
         // SAFETY: Invariants upheld by caller
         unsafe { *self.ivar_mut::<T>(name) = value };
     }
+}
 
+/// Associated objects.
+///
+/// TODO: Make a public API for these.
+///
+/// See [Apple's documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocAssociativeReferences.html).
+impl Object {
     // objc_setAssociatedObject
     // objc_getAssociatedObject
     // objc_removeAssociatedObjects
+
+    // https://nshipster.com/associated-objects/
 }
 
 unsafe impl RefEncode for Object {


### PR DESCRIPTION
Resolves upstream https://github.com/SSheldon/rust-objc-id/issues/5.

A downside to this is that `ManuallyDrop::new(id)` no longer works properly, you'd have to use `id.forget()`, which is less ergonomic.

I do think this is a good idea, it helped me catch a bug in `NSArray::new` (`NSArray::new` always returns the same object), fix included in #163.

TODO:
- [ ] Documentation
- [ ] ...