### PR TITLE
New versions

### DIFF
--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.0.4 - 2022-06-13
+
 ### Changed
 * **BREAKING**: Changed `links` key from `block` to `block_0_0` for better
   future compatibility, until we reach 1.0 (so `DEP_BLOCK_CC_ARGS` in build

--- a/block-sys/CHANGELOG.md
+++ b/block-sys/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   future compatibility, until we reach 1.0 (so `DEP_BLOCK_CC_ARGS` in build
   scripts becomes `DEP_BLOCK_0_0_CC_ARGS`).
 * **BREAKING**: Apple's runtime is now always the default.
+* **BREAKING**: Updated `objc-sys` to `v0.2.0-beta.0`.
 
 ### Fixed
 * **BREAKING**: Tweak the types of a lot of fields and arguments.

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-sys"
-version = "0.0.3" # Remember to update html_root_url in lib.rs
+version = "0.0.4" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/block-sys/Cargo.toml
+++ b/block-sys/Cargo.toml
@@ -50,7 +50,7 @@ unstable-objfw = []
 unstable-docsrs = ["objc-sys"] # Need `objc-sys` on certain platforms
 
 [dependencies]
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features = false, optional = true }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.0", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/block-sys/src/lib.rs
+++ b/block-sys/src/lib.rs
@@ -14,7 +14,7 @@
 
 #![no_std]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block-sys/0.0.3")]
+#![doc(html_root_url = "https://docs.rs/block-sys/0.0.4")]
 
 extern crate std;
 

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 ### Changed
-* **BREAKING**: Updated `objc2-encode` to `v2.0.0-pre.0`
+* **BREAKING**: Updated `objc2-encode` to `v2.0.0-pre.0`.
+* **BREAKING**: Updated `ffi` module to `block-sys v0.0.4`.
 
 ### Removed
 * **BREAKING**: Removed `DerefMut` implementation for `ConcreteBlock`.
@@ -18,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Changed `global_block!` macro to take an optional semicolon at the end.
 * Improved documentation.
-* **BREAKING**: Updated `ffi` module to `block-sys v0.0.3`
+* **BREAKING**: Updated `ffi` module to `block-sys v0.0.3`.
 
 
 ## 0.2.0-alpha.2 - 2021-12-22

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.4 - 2022-06-13
+
 ### Changed
 * **BREAKING**: Updated `objc2-encode` to `v2.0.0-pre.0`.
 * **BREAKING**: Updated `ffi` module to `block-sys v0.0.4`.

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Updated `objc2-encode` to `v2.0.0-pre.0`
+
+### Removed
+* **BREAKING**: Removed `DerefMut` implementation for `ConcreteBlock`.
+
 
 ## 0.2.0-alpha.3 - 2022-01-03
 
@@ -13,9 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Changed `global_block!` macro to take an optional semicolon at the end.
 * Improved documentation.
 * **BREAKING**: Updated `ffi` module to `block-sys v0.0.3`
-
-### Removed
-* **BREAKING**: Removed `DerefMut` implementation for `ConcreteBlock`.
 
 
 ## 0.2.0-alpha.2 - 2021-12-22

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -31,7 +31,7 @@ gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1"]
 
 [dependencies]
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.0", default-features = false }
-block-sys = { path = "../block-sys", version = "0.0.3", default-features = false }
+block-sys = { path = "../block-sys", version = "0.0.4", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -30,7 +30,7 @@ gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1"]
 
 [dependencies]
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.0", default-features = false }
 block-sys = { path = "../block-sys", version = "0.0.3", default-features = false }
 
 [package.metadata.docs.rs]

--- a/block2/Cargo.toml
+++ b/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs and README.md
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -81,7 +81,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.3")]
+#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.4")]
 
 extern crate std;
 

--- a/objc-sys/CHANGELOG.md
+++ b/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-beta.0 - 2022-06-13
+
 ### Changed
 * **BREAKING**: Changed `links` key from `objc` to `objc_0_2` for better
   future compatibility, until we reach 1.0 (so `DEP_OBJC_CC_ARGS` in build

--- a/objc-sys/Cargo.toml
+++ b/objc-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "objc-sys"
 # Remember to update `html_root_url` in lib.rs, the `links` key, and the
 # exception function name.
-version = "0.2.0-alpha.1"
+version = "0.2.0-beta.0"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/objc-sys/src/lib.rs
+++ b/objc-sys/src/lib.rs
@@ -18,7 +18,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-beta.0")]
 
 // TODO: Replace `extern "C"` with `extern "C-unwind"` where applicable.
 // See https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html.

--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 2.0.0-pre.0 - 2022-06-13
+
 ### Added
 * Added `Encoding::C_LONG` and `Encoding::C_U_LONG` to help with platform
   compatibility; use these instead of `c_long::ENCODING` and

--- a/objc2-encode/Cargo.toml
+++ b/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs and README.md
-version = "2.0.0-beta.2"
+version = "2.0.0-pre.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -91,7 +91,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-beta.2")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-pre.0")]
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.5 - 2022-06-13
+
 ### Added
 * Objects now `Deref` to their superclasses. E.g. `NSMutableArray` derefs to
   `NSArray`, which derefs to `NSObject`, which derefs to `Object`.

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2-foundation"
-version = "0.2.0-alpha.4" # Remember to update html_root_url in lib.rs
+version = "0.2.0-alpha.5" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -31,7 +31,7 @@ gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1", "block2?/gnustep-2-1"]
 
 [dependencies]
 block2 = { path = "../block2", version = "=0.2.0-alpha.4", default-features = false, optional = true }
-objc2 = { path = "../objc2", version = "=0.3.0-alpha.6", default-features = false }
+objc2 = { path = "../objc2", version = "=0.3.0-beta.0", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/objc2-foundation/Cargo.toml
+++ b/objc2-foundation/Cargo.toml
@@ -30,7 +30,7 @@ gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0", "block2?/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1", "block2?/gnustep-2-1"]
 
 [dependencies]
-block2 = { path = "../block2", version = "=0.2.0-alpha.3", default-features = false, optional = true }
+block2 = { path = "../block2", version = "=0.2.0-alpha.4", default-features = false, optional = true }
 objc2 = { path = "../objc2", version = "=0.3.0-alpha.6", default-features = false }
 
 [package.metadata.docs.rs]

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -32,7 +32,7 @@
 // TODO: #![warn(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.0-alpha.4")]
+#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.0-alpha.5")]
 
 extern crate alloc;
 extern crate std;

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.0-beta.0 - 2022-06-13
+
 ### Added
 * Added deprecated `Object::get_ivar` and `Object::get_mut_ivar` to make
   upgrading easier.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Sealed the `MethodImplementation` trait, and made it's `imp`
   method privat.
 * **BREAKING**: Updated `ffi` module to `objc-sys v0.2.0-beta.0`.
+* **BREAKING**: Updated `objc2-encode` (`Encoding`, `Encode`, `RefEncode` and
+  `EncodeArguments`) to `v2.0.0-pre.0`.
 
 ### Fixed
 * Properly sealed the `MessageArguments` trait (it already had a hidden

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   in practice).
 * **BREAKING**: Sealed the `MethodImplementation` trait, and made it's `imp`
   method privat.
+* **BREAKING**: Updated `ffi` module to `objc-sys v0.2.0-beta.0`.
 
 ### Fixed
 * Properly sealed the `MessageArguments` trait (it already had a hidden

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.3.0-alpha.6" # Remember to update html_root_url in lib.rs
+version = "0.3.0-beta.0" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -50,7 +50,7 @@ gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-alpha.1", default-features = false }
+objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.0", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2", default-features = false }
 
 [dev-dependencies]

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -51,7 +51,7 @@ gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.0", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-beta.2", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.0", default-features = false }
 
 [dev-dependencies]
 iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callgrind" }

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -131,7 +131,7 @@
 #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-alpha.6")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.0")]
 
 extern crate alloc;
 extern crate std;


### PR DESCRIPTION
We're getting close to the "pre-release testing phase" where I'll go and submit a bunch of PRs to crates in the ecosystem, yay!

Have run local tests on:
- macOS 10.14.6 32bit
- iPad Mini (1st generation, iOS 9.3.6) (currently getting `thread panicked while panicking. aborting.` errors, but otherwise seems to work - will post an issue)
