### PR TITLE
Prepare for a time when we can make the crates `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
       CXXFLAGS: ${{ matrix.cflags }}
       ASMFLAGS: ${{ matrix.cflags }}
       LDFLAGS: ${{ matrix.cflags }}
-      HOSTARGS: --no-default-features --features ${{ matrix.runtime || 'apple' }}
-      ARGS: --no-default-features --features ${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
+      HOSTARGS: --no-default-features --features std --features ${{ matrix.runtime || 'apple' }}
+      ARGS: --no-default-features --features std --features ${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
       FEATURES: ${{ matrix.features || 'malloc,block,exception,catch_all,verify_message' }}

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -25,7 +25,11 @@ build = "build.rs"
 [features]
 # The default runtime is Apple's. Other platforms will probably error if the
 # correct feature flag is not specified.
-default = ["apple"]
+default = ["std", "apple"]
+
+# Currently not possible to turn off, put here for forwards compatibility.
+std = ["alloc", "objc-sys?/std"]
+alloc = ["objc-sys?/alloc"]
 
 # Link to Apple's libclosure (exists in libSystem)
 apple = []

--- a/block-sys/src/lib.rs
+++ b/block-sys/src/lib.rs
@@ -24,6 +24,9 @@
 
 extern crate std;
 
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature currently must be enabled.");
+
 // Ensure linkage actually happens
 #[cfg(feature = "gnustep-1-7")]
 extern crate objc_sys as _;

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -18,7 +18,11 @@ documentation = "https://docs.rs/block2/"
 license = "MIT"
 
 [features]
-default = ["apple"]
+default = ["std", "apple"]
+
+# Currently not possible to turn off, put here for forwards compatibility.
+std = ["alloc", "objc2-encode/std", "block-sys/std"]
+alloc = ["objc2-encode/alloc", "block-sys/alloc"]
 
 # Runtime selection. Default is `apple`. See `block-sys` for details.
 apple = ["block-sys/apple"]

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -88,6 +88,9 @@
 extern crate alloc;
 extern crate std;
 
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature currently must be enabled.");
+
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
 extern "C" {}

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -27,7 +27,11 @@ build = "build.rs"
 [features]
 # The default runtime is Apple's. Other platforms will probably error if the
 # correct feature flag is not specified.
-default = ["apple"]
+default = ["std", "apple"]
+
+# Currently not possible to turn off, put here for forwards compatibility.
+std = ["alloc"]
+alloc = []
 
 # Link to Apple's objc4
 apple = []

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -34,6 +34,9 @@
 // See https://github.com/japaric/cty/issues/14.
 extern crate std;
 
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature currently must be enabled.");
+
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
 extern "C" {}

--- a/objc2-encode/Cargo.toml
+++ b/objc2-encode/Cargo.toml
@@ -18,6 +18,14 @@ repository = "https://github.com/madsmtm/objc2"
 documentation = "https://docs.rs/objc2-encode/"
 license = "MIT"
 
+[features]
+default = ["std"]
+
+# Doesn't do anything (this crate works on no_std), put here for forwards
+# compatibility.
+std = ["alloc"]
+alloc = []
+
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -99,10 +99,10 @@
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
-#[cfg(doc)]
+#[cfg(any(feature = "std", doc))]
 extern crate std;
 
-#[cfg(any(test, doc))]
+#[cfg(any(feature = "alloc", test, doc))]
 extern crate alloc;
 
 mod encode;

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -17,9 +17,13 @@ documentation = "https://docs.rs/objc2-foundation/"
 license = "MIT"
 
 [features]
-default = ["apple", "block"]
+default = ["std", "apple", "block"]
 # Provided as a way to cut down on dependencies
 block = ["block2"]
+
+# Currently not possible to turn off, put here for forwards compatibility.
+std = ["alloc", "objc2/std", "block2?/std"]
+alloc = ["objc2/alloc", "block2?/alloc"]
 
 # Runtime selection. See `objc-sys` and `block-sys` for details.
 apple = ["objc2/apple", "block2?/apple"]

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -40,6 +40,9 @@
 extern crate alloc;
 extern crate std;
 
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature currently must be enabled.");
+
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
 extern "C" {}

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -19,7 +19,11 @@ license = "MIT"
 # NOTE: 'unstable' features are _not_ considered part of the SemVer contract,
 # and may be removed in a minor release.
 [features]
-default = ["apple"]
+default = ["std", "apple"]
+
+# Currently not possible to turn off, put here for forwards compatibility.
+std = ["alloc", "objc2-encode/std", "objc-sys/std"]
+alloc = ["objc2-encode/alloc", "objc-sys/alloc"]
 
 # Enables `objc2::exception::throw` and `objc2::exception::catch`
 exception = ["objc-sys/unstable-exception"]

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -178,6 +178,12 @@
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.0")]
 
+#[cfg(not(feature = "alloc"))]
+compile_error!("The `alloc` feature currently must be enabled.");
+
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature currently must be enabled.");
+
 extern crate alloc;
 extern crate std;
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,8 @@ license = "MIT"
 build = "build.rs"
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["block2/std", "objc2-foundation/std"]
 # Enable UI tests
 #
 # These are not enabled by default because trybuild doesn't pass feature flags

--- a/tests/assembly/test_msg_send_id/Cargo.toml
+++ b/tests/assembly/test_msg_send_id/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 objc2 = { path = "../../../objc2", default-features = false }
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["objc2/std"]
 # Runtime
 apple = ["objc2/apple"]
 gnustep-1-7 = ["objc2/gnustep-1-7"]

--- a/tests/assembly/test_msg_send_static_sel/Cargo.toml
+++ b/tests/assembly/test_msg_send_static_sel/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 objc2 = { path = "../../../objc2", default-features = false }
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["objc2/std"]
 # Runtime
 apple = ["objc2/apple"]
 gnustep-1-7 = ["objc2/gnustep-1-7"]

--- a/tests/assembly/test_msg_send_zero_cost/Cargo.toml
+++ b/tests/assembly/test_msg_send_zero_cost/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 objc2 = { path = "../../../objc2", default-features = false }
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["objc2/std"]
 # Runtime
 apple = ["objc2/apple"]
 gnustep-1-7 = ["objc2/gnustep-1-7"]

--- a/tests/assembly/test_retain_autoreleased/Cargo.toml
+++ b/tests/assembly/test_retain_autoreleased/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 objc2 = { path = "../../../objc2", default-features = false }
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["objc2/std"]
 # Runtime
 apple = ["objc2/apple"]
 gnustep-1-7 = ["objc2/gnustep-1-7"]

--- a/tests/assembly/test_static_sel/Cargo.toml
+++ b/tests/assembly/test_static_sel/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 objc2 = { path = "../../../objc2", default-features = false }
 
 [features]
-default = ["apple"]
+default = ["apple", "std"]
+std = ["objc2/std"]
 # Runtime
 apple = ["objc2/apple"]
 gnustep-1-7 = ["objc2/gnustep-1-7"]


### PR DESCRIPTION
Add `std` and `alloc` features, with `std` being a default (that the user must turn off using `--no-default-features`)