### PR TITLE
Add `Id::cast`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   feature flags to make the `sel!` macro (and by extension, the `msg_send!`
   macros) faster.
 * Added `"unstable-c-unwind"` feature.
+* Added unsafe function `Id::cast` for converting between different types of
+  objects.
 
 ### Changed
 * **BREAKING:** `Sel` is now required to be non-null, which means that you


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/87. Related: https://github.com/madsmtm/objc2/issues/58.

Also slightly changes the contract of `Message` to support it, though those requirements were basically already true.