### PR TITLE
Define methods in `extern_class!` macro

### DIFF
--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -295,8 +295,8 @@ macro_rules! __def_fn {
     // some of that specialization though!
     {} => {};
     {
-        #[sel($($sel:tt)+)]
         $(#[$m:meta])*
+        #sel!($($sel:tt)+)
         $v:vis fn $name:ident(
             $(&$self:ident)?
             $(&mut $mut_self:ident)?
@@ -329,8 +329,8 @@ macro_rules! __def_fn {
         }
     };
     {
-        #[sel($($sel:tt)+)]
         $(#[$m:meta])*
+        #sel!($($sel:tt)+)
         $v:vis fn $name:ident(
             $(&$self:ident)?
             $(&mut $mut_self:ident)?
@@ -363,8 +363,8 @@ macro_rules! __def_fn {
         }
     };
     {
-        #[sel($($sel:tt)+)]
         $(#[$m:meta])*
+        #sel!($($sel:tt)+)
         $v:vis fn $name:ident(
             $(&$self:ident)?
             $(&mut $mut_self:ident)?
@@ -397,8 +397,8 @@ macro_rules! __def_fn {
         }
     };
     {
-        #[sel($($sel:tt)+)]
         $(#[$m:meta])*
+        #sel!($($sel:tt)+)
         $v:vis fn $name:ident(
             $(&$self:ident)?
             $(&mut $mut_self:ident)?

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -423,7 +423,7 @@ macro_rules! __def_fn {
                     @instance_or_class;
                     msg_send;
                     ($($sel)+);
-                    ($($self)? $($mut_self)?);
+                    ($($self)? $($mut_self)? $($first_arg)?);
                     ($($self)? $($mut_self)? $($first_arg)? $(, $rest_arg)*);
                 )
             }
@@ -447,6 +447,21 @@ macro_rules! __def_fn {
             @collect_msg_send;
             $macro;
             $self;
+            ($($sel)+);
+            ($($rest_arg)*);
+        )
+    };
+    (
+        @instance_or_class;
+        $macro:ident;
+        ($($sel:tt)+);
+        (this);
+        ($this:ident $(, $rest_arg:ident)*);
+    ) => {
+        $crate::__def_fn!(
+            @collect_msg_send;
+            $macro;
+            $this;
             ($($sel)+);
             ($($rest_arg)*);
         )

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -14,6 +14,12 @@ extern_class! {
     /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsmutablestring?language=objc).
     #[derive(PartialEq, Eq, Hash)]
     unsafe pub struct NSMutableString: NSString, NSObject;
+
+    unsafe impl {
+        /// Construct an empty [`NSMutableString`].
+        #sel!(new)
+        pub fn new() -> Id<Self, Owned>;
+    }
 }
 
 // TODO: SAFETY
@@ -22,11 +28,6 @@ unsafe impl Send for NSMutableString {}
 
 /// Creating mutable strings.
 impl NSMutableString {
-    unsafe_def_fn! {
-        /// Construct an empty [`NSMutableString`].
-        pub fn new -> Owned;
-    }
-
     /// Creates a new [`NSMutableString`] by copying the given string slice.
     #[doc(alias = "initWithBytes:length:encoding:")]
     #[allow(clippy::should_implement_trait)] // Not really sure of a better name

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -11,20 +11,20 @@ __inner_extern_class! {
     unsafe pub struct NSObject<>: Object {}
 
     unsafe impl {
-        #[sel(new)]
+        #sel!(new)
         pub fn new() -> Id<Self, Owned>;
 
-        #[sel(hash)]
+        #sel!(hash)
         pub fn hash_code(&self) -> usize;
 
-        #[sel(isEqual:)]
+        #sel!(isEqual:)
         pub fn is_equal(&self, other: &NSObject) -> bool;
 
         // TODO: Verify that description always returns a non-null string
-        #[sel(description)]
+        #sel!(description)
         pub fn description(&self) -> Id<NSString, Shared>;
 
-        #[sel(isKindOfClass:)]
+        #sel!(isKindOfClass:)
         pub fn is_kind_of(&self, cls: &Class) -> bool;
     }
 }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -3,33 +3,29 @@ use core::hash;
 
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
-use objc2::{msg_send, msg_send_bool, msg_send_id};
 
 use super::NSString;
 
 __inner_extern_class! {
     @__inner
     unsafe pub struct NSObject<>: Object {}
-}
 
-impl NSObject {
-    unsafe_def_fn!(pub fn new -> Owned);
+    unsafe impl {
+        #[sel(new)]
+        pub fn new() -> Id<Self, Owned>;
 
-    pub fn hash_code(&self) -> usize {
-        unsafe { msg_send![self, hash] }
-    }
+        #[sel(hash)]
+        pub fn hash_code(&self) -> usize;
 
-    pub fn is_equal(&self, other: &NSObject) -> bool {
-        unsafe { msg_send_bool![self, isEqual: other] }
-    }
+        #[sel(isEqual:)]
+        pub fn is_equal(&self, other: &NSObject) -> bool;
 
-    pub fn description(&self) -> Id<NSString, Shared> {
         // TODO: Verify that description always returns a non-null string
-        unsafe { msg_send_id![self, description].unwrap() }
-    }
+        #[sel(description)]
+        pub fn description(&self) -> Id<NSString, Shared>;
 
-    pub fn is_kind_of(&self, cls: &Class) -> bool {
-        unsafe { msg_send_bool![self, isKindOfClass: cls] }
+        #[sel(isKindOfClass:)]
+        pub fn is_kind_of(&self, cls: &Class) -> bool;
     }
 }
 


### PR DESCRIPTION
Part of #67.

Something that will greatly help consumers create their own Objective-C classes. For example, I'd like to use this in `winit` to define safe abstractions over `NSApplication`, `NSWindow`, `NSView`, `NSResponer` and so on.

TODO:
- [x] Make it easy to see which traits are implemented. Done in https://github.com/madsmtm/objc2/pull/188
- [ ] Figure out exact API
- [ ] Documentation