### PR TITLE
Add `MainThreadMarker`

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `MainThreadMarker` to help with designing APIs where a method is only
+  safe to call on the main thread.
+
 
 ## 0.2.0-alpha.5 - 2022-06-13
 

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -58,7 +58,7 @@ pub use self::object::NSObject;
 pub use self::process_info::NSProcessInfo;
 pub use self::range::NSRange;
 pub use self::string::NSString;
-pub use self::thread::{is_main_thread, is_multi_threaded, NSThread};
+pub use self::thread::{is_main_thread, is_multi_threaded, MainThreadMarker, NSThread};
 pub use self::uuid::NSUUID;
 pub use self::value::NSValue;
 

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use objc2::rc::{Id, Shared};
 use objc2::{msg_send, msg_send_bool, msg_send_id};
 
@@ -65,8 +67,79 @@ fn make_multithreaded() {
     // Don't bother waiting for it to complete!
 }
 
+/// A marker type taken by functions that can only be executed on the main
+/// thread.
+///
+/// By design, this is neither [`Send`] nor [`Sync`], and can only be created
+/// on the main thread, meaning that if you're holding this, you know you're
+/// running on the main thread.
+///
+/// See the following links for more information on main-thread-only APIs:
+/// - [Main Thread Only APIs on OS X](https://www.dribin.org/dave/blog/archives/2009/02/01/main_thread_apis/)
+/// - [Thread Safety Summary](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html#//apple_ref/doc/uid/10000057i-CH12-SW1)
+/// - [Are the Cocoa Frameworks Thread Safe?](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CocoaFundamentals/AddingBehaviortoaCocoaProgram/AddingBehaviorCocoa.html#//apple_ref/doc/uid/TP40002974-CH5-SW47)
+/// - [Technical Note TN2028 - Threading Architectures](https://developer.apple.com/library/archive/technotes/tn/tn2028.html#//apple_ref/doc/uid/DTS10003065)
+/// - [Thread Management](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html)
+/// - [Mike Ash' article on thread safety](https://www.mikeash.com/pyblog/friday-qa-2009-01-09.html)
+///
+///
+/// # Examples
+///
+/// Use when designing APIs that are only safe to use on the main thread:
+///
+/// ```no_run
+/// use objc2::msg_send;
+/// use objc2::runtime::Object;
+/// use objc2_foundation::MainThreadMarker;
+/// # let obj = 0 as *const Object;
+///
+/// // This action requires the main thread, so we take a marker as parameter.
+/// // It signals clearly to users "this requires the main thread".
+/// unsafe fn do_thing(obj: *const Object, _mtm: MainThreadMarker) {
+///     msg_send![obj, someActionThatRequiresTheMainThread]
+/// }
+///
+/// // Usage
+/// let mtm = MainThreadMarker::new().unwrap();
+/// unsafe { do_thing(obj, mtm) }
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+// This is valid to Copy because it's still `!Send` and `!Sync`.
+pub struct MainThreadMarker {
+    // No lifetime information needed; the main thread is static and available
+    // throughout the entire program!
+    _priv: PhantomData<*mut ()>,
+}
+
+impl MainThreadMarker {
+    /// Construct a new [`MainThreadMarker`].
+    ///
+    /// Returns [`None`] if the current thread was not the main thread.
+    pub fn new() -> Option<Self> {
+        if is_main_thread() {
+            // SAFETY: We just checked that we are running on the main thread.
+            Some(unsafe { Self::new_unchecked() })
+        } else {
+            None
+        }
+    }
+
+    /// Construct a new [`MainThreadMarker`] without first checking whether
+    /// the current thread is the main one.
+    ///
+    /// # Safety
+    ///
+    /// The current thread must be the main thread.
+    pub unsafe fn new_unchecked() -> Self {
+        // SAFETY: Upheld by caller
+        Self { _priv: PhantomData }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use core::panic::{RefUnwindSafe, UnwindSafe};
+
     use super::*;
 
     #[test]
@@ -95,5 +168,12 @@ mod tests {
             .join()
             .unwrap();
         assert_eq!(res, (false, false));
+    }
+
+    #[test]
+    fn test_main_thread_auto_traits() {
+        fn assert_traits<T: Unpin + UnwindSafe + RefUnwindSafe + Sized>() {}
+
+        assert_traits::<MainThreadMarker>()
     }
 }

--- a/tests/ui/mainthreadmarker_not_send_sync.rs
+++ b/tests/ui/mainthreadmarker_not_send_sync.rs
@@ -1,0 +1,10 @@
+//! Test that MainThreadMarker is neither Send nor Sync.
+use objc2_foundation::MainThreadMarker;
+
+fn needs_sync<T: Sync>() {}
+fn needs_send<T: Send>() {}
+
+fn main() {
+    needs_sync::<MainThreadMarker>();
+    needs_send::<MainThreadMarker>();
+}

--- a/tests/ui/mainthreadmarker_not_send_sync.stderr
+++ b/tests/ui/mainthreadmarker_not_send_sync.stderr
@@ -1,0 +1,29 @@
+error[E0277]: `*mut ()` cannot be shared between threads safely
+ --> ui/mainthreadmarker_not_send_sync.rs:8:5
+  |
+8 |     needs_sync::<MainThreadMarker>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
+  |
+  = help: within `MainThreadMarker`, the trait `Sync` is not implemented for `*mut ()`
+  = note: required because it appears within the type `PhantomData<*mut ()>`
+  = note: required because it appears within the type `MainThreadMarker`
+note: required by a bound in `needs_sync`
+ --> ui/mainthreadmarker_not_send_sync.rs:4:18
+  |
+4 | fn needs_sync<T: Sync>() {}
+  |                  ^^^^ required by this bound in `needs_sync`
+
+error[E0277]: `*mut ()` cannot be sent between threads safely
+ --> ui/mainthreadmarker_not_send_sync.rs:9:5
+  |
+9 |     needs_send::<MainThreadMarker>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
+  |
+  = help: within `MainThreadMarker`, the trait `Send` is not implemented for `*mut ()`
+  = note: required because it appears within the type `PhantomData<*mut ()>`
+  = note: required because it appears within the type `MainThreadMarker`
+note: required by a bound in `needs_send`
+ --> ui/mainthreadmarker_not_send_sync.rs:5:18
+  |
+5 | fn needs_send<T: Send>() {}
+  |                  ^^^^ required by this bound in `needs_send`


### PR DESCRIPTION
Fixes #27.

Not entirely sure this is the best design, will have to experiment with it in `winit`, but I think it is useful even if it doesn't help with _every_ case!

I'll defer writing an `MainThreadOnly<T>` helper class for now, since it is difficult to use across crates due to coherence (making it basically useless).