### PR TITLE
Only run UI tests on `nightly`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,9 @@ jobs:
           - name: Test macOS 10.15
             os: macos-10.15
             target: x86_64-apple-darwin
-          - name: Test macOS 11 w. ui tests
+          - name: Test macOS 11
             os: macos-11
             target: x86_64-apple-darwin
-            args: --features tests/ui
           - name: Build macOS AArch64
             os: macos-11
             target: aarch64-apple-darwin
@@ -60,6 +59,7 @@ jobs:
             target: x86_64-apple-darwin
             rust:
               toolchain: nightly
+            # Run on nightly to help find regressions
             args: --features tests/ui
           - name: Build macOS 32bit
             os: macos-10.15

--- a/tests/ui/msg_send_only_message.stderr
+++ b/tests/ui/msg_send_only_message.stderr
@@ -4,10 +4,4 @@ error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
 5 |     unsafe { msg_send![1, new] };
   |              ^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `{integer}`
   |
-  = help: the following implementations were found:
-            <&'a T as MessageReceiver>
-            <&'a mut T as MessageReceiver>
-            <*const T as MessageReceiver>
-            <*mut T as MessageReceiver>
-          and 3 others
   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/nsvalue_f32_not_eq.stderr
+++ b/tests/ui/nsvalue_f32_not_eq.stderr
@@ -4,6 +4,12 @@ error[E0277]: the trait bound `f32: Eq` is not satisfied
 11 |     needs_eq::<NSValue<f32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq` is not implemented for `f32`
    |
+   = help: the following implementations were found:
+             <i128 as Eq>
+             <i16 as Eq>
+             <i32 as Eq>
+             <i64 as Eq>
+           and 8 others
    = note: required because of the requirements on the impl of `Eq` for `NSValue<f32>`
 note: required by a bound in `needs_eq`
   --> ui/nsvalue_f32_not_eq.rs:5:16


### PR DESCRIPTION
Follow up on #35.

The UI tests' output currently differs between `stable` and `nightly`, and that is gonna keep happening. I'm fine with having to "keep up" with changes (and reporting them if significant), but it'll be difficult to try to work around them being different between releases.

~Requires #128.~