### PR TITLE
Expose `objc2-encode` under `objc2::encode`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `Bool::as_bool` (more descriptive name than `Bool::is_true`).
 * Added convenience methods `Id::new_null`, `Id::as_ptr` and
   `Id::retain_null`.
+* The `objc2-encode` dependency is now exposed as `objc2::encode`.
 
 
 ## 0.3.0-alpha.6 - 2022-01-03

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -89,7 +89,7 @@
 //! every time your send a message, and the message send will panic if they
 //! are not equivalent.
 //!
-//! [`objc2-encode`]: https://crates.io/crates/objc2-encode
+//! [`objc2-encode`]: objc2_encode
 //! [`Box`]: std::boxed::Box
 //!
 //!
@@ -141,8 +141,10 @@ extern crate std;
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
+pub use objc2_encode as encode;
 pub use objc_sys as ffi;
 
+#[doc(no_inline)]
 pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
 pub use crate::message::{Message, MessageArguments, MessageError, MessageReceiver};


### PR DESCRIPTION
Helps with documentation.

Related: #134.