### PR TITLE
More foundation traits

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `NSPoint`.
 * Added `NSSize`.
 * Added `NSRect`.
+* Implement `Borrow` and `BorrowMut` for all objects.
 
 ### Changed
 * **BREAKING**: Removed the following helper traits in favor of inherent

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `NSSize`.
 * Added `NSRect`.
 * Implement `Borrow` and `BorrowMut` for all objects.
+* Implement `ToOwned` for copyable types.
 
 ### Changed
 * **BREAKING**: Removed the following helper traits in favor of inherent

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -185,6 +185,13 @@ unsafe impl<T: Message> NSMutableCopying for NSArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
 }
 
+impl<T: Message> alloc::borrow::ToOwned for NSArray<T, Shared> {
+    type Owned = Id<NSArray<T, Shared>, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
+}
+
 unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSArray<T, O> {
     type Item = T;
 }
@@ -332,6 +339,13 @@ unsafe impl<T: Message> NSCopying for NSMutableArray<T, Shared> {
 
 unsafe impl<T: Message> NSMutableCopying for NSMutableArray<T, Shared> {
     type Output = NSMutableArray<T, Shared>;
+}
+
+impl<T: Message> alloc::borrow::ToOwned for NSMutableArray<T, Shared> {
+    type Owned = Id<NSMutableArray<T, Shared>, Owned>;
+    fn to_owned(&self) -> Self::Owned {
+        self.mutable_copy()
+    }
 }
 
 unsafe impl<T: Message, O: Ownership> NSFastEnumeration for NSMutableArray<T, O> {

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -118,6 +118,13 @@ unsafe impl NSMutableCopying for NSAttributedString {
     type Output = NSMutableAttributedString;
 }
 
+impl alloc::borrow::ToOwned for NSAttributedString {
+    type Owned = Id<NSAttributedString, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -92,6 +92,13 @@ unsafe impl NSMutableCopying for NSData {
     type Output = NSMutableData;
 }
 
+impl alloc::borrow::ToOwned for NSData {
+    type Owned = Id<NSData, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
+}
+
 impl AsRef<[u8]> for NSData {
     fn as_ref(&self) -> &[u8] {
         self.bytes()
@@ -218,6 +225,13 @@ unsafe impl NSCopying for NSMutableData {
 
 unsafe impl NSMutableCopying for NSMutableData {
     type Output = NSMutableData;
+}
+
+impl alloc::borrow::ToOwned for NSMutableData {
+    type Owned = Id<NSMutableData, Owned>;
+    fn to_owned(&self) -> Self::Owned {
+        self.mutable_copy()
+    }
 }
 
 impl AsRef<[u8]> for NSMutableData {

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -98,6 +98,9 @@ impl AsRef<[u8]> for NSData {
     }
 }
 
+// Note: We don't implement `Borrow<[u8]>` since we can't guarantee that `Eq`,
+// `Ord` and `Hash` are equal for `NSData` vs. `[u8]`!
+
 impl<I: SliceIndex<[u8]>> Index<I> for NSData {
     type Output = I::Output;
 
@@ -433,29 +436,34 @@ mod tests {
     }
 
     #[test]
-    fn test_as_ref() {
-        fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
-        fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
+    fn test_as_ref_borrow() {
+        use core::borrow::{Borrow, BorrowMut};
+
+        fn impls_borrow<T: AsRef<U> + Borrow<U> + ?Sized, U: ?Sized>(_: &T) {}
+        fn impls_borrow_mut<T: AsMut<U> + BorrowMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
 
         let mut obj = NSMutableData::new();
-        impls_as_ref::<Id<NSMutableData, Owned>, NSMutableData>(&obj);
-        impls_as_mut::<Id<NSMutableData, Owned>, NSMutableData>(&mut obj);
+        impls_borrow::<Id<NSMutableData, Owned>, NSMutableData>(&obj);
+        impls_borrow_mut::<Id<NSMutableData, Owned>, NSMutableData>(&mut obj);
 
-        impls_as_ref::<NSMutableData, NSMutableData>(&obj);
-        impls_as_mut::<NSMutableData, NSMutableData>(&mut obj);
-        impls_as_ref::<NSMutableData, NSData>(&obj);
-        impls_as_mut::<NSMutableData, NSData>(&mut obj);
-        impls_as_ref::<NSMutableData, NSObject>(&obj);
-        impls_as_mut::<NSMutableData, NSObject>(&mut obj);
-        impls_as_ref::<NSMutableData, Object>(&obj);
-        impls_as_mut::<NSMutableData, Object>(&mut obj);
+        impls_borrow::<NSMutableData, NSMutableData>(&obj);
+        impls_borrow_mut::<NSMutableData, NSMutableData>(&mut obj);
+        impls_borrow::<NSMutableData, NSData>(&obj);
+        impls_borrow_mut::<NSMutableData, NSData>(&mut obj);
+        impls_borrow::<NSMutableData, NSObject>(&obj);
+        impls_borrow_mut::<NSMutableData, NSObject>(&mut obj);
+        impls_borrow::<NSMutableData, Object>(&obj);
+        impls_borrow_mut::<NSMutableData, Object>(&mut obj);
 
-        impls_as_ref::<NSData, NSData>(&obj);
-        impls_as_mut::<NSData, NSData>(&mut obj);
-        impls_as_ref::<NSData, NSObject>(&obj);
-        impls_as_mut::<NSData, NSObject>(&mut obj);
-        impls_as_ref::<NSData, Object>(&obj);
-        impls_as_mut::<NSData, Object>(&mut obj);
+        impls_borrow::<NSData, NSData>(&obj);
+        impls_borrow_mut::<NSData, NSData>(&mut obj);
+        impls_borrow::<NSData, NSObject>(&obj);
+        impls_borrow_mut::<NSData, NSObject>(&mut obj);
+        impls_borrow::<NSData, Object>(&obj);
+        impls_borrow_mut::<NSData, Object>(&mut obj);
+
+        fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
+        fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
 
         impls_as_ref::<NSMutableData, [u8]>(&obj);
         impls_as_mut::<NSMutableData, [u8]>(&mut obj);

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -336,7 +336,7 @@ unsafe fn data_from_vec(cls: &Class, bytes: Vec<u8>) -> *mut Object {
 
 #[cfg(test)]
 mod tests {
-    use super::{NSData, NSMutableData};
+    use super::*;
     #[cfg(feature = "block")]
     use alloc::vec;
 
@@ -430,5 +430,42 @@ mod tests {
         let mut data = NSMutableData::with_bytes(&[1, 2]);
         data.extend(iter);
         assert_eq!(data.bytes(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_as_ref() {
+        fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
+        fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
+
+        let mut obj = NSMutableData::new();
+        impls_as_ref::<Id<NSMutableData, Owned>, NSMutableData>(&obj);
+        impls_as_mut::<Id<NSMutableData, Owned>, NSMutableData>(&mut obj);
+
+        impls_as_ref::<NSMutableData, NSMutableData>(&obj);
+        impls_as_mut::<NSMutableData, NSMutableData>(&mut obj);
+        impls_as_ref::<NSMutableData, NSData>(&obj);
+        impls_as_mut::<NSMutableData, NSData>(&mut obj);
+        impls_as_ref::<NSMutableData, NSObject>(&obj);
+        impls_as_mut::<NSMutableData, NSObject>(&mut obj);
+        impls_as_ref::<NSMutableData, Object>(&obj);
+        impls_as_mut::<NSMutableData, Object>(&mut obj);
+
+        impls_as_ref::<NSData, NSData>(&obj);
+        impls_as_mut::<NSData, NSData>(&mut obj);
+        impls_as_ref::<NSData, NSObject>(&obj);
+        impls_as_mut::<NSData, NSObject>(&mut obj);
+        impls_as_ref::<NSData, Object>(&obj);
+        impls_as_mut::<NSData, Object>(&mut obj);
+
+        impls_as_ref::<NSMutableData, [u8]>(&obj);
+        impls_as_mut::<NSMutableData, [u8]>(&mut obj);
+        impls_as_ref::<NSData, [u8]>(&obj);
+
+        let obj: &mut NSMutableData = &mut *obj;
+        let _: &[u8] = obj.as_ref();
+        let _: &mut [u8] = obj.as_mut();
+
+        let obj: &mut NSData = &mut **obj;
+        let _: &[u8] = obj.as_ref();
     }
 }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -1,4 +1,4 @@
-macro_rules! __impl_as_ref_as_mut {
+macro_rules! __impl_as_ref_borrow {
     ($name:ident<$($t:ident $(: $b:ident)?),*>,) => {};
     ($name:ident<$($t:ident $(: $b:ident)?),*>, $item:ty, $($tail:ty,)*) => {
         impl<$($t $(: $b)?),*> AsRef<$item> for $name<$($t),*> {
@@ -17,7 +17,29 @@ macro_rules! __impl_as_ref_as_mut {
             }
         }
 
-        __impl_as_ref_as_mut!($name<$($t $(: $b)?),*>, $($tail,)*);
+        // Borrow and BorrowMut are correct, since subclasses behaves
+        // identical to the class they inherit (message sending doesn't care).
+        //
+        // In particular, `Eq`, `Ord` and `Hash` all give the same results
+        // after borrow.
+
+        impl<$($t $(: $b)?),*> ::core::borrow::Borrow<$item> for $name<$($t),*> {
+            #[inline]
+            fn borrow(&self) -> &$item {
+                // Triggers Deref coercion depending on return type
+                &*self
+            }
+        }
+
+        impl<$($t $(: $b)?),*> ::core::borrow::BorrowMut<$item> for $name<$($t),*> {
+            #[inline]
+            fn borrow_mut(&mut self) -> &mut $item {
+                // Triggers Deref coercion depending on return type
+                &mut *self
+            }
+        }
+
+        __impl_as_ref_borrow!($name<$($t $(: $b)?),*>, $($tail,)*);
     };
 }
 
@@ -127,7 +149,21 @@ macro_rules! object {
             }
         }
 
-        __impl_as_ref_as_mut!($name<$($t $(: $b)?),*>, $name<$($t),*>, $inherits, $($inheritance_rest,)*);
+        impl<$($t $(: $b)?),*> AsRef<Self> for $name<$($t),*> {
+            #[inline]
+            fn as_ref(&self) -> &Self {
+                self
+            }
+        }
+
+        impl<$($t $(: $b)?),*> AsMut<Self> for $name<$($t),*> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut Self {
+                self
+            }
+        }
+
+        __impl_as_ref_borrow!($name<$($t $(: $b)?),*>, $inherits, $($inheritance_rest,)*);
 
         // Objective-C equality has approximately the same semantics as Rust
         // equality (although less aptly specified).

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -74,6 +74,13 @@ unsafe impl NSMutableCopying for NSMutableAttributedString {
     type Output = NSMutableAttributedString;
 }
 
+impl alloc::borrow::ToOwned for NSMutableAttributedString {
+    type Owned = Id<NSMutableAttributedString, Owned>;
+    fn to_owned(&self) -> Self::Owned {
+        self.mutable_copy()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -96,6 +96,13 @@ unsafe impl NSMutableCopying for NSMutableString {
     type Output = NSMutableString;
 }
 
+impl alloc::borrow::ToOwned for NSMutableString {
+    type Owned = Id<NSMutableString, Owned>;
+    fn to_owned(&self) -> Self::Owned {
+        self.mutable_copy()
+    }
+}
+
 impl AddAssign<&NSString> for NSMutableString {
     #[inline]
     fn add_assign(&mut self, other: &NSString) {

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -57,9 +57,11 @@ mod tests {
     }
 
     #[test]
-    fn test_as_ref() {
-        fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
-        fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
+    fn test_as_ref_borrow() {
+        use core::borrow::{Borrow, BorrowMut};
+
+        fn impls_as_ref<T: AsRef<U> + Borrow<U> + ?Sized, U: ?Sized>(_: &T) {}
+        fn impls_as_mut<T: AsMut<U> + BorrowMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
 
         let mut obj = NSObject::new();
         impls_as_ref::<Id<NSObject, Owned>, NSObject>(&obj);

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -44,9 +44,31 @@ impl DefaultId for NSObject {
 
 #[cfg(test)]
 mod tests {
-    use super::NSObject;
-    use crate::NSString;
+    use super::*;
     use alloc::format;
+
+    #[test]
+    fn test_deref() {
+        let mut obj: Id<NSObject, Owned> = NSObject::new();
+        let _: &NSObject = &*obj;
+        let _: &mut NSObject = &mut *obj;
+        let _: &Object = &*obj;
+        let _: &mut Object = &mut *obj;
+    }
+
+    #[test]
+    fn test_as_ref() {
+        fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
+        fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
+
+        let mut obj = NSObject::new();
+        impls_as_ref::<Id<NSObject, Owned>, NSObject>(&obj);
+        impls_as_mut::<Id<NSObject, Owned>, NSObject>(&mut obj);
+        impls_as_ref::<NSObject, NSObject>(&obj);
+        impls_as_mut::<NSObject, NSObject>(&mut obj);
+        impls_as_ref::<NSObject, Object>(&obj);
+        impls_as_mut::<NSObject, Object>(&mut obj);
+    }
 
     #[test]
     fn test_equality() {

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::ToOwned;
 use core::cmp;
 use core::ffi::c_void;
 use core::fmt;
@@ -6,7 +7,6 @@ use core::slice;
 use core::str;
 use std::os::raw::c_char;
 
-use alloc::borrow::ToOwned;
 use objc2::ffi;
 use objc2::rc::DefaultId;
 use objc2::rc::{autoreleasepool, AutoreleasePool};
@@ -253,6 +253,13 @@ unsafe impl NSCopying for NSString {
 
 unsafe impl NSMutableCopying for NSString {
     type Output = NSMutableString;
+}
+
+impl ToOwned for NSString {
+    type Owned = Id<NSString, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
 }
 
 impl fmt::Display for NSString {

--- a/objc2-foundation/src/uuid.rs
+++ b/objc2-foundation/src/uuid.rs
@@ -68,6 +68,13 @@ unsafe impl NSCopying for NSUUID {
     type Output = NSUUID;
 }
 
+impl alloc::borrow::ToOwned for NSUUID {
+    type Owned = Id<NSUUID, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -83,6 +83,13 @@ unsafe impl<T: 'static> NSCopying for NSValue<T> {
     type Output = NSValue<T>;
 }
 
+impl<T: 'static> alloc::borrow::ToOwned for NSValue<T> {
+    type Owned = Id<NSValue<T>, Shared>;
+    fn to_owned(&self) -> Self::Owned {
+        self.copy()
+    }
+}
+
 impl<T: 'static + Copy + Encode + Ord> Ord for NSValue<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.get().cmp(&other.get())


### PR DESCRIPTION
Part of #67.

Implement `AsRef`/`AsMut` that forward to objects themselves.
Implement `Borrow`/`BorrowMut` for objects.
Implement `ToOwned` using `NSCopying`/`NSMutableCopying` where appropriate.