### PR TITLE
Change null handling when creating `Id`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
 
     - name: Install Clang & Valgrind
       if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get -y install clang valgrind
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install clang valgrind
 
     - name: Install cross compilation tools
       if: matrix.target == 'i686-unknown-linux-gnu'

--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::ptr::NonNull;
 use std::sync::Once;
 
 use objc2::declare::ClassDecl;
@@ -30,7 +29,7 @@ impl<'a> MyObject<'a> {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithPtr: number_ptr];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -1,4 +1,3 @@
-use std::ptr::NonNull;
 use std::sync::Once;
 
 use objc2::declare::ClassDecl;
@@ -26,7 +25,7 @@ static MYOBJECT_REGISTER_CLASS: Once = Once::new();
 impl MYObject {
     fn new() -> Id<Self, Owned> {
         let cls = Self::class();
-        unsafe { Id::new(NonNull::new_unchecked(msg_send![cls, new])) }
+        unsafe { Id::new(msg_send![cls, new]).unwrap() }
     }
 
     fn number(&self) -> u32 {

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Shared};
 use objc2::runtime::Object;
@@ -51,7 +49,7 @@ impl NSAttributedString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithString: string, attributes: attributes];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 
@@ -61,7 +59,7 @@ impl NSAttributedString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/copying.rs
+++ b/objc2-foundation/src/copying.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::rc::{Id, Owned, Ownership};
 use objc2::{msg_send, Message};
 
@@ -35,7 +33,7 @@ pub unsafe trait NSCopying: Message {
     fn copy(&self) -> Id<Self::Output, Self::Ownership> {
         unsafe {
             let obj: *mut Self::Output = msg_send![self, copy];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }
@@ -50,7 +48,7 @@ pub unsafe trait NSMutableCopying: Message {
     fn mutable_copy(&self) -> Id<Self::Output, Owned> {
         unsafe {
             let obj: *mut Self::Output = msg_send![self, mutableCopy];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cmp::min;
 use core::marker::PhantomData;
 use core::ops::Index;
-use core::ptr::{self, NonNull};
+use core::ptr;
 
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
 use objc2::{msg_send, Message};
@@ -103,7 +103,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     pub fn keys_array(&self) -> Id<NSArray<K, Shared>, Shared> {
         unsafe {
             let keys = msg_send![self, allKeys];
-            Id::retain(NonNull::new_unchecked(keys))
+            Id::retain(keys).unwrap()
         }
     }
 
@@ -124,14 +124,13 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
                 count: count,
             ]
         };
-        let obj = unsafe { NonNull::new_unchecked(obj) };
-        unsafe { Id::new(obj) }
+        unsafe { Id::new(obj).unwrap() }
     }
 
     pub fn into_values_array(dict: Id<Self, Owned>) -> Id<NSArray<V, Owned>, Shared> {
         unsafe {
             let vals = msg_send![dict, allValues];
-            Id::retain(NonNull::new_unchecked(vals))
+            Id::retain(vals).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
-use core::ptr::NonNull;
 use core::slice;
 use std::os::raw::c_ulong;
 
@@ -23,9 +22,8 @@ impl<'a, T: Message> NSEnumerator<'a, T> {
     /// The object pointer must be a valid `NSEnumerator` with `Owned`
     /// ownership.
     pub unsafe fn from_ptr(ptr: *mut Object) -> Self {
-        let ptr = NonNull::new(ptr).unwrap();
         Self {
-            id: unsafe { Id::retain(ptr) },
+            id: unsafe { Id::retain(ptr) }.unwrap(),
             item: PhantomData,
         }
     }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -156,7 +156,7 @@ macro_rules! unsafe_def_fn {
         $(#[$m])*
         $v fn new() -> Id<Self, $o> {
             let cls = Self::class();
-            unsafe { Id::new(NonNull::new_unchecked(msg_send![cls, new])) }
+            unsafe { Id::new(msg_send![cls, new]).unwrap() }
         }
     };
 }

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 
@@ -30,7 +28,7 @@ impl NSMutableAttributedString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 
@@ -39,7 +37,7 @@ impl NSMutableAttributedString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithAttributedString: attributed_string];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -1,7 +1,6 @@
 use core::cmp;
 use core::fmt;
 use core::ops::AddAssign;
-use core::ptr::NonNull;
 use core::str;
 
 use objc2::msg_send;
@@ -32,7 +31,7 @@ impl NSMutableString {
     pub fn from_str(string: &str) -> Id<Self, Owned> {
         unsafe {
             let obj = super::string::from_str(Self::class(), string);
-            Id::new(obj.cast())
+            Id::new(obj.cast()).unwrap()
         }
     }
 
@@ -42,7 +41,7 @@ impl NSMutableString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithString: string];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 
@@ -51,7 +50,7 @@ impl NSMutableString {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithCapacity: capacity];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Bool, Class, Object};
@@ -26,7 +24,7 @@ impl NSObject {
         unsafe {
             let result: *mut NSString = msg_send![self, description];
             // TODO: Verify that description always returns a non-null string
-            Id::retain(NonNull::new_unchecked(result))
+            Id::retain(result).unwrap()
         }
     }
 

--- a/objc2-foundation/src/process_info.rs
+++ b/objc2-foundation/src/process_info.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::msg_send;
 use objc2::rc::{Id, Shared};
 
@@ -23,13 +21,12 @@ impl NSProcessInfo {
     pub fn process_info() -> Id<NSProcessInfo, Shared> {
         // currentThread is @property(strong), what does that mean?
         let obj: *mut Self = unsafe { msg_send![Self::class(), processInfo] };
-        let obj = unsafe { NonNull::new_unchecked(obj) };
-        unsafe { Id::retain(obj) }
+        // TODO: Always available?
+        unsafe { Id::retain(obj).unwrap() }
     }
 
     pub fn process_name(&self) -> Id<NSString, Shared> {
         let obj: *mut NSString = unsafe { msg_send![Self::class(), processName] };
-        let obj = NonNull::new(obj).unwrap();
-        unsafe { Id::retain(obj) }
+        unsafe { Id::retain(obj).unwrap() }
     }
 }

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -165,7 +165,7 @@ impl NSString {
     pub fn from_str(string: &str) -> Id<Self, Shared> {
         unsafe {
             let obj = from_str(Self::class(), string);
-            Id::new(obj.cast())
+            Id::new(obj.cast()).unwrap()
         }
     }
 
@@ -200,17 +200,16 @@ impl NSString {
     // https://developer.apple.com/documentation/foundation/1415155-nsstringfromrange?language=objc
 }
 
-pub(crate) fn from_str(cls: &Class, string: &str) -> NonNull<Object> {
+pub(crate) fn from_str(cls: &Class, string: &str) -> *mut Object {
     let bytes = string.as_ptr() as *const c_void;
     unsafe {
         let obj: *mut Object = msg_send![cls, alloc];
-        let obj: *mut Object = msg_send![
+        msg_send![
             obj,
             initWithBytes: bytes,
             length: string.len(),
             encoding: UTF8_ENCODING,
-        ];
-        NonNull::new_unchecked(obj)
+        ]
     }
 }
 

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::msg_send;
 use objc2::rc::{Id, Shared};
 use objc2::runtime::Bool;
@@ -21,8 +19,8 @@ impl NSThread {
     pub fn current() -> Id<NSThread, Shared> {
         // TODO: currentThread is @property(strong), what does that mean?
         let obj: *mut Self = unsafe { msg_send![Self::class(), currentThread] };
-        let obj = unsafe { NonNull::new_unchecked(obj) };
-        unsafe { Id::retain(obj) }
+        // TODO: Always available?
+        unsafe { Id::retain(obj).unwrap() }
     }
 
     /// Returns the [`NSThread`] object representing the main thread.
@@ -31,8 +29,7 @@ impl NSThread {
         let obj: *mut Self = unsafe { msg_send![Self::class(), mainThread] };
         // The main thread static may not have been initialized
         // This can at least fail in GNUStep!
-        let obj = NonNull::new(obj).expect("Could not retrieve main thread.");
-        unsafe { Id::retain(obj) }
+        unsafe { Id::retain(obj).expect("Could not retrieve main thread.") }
     }
 
     /// Returns `true` if the thread is the main thread.
@@ -44,7 +41,7 @@ impl NSThread {
     /// The name of the thread.
     pub fn name(&self) -> Option<Id<NSString, Shared>> {
         let obj: *mut NSString = unsafe { msg_send![self, name] };
-        unsafe { Id::retain_null(obj) }
+        unsafe { Id::retain(obj) }
     }
 }
 

--- a/objc2-foundation/src/uuid.rs
+++ b/objc2-foundation/src/uuid.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::rc::{Id, Shared};
 use objc2::{msg_send, Encode, Encoding, RefEncode};
 
@@ -37,7 +35,7 @@ impl NSUUID {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, init];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 
@@ -46,7 +44,7 @@ impl NSUUID {
         unsafe {
             let obj: *mut Self = msg_send![Self::class(), alloc];
             let obj: *mut Self = msg_send![obj, initWithUUIDBytes: &bytes];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -73,7 +73,7 @@ impl<T: 'static + Copy + Encode> NSValue<T> {
                 initWithBytes: bytes,
                 objCType: encoding.as_ptr(),
             ];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         }
     }
 }

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -11,9 +11,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   upgrading easier.
 * Allow using `From`/`TryFrom` to convert between `rc::Id` and `rc::WeakId`.
 * Added `Bool::as_bool` (more descriptive name than `Bool::is_true`).
-* Added convenience methods `Id::new_null`, `Id::as_ptr` and
-  `Id::retain_null`.
+* Added convenience method `Id::as_ptr`.
 * The `objc2-encode` dependency is now exposed as `objc2::encode`.
+
+### Changed
+* **BREAKING**: Changed signature of `Id::new` and `Id::retain` from
+  `fn(NonNull<T>) -> Id<T>` to `fn(*mut T) -> Option<Id<T>>`.
+
+  Concretely, you will have to change your code as follows.
+  ```rust
+  // Before
+  let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+  let obj = NonNull::new(obj).expect("Failed to allocate object.");
+  let obj = unsafe { Id::new(obj) };
+  // After
+  let obj: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+  let obj = unsafe { Id::new(obj) }.expect("Failed to allocate object.");
+  ```
 
 
 ## 0.3.0-alpha.6 - 2022-01-03

--- a/objc2/README.md
+++ b/objc2/README.md
@@ -13,14 +13,13 @@ written in Objective-C; this crate enables you to interract with those.
 ## Example
 
 ```rust
-use std::ptr::NonNull;
 use objc2::{class, msg_send};
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
 
 let cls = class!(NSObject);
 let obj: *mut Object = unsafe { msg_send![cls, new] };
-let obj: Id<Object, Owned> = unsafe { Id::new(NonNull::new(obj).unwrap()) };
+let obj: Id<Object, Owned> = unsafe { Id::new(obj).unwrap() };
 
 // TODO
 // let isa = unsafe { obj.ivar::<Class>("isa") };

--- a/objc2/benches/autorelease.rs
+++ b/objc2/benches/autorelease.rs
@@ -1,6 +1,5 @@
 use core::ffi::c_void;
 use std::mem::ManuallyDrop;
-use std::ptr::NonNull;
 
 use objc2::ffi;
 use objc2::rc::{autoreleasepool, Id, Shared};
@@ -47,7 +46,7 @@ fn alloc_nsobject() -> *mut Object {
 fn new_nsobject() -> Id<Object, Shared> {
     let obj = alloc_nsobject();
     let obj: *mut Object = unsafe { msg_send![obj, init] };
-    unsafe { Id::new(NonNull::new_unchecked(obj)) }
+    unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
 fn new_nsdata() -> Id<Object, Shared> {
@@ -60,7 +59,7 @@ fn new_nsdata() -> Id<Object, Shared> {
             length: BYTES.len(),
         ]
     };
-    unsafe { Id::new(NonNull::new_unchecked(obj)) }
+    unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
 fn new_leaked_nsdata() -> *mut Object {
@@ -82,7 +81,7 @@ fn autoreleased_nsdata() -> *mut Object {
 fn new_nsstring() -> Id<Object, Shared> {
     let obj: *mut Object = unsafe { msg_send![class!(NSString), alloc] };
     let obj: *mut Object = unsafe { msg_send![obj, init] };
-    unsafe { Id::new(NonNull::new_unchecked(obj)) }
+    unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
 fn new_leaked_nsstring() -> *mut Object {
@@ -96,7 +95,7 @@ fn autoreleased_nsstring() -> *mut Object {
 
 fn retain_autoreleased(obj: *mut Object) -> Id<Object, Shared> {
     let obj = unsafe { ffi::objc_retainAutoreleasedReturnValue(obj.cast()) };
-    unsafe { Id::new(NonNull::new_unchecked(obj).cast()) }
+    unsafe { Id::new(obj.cast()).unwrap_unchecked() }
 }
 
 fn autoreleased_nsdata_pool_cleanup() -> *mut Object {

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object};
 use objc2::{class, msg_send};
@@ -23,8 +21,8 @@ fn main() {
     // Allocate an instance
     let obj: Id<Object, Owned> = unsafe {
         let obj: *mut Object = msg_send![cls, alloc];
-        let obj: NonNull<Object> = msg_send![obj, init];
-        Id::new(obj)
+        let obj: *mut Object = msg_send![obj, init];
+        Id::new(obj).unwrap()
     };
     println!("NSObject address: {:p}", obj);
 

--- a/objc2/examples/talk_to_me.rs
+++ b/objc2/examples/talk_to_me.rs
@@ -3,7 +3,6 @@ use objc2::rc::{Id, Owned, Shared};
 use objc2::runtime::Object;
 use objc2::{class, msg_send};
 use std::ffi::c_void;
-use std::ptr::NonNull;
 
 #[cfg(apple)] // Does not work on GNUStep
 #[link(name = "AVFoundation", kind = "framework")]
@@ -22,14 +21,14 @@ fn main() {
             encoding: 4 as NSUInteger, // UTF8_ENCODING on macOS / iOS
         ]
     };
-    let string: Id<Object, Shared> = unsafe { Id::new(NonNull::new(string).unwrap()) };
+    let string: Id<Object, Shared> = unsafe { Id::new(string).unwrap() };
 
     let synthesizer: *mut Object = unsafe { msg_send![class!(AVSpeechSynthesizer), new] };
-    let synthesizer: Id<Object, Owned> = unsafe { Id::new(NonNull::new(synthesizer).unwrap()) };
+    let synthesizer: Id<Object, Owned> = unsafe { Id::new(synthesizer).unwrap() };
 
     let utterance: *mut Object = unsafe { msg_send![class!(AVSpeechUtterance), alloc] };
     let utterance: *mut Object = unsafe { msg_send![utterance, initWithString: &*string] };
-    let utterance: Id<Object, Owned> = unsafe { Id::new(NonNull::new(utterance).unwrap()) };
+    let utterance: Id<Object, Owned> = unsafe { Id::new(utterance).unwrap() };
 
     // let _: () = unsafe { msg_send![utterance, setVolume: 90.0f32 };
     // let _: () = unsafe { msg_send![utterance, setRate: 0.50f32 };

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -29,7 +29,6 @@
 //!
 #![cfg_attr(apple, doc = "```")]
 #![cfg_attr(not(apple), doc = "```no_run")]
-//! use core::ptr::NonNull;
 //! use objc2::{class, msg_send};
 //! use objc2::ffi::NSUInteger;
 //! use objc2::rc::{Id, Owned};
@@ -38,8 +37,9 @@
 //! // Creation
 //! let cls = class!(NSObject);
 //! let obj: *mut Object = unsafe { msg_send![cls, new] };
-//! let obj = NonNull::new(obj).expect("Failed allocating object");
-//! let obj: Id<Object, Owned> = unsafe { Id::new(obj) };
+//! let obj: Id<Object, Owned> = unsafe {
+//!     Id::new(obj).expect("Failed allocating object")
+//! };
 //!
 //! // Usage
 //! let hash: NSUInteger = unsafe { msg_send![obj, hash] };

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -38,7 +38,7 @@
 //!
 //! // Id will release the object when dropped
 //! let obj: Id<Object, Shared> = unsafe {
-//!     Id::new(msg_send![class!(NSObject), new])
+//!     Id::new(msg_send![class!(NSObject), new]).unwrap()
 //! };
 //!
 //! // Cloning retains the object an additional time

--- a/objc2/src/rc/weak_id.rs
+++ b/objc2/src/rc/weak_id.rs
@@ -72,7 +72,7 @@ impl<T: Message> WeakId<T> {
     pub fn load(&self) -> Option<Id<T, Shared>> {
         let ptr = self.inner.get();
         let obj = unsafe { ffi::objc_loadWeakRetained(ptr) } as *mut T;
-        unsafe { Id::new_null(obj) }
+        unsafe { Id::new(obj) }
     }
 
     // TODO: Add `autorelease(&self) -> Option<&T>` using `objc_loadWeak`?
@@ -151,8 +151,6 @@ impl<T: Message> TryFrom<WeakId<T>> for Id<T, Shared> {
 
 #[cfg(test)]
 mod tests {
-    use core::ptr::NonNull;
-
     use super::WeakId;
     use super::{Id, Shared};
     use crate::runtime::Object;
@@ -164,7 +162,7 @@ mod tests {
         let obj: Id<Object, Shared> = unsafe {
             let obj: *mut Object = msg_send![cls, alloc];
             let obj: *mut Object = msg_send![obj, init];
-            Id::new(NonNull::new_unchecked(obj))
+            Id::new(obj).unwrap()
         };
 
         let weak = WeakId::new(&obj);
@@ -180,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_weak_clone() {
-        let obj: Id<Object, Shared> = unsafe { Id::new(msg_send![class!(NSObject), new]) };
+        let obj: Id<Object, Shared> = unsafe { Id::new(msg_send![class!(NSObject), new]).unwrap() };
         let weak = WeakId::new(&obj);
 
         let weak2 = weak.clone();


### PR DESCRIPTION
`Option::unwrap_unchecked` is stable since 1.58, and that is IMO much clearer than wrapping things in `NonNull` beforehand (see the changelog entry for an example).

The real motivation for this change is from https://github.com/madsmtm/objc2/pull/81, where the naive implementation of `Id::retain_autoreleased_null` would have been completely broken (the extra branch in `NonNull::new(ptr).map(|ptr| unsafe { Id::retain_autoreleased(ptr) })` would interfere).

Also, looking through the code I seem to have used `NonNull::new_unchecked` a lot more than what's entirely correct (`+ alloc`/`+ new` can return `nil` when out of memory), so changing those to `unwrap` makes things better in that regard (albeit a tiny bit slower).