### PR TITLE
Refactor message verification functionality

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: `ClassBuilder::root` is now generic over the function pointer,
   meaning you will have to coerce initializer functions to pointers like in
   `ClassBuilder::add_method` before you can use it.
+* **BREAKING**: Moved `MessageReceiver::verify_message` to `Class::verify_sel`.
 
 ### Removed
 * **BREAKING:** Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -212,6 +212,8 @@ pub mod exception;
 mod message;
 pub mod rc;
 pub mod runtime;
+#[cfg(feature = "malloc")]
+mod verify;
 
 #[cfg(test)]
 mod test_utils;

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -39,7 +39,7 @@ mod platform;
 
 use self::platform::{send_super_unverified, send_unverified};
 #[cfg(feature = "malloc")]
-use self::verify::{verify_message_signature, VerificationError};
+pub(crate) use self::verify::{verify_message_signature, VerificationError};
 
 /// Types that can be sent Objective-C messages.
 ///
@@ -183,36 +183,6 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
             verify_message_signature::<A, R>(superclass, sel)?;
         }
         unsafe { send_super_unverified(this, superclass, sel, args) }
-    }
-
-    /// Verify that the argument and return types match the encoding of the
-    /// method for the given selector.
-    ///
-    /// This will look up the encoding of the method for the given selector,
-    /// `sel`, and return a [`MessageError`] if any encodings differ for the
-    /// arguments `A` and return type `R`.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use objc2::{class, msg_send, sel};
-    /// # use objc2::runtime::{Bool, Class, Object};
-    /// # use objc2::MessageReceiver;
-    /// let obj: &Object;
-    /// # obj = unsafe { msg_send![class!(NSObject), new] };
-    /// let sel = sel!(isKindOfClass:);
-    /// // Verify isKindOfClass: takes one Class and returns a BOOL
-    /// let result = obj.verify_message::<(&Class,), Bool>(sel);
-    /// assert!(result.is_ok());
-    /// ```
-    #[cfg(feature = "malloc")]
-    fn verify_message<A, R>(self, sel: Sel) -> Result<(), MessageError>
-    where
-        A: EncodeArguments,
-        R: Encode,
-    {
-        let obj = unsafe { self.__as_raw_receiver().as_ref().unwrap() };
-        verify_message_signature::<A, R>(obj.class(), sel).map_err(MessageError::from)
     }
 }
 
@@ -510,18 +480,5 @@ mod tests {
             let _: () = msg_send![obj, release];
         };
         // `obj` is consumed, can't use here
-    }
-
-    #[test]
-    #[cfg(feature = "malloc")]
-    fn test_verify_message() {
-        let obj = test_utils::custom_object();
-        assert!(obj.verify_message::<(), u32>(sel!(foo)).is_ok());
-        assert!(obj.verify_message::<(u32,), ()>(sel!(setFoo:)).is_ok());
-
-        // Incorrect types
-        assert!(obj.verify_message::<(), u64>(sel!(setFoo:)).is_err());
-        // Unimplemented selector
-        assert!(obj.verify_message::<(u32,), ()>(sel!(setFoo)).is_err());
     }
 }

--- a/objc2/src/message/verify.rs
+++ b/objc2/src/message/verify.rs
@@ -92,3 +92,20 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils;
+
+    #[test]
+    fn test_verify_message() {
+        let cls = test_utils::custom_class();
+        assert!(cls.verify_sel::<(), u32>(sel!(foo)).is_ok());
+        assert!(cls.verify_sel::<(u32,), ()>(sel!(setFoo:)).is_ok());
+
+        // Incorrect types
+        assert!(cls.verify_sel::<(), u64>(sel!(setFoo:)).is_err());
+        // Unimplemented selector
+        assert!(cls.verify_sel::<(u32,), ()>(sel!(setFoo)).is_err());
+    }
+}

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -16,11 +16,9 @@ use std::os::raw::c_char;
 use std::os::raw::c_uint;
 
 pub use super::bool::Bool;
-#[cfg(feature = "malloc")]
-use super::message::{verify_message_signature, MessageError};
-#[cfg(feature = "malloc")]
-use super::EncodeArguments;
 use crate::{ffi, Encode, Encoding, RefEncode};
+#[cfg(feature = "malloc")]
+use crate::{verify::verify_message_signature, EncodeArguments, MessageError};
 
 /// Use [`Bool`] or [`ffi::BOOL`] instead.
 #[deprecated = "Use `Bool` or `ffi::BOOL` instead"]

--- a/objc2/src/verify.rs
+++ b/objc2/src/verify.rs
@@ -3,7 +3,8 @@ use core::fmt;
 use crate::runtime::{Class, Method, Object, Sel};
 use crate::{Encode, EncodeArguments, Encoding};
 
-pub enum VerificationError<'a> {
+#[allow(dead_code)]
+pub(crate) enum VerificationError<'a> {
     NilReceiver(Sel),
     MethodNotFound(&'a Class, Sel),
     MismatchedReturn(&'a Method, Encoding<'static>),


### PR DESCRIPTION
Move `MessageReceiver::verify_message` to `Class::verify_msg_send`.

I intend to make further changes, but want to merge this now to preserve `git` history.