### PR TITLE
Try using the `allocator_api` to create objects

### DIFF
--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -125,6 +125,7 @@
     feature = "unstable_autoreleasesafe",
     feature(negative_impls, auto_traits)
 )]
+#![feature(allocator_api, new_uninit)]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]

--- a/objc2/src/rc/alloc.rs
+++ b/objc2/src/rc/alloc.rs
@@ -1,0 +1,67 @@
+use alloc::boxed::Box;
+use core::alloc::AllocError;
+use core::alloc::Allocator;
+use core::alloc::Layout;
+use core::mem::MaybeUninit;
+use core::ptr::slice_from_raw_parts_mut;
+use core::ptr::NonNull;
+
+use crate::ffi;
+use crate::runtime::Class;
+use crate::runtime::Object;
+
+unsafe impl Allocator for &'static Class {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr: *mut Object = unsafe { msg_send![*self, alloc] };
+        let size = unsafe { ffi::class_getInstanceSize(self.as_ptr()) };
+        std::println!("Allocate {layout:?}, size: {size}");
+        let ptr = slice_from_raw_parts_mut(ptr.cast::<u8>(), size);
+        if let Some(ptr) = NonNull::new(ptr) {
+            Ok(ptr)
+        } else {
+            Err(AllocError)
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        std::println!("Deallocate {layout:?}");
+        let obj: *mut ffi::objc_object = ptr.cast().as_ptr();
+        unsafe { ffi::objc_release(obj) };
+    }
+}
+
+impl Drop for Object {
+    fn drop(&mut self) {
+        std::println!("Drop called");
+    }
+}
+
+impl Object {
+    /// TODO
+    pub fn new1() -> Box<Self, &'static Class> {
+        let obj: Box<MaybeUninit<Object>, _> = Box::new_uninit_in(class!(NSObject));
+        let (obj, cls) = Box::into_raw_with_allocator(obj);
+        let obj: *mut Object = unsafe { msg_send![obj as *mut Object, init] };
+        unsafe { Box::from_raw_in(obj, cls) }
+    }
+
+    /// TODO
+    pub fn new2() -> Box<Self, &'static Class> {
+        let ptr: *mut Object = unsafe { msg_send![class!(NSObject), new] };
+        unsafe { Box::from_raw_in(ptr, class!(NSObject)) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alloc() {
+        let obj = Object::new1();
+        std::println!("{:?}", obj);
+
+        let obj = Object::new2();
+        std::println!("{:?}", obj);
+    }
+}

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -55,6 +55,7 @@
 //! assert!(weak.load().is_none());
 //! ```
 
+mod alloc;
 mod autorelease;
 mod id;
 mod id_forwarding_impls;


### PR DESCRIPTION
Just a fun idea for making `Box<Object> ~= Id<Object, Owned>`.

One _could_ probably make it work better than I have here, but there are some pretty fundamental issues that are not easily fixed, like `Layout` being entirely unfit for this application. Maybe [making `Layout` an associated type of `Allocator`](https://rust-lang.github.io/rfcs/1398-kinds-of-allocators.html#make-layout-an-associated-type-of-allocator-trait) could do the trick, maybe not.