### PR TITLE
Add `rc::Allocated`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   through `&Object`.
 * Added `VerificationError` as more specific return type from
   `Class::verify_sel`.
+* Added `rc::Allocated` struct which is used within `msg_send_id!`.
 
 ### Changed
 * **BREAKING**: `Sel` is now required to be non-null, which means that you

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -590,11 +590,12 @@ macro_rules! msg_send_bool {
 ///   is a generic `Option<Id<T, O>>`.
 ///
 /// - The `alloc` family: The receiver must be `&Class`, and the return type
-///   is a generic `Option<Id<T, O>>`. (This will change, see [#172]).
+///   is a generic `Option<Id<Allocated<T>, O>>`.
 ///
-/// - The `init` family: The receiver must be `Option<Id<T, O>>` as returned
-///   from `alloc`. The receiver is consumed, and a the now-initialized
-///   `Option<Id<T, O>>` (with the same `T` and `O`) is returned.
+/// - The `init` family: The receiver must be `Option<Id<Allocated<T>, O>>`
+///   as returned from `alloc`. The receiver is consumed, and a the
+///   now-initialized `Option<Id<T, O>>` (with the same `T` and `O`) is
+///   returned.
 ///
 /// - The `copy` family: The receiver may be anything that implements
 ///   [`MessageReceiver`] and the return type is a generic `Option<Id<T, O>>`.
@@ -615,7 +616,6 @@ macro_rules! msg_send_bool {
 /// [`Id::retain`], [`Id::drop`] and [`Id::autorelease`] for that.
 ///
 /// [sel-families]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#arc-method-families
-/// [#172]: https://github.com/madsmtm/objc2/pull/172
 /// [`MessageReceiver`]: crate::MessageReceiver
 /// [`Id::retain_autoreleased`]: crate::rc::Id::retain_autoreleased
 /// [arc-retainable]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#retainable-object-pointers-as-operands-and-arguments

--- a/objc2/src/rc/allocated.rs
+++ b/objc2/src/rc/allocated.rs
@@ -1,0 +1,15 @@
+/// A marker type that can be used within [`Id`] to indicate that the object
+/// has been allocated but not initialized.
+///
+/// The reason we use `Option<Id<Allocated<T>, O>>` instead of just `*mut T`
+/// is:
+/// - To allow releasing allocated objects, e.g. in the face of panics.
+/// - To safely know the object is valid (albeit uninitialized).
+/// - To allow specifying ownership.
+///
+/// [`Id`]: crate::rc::Id
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Allocated<T: ?Sized>(T);
+
+// Explicitly don't implement `Deref`, `Message` nor `RefEncode`!

--- a/objc2/src/rc/mod.rs
+++ b/objc2/src/rc/mod.rs
@@ -55,6 +55,7 @@
 //! assert!(weak.load().is_none());
 //! ```
 
+mod allocated;
 mod autorelease;
 mod id;
 mod id_forwarding_impls;
@@ -65,6 +66,7 @@ mod weak_id;
 #[cfg(test)]
 mod test_object;
 
+pub use self::allocated::Allocated;
 pub use self::autorelease::{autoreleasepool, AutoreleasePool, AutoreleaseSafe};
 pub use self::id::Id;
 pub use self::id_traits::{DefaultId, SliceId, SliceIdMut};

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -1,15 +1,18 @@
 //! Test assembly output of `msg_send_id!` internals.
 use objc2::__macro_helpers::{MsgSendId, RetainSemantics};
-use objc2::rc::{Id, Shared};
+use objc2::rc::{Allocated, Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
-unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
+unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Allocated<Object>, Shared>> {
     <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_init(obj: Option<Id<Object, Shared>>, sel: Sel) -> Option<Id<Object, Shared>> {
+unsafe fn handle_init(
+    obj: Option<Id<Allocated<Object>, Shared>>,
+    sel: Sel,
+) -> Option<Id<Object, Shared>> {
     <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ())
 }
 
@@ -21,7 +24,7 @@ unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Obje
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
-    let _obj: Id<Object, Shared> =
+    let _obj: Id<Allocated<Object>, Shared> =
         <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ())
             .unwrap_unchecked();
 }

--- a/tests/ui/msg_send_id_invalid_receiver.rs
+++ b/tests/ui/msg_send_id_invalid_receiver.rs
@@ -1,16 +1,20 @@
 //! Test compiler output with invalid msg_send_id receivers.
 use objc2::msg_send_id;
 use objc2::runtime::{Class, Object};
-use objc2::rc::{Id, Shared};
+use objc2::rc::{Allocated, Id, Shared};
 
 fn main() {
     let obj: &Object;
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new].unwrap() };
-    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
+    let _: Id<Allocated<Object>, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
 
     let cls: &Class;
     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, init].unwrap() };
+    let obj: Id<Object, Shared>;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+    let obj: Option<Id<Object, Shared>>;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
 
     let obj: Id<Object, Shared>;
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -16,13 +16,13 @@ note: associated function defined here
    |               ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_receiver.rs:9:55
+  --> ui/msg_send_id_invalid_receiver.rs:9:66
    |
-9  |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
-   |                                          -------------^^^--------
-   |                                          |            |
-   |                                          |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
-   |                                          arguments to this function are incorrect
+9  |     let _: Id<Allocated<Object>, Shared> = unsafe { msg_send_id![obj, alloc].unwrap() };
+   |                                                     -------------^^^--------
+   |                                                     |            |
+   |                                                     |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
+   |                                                     arguments to this function are incorrect
    |
    = note: expected reference `&objc2::runtime::Class`
               found reference `&objc2::runtime::Object`
@@ -41,7 +41,7 @@ error[E0308]: mismatched types
    |                                          |            expected enum `Option`, found `&objc2::runtime::Object`
    |                                          arguments to this function are incorrect
    |
-   = note:   expected enum `Option<Id<_, _>>`
+   = note:   expected enum `Option<Id<Allocated<_>, _>>`
            found reference `&objc2::runtime::Object`
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
@@ -58,7 +58,7 @@ error[E0308]: mismatched types
    |                                          |            expected enum `Option`, found `&objc2::runtime::Class`
    |                                          arguments to this function are incorrect
    |
-   = note:   expected enum `Option<Id<_, _>>`
+   = note:   expected enum `Option<Id<Allocated<_>, _>>`
            found reference `&objc2::runtime::Class`
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
@@ -66,10 +66,44 @@ note: associated function defined here
    |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
    |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
-  --> ui/msg_send_id_invalid_receiver.rs:16:42
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:15:55
    |
-16 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
+15 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected enum `Option`, found struct `Id`
+   |                                          arguments to this function are incorrect
+   |
+   = note: expected enum `Option<Id<Allocated<_>, _>>`
+            found struct `Id<objc2::runtime::Object, Shared>`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
+   |               ^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_receiver.rs:17:55
+   |
+17 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+   |                                          -------------^^^-------
+   |                                          |            |
+   |                                          |            expected struct `Allocated`, found struct `objc2::runtime::Object`
+   |                                          arguments to this function are incorrect
+   |
+   = note: expected enum `Option<Id<Allocated<_>, _>>`
+              found enum `Option<Id<objc2::runtime::Object, Shared>>`
+note: associated function defined here
+  --> $WORKSPACE/objc2/src/__macro_helpers.rs
+   |
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
+   |               ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs:20:42
+   |
+20 |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy].unwrap() };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object, Shared>`
    |
    = help: the following other types implement trait `MessageReceiver`:

--- a/tests/ui/msg_send_id_invalid_return.rs
+++ b/tests/ui/msg_send_id_invalid_return.rs
@@ -1,7 +1,7 @@
 //! Test compiler output with invalid msg_send_id receivers.
 use objc2::msg_send_id;
 use objc2::runtime::{Class, Object};
-use objc2::rc::{Id, Owned, Shared};
+use objc2::rc::{Allocated, Id, Owned, Shared};
 use objc2_foundation::NSObject;
 
 fn main() {
@@ -9,15 +9,16 @@ fn main() {
     let _: &Object = unsafe { msg_send_id![cls, new].unwrap() };
     let _: Id<Class, Shared> = unsafe { msg_send_id![cls, new].unwrap() };
     let _: &Object = unsafe { msg_send_id![cls, alloc].unwrap() };
-    let _: Id<Class, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+    let _: Id<Allocated<Class>, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+    let _: Id<Object, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
 
-    let obj: Option<Id<Object, Shared>>;
+    let obj: Option<Id<Allocated<Object>, Shared>>;
     let _: &Object = unsafe { msg_send_id![obj, init].unwrap() };
-    let obj: Option<Id<Object, Shared>>;
+    let obj: Option<Id<Allocated<Object>, Shared>>;
     let _: Id<Class, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-    let obj: Option<Id<Object, Shared>>;
+    let obj: Option<Id<Allocated<Object>, Shared>>;
     let _: Id<NSObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
-    let obj: Option<Id<Object, Shared>>;
+    let obj: Option<Id<Allocated<Object>, Shared>>;
     let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
 
     let obj: Id<Object, Shared>;

--- a/tests/ui/msg_send_id_invalid_return.stderr
+++ b/tests/ui/msg_send_id_invalid_return.stderr
@@ -33,19 +33,16 @@ error[E0308]: mismatched types
   --> ui/msg_send_id_invalid_return.rs:11:31
    |
 11 |     let _: &Object = unsafe { msg_send_id![cls, alloc].unwrap() };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                               |
-   |                               expected `&objc2::runtime::Object`, found struct `Id`
-   |                               help: consider borrowing here: `&msg_send_id![cls, alloc].unwrap()`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&objc2::runtime::Object`, found struct `Id`
    |
    = note: expected reference `&objc2::runtime::Object`
-                 found struct `Id<_, _>`
+                 found struct `Id<Allocated<_>, _>`
 
 error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
-  --> ui/msg_send_id_invalid_return.rs:12:41
+  --> ui/msg_send_id_invalid_return.rs:12:52
    |
-12 |     let _: Id<Class, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `objc2::runtime::Class`
+12 |     let _: Id<Allocated<Class>, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `objc2::runtime::Class`
    |
    = help: the following other types implement trait `Message`:
              NSArray<T, O>
@@ -57,13 +54,22 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSMutableData
              NSMutableString
            and 7 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>` for `RetainSemantics<false, true, false, false>`
+   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Id<Allocated<objc2::runtime::Class>, Shared>>` for `RetainSemantics<false, true, false, false>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_return.rs:15:31
+  --> ui/msg_send_id_invalid_return.rs:13:42
    |
-15 |     let _: &Object = unsafe { msg_send_id![obj, init].unwrap() };
+13 |     let _: Id<Object, Shared> = unsafe { msg_send_id![cls, alloc].unwrap() };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `objc2::runtime::Object`, found struct `Allocated`
+   |
+   = note: expected struct `Id<objc2::runtime::Object, Shared>`
+              found struct `Id<Allocated<_>, _>`
+
+error[E0308]: mismatched types
+  --> ui/msg_send_id_invalid_return.rs:16:31
+   |
+16 |     let _: &Object = unsafe { msg_send_id![obj, init].unwrap() };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                               |
    |                               expected `&objc2::runtime::Object`, found struct `Id`
@@ -73,36 +79,36 @@ error[E0308]: mismatched types
                  found struct `Id<objc2::runtime::Object, Shared>`
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_return.rs:17:41
+  --> ui/msg_send_id_invalid_return.rs:18:41
    |
-17 |     let _: Id<Class, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+18 |     let _: Id<Class, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
    |
    = note: expected struct `Id<objc2::runtime::Class, _>`
               found struct `Id<objc2::runtime::Object, _>`
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_return.rs:19:44
+  --> ui/msg_send_id_invalid_return.rs:20:44
    |
-19 |     let _: Id<NSObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
+20 |     let _: Id<NSObject, Shared> = unsafe { msg_send_id![obj, init].unwrap() };
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `NSObject`, found struct `objc2::runtime::Object`
    |
    = note: expected struct `Id<NSObject, _>`
               found struct `Id<objc2::runtime::Object, _>`
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_return.rs:21:41
+  --> ui/msg_send_id_invalid_return.rs:22:41
    |
-21 |     let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
+22 |     let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `objc2::rc::Owned`, found enum `Shared`
    |
    = note: expected struct `Id<_, objc2::rc::Owned>`
               found struct `Id<_, Shared>`
 
 error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_return.rs:24:31
+  --> ui/msg_send_id_invalid_return.rs:25:31
    |
-24 |     let _: &Object = unsafe { msg_send_id![&obj, description].unwrap() };
+25 |     let _: &Object = unsafe { msg_send_id![&obj, description].unwrap() };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                               |
    |                               expected `&objc2::runtime::Object`, found struct `Id`


### PR DESCRIPTION
~Blocked on https://github.com/madsmtm/objc2/pull/120.~

Add a new user facing opaque struct `rc::Allocated<T>`, which is intended to be used inside `Id` as `Id<Allocated<T>, O>`, and can be gotten from `msg_send_id![cls, alloc]`. This will help users differentiate between allocated and initialized objects.

See also https://github.com/madsmtm/objc2/issues/87 for more discussion about why we want this.

TODO:
- [x] Documentation
- [x] ~More functionality on `Allocated<T>`?~ Postponed
- [x] ~More functionality on `Id<Allocated<T>, O>`?~ Postponed
- [x] ~Should it be possible to retrieve ivars and initialize them?~ Postponed to #30
- [x] Consider `Allocated<T>(*mut T)`
