### PR TITLE
Remove `Message` impl for `ManuallyDrop` + fix UI test

### DIFF
--- a/objc2-encode/src/encode.rs
+++ b/objc2-encode/src/encode.rs
@@ -610,6 +610,25 @@ mod tests {
     }
 
     #[test]
+    fn test_extern_fn_pointer_elided_lifetime() {
+        fn impls_encode<T: Encode>(_x: T) {}
+
+        extern "C" fn my_fn1(_x: &i32) {}
+        extern "C" fn my_fn2(_x: &i32, _y: &u8) {}
+        extern "C" fn my_fn3(x: &u8) -> &u8 {
+            x
+        }
+        extern "C" fn my_fn4<'a, 'b>(x: &'a u8, _y: &'b i32) -> &'a u8 {
+            x
+        }
+
+        impls_encode(my_fn1 as extern "C" fn(_));
+        impls_encode(my_fn2 as extern "C" fn(_, _));
+        impls_encode(my_fn3 as extern "C" fn(_) -> _);
+        impls_encode(my_fn4 as extern "C" fn(_, _) -> _);
+    }
+
+    #[test]
     fn test_encode_arguments() {
         assert!(<()>::ENCODINGS.is_empty());
         assert_eq!(<(i8,)>::ENCODINGS, &[i8::ENCODING]);

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -66,6 +66,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Properly sealed the `MessageArguments` trait (it already had a hidden
   method, so this is not really a breaking change).
 
+### Removed
+* **BREAKING**: `ManuallyDrop` no longer implements `Message` directly.
+
 
 ## 0.3.0-alpha.6 - 2022-01-03
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -61,9 +61,6 @@ use self::verify::{verify_message_signature, VerificationError};
 /// [`objc_msgSend`]: https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend
 pub unsafe trait Message: RefEncode {}
 
-// SAFETY: `ManuallyDrop` is `repr(transparent)`.
-unsafe impl<T: Message + ?Sized> Message for ManuallyDrop<T> {}
-
 unsafe impl Message for Object {}
 
 // TODO: Make this fully private

--- a/tests/ui/fn_ptr_reference_encode.rs
+++ b/tests/ui/fn_ptr_reference_encode.rs
@@ -2,22 +2,19 @@
 //! higher-ranked over lifetimes.
 //!
 //! Ideally, they should be, but they can't be right now.
-//!
-//! (Also test that we can use `_` to work around this).
 use objc2::Encode;
 
 extern "C" fn my_fn(_x: &i32) {}
 
-fn e<T: Encode>(_x: T) {}
+fn impls_encode<T: Encode>(_x: T) {}
 
 fn main() {
-    // Works
-    e(my_fn as extern "C" fn(_));
+    // Works (though currently fails on nightly, see https://github.com/rust-lang/rust/issues/97997).
+    impls_encode(my_fn as extern "C" fn(_));
     // Can't be written:
     // let encoding = <extern "C" fn(_) as Encode>::ENCODING;
 
     // Fails
-    e(my_fn as extern "C" fn(&i32));
-    // Also fails, properly tested in `fn_ptr_reference_encode2`
-    let encoding = <extern "C" fn(&i32) as Encode>::ENCODING;
+    impls_encode(my_fn as extern "C" fn(&i32));
+    let _encoding = <extern "C" fn(&i32) as Encode>::ENCODING;
 }

--- a/tests/ui/fn_ptr_reference_encode.stderr
+++ b/tests/ui/fn_ptr_reference_encode.stderr
@@ -1,8 +1,26 @@
 error: implementation of `Encode` is not general enough
-  --> ui/fn_ptr_reference_encode.rs:20:5
+  --> ui/fn_ptr_reference_encode.rs:13:5
    |
-20 |     e(my_fn as extern "C" fn(&i32));
-   |     ^ implementation of `Encode` is not general enough
+13 |     impls_encode(my_fn as extern "C" fn(_));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Encode` is not general enough
+   |
+   = note: `Encode` would have to be implemented for the type `for<'r> extern "C" fn(&'r i32)`
+   = note: ...but `Encode` is actually implemented for the type `extern "C" fn(&'0 i32)`, for some specific lifetime `'0`
+
+error: implementation of `Encode` is not general enough
+  --> ui/fn_ptr_reference_encode.rs:18:5
+   |
+18 |     impls_encode(my_fn as extern "C" fn(&i32));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Encode` is not general enough
+   |
+   = note: `Encode` would have to be implemented for the type `for<'r> extern "C" fn(&'r i32)`
+   = note: ...but `Encode` is actually implemented for the type `extern "C" fn(&'0 i32)`, for some specific lifetime `'0`
+
+error: implementation of `Encode` is not general enough
+  --> ui/fn_ptr_reference_encode.rs:19:21
+   |
+19 |     let _encoding = <extern "C" fn(&i32) as Encode>::ENCODING;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Encode` is not general enough
    |
    = note: `Encode` would have to be implemented for the type `for<'r> extern "C" fn(&'r i32)`
    = note: ...but `Encode` is actually implemented for the type `extern "C" fn(&'0 i32)`, for some specific lifetime `'0`

--- a/tests/ui/fn_ptr_reference_encode2.rs
+++ b/tests/ui/fn_ptr_reference_encode2.rs
@@ -1,7 +1,0 @@
-//! Extra test for `fn_ptr_reference_encode`
-//! (They fail at different compilation passes).
-use objc2::Encode;
-
-fn main() {
-    let encoding = <extern "C" fn(&i32) as Encode>::ENCODING;
-}

--- a/tests/ui/fn_ptr_reference_encode2.stderr
+++ b/tests/ui/fn_ptr_reference_encode2.stderr
@@ -1,8 +1,0 @@
-error: implementation of `Encode` is not general enough
- --> ui/fn_ptr_reference_encode2.rs:6:20
-  |
-6 |     let encoding = <extern "C" fn(&i32) as Encode>::ENCODING;
-  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Encode` is not general enough
-  |
-  = note: `Encode` would have to be implemented for the type `for<'r> extern "C" fn(&'r i32)`
-  = note: ...but `Encode` is actually implemented for the type `extern "C" fn(&'0 i32)`, for some specific lifetime `'0`

--- a/tests/ui/fn_ptr_reference_method.rs
+++ b/tests/ui/fn_ptr_reference_method.rs
@@ -12,7 +12,7 @@ use objc2::runtime::{Object, Sel};
 extern "C" fn my_fn(_this: &Object, _cmd: Sel, _x: &Object) {}
 
 fn main() {
-    let builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
+    let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
     unsafe {
         // Works
         builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));

--- a/tests/ui/fn_ptr_reference_method2.rs
+++ b/tests/ui/fn_ptr_reference_method2.rs
@@ -7,7 +7,7 @@ use objc2::runtime::{Object, Sel};
 extern "C" fn my_fn(_this: &Object, _cmd: Sel, _x: &Object) {}
 
 fn main() {
-    let builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
+    let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
     unsafe {
         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
     }

--- a/tests/ui/fn_ptr_reference_method2.stderr
+++ b/tests/ui/fn_ptr_reference_method2.stderr
@@ -1,8 +1,8 @@
 error: implementation of `MethodImplementation` is not general enough
-  --> ui/fn_ptr_reference_method2.rs:12:17
+  --> ui/fn_ptr_reference_method2.rs:12:9
    |
 12 |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
-   |                 ^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
    |
    = note: `MethodImplementation` would have to be implemented for the type `for<'r, 's> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &'s objc2::runtime::Object)`
    = note: ...but `MethodImplementation` is actually implemented for the type `for<'r> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &'0 objc2::runtime::Object)`, for some specific lifetime `'0`


### PR DESCRIPTION
This was added in error, really, there is no case where we would want `T: Message` to include `ManuallyDrop<T>` - that would simply only serve to confuse the user, as they might think the `dealloc` method wouldn't be called for `Id<ManuallyDrop<MyObject>, O>`, which it definitely would!