### PR TITLE
Runtime selection using crate features in "higher level" crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,13 @@ jobs:
           - name: Test GNUStep
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            host-args: --no-default-features --features gnustep-1-9
-            args: --no-default-features --features objc2-foundation/block --features gnustep-1-9
+            runtime: gnustep-1-9
           - name: Test GNUStep 32bit
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
             cflags: -m32
             configureflags: --target=x86-pc-linux-gnu
-            host-args: --no-default-features --features gnustep-1-9
-            args: --no-default-features --features objc2-foundation/block --features gnustep-1-9
+            runtime: gnustep-1-9
           - name: Test iOS simulator x86 64bit
             os: macos-11
             target: x86_64-apple-ios
@@ -134,8 +132,10 @@ jobs:
       CXXFLAGS: ${{ matrix.cflags }}
       ASMFLAGS: ${{ matrix.cflags }}
       LDFLAGS: ${{ matrix.cflags }}
+      HOSTARGS: --no-default-features --features ${{ matrix.runtime || 'apple' }}
+      ARGS: --no-default-features --features ${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       # Use --no-fail-fast, except with dinghy
-      TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.args }} ${{ matrix.test-args }}
+      TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
 
     runs-on: ${{ matrix.os }}
 
@@ -280,42 +280,42 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: ${{ matrix.args }}
+        args: ${{ env.ARGS }}
 
     - name: Check documentation
       if: ${{ !matrix.dinghy }}
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-deps --document-private-items ${{ matrix.args }}
+        args: ${{ env.ARGS }} --no-deps --document-private-items
 
     - name: Test without features
       if: ${{ !matrix.dinghy }}
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --no-default-features ${{ env.TESTARGS }}
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }}
 
     - name: Test with features
       if: ${{ !matrix.dinghy }}
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features ${{ env.FEATURES }} ${{ env.TESTARGS }}
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }} --features ${{ env.FEATURES }}
 
-    - name: Test in release mode
+    - name: Test in release mode without features
       if: ${{ !matrix.dinghy }}
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --no-default-features ${{ env.TESTARGS }} --release
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }} --release
 
     - name: Test in release mode with features
       if: ${{ !matrix.dinghy }}
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features ${{ env.FEATURES }} ${{ env.TESTARGS }} --release
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }} --features ${{ env.FEATURES }} --release
 
     - name: Run benchmarks
       # Difficult to install Valgrind on macOS
@@ -324,7 +324,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: bench
-        args: --bench autorelease ${{ env.TESTARGS }}
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }} --bench autorelease
 
     - name: Test with unstable features
       if: ${{ !matrix.dinghy && matrix.rust.toolchain == 'nightly' }}
@@ -332,7 +332,7 @@ jobs:
       with:
         command: test
         # Not using --all-features because that would enable e.g. gnustep
-        args: --features ${{ env.FEATURES }},${{ env.UNSTABLE_FEATURES }} ${{ env.TESTARGS }}
+        args: ${{ env.ARGS }} ${{ env.TESTARGS }} --features ${{ env.FEATURES }},${{ env.UNSTABLE_FEATURES }}
 
     - name: Run assembly tests
       # Not run on GNUStep yet since a lot of function labels are mangled and
@@ -343,7 +343,7 @@ jobs:
       run:
         export HOST_TARGET=$(rustc -vV | grep host | cut -f2 -d' ')
 
-        cargo run ${{ matrix.host-args }} --features assembly --target=$HOST_TARGET test_assembly ${{ matrix.args }}
+        cargo run ${{ env.HOSTARGS }} --features assembly --target=$HOST_TARGET test_assembly ${{ env.ARGS }}
 
     - name: Run Cargo Dinghy
       if: matrix.dinghy
@@ -355,16 +355,16 @@ jobs:
         xcrun simctl boot $SIM_ID
 
         # Build
-        cargo dinghy --device=$SIM_ID build
+        cargo dinghy --device=$SIM_ID build ${{ env.ARGS }}
 
         # Run tests
-        cargo dinghy --device=$SIM_ID test --no-default-features
-        cargo dinghy --device=$SIM_ID test --release
+        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }}
+        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }} --release
 
         # Enable a few features. We're doing it this way because cargo dingy
         # doesn't support specifying features from a workspace.
         sed -i -e '/\[features\]/a\
         default = ["exception", "verify_message", "catch_all"]
         ' objc2/Cargo.toml
-        cargo dinghy --device=$SIM_ID test
-        cargo dinghy --device=$SIM_ID test --release
+        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }}
+        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }} --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,15 @@ jobs:
           - name: Test GNUStep
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            host-args: --features gnustep-1-9
-            args: --features gnustep-1-9
+            host-args: --no-default-features --features gnustep-1-9
+            args: --no-default-features --features objc2-foundation/block --features gnustep-1-9
           - name: Test GNUStep 32bit
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
             cflags: -m32
             configureflags: --target=x86-pc-linux-gnu
-            host-args: --features gnustep-1-9
-            args: --features gnustep-1-9
+            host-args: --no-default-features --features gnustep-1-9
+            args: --no-default-features --features objc2-foundation/block --features gnustep-1-9
           - name: Test iOS simulator x86 64bit
             os: macos-11
             target: x86_64-apple-ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           ~/extern/include
           ~/extern/sdk
         # Change this key if we start caching more things
-        key: ${{ matrix.name }}-extern-v1
+        key: ${{ matrix.name }}-extern-v2
 
     - name: Setup environment
       # These add to PATH-like variables, so they can always be set
@@ -273,7 +273,9 @@ jobs:
 
     - name: Install Cargo Dinghy
       if: matrix.dinghy && steps.extern-cache.outputs.cache-hit != 'true'
-      run: cargo install cargo-dinghy --version=^0.4 --root=$HOME/extern --target=x86_64-apple-darwin
+      # TODO: Replace once cargo dinghy gets updated
+      # cargo install cargo-dinghy --version=^0.4 --root=$HOME/extern --target=x86_64-apple-darwin
+      run: cargo install --git https://github.com/madsmtm/dinghy.git --branch update-cargo --bin cargo-dinghy --root=$HOME/extern --target=x86_64-apple-darwin
 
     - name: Build
       if: ${{ !matrix.dinghy }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,26 +345,24 @@ jobs:
 
         cargo run ${{ env.HOSTARGS }} --features assembly --target=$HOST_TARGET test_assembly ${{ env.ARGS }}
 
-    - name: Run Cargo Dinghy
+    - name: Launch XCode Simulator
       if: matrix.dinghy
       run: |
-        # Launch the simulator
+        # Get system info
         xcrun simctl list runtimes
+
+        # Launch the simulator
         RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1)
         export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 $RUNTIME_ID)
         xcrun simctl boot $SIM_ID
 
-        # Build
-        cargo dinghy --device=$SIM_ID build ${{ env.ARGS }}
+    - name: Build w. Cargo Dinghy
+      if: matrix.dinghy
+      run: cargo dinghy --device=$SIM_ID build ${{ matrix.args }}
 
-        # Run tests
-        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }}
-        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }} --release
-
-        # Enable a few features. We're doing it this way because cargo dingy
-        # doesn't support specifying features from a workspace.
-        sed -i -e '/\[features\]/a\
-        default = ["exception", "verify_message", "catch_all"]
-        ' objc2/Cargo.toml
-        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }}
-        cargo dinghy --device=$SIM_ID test ${{ env.ARGS }} --release
+    - name: Test w. Cargo Dinghy
+      if: matrix.dinghy
+      # Note that we're not testing more complex configurations, since that
+      # takes a very long time to run in CI, and that impedes general
+      # development work.
+      run: cargo dinghy --device=$SIM_ID test ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,15 @@ jobs:
           - name: Test GNUStep
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            host-args: --features block-sys/gnustep-1-9,objc-sys/gnustep-1-9
-            args: --features block-sys/gnustep-1-9,objc-sys/gnustep-1-9
+            host-args: --features gnustep-1-9
+            args: --features gnustep-1-9
           - name: Test GNUStep 32bit
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
             cflags: -m32
             configureflags: --target=x86-pc-linux-gnu
-            host-args: --features block-sys/gnustep-1-9,objc-sys/gnustep-1-9
-            args: --features block-sys/gnustep-1-9,objc-sys/gnustep-1-9
+            host-args: --features gnustep-1-9
+            args: --features gnustep-1-9
           - name: Test iOS simulator x86 64bit
             os: macos-11
             target: x86_64-apple-ios

--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * **BREAKING**: Changed `links` key from `block` to `block_0_0` for better
-  future compatibility, until we reach 1.0 (so `DEP_BLOCK_X` in build scripts
-  becomes `DEP_BLOCK_0_0_X`).
+  future compatibility, until we reach 1.0 (so `DEP_BLOCK_CC_ARGS` in build
+  scripts becomes `DEP_BLOCK_0_0_CC_ARGS`).
 * **BREAKING**: Apple's runtime is now always the default.
 
 

--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Changed `links` key from `block` to `block_0_0` for better
   future compatibility, until we reach 1.0 (so `DEP_BLOCK_X` in build scripts
   becomes `DEP_BLOCK_0_0_X`).
+* **BREAKING**: Apple's runtime is now always the default.
 
 
 ## 0.0.3 - 2022-01-03

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -34,7 +34,7 @@ apple = []
 compiler-rt = []
 
 # Link to GNUStep's libobjc2 (which contains the block implementation)
-gnustep-1-7 = ["objc-sys/gnustep-1-7"]
+gnustep-1-7 = ["objc-sys", "objc-sys/gnustep-1-7"]
 gnustep-1-8 = ["objc-sys/gnustep-1-8", "gnustep-1-7"]
 gnustep-1-9 = ["objc-sys/gnustep-1-9", "gnustep-1-8"]
 gnustep-2-0 = ["objc-sys/gnustep-2-0", "gnustep-1-9"]

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -23,14 +23,14 @@ links = "block_0_0"
 build = "build.rs"
 
 [features]
+# The default runtime is Apple's. Other platforms will probably error if the
+# correct feature flag is not specified.
+default = ["apple"]
+
 # Link to Apple's libclosure (exists in libSystem)
-#
-# This is the default on Apple platforms
 apple = []
 
 # Link to libBlocksRuntime from compiler-rt
-#
-# This is the default on non-Apple platforms
 compiler-rt = []
 
 # Link to GNUStep's libobjc2 (which contains the block implementation)
@@ -51,3 +51,4 @@ objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+no-default-features = true

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -47,7 +47,7 @@ winobjc = ["objc-sys/winobjc", "gnustep-1-8"]
 objfw = []
 
 [dependencies]
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", optional = true }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/block-sys/README.md
+++ b/block-sys/README.md
@@ -20,9 +20,9 @@ several different helper functions), the most important aspect being that the
 libraries are named differently, so the linking must take that into account.
 
 The user can choose the desired runtime by using the relevant cargo feature
-flags, see the following sections. Note that if the `objc-sys` crate is
-present in the module tree, this should have the same feature flag enabled as
-that.
+flags, see the following sections (might have to disable the default `apple`
+feature first). Note that if the `objc-sys` crate is present in the module
+tree, this should have the same feature flag enabled as that.
 
 
 ### Apple's [`libclosure`](https://github.com/apple-oss-distributions/libclosure)
@@ -30,8 +30,7 @@ that.
 - Feature flag: `apple`.
 
 This is naturally the most sophisticated runtime, and it has quite a lot more
-features than the specification mandates. This is used by default on Apple
-platforms when no feature flags are specified.
+features than the specification mandates. This is used by default.
 
 The minimum required operating system versions are as follows:
 - macOS: `10.6`
@@ -45,9 +44,6 @@ Though in practice Rust itself requires higher versions than this.
 ### LLVM `compiler-rt`'s [`libBlocksRuntime`](https://github.com/llvm/llvm-project/tree/release/13.x/compiler-rt/lib/BlocksRuntime)
 
 - Feature flag: `compiler-rt`.
-
-This is the default runtime on all non-Apple platforms when no feature flags
-are specified.
 
 This is effectively just a copy of Apple's older (around macOS 10.6) runtime,
 and is now used in [Swift's `libdispatch`] and [Swift's Foundation] as well.

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -17,6 +17,17 @@ repository = "https://github.com/madsmtm/objc2"
 documentation = "https://docs.rs/block2/"
 license = "MIT"
 
+[features]
+# Runtime selection. Default is `apple`. See `block-sys` for details.
+apple = ["block-sys/apple"]
+compiler-rt = ["block-sys/compiler-rt"]
+gnustep-1-7 = ["block-sys/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "block-sys/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "block-sys/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "block-sys/winobjc"]
+
 [dependencies]
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
 block-sys = { path = "../block-sys", version = "0.0.3" }

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -18,6 +18,8 @@ documentation = "https://docs.rs/block2/"
 license = "MIT"
 
 [features]
+default = ["apple"]
+
 # Runtime selection. Default is `apple`. See `block-sys` for details.
 apple = ["block-sys/apple"]
 compiler-rt = ["block-sys/compiler-rt"]

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -31,8 +31,8 @@ gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1"]
 winobjc = ["gnustep-1-8", "block-sys/winobjc"]
 
 [dependencies]
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
-block-sys = { path = "../block-sys", version = "0.0.3" }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2", default-features = false }
+block-sys = { path = "../block-sys", version = "0.0.3", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * **BREAKING**: Changed `links` key from `objc` to `objc_0_2` for better
-  future compatibility, until we reach 1.0 (so `DEP_OBJC_X` in build scripts
-  becomes `DEP_OBJC_0_2_X`).
+  future compatibility, until we reach 1.0 (so `DEP_OBJC_CC_ARGS` in build
+  scripts becomes `DEP_OBJC_0_2_CC_ARGS`).
 * **BREAKING**: Apple's runtime is now always the default.
 
 ### Removed
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Removed `objc_property_t`.
 * **BREAKING**: Removed `objc_hook_getClass` and `objc_hook_lazyClassNamer`
   type aliases (for now).
+* **BREAKING**: Removed `DEP_OBJC_RUNTIME` build script output.
 
 
 ## 0.2.0-alpha.1 - 2022-01-03

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Changed `links` key from `objc` to `objc_0_2` for better
   future compatibility, until we reach 1.0 (so `DEP_OBJC_X` in build scripts
   becomes `DEP_OBJC_0_2_X`).
+* **BREAKING**: Apple's runtime is now always the default.
 
 ### Removed
 * **BREAKING**: Removed type aliases `Class`, `Ivar`, `Method` and `Protocol`

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -22,9 +22,11 @@ readme = "README.md"
 links = "objc_0_2"
 build = "build.rs"
 
-# The default is `apple` on Apple platforms; all other platforms will error
-# if no feature flag is specified.
 [features]
+# The default runtime is Apple's. Other platforms will probably error if the
+# correct feature flag is not specified.
+default = ["apple"]
+
 # Link to Apple's objc4
 apple = []
 
@@ -43,6 +45,7 @@ objfw = []
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+no-default-features = true
 
 targets = [
     # MacOS

--- a/objc-sys/README.md
+++ b/objc-sys/README.md
@@ -16,7 +16,8 @@ see that for related crates.
 Objective-C has a runtime, different implementations of said runtime exist,
 and they act in slightly different ways. By default, Apple platforms link to
 Apple's runtime, but if you're using another runtime you must tell it to this
-library using feature flags.
+library using feature flags (you might have to disable the default `apple`
+feature first).
 
 One could ask, why even bother supporting other runtimes? To that, there's a
 simple answer: _Robustness_. By testing with these alternative runtimes in CI,
@@ -29,8 +30,7 @@ iOS versions.
 
 - Feature flag: `apple`.
 
-This is used by default on Apple platforms when no other feature flags are
-specified.
+This is used by default.
 
 The supported runtime version (higher versions lets the compiler enable newer
 optimizations, at the cost of not supporting older operating systems) can be

--- a/objc-sys/build.rs
+++ b/objc-sys/build.rs
@@ -69,15 +69,15 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     let mut apple = env::var_os("CARGO_FEATURE_APPLE").is_some();
-    let gnustep = env::var_os("CARGO_FEATURE_GNUSTEP_1_7").is_some();
+    let mut gnustep = env::var_os("CARGO_FEATURE_GNUSTEP_1_7").is_some();
     let objfw = env::var_os("CARGO_FEATURE_OBJFW").is_some();
 
-    if let (false, false, false) = (apple, gnustep, objfw) {
-        // Enable `apple` by default on Apple platforms
+    // Choose defaults when generating docs
+    if std::env::var("DOCS_RS").is_ok() {
         if let "macos" | "ios" | "tvos" | "watchos" = &*target_os {
             apple = true;
-            // Add cheaty #[cfg(feature = "apple")] directive
-            println!("cargo:rustc-cfg=feature=\"apple\"");
+        } else {
+            gnustep = true; // Also winobjc
         }
     }
 
@@ -98,7 +98,14 @@ fn main() {
             })
         }
         (false, true, false) => {
-            if env::var_os("CARGO_FEATURE_WINOBJC").is_some() {
+            // Choose defaults when generating docs
+            if std::env::var("DOCS_RS").is_ok() {
+                if "windows" == target_os {
+                    WinObjC
+                } else {
+                    GNUStep(1, 7)
+                }
+            } else if env::var_os("CARGO_FEATURE_WINOBJC").is_some() {
                 WinObjC
             } else if env::var_os("CARGO_FEATURE_GNUSTEP_2_1").is_some() {
                 GNUStep(2, 1)
@@ -118,21 +125,8 @@ fn main() {
             unimplemented!("ObjFW is not yet supported")
             // ObjFW(None)
         }
-        (false, false, false) => {
-            // Choose sensible defaults when generating docs
-            if std::env::var("DOCS_RS").is_ok() {
-                if target_os == "windows" {
-                    WinObjC
-                } else {
-                    GNUStep(1, 7)
-                }
-            } else {
-                panic!("Must specify the desired runtime (using features) on non-apple platforms.")
-            }
-        }
-        _ => {
-            panic!("Invalid feature combination; only one runtime may be selected!")
-        }
+        (false, false, false) => panic!("Must specify the desired runtime (using cargo features)."),
+        _ => panic!("Invalid feature combination; only one runtime may be selected!"),
     };
 
     // Add `#[cfg(RUNTIME)]` directive

--- a/objc-sys/build.rs
+++ b/objc-sys/build.rs
@@ -137,35 +137,6 @@ fn main() {
         ObjFW(_) => "objfw",
     };
     println!("cargo:rustc-cfg={}", runtime_cfg);
-    // Allow downstream build scripts to do the same
-    println!("cargo:runtime={}", runtime_cfg); // DEP_OBJC_[version]_RUNTIME
-
-    // Tell downstream build scripts our features
-    // match &runtime {
-    //     Apple(_) => println!("cargo:apple=1"), // DEP_OBJC_APPLE
-    //     GNUStep(major, minor) => {
-    //         let version = (*major, *minor);
-    //         println!("cargo:gnustep-1-7=1"); // DEP_OBJC_GNUSTEP_1_7
-    //         if version >= (1, 8) {
-    //             println!("cargo:gnustep-1-8=1"); // DEP_OBJC_GNUSTEP_1_8
-    //         }
-    //         if version >= (1, 9) {
-    //             println!("cargo:gnustep-1-9=1"); // DEP_OBJC_GNUSTEP_1_9
-    //         }
-    //         if version >= (2, 0) {
-    //             println!("cargo:gnustep-2-0=1"); // DEP_OBJC_GNUSTEP_2_0
-    //         }
-    //         if version >= (2, 1) {
-    //             println!("cargo:gnustep-2-1=1"); // DEP_OBJC_GNUSTEP_2_1
-    //         }
-    //     }
-    //     WinObjC => {
-    //         println!("cargo:gnustep-1-7=1"); // DEP_OBJC_GNUSTEP_1_7
-    //         println!("cargo:gnustep-1-8=1"); // DEP_OBJC_GNUSTEP_1_8
-    //         println!("cargo:winobjc=1"); // DEP_OBJC_WINOBJC
-    //     }
-    //     ObjFW(_) => println!("cargo:objfw=1"), // DEP_OBJC_APPLE
-    // }
 
     let clang_runtime = match &runtime {
         Apple(runtime) => {

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -23,6 +23,15 @@ default = ["block"]
 # Provided as a way to cut down on dependencies
 block = ["block2"]
 
+# Runtime selection. See `objc-sys` and `block-sys` for details.
+apple = ["objc2/apple", "block2?/apple"]
+gnustep-1-7 = ["objc2/gnustep-1-7", "block2?/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc2/gnustep-1-8", "block2?/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9", "block2?/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0", "block2?/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1", "block2?/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "objc2/winobjc", "block2?/winobjc"]
+
 [dependencies]
 block2 = { path = "../block2", version = "=0.2.0-alpha.3", optional = true }
 objc2 = { path = "../objc2", version = "=0.3.0-alpha.6" }

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -16,8 +16,6 @@ repository = "https://github.com/madsmtm/objc2"
 documentation = "https://docs.rs/objc2-foundation/"
 license = "MIT"
 
-build = "build.rs"
-
 [features]
 default = ["apple", "block"]
 # Provided as a way to cut down on dependencies
@@ -35,7 +33,6 @@ winobjc = ["gnustep-1-8", "objc2/winobjc", "block2?/winobjc"]
 [dependencies]
 block2 = { path = "../block2", version = "=0.2.0-alpha.3", optional = true }
 objc2 = { path = "../objc2", version = "=0.3.0-alpha.6" }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -31,8 +31,8 @@ gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1", "block2?/gnustep-2-1"]
 winobjc = ["gnustep-1-8", "objc2/winobjc", "block2?/winobjc"]
 
 [dependencies]
-block2 = { path = "../block2", version = "=0.2.0-alpha.3", optional = true }
-objc2 = { path = "../objc2", version = "=0.3.0-alpha.6" }
+block2 = { path = "../block2", version = "=0.2.0-alpha.3", default-features = false, optional = true }
+objc2 = { path = "../objc2", version = "=0.3.0-alpha.6", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 build = "build.rs"
 
 [features]
-default = ["block"]
+default = ["apple", "block"]
 # Provided as a way to cut down on dependencies
 block = ["block2"]
 

--- a/objc2-foundation/build.rs
+++ b/objc2-foundation/build.rs
@@ -1,9 +1,0 @@
-use std::env;
-
-fn main() {
-    // The script doesn't depend on our code
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let runtime = env::var("DEP_OBJC_0_2_RUNTIME").unwrap();
-    println!("cargo:rustc-cfg={}", runtime);
-}

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -74,9 +74,9 @@ impl NSData {
         // So we just use NSDataWithDeallocatorBlock directly.
         //
         // NSMutableData does not have this problem.
-        #[cfg(gnustep)]
+        #[cfg(feature = "gnustep-1-7")]
         let cls = objc2::class!(NSDataWithDeallocatorBlock);
-        #[cfg(not(gnustep))]
+        #[cfg(not(feature = "gnustep-1-7"))]
         let cls = Self::class();
 
         unsafe { Id::new(data_from_vec(cls, bytes).cast()).unwrap() }

--- a/objc2-foundation/src/geometry.rs
+++ b/objc2-foundation/src/geometry.rs
@@ -20,14 +20,20 @@ pub type CGFloat = InnerFloat;
 
 // NSGeometry types are just aliases to CGGeometry types on iOS, tvOS, watchOS
 // and macOS 64bit (and hence their Objective-C encodings are different).
-#[cfg(all(apple, not(all(target_os = "macos", target_pointer_width = "32"))))]
+#[cfg(all(
+    feature = "apple",
+    not(all(target_os = "macos", target_pointer_width = "32"))
+))]
 mod names {
     pub(super) const POINT: &str = "_CGPoint";
     pub(super) const SIZE: &str = "_CGSize";
     pub(super) const RECT: &str = "_CGRect";
 }
 
-#[cfg(any(gnustep, all(target_os = "macos", target_pointer_width = "32")))]
+#[cfg(any(
+    feature = "gnustep-1-7",
+    all(target_os = "macos", target_pointer_width = "32")
+))]
 mod names {
     pub(super) const POINT: &str = "_NSPoint";
     pub(super) const SIZE: &str = "_NSSize";
@@ -305,7 +311,7 @@ mod tests {
     // and so on properly, so let's ensure that NSEqualXXX handles these as
     // well (so that we're confident that the implementations are equivalent).
     #[test]
-    #[cfg(any(all(apple, target_os = "macos"), gnustep))] // or macabi
+    #[cfg(any(all(feature = "apple", target_os = "macos"), feature = "gnustep-1-7"))] // or macabi
     fn test_partial_eq() {
         use objc2::runtime::Bool;
 

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -64,11 +64,11 @@ pub use self::value::NSValue;
 #[doc(no_inline)]
 pub use objc2::ffi::{NSInteger, NSUInteger};
 
-#[cfg(apple)]
+#[cfg(feature = "apple")]
 #[link(name = "Foundation", kind = "framework")]
 extern "C" {}
 
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 #[link(name = "gnustep-base", kind = "dylib")]
 extern "C" {}
 

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -16,9 +16,9 @@ use objc2::runtime::{Bool, Class, Object};
 
 use crate::{NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject};
 
-#[cfg(apple)]
+#[cfg(feature = "apple")]
 const UTF8_ENCODING: usize = 4;
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 const UTF8_ENCODING: i32 = 4;
 
 #[allow(unused)]
@@ -272,7 +272,7 @@ mod tests {
     use super::*;
     use alloc::format;
 
-    #[cfg(gnustep)]
+    #[cfg(feature = "gnustep-1-7")]
     #[test]
     fn ensure_linkage() {
         unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
@@ -380,9 +380,9 @@ mod tests {
         let s = "\u{feff}\u{feff}a\u{feff}";
 
         // Huh, this difference might be a GNUStep bug?
-        #[cfg(apple)]
+        #[cfg(feature = "apple")]
         let expected = "\u{feff}a\u{feff}";
-        #[cfg(gnustep)]
+        #[cfg(feature = "gnustep-1-7")]
         let expected = "a\u{feff}";
 
         let ns_string = NSString::from_str(s);

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -62,7 +62,10 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg_attr(gnustep, should_panic = "Could not retrieve main thread")]
+    #[cfg_attr(
+        feature = "gnustep-1-7",
+        should_panic = "Could not retrieve main thread"
+    )]
     fn test_main_thread() {
         let current = NSThread::current();
         let main = NSThread::main();

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -180,7 +180,7 @@ mod tests {
         let range: NSRange = unsafe { objc2::msg_send![val, rangeValue] };
         assert_eq!(range, NSRange::from(1..2));
         // NSValue -getValue is broken on GNUStep for some types
-        #[cfg(not(gnustep))]
+        #[cfg(not(feature = "gnustep-1-7"))]
         assert_eq!(val.get(), NSRange::from(1..2));
     }
 }

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -53,8 +53,8 @@ winobjc = ["gnustep-1-8", "objc-sys/winobjc"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2" }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2", default-features = false }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -21,6 +21,8 @@ build = "build.rs"
 # NOTE: 'unstable' features are _not_ considered part of the SemVer contract,
 # and may be removed in a minor release.
 [features]
+default = ["apple"]
+
 # Enables `objc2::exception::throw` and `objc2::exception::catch`
 exception = ["cc"]
 

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -40,6 +40,15 @@ malloc = ["malloc_buf"]
 # Uses nightly features to make AutoreleasePool zero-cost even in debug mode
 unstable_autoreleasesafe = []
 
+# Runtime selection. See `objc-sys` for details.
+apple = ["objc-sys/apple"]
+gnustep-1-7 = ["objc-sys/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "objc-sys/winobjc"]
+
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1" }

--- a/objc2/benches/autorelease.rs
+++ b/objc2/benches/autorelease.rs
@@ -5,18 +5,18 @@ use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{class, msg_send, sel};
 
-#[cfg(apple)]
+#[cfg(feature = "apple")]
 #[link(name = "Foundation", kind = "framework")]
 extern "C" {}
 
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 #[link(name = "gnustep-base", kind = "dylib")]
 extern "C" {}
 
 const BYTES: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 fn empty() {
-    #[cfg(gnustep)]
+    #[cfg(feature = "gnustep-1-7")]
     unsafe {
         objc2::__gnustep_hack::get_class_to_force_linkage()
     };

--- a/objc2/build.rs
+++ b/objc2/build.rs
@@ -1,14 +1,11 @@
-use std::env;
-
 fn main() {
     // The script doesn't depend on our code
     println!("cargo:rerun-if-changed=build.rs");
 
-    let runtime = env::var("DEP_OBJC_0_2_RUNTIME").unwrap();
-    println!("cargo:rustc-cfg={}", runtime);
-
     #[cfg(feature = "exception")]
     {
+        use std::env;
+
         if std::env::var("DOCS_RS").is_ok() {
             // docs.rs doesn't have clang, so skip building this. The
             // documentation will still work since it doesn't need to link.

--- a/objc2/examples/talk_to_me.rs
+++ b/objc2/examples/talk_to_me.rs
@@ -4,7 +4,7 @@ use objc2::runtime::Object;
 use objc2::{class, msg_send};
 use std::ffi::c_void;
 
-#[cfg(apple)] // Does not work on GNUStep
+#[cfg(feature = "apple")] // Does not work on GNUStep
 #[link(name = "AVFoundation", kind = "framework")]
 extern "C" {}
 

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -27,8 +27,8 @@
 //! the [`msg_send!`] macro, and lastly, the `Id<Object, _>` goes out of
 //! scope, and the object is deallocated.
 //!
-#![cfg_attr(apple, doc = "```")]
-#![cfg_attr(not(apple), doc = "```no_run")]
+#![cfg_attr(feature = "apple", doc = "```")]
+#![cfg_attr(not(feature = "apple"), doc = "```no_run")]
 //! use objc2::{class, msg_send};
 //! use objc2::ffi::NSUInteger;
 //! use objc2::rc::{Id, Owned};
@@ -137,7 +137,7 @@ extern crate alloc;
 extern crate std;
 
 // The example uses NSObject without doing the __gnustep_hack
-#[cfg(all(apple, doctest))]
+#[cfg(all(feature = "apple", doctest))]
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
@@ -171,7 +171,7 @@ mod test_utils;
 ///
 /// This is a temporary solution to make our CI work for now!
 #[doc(hidden)]
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 pub mod __gnustep_hack {
     use super::runtime::Class;
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -30,10 +30,10 @@ unsafe fn conditional_try<R: Encode>(f: impl FnOnce() -> R) -> Result<R, Message
 #[cfg(feature = "malloc")]
 mod verify;
 
-#[cfg(apple)]
+#[cfg(feature = "apple")]
 #[path = "apple/mod.rs"]
 mod platform;
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 #[path = "gnustep.rs"]
 mod platform;
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -308,7 +308,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
 
         // Only worth doing on the Apple runtime.
         // Not supported on TARGET_OS_WIN32.
-        #[cfg(all(apple, not(target_os = "windows")))]
+        #[cfg(all(feature = "apple", not(target_os = "windows")))]
         {
             // Supported since macOS 10.7.
             #[cfg(target_arch = "x86_64")]
@@ -352,7 +352,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
         // less likely to occur.
         //
         // This is brittle! We should find a better solution!
-        #[cfg(all(apple, not(target_os = "windows"), target_arch = "x86_64"))]
+        #[cfg(all(feature = "apple", not(target_os = "windows"), target_arch = "x86_64"))]
         {
             // SAFETY: Similar to above.
             unsafe { core::arch::asm!("nop", options(nomem, preserves_flags, nostack)) };

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -30,8 +30,8 @@
 //!
 //! ## Example
 //!
-#![cfg_attr(apple, doc = "```")]
-#![cfg_attr(not(apple), doc = "```no_run")]
+#![cfg_attr(feature = "apple", doc = "```")]
+#![cfg_attr(not(feature = "apple"), doc = "```no_run")]
 //! use objc2::{class, msg_send};
 //! use objc2::rc::{autoreleasepool, Id, Shared, WeakId};
 //! use objc2::runtime::Object;

--- a/objc2/tests/id_retain_autoreleased.rs
+++ b/objc2/tests/id_retain_autoreleased.rs
@@ -37,12 +37,12 @@ fn create_data(bytes: &[u8]) -> Id<Object, Shared> {
 
 #[test]
 fn test_retain_autoreleased() {
-    #[cfg(gnustep)]
+    #[cfg(feature = "gnustep-1-7")]
     unsafe {
         objc2::__gnustep_hack::get_class_to_force_linkage()
     };
 
-    #[cfg(apple)]
+    #[cfg(feature = "apple")]
     #[link(name = "Foundation", kind = "framework")]
     extern "C" {}
 
@@ -54,7 +54,7 @@ fn test_retain_autoreleased() {
         // When compiled in release mode / with optimizations enabled,
         // subsequent usage of `retain_autoreleased` will succeed in retaining
         // the autoreleased value!
-        let expected = if cfg!(gnustep) {
+        let expected = if cfg!(feature = "gnustep-1-7") {
             1
         } else if cfg!(any(
             debug_assertions,

--- a/objc2/tests/use_macros.rs
+++ b/objc2/tests/use_macros.rs
@@ -1,7 +1,7 @@
 use objc2::runtime::Object;
 use objc2::{class, msg_send, sel};
 
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 #[test]
 fn ensure_linkage() {
     unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 build = "build.rs"
 
 [features]
+default = ["apple"]
 # Enable UI tests
 #
 # These are not enabled by default because trybuild doesn't pass feature flags

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,6 +20,16 @@ build = "build.rs"
 ui = ["trybuild"]
 assembly = ["cargo_metadata"]
 
+# Runtime features. Rely on `objc2-foundation` and `block2` to enable these
+# for the other dependencies.
+apple = ["block2/apple", "objc2-foundation/apple"]
+gnustep-1-7 = ["block2/gnustep-1-7", "objc2-foundation/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "block2/gnustep-1-8", "objc2-foundation/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2-foundation/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2-foundation/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2-foundation/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "block2/winobjc", "objc2-foundation/winobjc"]
+
 [dependencies]
 block2 = { path = "../block2" }
 block-sys = { path = "../block-sys" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,12 +32,11 @@ gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2-foundation/gnustep-2-
 winobjc = ["gnustep-1-8", "block2/winobjc", "objc2-foundation/winobjc"]
 
 [dependencies]
-block2 = { path = "../block2" }
-block-sys = { path = "../block-sys" }
-objc-sys = { path = "../objc-sys" }
-objc2 = { path = "../objc2" }
-objc2-encode = { path = "../objc2-encode" }
-objc2-foundation = { path = "../objc2-foundation" }
+block2 = { path = "../block2", default-features = false }
+block-sys = { path = "../block-sys", default-features = false }
+objc-sys = { path = "../objc-sys", default-features = false }
+objc2 = { path = "../objc2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", default-features = false }
 
 # Put here instead of dev-dependencies because we want to make it optional
 trybuild = { version = "1.0", optional = true }

--- a/tests/assembly/test_msg_send_zero_cost/Cargo.toml
+++ b/tests/assembly/test_msg_send_zero_cost/Cargo.toml
@@ -8,6 +8,15 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-objc2 = { path = "../../../objc2" }
-objc-sys = { path = "../../../objc-sys" }
-block-sys = { path = "../../../block-sys" }
+objc2 = { path = "../../../objc2", default-features = false }
+
+[features]
+default = ["apple"]
+# Runtime
+apple = ["objc2/apple"]
+gnustep-1-7 = ["objc2/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc2/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "objc2/winobjc"]

--- a/tests/assembly/test_retain_autoreleased/Cargo.toml
+++ b/tests/assembly/test_retain_autoreleased/Cargo.toml
@@ -8,6 +8,15 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-objc2 = { path = "../../../objc2" }
-objc-sys = { path = "../../../objc-sys" }
-block-sys = { path = "../../../block-sys" }
+objc2 = { path = "../../../objc2", default-features = false }
+
+[features]
+default = ["apple"]
+# Runtime
+apple = ["objc2/apple"]
+gnustep-1-7 = ["objc2/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc2/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1"]
+winobjc = ["gnustep-1-8", "objc2/winobjc"]

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -4,9 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=extern/block_utils.c");
     println!("cargo:rerun-if-changed=extern/encode_utils.m");
 
-    let runtime = env::var("DEP_OBJC_0_2_RUNTIME").unwrap();
-    println!("cargo:rustc-cfg={}", runtime);
-
     let mut builder = cc::Build::new();
     builder.compiler("clang");
     builder.file("extern/block_utils.c");

--- a/tests/src/ffi.rs
+++ b/tests/src/ffi.rs
@@ -1,4 +1,4 @@
-use objc2_encode::{Encode, Encoding};
+use objc2::{Encode, Encoding};
 
 /// A block that takes no arguments and returns an integer: `int32_t (^)()`.
 #[repr(C)]

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -226,7 +226,7 @@ assert_inner!(str ENCODING_STRUCT_WITH_ARRAYS_ATOMIC => "A{with_arrays}");
 
 // Bitfields
 
-#[cfg(not(gnustep))]
+#[cfg(feature = "apple")]
 mod bitfields {
     use super::*;
 
@@ -242,7 +242,7 @@ mod bitfields {
     assert_inner!(str ENCODING_BITFIELD_ATOMIC => "A{bitfield}");
 }
 
-#[cfg(gnustep)]
+#[cfg(feature = "gnustep-1-7")]
 mod bitfields {
     use super::*;
 

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -3,7 +3,7 @@ use alloc::format;
 use core::fmt::Display;
 use objc2::ffi::{NSInteger, NSUInteger};
 use objc2::runtime::{Bool, Class, Object, Sel};
-use objc2_encode::{Encode, Encoding, RefEncode};
+use objc2::{Encode, Encoding, RefEncode};
 use paste::paste;
 use std::ffi::CStr;
 use std::os::raw::*;


### PR DESCRIPTION
Change how the Objective-C runtime is selected by making it a feature on all crates (instead of making it a feature in `-sys` crates, and then "communicating" upwards via. build scripts which runtime was selected).

Also make Apple's runtime the default everywhere, which fixes #140. This means that to use these crates on other systems, you'll have to specify so manually in your `Cargo.toml`, and every dependency has to do so as well. This is a good thing though! It means that e.g. `winit` wouldn't try to "automatically" work on GNUStep, without the `winit` project actually supporting that platform.