### PR TITLE
Change how mutability in `msg_send!` is done

### DIFF
--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -70,12 +70,12 @@ fn main() {
 
     obj.set_number(7);
     println!("Number: {}", unsafe {
-        let number: u32 = msg_send![obj, number];
+        let number: u32 = msg_send![&obj, number];
         number
     });
 
     unsafe {
-        let _: () = msg_send![obj, setNumber: 12u32];
+        let _: () = msg_send![&mut obj, setNumber: 12u32];
     }
     println!("Number: {}", obj.number());
 }

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -272,14 +272,16 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
         obj
     }
 
+    fn remove_last(&mut self) {
+        unsafe { msg_send![self, removeLastObject] }
+    }
+
     #[doc(alias = "removeLastObject")]
     pub fn pop(&mut self) -> Option<Id<T, O>> {
         self.last()
             .map(|obj| unsafe { Id::retain(obj as *const T as *mut T).unwrap_unchecked() })
             .map(|obj| {
-                unsafe {
-                    let _: () = msg_send![self, removeLastObject];
-                }
+                self.remove_last();
                 obj
             })
     }

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -274,13 +274,14 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
 
     #[doc(alias = "removeLastObject")]
     pub fn pop(&mut self) -> Option<Id<T, O>> {
-        self.last().map(|obj| {
-            let obj = unsafe { Id::retain(obj as *const T as *mut T).unwrap_unchecked() };
-            unsafe {
-                let _: () = msg_send![self, removeLastObject];
-            }
-            obj
-        })
+        self.last()
+            .map(|obj| unsafe { Id::retain(obj as *const T as *mut T).unwrap_unchecked() })
+            .map(|obj| {
+                unsafe {
+                    let _: () = msg_send![self, removeLastObject];
+                }
+                obj
+            })
     }
 
     #[doc(alias = "removeAllObjects")]

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -157,7 +157,10 @@ mod tests {
         assert!(s2.is_kind_of(NSAttributedString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3) as *mut NSAttributedString);
+        assert_ne!(
+            Id::as_ptr(&s1),
+            Id::as_ptr(&s3) as *const NSAttributedString
+        );
         assert!(s3.is_kind_of(NSMutableAttributedString::class()));
     }
 }

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -153,11 +153,11 @@ mod tests {
         let s2 = s1.copy();
         // NSAttributedString performs this optimization in GNUStep's runtime,
         // but not in Apple's; so we don't test for it!
-        // assert_eq!(s1.as_ptr(), s2.as_ptr());
+        // assert_eq!(Id::as_ptr(&s1), Id::as_ptr(&s2));
         assert!(s2.is_kind_of(NSAttributedString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(s1.as_ptr(), s3.as_ptr() as *mut NSAttributedString);
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3) as *mut NSAttributedString);
         assert!(s3.is_kind_of(NSMutableAttributedString::class()));
     }
 }

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -156,7 +156,8 @@ impl NSMutableData {
 impl NSMutableData {
     #[doc(alias = "mutableBytes")]
     pub fn bytes_mut(&mut self) -> &mut [u8] {
-        let ptr: *mut c_void = unsafe { msg_send![self, mutableBytes] };
+        let this = &mut *self; // Reborrow
+        let ptr: *mut c_void = unsafe { msg_send![this, mutableBytes] };
         // The bytes pointer may be null for length zero
         if ptr.is_null() {
             &mut []

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -154,10 +154,14 @@ impl NSMutableData {
 
 /// Mutation methods
 impl NSMutableData {
+    // Helps with reborrowing issue
+    fn raw_bytes_mut(&mut self) -> *mut c_void {
+        unsafe { msg_send![self, mutableBytes] }
+    }
+
     #[doc(alias = "mutableBytes")]
     pub fn bytes_mut(&mut self) -> &mut [u8] {
-        let this = &mut *self; // Reborrow
-        let ptr: *mut c_void = unsafe { msg_send![this, mutableBytes] };
+        let ptr = self.raw_bytes_mut();
         // The bytes pointer may be null for length zero
         if ptr.is_null() {
             &mut []

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -129,7 +129,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
 
     pub fn into_values_array(dict: Id<Self, Owned>) -> Id<NSArray<V, Owned>, Shared> {
         unsafe {
-            let vals = msg_send![dict, allValues];
+            let vals = msg_send![&dict, allValues];
             Id::retain_autoreleased(vals).unwrap()
         }
     }

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -33,7 +33,7 @@ impl<'a, T: Message> Iterator for NSEnumerator<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-        unsafe { msg_send![self.id, nextObject] }
+        unsafe { msg_send![&mut self.id, nextObject] }
     }
 }
 

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -90,7 +90,10 @@ mod tests {
     fn test_copy() {
         let s1 = NSMutableAttributedString::from_nsstring(&NSString::from_str("abc"));
         let s2 = s1.copy();
-        assert_ne!(Id::as_ptr(&s1) as *mut NSAttributedString, Id::as_ptr(&s2));
+        assert_ne!(
+            Id::as_ptr(&s1) as *const NSAttributedString,
+            Id::as_ptr(&s2)
+        );
         assert!(s2.is_kind_of(NSAttributedString::class()));
 
         let s3 = s1.mutable_copy();

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -90,11 +90,11 @@ mod tests {
     fn test_copy() {
         let s1 = NSMutableAttributedString::from_nsstring(&NSString::from_str("abc"));
         let s2 = s1.copy();
-        assert_ne!(s1.as_ptr() as *const NSAttributedString, s2.as_ptr());
+        assert_ne!(Id::as_ptr(&s1) as *mut NSAttributedString, Id::as_ptr(&s2));
         assert!(s2.is_kind_of(NSAttributedString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(s1.as_ptr(), s3.as_ptr());
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3));
         assert!(s3.is_kind_of(NSMutableAttributedString::class()));
     }
 }

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -200,11 +200,11 @@ mod tests {
     fn test_copy() {
         let s1 = NSMutableString::from_str("abc");
         let s2 = s1.copy();
-        assert_ne!(s1.as_ptr(), s2.as_ptr() as *mut NSMutableString);
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s2) as *mut NSMutableString);
         assert!(s2.is_kind_of(NSString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(s1.as_ptr(), s3.as_ptr());
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3));
         assert!(s3.is_kind_of(NSMutableString::class()));
     }
 }

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -200,7 +200,7 @@ mod tests {
     fn test_copy() {
         let s1 = NSMutableString::from_str("abc");
         let s2 = s1.copy();
-        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s2) as *mut NSMutableString);
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s2) as *const NSMutableString);
         assert!(s2.is_kind_of(NSString::class()));
 
         let s3 = s1.mutable_copy();

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -350,7 +350,7 @@ mod tests {
         assert!(s2.is_kind_of(NSString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3) as *mut NSString);
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3) as *const NSString);
         assert!(s3.is_kind_of(NSMutableString::class()));
     }
 

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -346,11 +346,11 @@ mod tests {
         let s1 = NSString::from_str("abc");
         let s2 = s1.copy();
         // An optimization that NSString makes, since it is immutable
-        assert_eq!(s1.as_ptr(), s2.as_ptr());
+        assert_eq!(Id::as_ptr(&s1), Id::as_ptr(&s2));
         assert!(s2.is_kind_of(NSString::class()));
 
         let s3 = s1.mutable_copy();
-        assert_ne!(s1.as_ptr(), s3.as_ptr() as *mut NSString);
+        assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3) as *mut NSString);
         assert!(s3.is_kind_of(NSMutableString::class()));
     }
 

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_value_nsrange() {
         let val = NSValue::new(NSRange::from(1..2));
         assert!(NSRange::ENCODING.equivalent_to_str(val.encoding().unwrap()));
-        let range: NSRange = unsafe { objc2::msg_send![val, rangeValue] };
+        let range: NSRange = unsafe { objc2::msg_send![&val, rangeValue] };
         assert_eq!(range, NSRange::from(1..2));
         // NSValue -getValue is broken on GNUStep for some types
         #[cfg(not(feature = "gnustep-1-7"))]

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   upgrading easier.
 * Allow using `From`/`TryFrom` to convert between `rc::Id` and `rc::WeakId`.
 * Added `Bool::as_bool` (more descriptive name than `Bool::is_true`).
-* Added convenience method `Id::as_ptr`.
+* Added convenience method `Id::as_ptr` and `Id::as_mut_ptr`.
 * The `objc2-encode` dependency is now exposed as `objc2::encode`.
 * Added `Id::retain_autoreleased` to allow following Cocoas memory management
   rules more efficiently.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -38,6 +38,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `ClassBuilder::add_method`.
 * Renamed `ClassDecl` and `ProtocolDecl` to `ClassBuilder` and
   `ProtocolBuilder`. The old names are kept as deprecated aliases.
+* **BREAKING**: Changed how `msg_send!` works wrt. capturing its arguments.
+
+  This will require changes to your code wherever you used `Id`, for example:
+  ```rust
+  // Before
+  let obj: Id<Object, Owned> = ...;
+  let p: i32 = unsafe { msg_send![obj, parameter] };
+  let _: () = unsafe { msg_send![obj, setParameter: p + 1] };
+  // After
+  let mut obj: Id<Object, Owned> = ...;
+  let p: i32 = unsafe { msg_send![&obj, parameter] };
+  let _: () = unsafe { msg_send![&mut obj, setParameter: p + 1] };
+  ```
+
+  Notice that we now clearly pass `obj` by reference, and therein also
+  communicate the mutability of the object (in the first case, immutable, and
+  in the second, mutable).
+
+  If you previously used `*mut Object` or `&Object` as the receiver, message
+  sending should work exactly as before.
 
 ### Fixed
 * Properly sealed the `MessageArguments` trait (it already had a hidden

--- a/objc2/benches/autorelease.rs
+++ b/objc2/benches/autorelease.rs
@@ -62,7 +62,7 @@ fn new_nsdata() -> Id<Object, Shared> {
 }
 
 fn new_leaked_nsdata() -> *mut Object {
-    ManuallyDrop::new(new_nsdata()).as_ptr()
+    Id::as_ptr(&*ManuallyDrop::new(new_nsdata()))
 }
 
 fn autoreleased_nsdata() -> *mut Object {
@@ -84,7 +84,7 @@ fn new_nsstring() -> Id<Object, Shared> {
 }
 
 fn new_leaked_nsstring() -> *mut Object {
-    ManuallyDrop::new(new_nsstring()).as_ptr()
+    Id::as_ptr(&*ManuallyDrop::new(new_nsstring()))
 }
 
 fn autoreleased_nsstring() -> *mut Object {

--- a/objc2/benches/autorelease.rs
+++ b/objc2/benches/autorelease.rs
@@ -61,11 +61,11 @@ fn new_nsdata() -> Id<Object, Shared> {
     unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
-fn new_leaked_nsdata() -> *mut Object {
+fn new_leaked_nsdata() -> *const Object {
     Id::as_ptr(&*ManuallyDrop::new(new_nsdata()))
 }
 
-fn autoreleased_nsdata() -> *mut Object {
+fn autoreleased_nsdata() -> *const Object {
     // let bytes_ptr = BYTES.as_ptr() as *const c_void;
     // unsafe {
     //     msg_send![
@@ -83,20 +83,20 @@ fn new_nsstring() -> Id<Object, Shared> {
     unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
-fn new_leaked_nsstring() -> *mut Object {
+fn new_leaked_nsstring() -> *const Object {
     Id::as_ptr(&*ManuallyDrop::new(new_nsstring()))
 }
 
-fn autoreleased_nsstring() -> *mut Object {
+fn autoreleased_nsstring() -> *const Object {
     // unsafe { msg_send![class!(NSString), string] }
     unsafe { msg_send![new_leaked_nsstring(), autorelease] }
 }
 
-fn retain_autoreleased(obj: *mut Object) -> Id<Object, Shared> {
-    unsafe { Id::retain_autoreleased(obj.cast()).unwrap_unchecked() }
+fn retain_autoreleased(obj: *const Object) -> Id<Object, Shared> {
+    unsafe { Id::retain_autoreleased((obj as *mut Object).cast()).unwrap_unchecked() }
 }
 
-fn autoreleased_nsdata_pool_cleanup() -> *mut Object {
+fn autoreleased_nsdata_pool_cleanup() -> *const Object {
     autoreleasepool(|_| autoreleased_nsdata())
 }
 
@@ -108,7 +108,7 @@ fn autoreleased_nsdata_fast_caller_cleanup_pool_cleanup() -> Id<Object, Shared> 
     autoreleasepool(|_| retain_autoreleased(autoreleased_nsdata()))
 }
 
-fn autoreleased_nsstring_pool_cleanup() -> *mut Object {
+fn autoreleased_nsstring_pool_cleanup() -> *const Object {
     autoreleasepool(|_| autoreleased_nsstring())
 }
 

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -42,6 +42,6 @@ fn main() {
     }
 
     // Invoke a method on the object
-    let hash: usize = unsafe { msg_send![obj, hash] };
+    let hash: usize = unsafe { msg_send![&obj, hash] };
     println!("NSObject hash: {}", hash);
 }

--- a/objc2/examples/talk_to_me.rs
+++ b/objc2/examples/talk_to_me.rs
@@ -31,9 +31,9 @@ fn main() {
     let utterance: *mut Object = unsafe { msg_send![utterance, initWithString: &*string] };
     let utterance: Id<Object, Owned> = unsafe { Id::new(utterance).unwrap() };
 
-    // let _: () = unsafe { msg_send![utterance, setVolume: 90.0f32 };
-    // let _: () = unsafe { msg_send![utterance, setRate: 0.50f32 };
-    // let _: () = unsafe { msg_send![utterance, setPitchMultiplier: 0.80f32 };
+    // let _: () = unsafe { msg_send![&utterance, setVolume: 90.0f32 };
+    // let _: () = unsafe { msg_send![&utterance, setRate: 0.50f32 };
+    // let _: () = unsafe { msg_send![&utterance, setPitchMultiplier: 0.80f32 };
 
-    let _: () = unsafe { msg_send![synthesizer, speakUtterance: &*utterance] };
+    let _: () = unsafe { msg_send![&synthesizer, speakUtterance: &*utterance] };
 }

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -415,9 +415,9 @@ mod tests {
     #[test]
     fn test_custom_class() {
         // Registering the custom class is in test_utils
-        let obj = test_utils::custom_object();
-        let _: () = unsafe { msg_send![obj, setFoo: 13u32] };
-        let result: u32 = unsafe { msg_send![obj, foo] };
+        let mut obj = test_utils::custom_object();
+        let _: () = unsafe { msg_send![&mut obj, setFoo: 13u32] };
+        let result: u32 = unsafe { msg_send![&obj, foo] };
         assert_eq!(result, 13);
     }
 

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -42,8 +42,8 @@
 //! };
 //!
 //! // Usage
-//! let hash: NSUInteger = unsafe { msg_send![obj, hash] };
-//! let is_kind = unsafe { msg_send_bool![obj, isKindOfClass: cls] };
+//! let hash: NSUInteger = unsafe { msg_send![&obj, hash] };
+//! let is_kind = unsafe { msg_send_bool![&obj, isKindOfClass: cls] };
 //! assert!(is_kind);
 //! ```
 //!

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -83,8 +83,7 @@ pub(crate) mod private {
     impl<'a, T: Message + ?Sized, O: Ownership> Sealed for &'a Id<T, O> {}
     impl<'a, T: Message + ?Sized> Sealed for &'a mut Id<T, Owned> {}
 
-    impl<'a, T: Message + ?Sized, O: Ownership> Sealed for &'a ManuallyDrop<Id<T, O>> {}
-    impl<'a, T: Message + ?Sized> Sealed for &'a mut ManuallyDrop<Id<T, Owned>> {}
+    impl<T: Message + ?Sized, O: Ownership> Sealed for ManuallyDrop<Id<T, O>> {}
 }
 
 /// Types that can directly be used as the receiver of Objective-C messages.
@@ -267,17 +266,10 @@ unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut Id<T, Owned> {
     }
 }
 
-unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a ManuallyDrop<Id<T, O>> {
+unsafe impl<T: Message + ?Sized, O: Ownership> MessageReceiver for ManuallyDrop<Id<T, O>> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        Id::as_ptr(&**self) as *mut Object
-    }
-}
-
-unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut ManuallyDrop<Id<T, Owned>> {
-    #[inline]
-    fn as_raw_receiver(self) -> *mut Object {
-        Id::as_mut_ptr(&mut **self) as *mut Object
+        Id::consume_as_ptr(self) as *mut Object
     }
 }
 
@@ -481,17 +473,11 @@ mod tests {
 
     #[test]
     fn test_send_message_manuallydrop() {
-        let obj = test_utils::custom_object();
-        let mut obj = ManuallyDrop::new(obj);
-        let result: u32 = unsafe {
-            let _: () = msg_send![&mut obj, setFoo: 4u32];
-            msg_send![&obj, foo]
+        let obj = ManuallyDrop::new(test_utils::custom_object());
+        unsafe {
+            let _: () = msg_send![obj, release];
         };
-        assert_eq!(result, 4);
-
-        let obj: *const ManuallyDrop<Object> = obj.as_ptr().cast();
-        let result: u32 = unsafe { msg_send![obj, foo] };
-        assert_eq!(result, 4);
+        // `obj` is consumed, can't use here
     }
 
     #[test]

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -256,28 +256,28 @@ unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut T {
 unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a Id<T, O> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        self.as_ptr() as *mut Object
+        Id::as_ptr(self) as *mut Object
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut Id<T, Owned> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        self.as_ptr() as *mut Object
+        Id::as_ptr(self) as *mut Object
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a ManuallyDrop<Id<T, O>> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        (**self).as_ptr() as *mut Object
+        Id::as_ptr(&**self) as *mut Object
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut ManuallyDrop<Id<T, Owned>> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        (**self).as_ptr() as *mut Object
+        Id::as_ptr(&mut **self) as *mut Object
     }
 }
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -395,7 +395,25 @@ impl<'a> From<VerificationError<'a>> for MessageError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rc::{Id, Owned};
     use crate::test_utils;
+
+    #[allow(unused)]
+    fn test_different_receivers(mut obj: Id<Object, Owned>) {
+        unsafe {
+            let x = &mut obj;
+            let _: () = msg_send![x, mutable1];
+            // let _: () = msg_send![x, mutable2];
+            let _: () = msg_send![&mut *obj, mutable1];
+            let _: () = msg_send![&mut *obj, mutable2];
+            let obj: NonNull<Object> = (&mut *obj).into();
+            let _: () = msg_send![obj, mutable1];
+            let _: () = msg_send![obj, mutable2];
+            let obj: *mut Object = obj.as_ptr();
+            let _: () = msg_send![obj, mutable1];
+            let _: () = msg_send![obj, mutable2];
+        }
+    }
 
     #[test]
     fn test_send_message() {

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -263,7 +263,7 @@ unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a Id<T,
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut Id<T, Owned> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        Id::as_ptr(self) as *mut Object
+        Id::as_mut_ptr(self) as *mut Object
     }
 }
 
@@ -277,7 +277,7 @@ unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a Manua
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut ManuallyDrop<Id<T, Owned>> {
     #[inline]
     fn as_raw_receiver(self) -> *mut Object {
-        Id::as_ptr(&mut **self) as *mut Object
+        Id::as_mut_ptr(&mut **self) as *mut Object
     }
 }
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -192,9 +192,26 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     ///
     /// The pointer is valid for at least as long as the `Id` is held.
     ///
+    /// See [`Id::as_mut_ptr`] for the mutable equivalent.
+    ///
     /// This is an associated method, and must be called as `Id::as_ptr(obj)`.
     #[inline]
-    pub fn as_ptr(this: &Id<T, O>) -> *mut T {
+    pub fn as_ptr(this: &Id<T, O>) -> *const T {
+        this.ptr.as_ptr()
+    }
+}
+
+impl<T: Message + ?Sized> Id<T, Owned> {
+    /// Returns a raw mutable pointer to the object.
+    ///
+    /// The pointer is valid for at least as long as the `Id` is held.
+    ///
+    /// See [`Id::as_ptr`] for the immutable equivalent.
+    ///
+    /// This is an associated method, and must be called as
+    /// `Id::as_mut_ptr(obj)`.
+    #[inline]
+    pub fn as_mut_ptr(this: &mut Id<T, Owned>) -> *mut T {
         this.ptr.as_ptr()
     }
 }

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -191,14 +191,11 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     /// Returns a raw pointer to the object.
     ///
     /// The pointer is valid for at least as long as the `Id` is held.
+    ///
+    /// This is an associated method, and must be called as `Id::as_ptr(obj)`.
     #[inline]
-    pub fn as_ptr(&self) -> *mut T {
-        // Note: This is not an associated function, which breaks the
-        // guideline that smart pointers shouldn't add inherent methods!
-        //
-        // However, this method is quite useful when migrating old codebases,
-        // so I think we'll let it be here for now.
-        self.ptr.as_ptr()
+    pub fn as_ptr(this: &Id<T, O>) -> *mut T {
+        this.ptr.as_ptr()
     }
 }
 
@@ -382,7 +379,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
         // retained objects it is hard to imagine a case where the inner type
         // has a method with the same name.
 
-        let ptr = ManuallyDrop::new(self).as_ptr() as *mut ffi::objc_object;
+        let ptr = ManuallyDrop::new(self).ptr.as_ptr() as *mut ffi::objc_object;
         // SAFETY: The `ptr` is guaranteed to be valid and have at least one
         // retain count.
         // And because of the ManuallyDrop, we don't call the Drop

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -199,6 +199,11 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     pub fn as_ptr(this: &Id<T, O>) -> *const T {
         this.ptr.as_ptr()
     }
+
+    #[inline]
+    pub(crate) fn consume_as_ptr(this: ManuallyDrop<Self>) -> *mut T {
+        this.ptr.as_ptr()
+    }
 }
 
 impl<T: Message + ?Sized> Id<T, Owned> {

--- a/objc2/src/rc/weak_id.rs
+++ b/objc2/src/rc/weak_id.rs
@@ -49,10 +49,10 @@ impl<T: Message> WeakId<T> {
     /// # Safety
     ///
     /// The object must be valid or null.
-    unsafe fn new_inner(obj: *mut T) -> Self {
+    unsafe fn new_inner(obj: *const T) -> Self {
         let inner = Box::new(UnsafeCell::new(ptr::null_mut()));
         // SAFETY: `ptr` will never move, and the caller verifies `obj`
-        let _ = unsafe { ffi::objc_initWeak(inner.get(), obj as *mut ffi::objc_object) };
+        let _ = unsafe { ffi::objc_initWeak(inner.get(), obj as *mut T as *mut ffi::objc_object) };
         Self {
             inner,
             item: PhantomData,
@@ -108,7 +108,7 @@ impl<T: Message> Default for WeakId<T> {
     #[inline]
     fn default() -> Self {
         // SAFETY: The pointer is null
-        unsafe { Self::new_inner(ptr::null_mut()) }
+        unsafe { Self::new_inner(ptr::null()) }
     }
 }
 

--- a/objc2/src/rc/weak_id.rs
+++ b/objc2/src/rc/weak_id.rs
@@ -43,7 +43,7 @@ impl<T: Message> WeakId<T> {
         // allow loading an `Id<T, Shared>` later on.
 
         // SAFETY: `obj` is valid
-        unsafe { Self::new_inner(obj.as_ptr()) }
+        unsafe { Self::new_inner(Id::as_ptr(obj)) }
     }
 
     /// # Safety

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -1,3 +1,4 @@
+use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 use std::os::raw::c_char;
 use std::sync::Once;
@@ -20,12 +21,36 @@ impl CustomObject {
 }
 
 // TODO: Remove the need for this hack
-impl crate::message::private::Sealed for CustomObject {}
+impl crate::message::private::Sealed for &CustomObject {}
+impl crate::message::private::Sealed for &mut CustomObject {}
+impl crate::message::private::Sealed for &ManuallyDrop<CustomObject> {}
+impl crate::message::private::Sealed for &mut ManuallyDrop<CustomObject> {}
 
-unsafe impl MessageReceiver for CustomObject {
+unsafe impl MessageReceiver for &CustomObject {
     #[inline]
-    fn as_raw_receiver(&self) -> *mut Object {
-        self.obj
+    fn as_raw_receiver(self) -> *mut Object {
+        (&**self).as_raw_receiver()
+    }
+}
+
+unsafe impl MessageReceiver for &mut CustomObject {
+    #[inline]
+    fn as_raw_receiver(self) -> *mut Object {
+        (&**self).as_raw_receiver()
+    }
+}
+
+unsafe impl MessageReceiver for &ManuallyDrop<CustomObject> {
+    #[inline]
+    fn as_raw_receiver(self) -> *mut Object {
+        (&**self).as_raw_receiver()
+    }
+}
+
+unsafe impl MessageReceiver for &mut ManuallyDrop<CustomObject> {
+    #[inline]
+    fn as_raw_receiver(self) -> *mut Object {
+        (&**self).as_raw_receiver()
     }
 }
 

--- a/tests/assembly/test_msg_send_zero_cost/lib.rs
+++ b/tests/assembly/test_msg_send_zero_cost/lib.rs
@@ -5,5 +5,5 @@ use objc2::MessageReceiver;
 
 #[no_mangle]
 pub fn handle(obj: &Object, sel: Sel) -> *mut Object {
-    unsafe { MessageReceiver::send_message(&obj, sel, ()).unwrap() }
+    unsafe { MessageReceiver::send_message(obj, sel, ()).unwrap() }
 }

--- a/tests/assembly/test_retain_autoreleased/lib.rs
+++ b/tests/assembly/test_retain_autoreleased/lib.rs
@@ -6,6 +6,6 @@ use objc2::MessageReceiver;
 
 #[no_mangle]
 pub fn handle(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    let ptr: *mut Object = unsafe { MessageReceiver::send_message(&obj, sel, ()).unwrap() };
+    let ptr: *mut Object = unsafe { MessageReceiver::send_message(obj, sel, ()).unwrap() };
     unsafe { Id::retain_autoreleased(ptr) }
 }

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -179,12 +179,12 @@ fn test_object() {
     assert!(obj.var3().is_null());
     assert!(obj.var3_ivar().is_null());
 
-    let obj2 = ManuallyDrop::new(NSObject::new()).as_ptr().cast::<Object>();
+    let obj2 = Id::as_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
     obj.set_var3(obj2);
     assert_eq!(obj.var3(), obj2);
     assert_eq!(*obj.var3_ivar(), obj2);
 
-    let obj3 = ManuallyDrop::new(NSObject::new()).as_ptr().cast::<Object>();
+    let obj3 = Id::as_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
     *obj.var3_ivar_mut() = obj3;
     assert_ne!(obj.var3(), obj2);
     assert_ne!(*obj.var3_ivar(), obj2);

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -179,12 +179,12 @@ fn test_object() {
     assert!(obj.var3().is_null());
     assert!(obj.var3_ivar().is_null());
 
-    let obj2 = Id::as_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
+    let obj2 = Id::as_mut_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
     obj.set_var3(obj2);
     assert_eq!(obj.var3(), obj2);
     assert_eq!(*obj.var3_ivar(), obj2);
 
-    let obj3 = Id::as_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
+    let obj3 = Id::as_mut_ptr(&mut *ManuallyDrop::new(NSObject::new())).cast::<Object>();
     *obj.var3_ivar_mut() = obj3;
     assert_ne!(obj.var3(), obj2);
     assert_ne!(*obj.var3_ivar(), obj2);

--- a/tests/ui/msg_send_mutable.rs
+++ b/tests/ui/msg_send_mutable.rs
@@ -1,0 +1,14 @@
+//! Test that `msg_send!` consumes their arguments, including the receiver.
+//!
+//! Ideally, it shouldn't be so, but that's how it works currently.
+use objc2::{msg_send, class};
+use objc2::runtime::Object;
+
+fn main() {
+    let cls = class!(NSObject);
+    let obj: &mut Object = unsafe { msg_send![cls, new] };
+
+    let _: () = unsafe { msg_send![obj, selector] };
+    // Could be solved with a reborrow
+    let _: () = unsafe { msg_send![obj, selector] };
+}

--- a/tests/ui/msg_send_mutable.stderr
+++ b/tests/ui/msg_send_mutable.stderr
@@ -1,0 +1,17 @@
+error[E0382]: use of moved value: `obj`
+   --> ui/msg_send_mutable.rs:13:36
+    |
+9   |     let obj: &mut Object = unsafe { msg_send![cls, new] };
+    |         --- move occurs because `obj` has type `&mut objc2::runtime::Object`, which does not implement the `Copy` trait
+10  |
+11  |     let _: () = unsafe { msg_send![obj, selector] };
+    |                          ------------------------ `obj` moved due to this method call
+12  |     // Could be solved with a reborrow
+13  |     let _: () = unsafe { msg_send![obj, selector] };
+    |                                    ^^^ value used here after move
+    |
+note: this function takes ownership of the receiver `self`, which moves `obj`
+   --> $WORKSPACE/objc2/src/message/mod.rs
+    |
+    |     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> Result<R, MessageError>
+    |                                  ^^^^

--- a/tests/ui/msg_send_not_encode.rs
+++ b/tests/ui/msg_send_not_encode.rs
@@ -1,9 +1,12 @@
-//! Test that return types that are not `Encode` are not accepted.
+//! Test that types that are not `Encode` are not accepted.
 use objc2::{class, msg_send};
 
 fn main() {
+    let cls = class!(NSData);
     unsafe {
-        let cls = class!(NSData);
         let _: Vec<u8> = msg_send![cls, new];
+
+        let x: Vec<u8>;
+        let _: () = msg_send![cls, newWith: x];
     }
 }

--- a/tests/ui/msg_send_not_encode.stderr
+++ b/tests/ui/msg_send_not_encode.stderr
@@ -20,3 +20,27 @@ note: required by a bound in `send_message`
     |         R: Encode,
     |            ^^^^^^ required by this bound in `send_message`
     = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
+   --> ui/msg_send_not_encode.rs:10:21
+    |
+10  |         let _: () = msg_send![cls, newWith: x];
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`
+    |
+    = help: the following other types implement trait `Encode`:
+              &'a T
+              &'a mut T
+              ()
+              *const T
+              *const c_void
+              *mut T
+              *mut c_void
+              ManuallyDrop<T>
+            and 142 others
+    = note: required because of the requirements on the impl of `MessageArguments` for `(Vec<u8>,)`
+note: required by a bound in `send_message`
+   --> $WORKSPACE/objc2/src/message/mod.rs
+    |
+    |         A: MessageArguments,
+    |            ^^^^^^^^^^^^^^^^ required by this bound in `send_message`
+    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_only_message.stderr
+++ b/tests/ui/msg_send_only_message.stderr
@@ -5,11 +5,13 @@ error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
   |              ^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `{integer}`
   |
   = help: the following other types implement trait `MessageReceiver`:
+            &'a Id<T, O>
+            &'a ManuallyDrop<Id<T, O>>
             &'a T
+            &'a mut Id<T, objc2::rc::Owned>
+            &'a mut ManuallyDrop<Id<T, objc2::rc::Owned>>
             &'a mut T
             *const T
             *mut T
-            Id<T, O>
-            ManuallyDrop<T>
             NonNull<T>
   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/msg_send_only_message.stderr
+++ b/tests/ui/msg_send_only_message.stderr
@@ -6,12 +6,11 @@ error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
   |
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T, O>
-            &'a ManuallyDrop<Id<T, O>>
             &'a T
             &'a mut Id<T, objc2::rc::Owned>
-            &'a mut ManuallyDrop<Id<T, objc2::rc::Owned>>
             &'a mut T
             *const T
             *mut T
+            ManuallyDrop<Id<T, O>>
             NonNull<T>
   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Resolves upstream issue https://github.com/SSheldon/rust-objc/issues/112.

Whichever solution we choose has quite the large effect on https://github.com/madsmtm/objc2/pull/120, since we'd like `msg_send!` and `msg_send_id!` to be consistent, and e.g. `msg_send_id!` sometimes needs the ability to consume its arguments.

This PR is a stab at implementing idea 3 as outlined in https://github.com/SSheldon/rust-objc/issues/112#issuecomment-1134422347. Not quite happy with the fact that we use fully qualified method calls, which means reborrows are sometimes necessary (see diff in `objc2-foundation/src/array.rs` and `objc2-foundation/src/data.rs`, may or may not be a big problem in practice?).

I'm reluctant to do idea 2 (add `msg_send_mut!`) since we would also need `msg_send_bool_mut!` and `msg_send_id_mut!` which is quite cumbersome!