### PR TITLE
Ensure covariance

### DIFF
--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -12,10 +12,7 @@ use objc2_foundation::NSObject;
 /// see [RFC-1861](https://rust-lang.github.io/rfcs/1861-extern-types.html).
 #[repr(C)]
 pub struct MYObject {
-    /// See the [Nomicon] for details on representing opaque structs.
-    ///
-    /// [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
-    _priv: [u8; 0],
+    inner: Object,
 }
 
 unsafe impl RefEncode for MYObject {
@@ -33,17 +30,11 @@ impl MYObject {
     }
 
     fn number(&self) -> u32 {
-        unsafe {
-            let obj = &*(self as *const _ as *const Object);
-            *obj.ivar("_number")
-        }
+        unsafe { *self.inner.ivar("_number") }
     }
 
     fn set_number(&mut self, number: u32) {
-        unsafe {
-            let obj = &mut *(self as *mut _ as *mut Object);
-            obj.set_ivar("_number", number);
-        }
+        unsafe { self.inner.set_ivar("_number", number) };
     }
 
     fn class() -> &'static Class {

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -9,6 +9,7 @@ use objc2::rc::{Id, Owned};
 use objc2::runtime::Object;
 use objc2::{msg_send, Encode, Encoding, Message, RefEncode};
 
+// TODO: https://doc.rust-lang.org/stable/reference/trait-bounds.html#lifetime-bounds
 pub struct NSEnumerator<'a, T: Message> {
     id: Id<Object, Owned>,
     item: PhantomData<&'a T>,

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -21,7 +21,7 @@ pub struct AutoreleasePool {
     /// This is an opaque handle, and is not guaranteed to be neither a valid
     /// nor aligned pointer.
     context: *mut c_void,
-    // May pointer to data that is mutated (even though we hold shared access)
+    /// May point to data that is mutated (even though we hold shared access).
     p: PhantomData<*mut UnsafeCell<c_void>>,
 }
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -412,6 +412,7 @@ impl<T: ?Sized, O: Ownership> Drop for Id<T, O> {
     }
 }
 
+// https://doc.rust-lang.org/nomicon/arc-mutex/arc-base.html#send-and-sync
 /// The `Send` implementation requires `T: Sync` because `Id<T, Shared>` give
 /// access to `&T`.
 ///

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -94,6 +94,14 @@ mod tests {
         obj
     }
 
+    /// Test that `WeakId<T>` is covariant over `T`.
+    #[allow(unused)]
+    fn assert_weak_id_variance<'a, 'b>(
+        obj: &'a WeakId<MyObject<'static>>,
+    ) -> &'a WeakId<MyObject<'b>> {
+        obj
+    }
+
     #[test]
     fn test_size_of() {
         assert_eq!(size_of::<Id<TestType, Owned>>(), size_of::<&TestType>());

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -70,12 +70,28 @@ pub use self::weak_id::WeakId;
 
 #[cfg(test)]
 mod tests {
+    use core::marker::PhantomData;
     use core::mem::size_of;
 
-    use super::{Id, Owned, Shared, WeakId};
+    use super::{Id, Owned, Ownership, Shared, WeakId};
+    use crate::runtime::Object;
 
     struct TestType {
         _data: [u8; 0], // TODO: `UnsafeCell`?
+    }
+
+    #[repr(C)]
+    struct MyObject<'a> {
+        inner: Object,
+        p: PhantomData<&'a str>,
+    }
+
+    /// Test that `Id<T, O>` is covariant over `T`.
+    #[allow(unused)]
+    fn assert_id_variance<'a, 'b, O: Ownership>(
+        obj: &'a Id<MyObject<'static>, O>,
+    ) -> &'a Id<MyObject<'b>, O> {
+        obj
     }
 
     #[test]

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -76,8 +76,9 @@ mod tests {
     use super::{Id, Owned, Ownership, Shared, WeakId};
     use crate::runtime::Object;
 
+    #[repr(C)]
     struct TestType {
-        _data: [u8; 0], // TODO: `UnsafeCell`?
+        inner: Object,
     }
 
     #[repr(C)]


### PR DESCRIPTION
`Id<T, O>` and `WeakId<T>` should be covariant over `T`; this is now fixed for `WeakId`, and tested.