### PR TITLE
Set `docs.rs` targets on all crates

### DIFF
--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -46,12 +46,16 @@ unstable-winobjc = ["objc-sys/unstable-winobjc", "gnustep-1-8"]
 # Link to ObjFW
 unstable-objfw = []
 
+# Private
+unstable-docsrs = ["objc-sys"] # Need `objc-sys` on certain platforms
+
 [dependencies]
 objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 no-default-features = true
+features = ["unstable-docsrs"]
 
 targets = [
     # MacOS

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -52,3 +52,20 @@ objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 no-default-features = true
+
+targets = [
+    # MacOS
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    # "i686-apple-darwin",
+    # iOS
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
+    # GNUStep
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
+]

--- a/block-sys/build.rs
+++ b/block-sys/build.rs
@@ -12,7 +12,8 @@ fn main() {
     let mut gnustep = env::var_os("CARGO_FEATURE_GNUSTEP_1_7").is_some();
     let objfw = env::var_os("CARGO_FEATURE_UNSTABLE_OBJFW").is_some();
 
-    if std::env::var("DOCS_RS").is_ok() {
+    // Only when the crate is being compiled directly
+    if cfg!(feature = "unstable-docsrs") {
         if let "macos" | "ios" | "tvos" | "watchos" = &*target_os {
             apple = true;
             // Add cheaty #[cfg(feature = "apple")] directive

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -35,3 +35,20 @@ block-sys = { path = "../block-sys", version = "0.0.3", default-features = false
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+
+targets = [
+    # MacOS
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    # "i686-apple-darwin",
+    # iOS
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
+    # GNUStep
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
+]

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -47,6 +47,7 @@ unstable-objfw = []
 
 # Private
 unstable-exception = ["cc"]
+unstable-docsrs = []
 
 [build-dependencies]
 cc = { version = "1", optional = true }
@@ -54,6 +55,7 @@ cc = { version = "1", optional = true }
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 no-default-features = true
+features = ["unstable-docsrs"]
 
 targets = [
     # MacOS

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -58,11 +58,16 @@ no-default-features = true
 targets = [
     # MacOS
     "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
     # "i686-apple-darwin",
     # iOS
     "aarch64-apple-ios",
     "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
     # GNUStep
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
 ]

--- a/objc-sys/build.rs
+++ b/objc-sys/build.rs
@@ -74,7 +74,8 @@ fn main() {
     let objfw = env::var_os("CARGO_FEATURE_UNSTABLE_OBJFW").is_some();
 
     // Choose defaults when generating docs
-    if std::env::var("DOCS_RS").is_ok() {
+    // Only when the crate is being compiled directly
+    if cfg!(feature = "unstable-docsrs") {
         if let "macos" | "ios" | "tvos" | "watchos" = &*target_os {
             apple = true;
         } else {
@@ -100,7 +101,7 @@ fn main() {
         }
         (false, true, false) => {
             // Choose defaults when generating docs
-            if std::env::var("DOCS_RS").is_ok() {
+            if cfg!(feature = "unstable-docsrs") {
                 if "windows" == target_os {
                     WinObjC
                 } else {
@@ -229,6 +230,11 @@ fn main() {
         if std::env::var("DOCS_RS").is_ok() {
             // docs.rs doesn't have clang, so skip building this. The
             // documentation will still work since it doesn't need to link.
+            //
+            // This is independent of the `unstable-docsrs` feature flag; we
+            // never want to try invoking clang on docs.rs, whether we're the
+            // crate being documented currently, or a dependency of another
+            // crate.
             return;
         }
         println!("cargo:rerun-if-changed=extern/exception.m");

--- a/objc2-encode/Cargo.toml
+++ b/objc2-encode/Cargo.toml
@@ -20,3 +20,20 @@ license = "MIT"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+
+targets = [
+    # MacOS
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    # "i686-apple-darwin",
+    # iOS
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
+    # GNUStep
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
+]

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -35,3 +35,21 @@ objc2 = { path = "../objc2", version = "=0.3.0-alpha.6", default-features = fals
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
+features = ["block"]
+
+targets = [
+    # MacOS
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    # "i686-apple-darwin",
+    # iOS
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
+    # GNUStep
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
+]

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -62,17 +62,21 @@ harness = false
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
-
 features = ["exception", "malloc"]
 
 targets = [
     # MacOS
     "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
     # "i686-apple-darwin",
     # iOS
     "aarch64-apple-ios",
     "x86_64-apple-ios",
+    # "armv7-apple-ios",
+    # "i386-apple-ios",
     # GNUStep
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
+    # Windows
+    "x86_64-pc-windows-msvc",
 ]


### PR DESCRIPTION
Tested with local [`docs.rs`](https://github.com/rust-lang/docs.rs) instance.

Tier 3 (and below) targets are not yet supported, see https://github.com/rust-lang/docs.rs/issues/1561