### PR TITLE
Impl `AsRef` and `AsMut` for objects, to convert them to their superclasses

### DIFF
--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -43,7 +43,7 @@ unsafe impl<T: Send> Send for NSArray<T, Owned> {}
 object! {
     // TODO: Ensure that this deref to NSArray is safe!
     // This "inherits" NSArray, and has the same `Send`/`Sync` impls as that.
-    unsafe pub struct NSMutableArray<T, O: Ownership>: NSArray<T, O> {}
+    unsafe pub struct NSMutableArray<T, O: Ownership>: NSArray<T, O>, NSObject {}
 }
 
 unsafe fn from_refs<T: Message + ?Sized>(cls: &Class, refs: &[&T]) -> *mut Object {

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -32,7 +32,7 @@ object! {
     /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsmutabledata?language=objc).
     ///
     /// [`Vec`]: std::vec::Vec
-    unsafe pub struct NSMutableData: NSData;
+    unsafe pub struct NSMutableData: NSData, NSObject;
 }
 
 // TODO: SAFETY

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -100,13 +100,7 @@ macro_rules! object {
         impl<$($t: ::core::cmp::PartialEq $(+ $b)?),*> ::core::cmp::PartialEq for $name<$($t),*> {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
-                use ::objc2::MessageReceiver;
-                use $crate::NSObject;
-                // "downgrading" to  NSObject to work around generic
-                // downgrading not having been set up yet.
-                // TODO: Fix this.
-                let other: &NSObject = unsafe { &*other.as_raw_receiver().cast() };
-                self.is_equal(other)
+                self.is_equal(&*other)
             }
         }
 

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -1,13 +1,13 @@
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 
-use crate::{NSAttributedString, NSCopying, NSMutableCopying, NSString};
+use crate::{NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
 
 object! {
     /// A mutable string that has associated attributes.
     ///
     /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsmutableattributedstring?language=objc).
-    unsafe pub struct NSMutableAttributedString: NSAttributedString;
+    unsafe pub struct NSMutableAttributedString: NSAttributedString, NSObject;
 }
 
 // TODO: SAFETY

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -6,13 +6,13 @@ use core::str;
 use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 
-use crate::{NSCopying, NSMutableCopying, NSString};
+use crate::{NSCopying, NSMutableCopying, NSObject, NSString};
 
 object! {
     /// A dynamic plain-text Unicode string object.
     ///
     /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsmutablestring?language=objc).
-    unsafe pub struct NSMutableString: NSString;
+    unsafe pub struct NSMutableString: NSString, NSObject;
 }
 
 // TODO: SAFETY

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -5,7 +5,8 @@ use objc2::runtime::{Bool, Class, Object};
 use super::NSString;
 
 object! {
-    unsafe pub struct NSObject: Object;
+    @__inner
+    unsafe pub struct NSObject<>: Object {}
 }
 
 impl NSObject {


### PR DESCRIPTION
This allows converting objects to their superclasses directly (instead of e.g. going through `Deref`).