### PR TITLE
Add empty proc-macro `objc2-proc-macros` for use in the future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "objc-sys",
     "objc2-encode",
     "objc2-foundation",
+    "objc2-proc-macros",
     "block2",
     "block-sys",
     "tests",

--- a/objc2-proc-macros/CHANGELOG.md
+++ b/objc2-proc-macros/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+Notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Unreleased - YYYY-MM-DD
+
+
+## 0.0.0 - 2022-06-16
+
+Initial empty release.

--- a/objc2-proc-macros/Cargo.toml
+++ b/objc2-proc-macros/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "objc2-proc-macros"
+# Remember to update html_root_url in lib.rs
+version = "0.0.0"
+authors = ["Mads Marquart <mads@marquart.dk>"]
+edition = "2021"
+
+description = "Procedural macros for the objc2 project"
+keywords = ["objective-c", "macos", "ios", "proc-macro"]
+categories = [
+    "development-tools",
+    "os::macos-apis",
+]
+readme = "README.md"
+repository = "https://github.com/madsmtm/objc2"
+documentation = "https://docs.rs/objc2-proc-macros/"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[features]
+default = ["apple"]
+
+# Runtime selection (for future compatibility)
+apple = []
+gnustep-1-7 = []
+gnustep-1-8 = ["gnustep-1-7"]
+gnustep-1-9 = ["gnustep-1-8"]
+gnustep-2-0 = ["gnustep-1-9"]
+gnustep-2-1 = ["gnustep-2-0"]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"

--- a/objc2-proc-macros/README.md
+++ b/objc2-proc-macros/README.md
@@ -1,0 +1,11 @@
+# `objc2-proc-macros`
+
+[![Latest version](https://badgen.net/crates/v/objc2-proc-macros)](https://crates.io/crates/objc2-proc-macros)
+[![License](https://badgen.net/badge/license/MIT/blue)](../LICENSE.txt)
+[![Documentation](https://docs.rs/objc2-proc-macros/badge.svg)](https://docs.rs/objc2-proc-macros/)
+[![CI](https://github.com/madsmtm/objc2/actions/workflows/ci.yml/badge.svg)](https://github.com/madsmtm/objc2/actions/workflows/ci.yml)
+
+Procedural macros for the [`objc2` project](https://github.com/madsmtm/objc2).
+
+You should not need to use this crate directly, all its public items are
+exported in other crates.

--- a/objc2-proc-macros/src/lib.rs
+++ b/objc2-proc-macros/src/lib.rs
@@ -1,0 +1,18 @@
+//! Procedural macros for the [`objc2` project](https://github.com/madsmtm/objc2).
+//!
+//! You should not need to use this crate directly, all its public items are
+//! exported in other crates.
+
+#![warn(elided_lifetimes_in_paths)]
+#![warn(missing_docs)]
+#![deny(non_ascii_idents)]
+#![warn(unreachable_pub)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::cargo)]
+#![warn(clippy::ptr_as_ptr)]
+// Update in Cargo.toml as well.
+#![doc(html_root_url = "https://docs.rs/objc2-proc-macros/0.0.0")]
+
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+extern "C" {}


### PR DESCRIPTION
Will be used by https://github.com/madsmtm/objc2/pull/104, https://github.com/madsmtm/objc2/pull/123 and a third thing concerning Objective-C's `@available`