### PR TITLE
Small soundness fixes and code cleanup

### DIFF
--- a/block2/src/global.rs
+++ b/block2/src/global.rs
@@ -83,8 +83,10 @@ where
     type Target = Block<A, R>;
 
     fn deref(&self) -> &Self::Target {
+        let ptr: *const Self = self;
+        let ptr: *const Block<A, R> = ptr.cast();
         // TODO: SAFETY
-        unsafe { &*(self as *const Self as *const Block<A, R>) }
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 }
 

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -468,7 +468,10 @@ impl<A, R, F> Deref for ConcreteBlock<A, R, F> {
     type Target = Block<A, R>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &*(self as *const Self as *const Block<A, R>) }
+        let ptr: *const Self = self;
+        let ptr: *const Block<A, R> = ptr.cast();
+        // TODO: SAFETY
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 }
 

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -310,7 +310,7 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
             // Bring back a reference to the closure.
             // Guaranteed to be unique, we gave `sortUsingFunction` unique is
             // ownership, and that method only runs one function at a time.
-            let closure: &mut F = unsafe { &mut *(context as *mut F) };
+            let closure: &mut F = unsafe { (context as *mut F).as_mut().unwrap_unchecked() };
 
             NSComparisonResult::from((*closure)(obj1, obj2))
         }

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -172,25 +172,25 @@ mod tests {
 
     #[test]
     fn test_enumerator() {
-        let vec = (0u32..4).map(NSValue::new).collect();
+        let vec = (0usize..4).map(NSValue::new).collect();
         let array = NSArray::from_vec(vec);
 
         let enumerator = array.iter();
         assert_eq!(enumerator.count(), 4);
 
         let enumerator = array.iter();
-        assert!(enumerator.enumerate().all(|(i, obj)| obj.get() == i as u32));
+        assert!(enumerator.enumerate().all(|(i, obj)| obj.get() == i));
     }
 
     #[test]
     fn test_fast_enumerator() {
-        let vec = (0u32..4).map(NSValue::new).collect();
+        let vec = (0usize..4).map(NSValue::new).collect();
         let array = NSArray::from_vec(vec);
 
         let enumerator = array.iter_fast();
         assert_eq!(enumerator.count(), 4);
 
         let enumerator = array.iter_fast();
-        assert!(enumerator.enumerate().all(|(i, obj)| obj.get() == i as u32));
+        assert!(enumerator.enumerate().all(|(i, obj)| obj.get() == i));
     }
 }

--- a/objc2-foundation/src/enumerator.rs
+++ b/objc2-foundation/src/enumerator.rs
@@ -159,7 +159,7 @@ impl<'a, C: NSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
             unsafe {
                 let obj = *self.ptr;
                 self.ptr = self.ptr.offset(1);
-                Some(&*obj)
+                Some(obj.as_ref().unwrap_unchecked())
             }
         }
     }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -178,7 +178,7 @@ macro_rules! object {
         impl<$($t: ::core::cmp::PartialEq $(+ $b)?),*> ::core::cmp::PartialEq for $name<$($t),*> {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
-                self.is_equal(&*other)
+                self.is_equal(other.as_ref())
             }
         }
 

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -140,7 +140,7 @@ impl NSString {
         //
         // https://developer.apple.com/documentation/foundation/nsstring/1411189-utf8string?language=objc
         let bytes: *const c_char = unsafe { msg_send![self, UTF8String] };
-        let bytes = bytes as *const u8;
+        let bytes: *const u8 = bytes.cast();
         let len = self.len();
 
         // SAFETY:
@@ -199,7 +199,7 @@ impl NSString {
 }
 
 pub(crate) fn from_str(cls: &Class, string: &str) -> *mut Object {
-    let bytes = string.as_ptr() as *const c_void;
+    let bytes: *const c_void = string.as_ptr().cast();
     unsafe {
         let obj: *mut Object = msg_send![cls, alloc];
         msg_send![

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -276,6 +276,7 @@ impl fmt::Display for NSString {
 mod tests {
     use super::*;
     use alloc::format;
+    use core::ptr;
 
     #[cfg(feature = "gnustep-1-7")]
     #[test]
@@ -365,11 +366,10 @@ mod tests {
     fn test_copy_nsstring_is_same() {
         let string1 = NSString::from_str("Hello, world!");
         let string2 = string1.copy();
-
-        let s1: *const NSString = &*string1;
-        let s2: *const NSString = &*string2;
-
-        assert_eq!(s1, s2, "Cloned NSString didn't have the same address");
+        assert!(
+            ptr::eq(&*string1, &*string2),
+            "Cloned NSString didn't have the same address"
+        );
     }
 
     #[test]

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -52,7 +52,7 @@ impl<T: 'static + Copy + Encode> NSValue<T> {
     /// The user must ensure that the inner value is properly initialized.
     pub unsafe fn get_unchecked(&self) -> T {
         let mut value = MaybeUninit::<T>::uninit();
-        let ptr = value.as_mut_ptr() as *mut c_void;
+        let ptr: *mut c_void = value.as_mut_ptr().cast();
         let _: () = unsafe { msg_send![self, getValue: ptr] };
         unsafe { value.assume_init() }
     }
@@ -64,7 +64,8 @@ impl<T: 'static + Copy + Encode> NSValue<T> {
 
     pub fn new(value: T) -> Id<Self, Shared> {
         let cls = Self::class();
-        let bytes = &value as *const T as *const c_void;
+        let bytes: *const T = &value;
+        let bytes: *const c_void = bytes.cast();
         let encoding = CString::new(T::ENCODING.to_string()).unwrap();
         unsafe {
             let obj: *mut Self = msg_send![cls, alloc];

--- a/objc2/examples/talk_to_me.rs
+++ b/objc2/examples/talk_to_me.rs
@@ -14,10 +14,11 @@ fn main() {
     const UTF8_ENCODING: NSUInteger = 4;
 
     let string: *const Object = unsafe { msg_send![class!(NSString), alloc] };
+    let text_ptr: *const c_void = text.as_ptr().cast();
     let string = unsafe {
         msg_send![
             string,
-            initWithBytes: text.as_ptr() as *const c_void,
+            initWithBytes: text_ptr,
             length: text.len(),
             encoding: UTF8_ENCODING,
         ]

--- a/objc2/src/cache.rs
+++ b/objc2/src/cache.rs
@@ -27,9 +27,9 @@ impl CachedSel {
         // `Relaxed` should be fine since `sel_registerName` is thread-safe.
         let ptr = self.ptr.load(Ordering::Relaxed);
         if ptr.is_null() {
-            let ptr = unsafe { ffi::sel_registerName(name.as_ptr() as *const _) };
-            self.ptr.store(ptr as *mut _, Ordering::Relaxed);
-            unsafe { Sel::from_ptr(ptr as *const _) }
+            let ptr: *const c_void = unsafe { ffi::sel_registerName(name.as_ptr().cast()).cast() };
+            self.ptr.store(ptr as *mut c_void, Ordering::Relaxed);
+            unsafe { Sel::from_ptr(ptr) }
         } else {
             unsafe { Sel::from_ptr(ptr) }
         }
@@ -58,8 +58,8 @@ impl CachedClass {
         // `Relaxed` should be fine since `objc_getClass` is thread-safe.
         let ptr = self.ptr.load(Ordering::Relaxed);
         if ptr.is_null() {
-            let cls = unsafe { ffi::objc_getClass(name.as_ptr() as *const _) } as *const Class;
-            self.ptr.store(cls as *mut _, Ordering::Relaxed);
+            let cls: *const Class = unsafe { ffi::objc_getClass(name.as_ptr().cast()) }.cast();
+            self.ptr.store(cls as *mut Class, Ordering::Relaxed);
             unsafe { cls.as_ref() }
         } else {
             Some(unsafe { &*ptr })

--- a/objc2/src/cache.rs
+++ b/objc2/src/cache.rs
@@ -57,12 +57,12 @@ impl CachedClass {
     pub unsafe fn get(&self, name: &str) -> Option<&'static Class> {
         // `Relaxed` should be fine since `objc_getClass` is thread-safe.
         let ptr = self.ptr.load(Ordering::Relaxed);
-        if ptr.is_null() {
-            let cls: *const Class = unsafe { ffi::objc_getClass(name.as_ptr().cast()) }.cast();
-            self.ptr.store(cls as *mut Class, Ordering::Relaxed);
-            unsafe { cls.as_ref() }
+        if let Some(cls) = unsafe { ptr.as_ref() } {
+            Some(cls)
         } else {
-            Some(unsafe { &*ptr })
+            let ptr: *const Class = unsafe { ffi::objc_getClass(name.as_ptr().cast()) }.cast();
+            self.ptr.store(ptr as *mut Class, Ordering::Relaxed);
+            unsafe { ptr.as_ref() }
         }
     }
 }

--- a/objc2/src/message/apple/mod.rs
+++ b/objc2/src/message/apple/mod.rs
@@ -48,11 +48,14 @@ where
     A: MessageArguments,
     R: Encode,
 {
-    let sup = ffi::objc_super {
-        receiver: receiver as *mut _,
-        super_class: superclass as *const Class as *const _,
+    let superclass: *const Class = superclass;
+    let mut sup = ffi::objc_super {
+        receiver: receiver.cast(),
+        super_class: superclass.cast(),
     };
-    let receiver = &sup as *const ffi::objc_super as *mut Object;
+    let receiver: *mut ffi::objc_super = &mut sup;
+    let receiver = receiver.cast();
+
     let msg_send_fn = R::MSG_SEND_SUPER;
     unsafe { conditional_try(|| A::__invoke(msg_send_fn, receiver, sel, args)) }
 }

--- a/objc2/src/message/gnustep.rs
+++ b/objc2/src/message/gnustep.rs
@@ -23,8 +23,8 @@ where
         return unsafe { mem::zeroed() };
     }
 
-    let sel_ptr = sel.as_ptr() as *const _;
-    let msg_send_fn = unsafe { ffi::objc_msg_lookup(receiver as *mut _, sel_ptr) };
+    let sel_ptr = sel.as_ptr().cast();
+    let msg_send_fn = unsafe { ffi::objc_msg_lookup(receiver.cast(), sel_ptr) };
     let msg_send_fn = msg_send_fn.expect("Null IMP");
     unsafe { conditional_try(|| A::__invoke(msg_send_fn, receiver, sel, args)) }
 }
@@ -44,11 +44,12 @@ where
         return unsafe { mem::zeroed() };
     }
 
+    let superclass: *const Class = superclass;
     let sup = ffi::objc_super {
-        receiver: receiver as *mut _,
-        super_class: superclass as *const Class as *const _,
+        receiver: receiver.cast(),
+        super_class: superclass.cast(),
     };
-    let sel_ptr = sel.as_ptr() as *const _;
+    let sel_ptr = sel.as_ptr().cast();
     let msg_send_fn = unsafe { ffi::objc_msg_lookup_super(&sup, sel_ptr) };
     let msg_send_fn = msg_send_fn.expect("Null IMP");
     unsafe { conditional_try(|| A::__invoke(msg_send_fn, receiver, sel, args)) }

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -229,49 +229,51 @@ unsafe impl<T: Message + ?Sized> MessageReceiver for *const T {
 unsafe impl<T: Message + ?Sized> MessageReceiver for *mut T {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self as *mut Object
+        self.cast()
     }
 }
 
 unsafe impl<T: Message + ?Sized> MessageReceiver for NonNull<T> {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self.as_ptr() as *mut Object
+        self.as_ptr().cast()
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a T {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self as *const T as *mut T as *mut Object
+        let ptr: *const T = self;
+        ptr as *mut T as *mut Object
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut T {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self as *mut T as *mut Object
+        let ptr: *mut T = self;
+        ptr.cast()
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized, O: Ownership> MessageReceiver for &'a Id<T, O> {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        Id::as_ptr(self) as *mut Object
+        Id::as_ptr(self) as *mut T as *mut Object
     }
 }
 
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut Id<T, Owned> {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        Id::as_mut_ptr(self) as *mut Object
+        Id::as_mut_ptr(self).cast()
     }
 }
 
 unsafe impl<T: Message + ?Sized, O: Ownership> MessageReceiver for ManuallyDrop<Id<T, O>> {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        Id::consume_as_ptr(self) as *mut Object
+        Id::consume_as_ptr(self).cast()
     }
 }
 
@@ -285,7 +287,8 @@ unsafe impl MessageReceiver for *const Class {
 unsafe impl<'a> MessageReceiver for &'a Class {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self as *const Class as *mut Class as *mut Object
+        let ptr: *const Class = self;
+        ptr as *mut Class as *mut Object
     }
 }
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -250,7 +250,7 @@ unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a T {
 unsafe impl<'a, T: Message + ?Sized> MessageReceiver for &'a mut T {
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
-        self as *const T as *mut T as *mut Object
+        self as *mut T as *mut Object
     }
 }
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -211,7 +211,7 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
         A: EncodeArguments,
         R: Encode,
     {
-        let obj = unsafe { &*self.__as_raw_receiver() };
+        let obj = unsafe { self.__as_raw_receiver().as_ref().unwrap() };
         verify_message_signature::<A, R>(obj.class(), sel).map_err(MessageError::from)
     }
 }

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -88,7 +88,7 @@ impl AutoreleasePool {
     pub unsafe fn ptr_as_ref<'p, T: ?Sized>(&'p self, ptr: *const T) -> &'p T {
         self.__verify_is_inner();
         // SAFETY: Checked by the caller
-        unsafe { &*ptr }
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 
     /// Returns a unique reference to the given autoreleased pointer object.
@@ -109,7 +109,7 @@ impl AutoreleasePool {
     pub unsafe fn ptr_as_mut<'p, T: ?Sized>(&'p self, ptr: *mut T) -> &'p mut T {
         self.__verify_is_inner();
         // SAFETY: Checked by the caller
-        unsafe { &mut *ptr }
+        unsafe { ptr.as_mut().unwrap_unchecked() }
     }
 }
 

--- a/objc2/src/rc/id_traits.rs
+++ b/objc2/src/rc/id_traits.rs
@@ -29,14 +29,14 @@ impl<T: Message + ?Sized, O: Ownership> SliceId for [Id<T, O>] {
         let ptr = self as *const Self as *const [&T];
         // SAFETY: Id<T, O> and &T have the same memory layout. Further safety
         // follows from `Deref` impl.
-        unsafe { &*ptr }
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 
     fn as_slice_mut(&mut self) -> &mut [&T] {
         let ptr = self as *mut Self as *mut [&T];
         // SAFETY: Id<T, O> and &T have the same memory layout. Further safety
         // follows from `Deref` impl.
-        unsafe { &mut *ptr }
+        unsafe { ptr.as_mut().unwrap_unchecked() }
     }
 }
 
@@ -46,7 +46,7 @@ impl<T: Message + ?Sized> SliceIdMut for [Id<T, Owned>] {
         // SAFETY: Id<T, O> and &mut T have the same memory layout, and the
         // `Id` is `Owned` so we're allowed to hand out mutable references.
         // Further safety follows from `DerefMut` impl.
-        unsafe { &mut *ptr }
+        unsafe { ptr.as_mut().unwrap_unchecked() }
     }
 }
 

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -290,7 +290,8 @@ impl Class {
 
     /// Returns the metaclass of self.
     pub fn metaclass(&self) -> &Self {
-        unsafe { &*(ffi::object_getClass(self.as_ptr().cast()).cast()) }
+        let ptr: *const Self = unsafe { ffi::object_getClass(self.as_ptr().cast()) }.cast();
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 
     // objc_getMetaClass -> Same as `Class::get(name).metaclass()`
@@ -514,7 +515,8 @@ impl Object {
 
     /// Dynamically find the class of this object.
     pub fn class(&self) -> &Class {
-        unsafe { &*(ffi::object_getClass(self.as_ptr()).cast()) }
+        let ptr: *const Class = unsafe { ffi::object_getClass(self.as_ptr()) }.cast();
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 
     /// Returns a shared reference to the ivar with the given name.
@@ -538,7 +540,7 @@ impl Object {
         let ptr = unsafe { ptr.offset(offset) };
         let ptr: *const T = ptr.cast();
 
-        unsafe { &*ptr }
+        unsafe { ptr.as_ref().unwrap_unchecked() }
     }
 
     /// Use [`ivar`][`Self::ivar`] instead.
@@ -573,7 +575,7 @@ impl Object {
         let ptr = unsafe { ptr.offset(offset) };
         let ptr: *mut T = ptr.cast();
 
-        unsafe { &mut *ptr }
+        unsafe { ptr.as_mut().unwrap_unchecked() }
     }
 
     /// Use [`ivar_mut`](`Self::ivar_mut`) instead.

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -14,9 +14,9 @@ pub(crate) struct CustomObject {
 
 impl CustomObject {
     fn new(class: &Class) -> Self {
-        let ptr = class as *const Class as _;
-        let obj = unsafe { ffi::class_createInstance(ptr, 0) };
-        CustomObject { obj: obj as _ }
+        let ptr: *const Class = class;
+        let obj = unsafe { ffi::class_createInstance(ptr.cast(), 0) }.cast();
+        CustomObject { obj }
     }
 }
 
@@ -64,7 +64,7 @@ impl Drop for CustomObject {
     fn drop(&mut self) {
         unsafe {
             #[allow(deprecated)]
-            ffi::object_dispose(self.obj as _);
+            ffi::object_dispose(self.obj.cast());
         }
     }
 }

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -50,13 +50,13 @@ impl Deref for CustomObject {
     type Target = Object;
 
     fn deref(&self) -> &Object {
-        unsafe { &*self.obj }
+        unsafe { self.obj.as_ref().unwrap_unchecked() }
     }
 }
 
 impl DerefMut for CustomObject {
     fn deref_mut(&mut self) -> &mut Object {
-        unsafe { &mut *self.obj }
+        unsafe { self.obj.as_mut().unwrap_unchecked() }
     }
 }
 

--- a/objc2/tests/id_retain_autoreleased.rs
+++ b/objc2/tests/id_retain_autoreleased.rs
@@ -9,7 +9,7 @@ fn retain_count(obj: &Object) -> usize {
 }
 
 fn create_data(bytes: &[u8]) -> Id<Object, Shared> {
-    let bytes_ptr = bytes.as_ptr() as *const c_void;
+    let bytes_ptr: *const c_void = bytes.as_ptr().cast();
     unsafe {
         // let obj: *mut Object = msg_send![
         //     class!(NSMutableData),


### PR DESCRIPTION
Fix mutability of pointers when sending a message to `&mut T`, the pointer was coerced using `&mut T -> &T`, which gives the wrong provenance.

`Fix NSArray::new` returning an `Owned` object - Found while experimenting with verification using associated objects in https://github.com/madsmtm/objc2/pull/127.