### PR TITLE
Test `libobjc2` v2.0 and v2.1 as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             os: macos-11
             target: x86_64-apple-darwin
             # Oldest macOS version we support
-            sdk: 10.7
+            sdk: "10.7"
           - name: Test macOS nightly w. ui tests
             os: macos-latest
             target: x86_64-apple-darwin
@@ -73,17 +73,24 @@ jobs:
             # binary, only build it
             test-args: --no-run
             # Newest SDK that supports 32-bit
-            sdk: 10.13
-          - name: Test GNUStep
+            sdk: "10.13"
+          - name: Test GNUStep with libobjc2 v1.9
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             runtime: gnustep-1-9
+            libobjc2: "1.9"
+          - name: Test GNUStep with libobjc2 v2.0
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            runtime: gnustep-2-0
+            libobjc2: "2.0"
           - name: Test GNUStep 32bit
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
             cflags: -m32
             configureflags: --target=x86-pc-linux-gnu
             runtime: gnustep-1-9
+            libobjc2: "1.9"
           - name: Test iOS simulator x86 64bit
             os: macos-11
             target: x86_64-apple-ios
@@ -234,13 +241,13 @@ jobs:
       if: contains(matrix.runtime, 'gnustep') && steps.extern-cache.outputs.cache-hit != 'true'
       run: sudo apt-get -y install make cmake
 
-    - name: Install GNUStep libobjc2 v1.9
-      if: contains(matrix.runtime, 'gnustep') && steps.extern-cache.outputs.cache-hit != 'true'
+    - name: Install GNUStep libobjc2
+      if: matrix.libobjc2 && steps.extern-cache.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/gnustep/libobjc2/archive/refs/tags/v1.9.tar.gz
-        tar -xzf v1.9.tar.gz
-        mkdir -p libobjc2-1.9/build
-        cd libobjc2-1.9/build
+        wget https://github.com/gnustep/libobjc2/archive/refs/tags/v${{ matrix.libobjc2 }}.tar.gz
+        tar -xzf v${{ matrix.libobjc2 }}.tar.gz
+        mkdir -p libobjc2-${{ matrix.libobjc2 }}/build
+        cd libobjc2-${{ matrix.libobjc2 }}/build
         cmake -Wno-dev -DCMAKE_INSTALL_PREFIX=$HOME/extern -DTESTS=OFF ..
         make install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             runtime: gnustep-2-0
             libobjc2: "2.0"
+          - name: Test GNUStep with libobjc2 v2.1
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            runtime: gnustep-2-1
+            libobjc2: "2.1"
           - name: Test GNUStep 32bit
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
@@ -246,6 +251,18 @@ jobs:
       run: |
         wget https://github.com/gnustep/libobjc2/archive/refs/tags/v${{ matrix.libobjc2 }}.tar.gz
         tar -xzf v${{ matrix.libobjc2 }}.tar.gz
+
+        # Install robin-map on v2.1
+        if test -d libobjc2-2.1; then
+          cd libobjc2-2.1/third_party
+          # Remove possibly existing `robin-map` folder
+          rm -rf robin-map
+          wget https://github.com/Tessil/robin-map/archive/757de829927489bee55ab02147484850c687b620.tar.gz
+          tar -xzf 757de829927489bee55ab02147484850c687b620.tar.gz
+          mv robin-map-757de829927489bee55ab02147484850c687b620 robin-map
+          cd ../..
+        fi
+
         mkdir -p libobjc2-${{ matrix.libobjc2 }}/build
         cd libobjc2-${{ matrix.libobjc2 }}/build
         cmake -Wno-dev -DCMAKE_INSTALL_PREFIX=$HOME/extern -DTESTS=OFF ..

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -178,11 +178,17 @@ pub mod __gnustep_hack {
     #[link(name = "gnustep-base", kind = "dylib")]
     // This linking doesn't have to be on the correct `extern` block.
     extern "C" {
-        static _OBJC_CLASS_NSObject: Class;
+        // The linking changed in libobjc2 v2.0
+        #[cfg_attr(feature = "gnustep-2-0", link_name = "._OBJC_CLASS_NSObject")]
+        #[cfg_attr(not(feature = "gnustep-2-0"), link_name = "_OBJC_CLASS_NSObject")]
+        static OBJC_CLASS_NSObject: Class;
+        // Others:
+        // __objc_class_name_NSObject
+        // _OBJC_CLASS_REF_NSObject
     }
 
     pub unsafe fn get_class_to_force_linkage() -> &'static Class {
-        unsafe { core::ptr::read_volatile(&&_OBJC_CLASS_NSObject) }
+        unsafe { core::ptr::read_volatile(&&OBJC_CLASS_NSObject) }
     }
 
     #[test]


### PR DESCRIPTION
Already found a bug that prevented examples from running, will help a lot with https://github.com/madsmtm/objc2/pull/104 in the future.

This won't really slow our CI runs down, since the linux machines that these run on have much higher availability (we're only allowed a certain number of concurrent macOS instances, so our CI is currently waiting a lot on that).

Couldn't easily get v1.7 and v1.8 up n' running, so I guess we won't test those yet.