### PR TITLE
Improve message verification and error handling

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `Class::verify_sel`.
 
 ### Changed
-* **BREAKING:** `Sel` is now required to be non-null, which means that you
+* **BREAKING**: `Sel` is now required to be non-null, which means that you
   have to ensure that any selectors you receive from method calls are
   non-null before using them.
 * **BREAKING**: `ClassBuilder::root` is now generic over the function pointer,
@@ -46,9 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Moved `MessageReceiver::verify_message` to `Class::verify_sel`
   and changed return type.
 * Improved debug output with `verify_message` feature enabled.
+* **BREAKING**: Changed `MessageReceiver::send_message` to panic instead of
+  returning an error.
 
 ### Removed
-* **BREAKING:** Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.
+* **BREAKING**: Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.
+* **BREAKING**: Removed `MessageError`.
 
 
 ## 0.3.0-beta.0 - 2022-06-13

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `ClassBuilder::add_method` before you can use it.
 * **BREAKING**: Moved `MessageReceiver::verify_message` to `Class::verify_sel`
   and changed return type.
+* Improved debug output with `verify_message` feature enabled.
 
 ### Removed
 * **BREAKING:** Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   objects.
 * Added `Object::ivar_ptr` to allow direct access to instance variables
   through `&Object`.
+* Added `VerificationError` as more specific return type from
+  `Class::verify_sel`.
 
 ### Changed
 * **BREAKING:** `Sel` is now required to be non-null, which means that you
@@ -41,7 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: `ClassBuilder::root` is now generic over the function pointer,
   meaning you will have to coerce initializer functions to pointers like in
   `ClassBuilder::add_method` before you can use it.
-* **BREAKING**: Moved `MessageReceiver::verify_message` to `Class::verify_sel`.
+* **BREAKING**: Moved `MessageReceiver::verify_message` to `Class::verify_sel`
+  and changed return type.
 
 ### Removed
 * **BREAKING:** Removed the `Sel::from_ptr` and `Sel::as_ptr` methods.

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -200,6 +200,8 @@ pub use objc_sys as ffi;
 pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
 pub use crate::message::{Message, MessageArguments, MessageError, MessageReceiver};
+#[cfg(feature = "malloc")]
+pub use crate::verify::VerificationError;
 
 #[macro_use]
 mod macros;

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -199,7 +199,7 @@ pub use objc_sys as ffi;
 #[doc(no_inline)]
 pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
-pub use crate::message::{Message, MessageArguments, MessageError, MessageReceiver};
+pub use crate::message::{Message, MessageArguments, MessageReceiver};
 #[cfg(feature = "malloc")]
 pub use crate::verify::VerificationError;
 

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -455,45 +455,30 @@ macro_rules! __sel_inner {
 #[macro_export]
 macro_rules! msg_send {
     [super($obj:expr, $superclass:expr), $selector:ident $(,)?] => ({
-        // Note: this import means that using these types inside `expr` will
-        // generate an error. We won't bother with that (yet) though.
-        use $crate::__macro_helpers::{Err, Ok, panic};
         let sel = $crate::sel!($selector);
         let result;
-        match $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ()) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        // Note: `sel` and `result` can be accessed from the `obj` and
+        // `superclass` expressions - we won't (yet) bother with preventing
+        // that though.
+        result = $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ());
         result
     });
     [super($obj:expr, $superclass:expr), $($selector:ident : $argument:expr $(,)?)+] => ({
-        use $crate::__macro_helpers::{Err, Ok, panic};
         let sel = $crate::sel!($($selector :)+);
         let result;
-        match $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ($($argument,)+)) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        result = $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ($($argument,)+));
         result
     });
     [$obj:expr, $selector:ident $(,)?] => ({
-        use $crate::__macro_helpers::{Err, Ok, panic};
         let sel = $crate::sel!($selector);
         let result;
-        match $crate::MessageReceiver::send_message($obj, sel, ()) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        result = $crate::MessageReceiver::send_message($obj, sel, ());
         result
     });
     [$obj:expr, $($selector:ident : $argument:expr $(,)?)+] => ({
-        use $crate::__macro_helpers::{Err, Ok, panic};
         let sel = $crate::sel!($($selector :)+);
         let result;
-        match $crate::MessageReceiver::send_message($obj, sel, ($($argument,)+)) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        result = $crate::MessageReceiver::send_message($obj, sel, ($($argument,)+));
         result
     });
 }
@@ -669,29 +654,25 @@ macro_rules! msg_send_id {
     [$obj:expr, $selector:ident $(,)?] => ({
         $crate::__msg_send_id_helper!(@verify $selector);
 
-        use $crate::__macro_helpers::{u8, Err, Ok, Option, panic, stringify};
+        // Note: this import means that using these types inside `expr` may
+        // generate an error. We won't (yet) bother with that though.
+        use $crate::__macro_helpers::{u8, Option, stringify};
 
         let sel = $crate::sel!($selector);
         const NAME: &[u8] = stringify!($selector).as_bytes();
         $crate::__msg_send_id_helper!(@get_assert_consts NAME);
         let result: Option<$crate::rc::Id<_, _>>;
-        match <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ()) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        result = <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ());
         result
     });
     [$obj:expr, $($selector:ident : $argument:expr),+ $(,)?] => ({
-        use $crate::__macro_helpers::{concat, u8, Err, Ok, Option, panic, stringify};
+        use $crate::__macro_helpers::{concat, u8, Option, stringify};
 
         let sel = $crate::sel!($($selector:)+);
         const NAME: &[u8] = concat!($(stringify!($selector), ':'),+).as_bytes();
         $crate::__msg_send_id_helper!(@get_assert_consts NAME);
         let result: Option<$crate::rc::Id<_, _>>;
-        match <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+)) {
-            Err(s) => panic!("{}", s),
-            Ok(r) => result = r,
-        }
+        result = <RS as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+));
         result
     });
 }

--- a/objc2/src/message/apple/mod.rs
+++ b/objc2/src/message/apple/mod.rs
@@ -1,6 +1,7 @@
-use super::{conditional_try, Encode, MessageArguments, MessageError};
+use super::conditional_try;
 use crate::ffi;
 use crate::runtime::{Class, Imp, Object, Sel};
+use crate::{Encode, MessageArguments};
 
 #[cfg(target_arch = "x86")]
 #[path = "x86.rs"]
@@ -24,11 +25,8 @@ unsafe trait MsgSendFn: Encode {
 }
 
 #[inline]
-pub(crate) unsafe fn send_unverified<A, R>(
-    receiver: *mut Object,
-    sel: Sel,
-    args: A,
-) -> Result<R, MessageError>
+#[track_caller]
+pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut Object, sel: Sel, args: A) -> R
 where
     A: MessageArguments,
     R: Encode,
@@ -38,12 +36,13 @@ where
 }
 
 #[inline]
+#[track_caller]
 pub(crate) unsafe fn send_super_unverified<A, R>(
     receiver: *mut Object,
     superclass: &Class,
     sel: Sel,
     args: A,
-) -> Result<R, MessageError>
+) -> R
 where
     A: MessageArguments,
     R: Encode,

--- a/objc2/src/message/gnustep.rs
+++ b/objc2/src/message/gnustep.rs
@@ -1,14 +1,12 @@
 use core::mem;
 
-use super::{conditional_try, Encode, MessageArguments, MessageError};
+use super::conditional_try;
 use crate::ffi;
 use crate::runtime::{Class, Object, Sel};
+use crate::{Encode, MessageArguments};
 
-pub(crate) unsafe fn send_unverified<A, R>(
-    receiver: *mut Object,
-    sel: Sel,
-    args: A,
-) -> Result<R, MessageError>
+#[track_caller]
+pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut Object, sel: Sel, args: A) -> R
 where
     A: MessageArguments,
     R: Encode,
@@ -28,12 +26,13 @@ where
     unsafe { conditional_try(|| A::__invoke(msg_send_fn, receiver, sel, args)) }
 }
 
+#[track_caller]
 pub(crate) unsafe fn send_super_unverified<A, R>(
     receiver: *mut Object,
     superclass: &Class,
     sel: Sel,
     args: A,
-) -> Result<R, MessageError>
+) -> R
 where
     A: MessageArguments,
     R: Encode,

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -453,8 +453,11 @@ mod tests {
         assert_eq!(result, expected);
     }
 
-    #[cfg(not(feature = "verify_message"))]
     #[test]
+    #[cfg_attr(
+        feature = "verify_message",
+        should_panic = "Messsaging description to nil"
+    )]
     fn test_send_message_nil() {
         use crate::rc::Shared;
 

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -399,8 +399,8 @@ impl Error for MessageError {
 }
 
 #[cfg(feature = "malloc")]
-impl<'a> From<VerificationError<'a>> for MessageError {
-    fn from(err: VerificationError<'_>) -> MessageError {
+impl From<VerificationError> for MessageError {
+    fn from(err: VerificationError) -> MessageError {
         use alloc::string::ToString;
         MessageError(err.to_string())
     }

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -164,7 +164,7 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
             let cls = if let Some(this) = this {
                 this.class()
             } else {
-                return Err(VerificationError::NilReceiver(sel).into());
+                return Err(MessageError(alloc::format!("Messsaging {:?} to nil", sel)));
             };
 
             cls.verify_sel::<A, R>(sel)?;
@@ -206,7 +206,7 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
         #[cfg(feature = "verify_message")]
         {
             if this.is_null() {
-                return Err(VerificationError::NilReceiver(sel).into());
+                return Err(MessageError(alloc::format!("Messsaging {:?} to nil", sel)));
             }
             superclass.verify_sel::<A, R>(sel)?;
         }

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -20,7 +20,7 @@ use std::os::raw::c_uint;
 pub use super::bool::Bool;
 use crate::{ffi, Encode, Encoding, RefEncode};
 #[cfg(feature = "malloc")]
-use crate::{verify::verify_message_signature, EncodeArguments, MessageError};
+use crate::{verify::verify_message_signature, EncodeArguments, VerificationError};
 
 /// Use [`Bool`] or [`ffi::BOOL`] instead.
 #[deprecated = "Use `Bool` or `ffi::BOOL` instead"]
@@ -347,7 +347,7 @@ impl Class {
     // objc_getMetaClass -> Same as `Class::get(name).metaclass()`
 
     #[allow(unused)]
-    fn is_metaclass(&self) -> bool {
+    pub(crate) fn is_metaclass(&self) -> bool {
         unsafe { Bool::from_raw(ffi::class_isMetaClass(self.as_ptr())).as_bool() }
     }
 
@@ -448,7 +448,7 @@ impl Class {
     /// Verify argument and return types for a given selector.
     ///
     /// This will look up the encoding of the method for the given selector
-    /// and return a [`MessageError`] if any encodings differ for the
+    /// and return a [`VerificationError`] if any encodings differ for the
     /// arguments `A` and return type `R`.
     ///
     ///
@@ -467,12 +467,12 @@ impl Class {
     /// assert!(result.is_ok());
     /// ```
     #[cfg(feature = "malloc")]
-    pub fn verify_sel<A, R>(&self, sel: Sel) -> Result<(), MessageError>
+    pub fn verify_sel<A, R>(&self, sel: Sel) -> Result<(), VerificationError>
     where
         A: EncodeArguments,
         R: Encode,
     {
-        verify_message_signature::<A, R>(self, sel).map_err(MessageError::from)
+        verify_message_signature::<A, R>(self, sel)
     }
 }
 

--- a/objc2/src/verify.rs
+++ b/objc2/src/verify.rs
@@ -30,9 +30,7 @@ impl fmt::Display for MallocEncoding {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[allow(dead_code)]
 pub(crate) enum VerificationError {
-    NilReceiver(Sel),
     MethodNotFound(Sel),
     MismatchedReturn(Sel, MallocEncoding, Encoding<'static>),
     MismatchedArgumentsCount(Sel, usize, usize),
@@ -42,9 +40,6 @@ pub(crate) enum VerificationError {
 impl fmt::Display for VerificationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NilReceiver(sel) => {
-                write!(f, "Messsaging {:?} to nil", sel)
-            }
             Self::MethodNotFound(sel) => {
                 write!(f, "Method {:?} not found on class", sel)
             }

--- a/tests/assembly/test_msg_send_id/lib.rs
+++ b/tests/assembly/test_msg_send_id/lib.rs
@@ -5,43 +5,41 @@ use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
 unsafe fn handle_alloc(obj: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_init(obj: Option<Id<Object, Shared>>, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init(obj: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object, Shared>> {
-    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel1, ()).unwrap();
-    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ()).unwrap()
+    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(obj, sel1, ());
+    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
     let _obj: Id<Object, Shared> =
         <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ())
-            .unwrap()
             .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
-    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel1, ()).unwrap();
+    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel1, ());
     let _obj: Id<Object, Shared> =
         <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ())
-            .unwrap()
             .unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, false, true>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, false, true>>::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, false, false>>::send_message_id(obj, sel, ()).unwrap()
+    <RetainSemantics<false, false, false, false>>::send_message_id(obj, sel, ())
 }

--- a/tests/assembly/test_msg_send_zero_cost/lib.rs
+++ b/tests/assembly/test_msg_send_zero_cost/lib.rs
@@ -7,7 +7,7 @@ use objc2::MessageReceiver;
 
 #[no_mangle]
 unsafe fn handle(obj: &Object, sel: Sel) -> *mut Object {
-    MessageReceiver::send_message(obj, sel, ()).unwrap()
+    MessageReceiver::send_message(obj, sel, ())
 }
 
 // This will definitely not work, but is useful for making the assembly look
@@ -23,5 +23,5 @@ fn selector() -> Sel {
 
 #[no_mangle]
 unsafe fn handle_with_sel(obj: &Object) -> *mut Object {
-    MessageReceiver::send_message(obj, selector(), ()).unwrap()
+    MessageReceiver::send_message(obj, selector(), ())
 }

--- a/tests/assembly/test_retain_autoreleased/lib.rs
+++ b/tests/assembly/test_retain_autoreleased/lib.rs
@@ -6,6 +6,6 @@ use objc2::MessageReceiver;
 
 #[no_mangle]
 unsafe fn handle(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    let ptr: *mut Object = MessageReceiver::send_message(obj, sel, ()).unwrap();
+    let ptr: *mut Object = MessageReceiver::send_message(obj, sel, ());
     Id::retain_autoreleased(ptr)
 }

--- a/tests/ui/msg_send_id_invalid_receiver.stderr
+++ b/tests/ui/msg_send_id_invalid_receiver.stderr
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
    |
-   |     unsafe fn send_message_id<A: MessageArguments>(
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
    |               ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
@@ -29,7 +29,7 @@ error[E0308]: mismatched types
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
    |
-   |     unsafe fn send_message_id<A: MessageArguments>(
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
    |               ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
@@ -46,7 +46,7 @@ error[E0308]: mismatched types
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
    |
-   |     unsafe fn send_message_id<A: MessageArguments>(
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
    |               ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
@@ -63,7 +63,7 @@ error[E0308]: mismatched types
 note: associated function defined here
   --> $WORKSPACE/objc2/src/__macro_helpers.rs
    |
-   |     unsafe fn send_message_id<A: MessageArguments>(
+   |     unsafe fn send_message_id<A: MessageArguments>(obj: T, sel: Sel, args: A) -> Option<U>;
    |               ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied

--- a/tests/ui/msg_send_mutable.stderr
+++ b/tests/ui/msg_send_mutable.stderr
@@ -13,5 +13,5 @@ error[E0382]: use of moved value: `obj`
 note: this function takes ownership of the receiver `self`, which moves `obj`
    --> $WORKSPACE/objc2/src/message/mod.rs
     |
-    |     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> Result<R, MessageError>
+    |     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> R
     |                                  ^^^^


### PR DESCRIPTION
`MessageError` has been removed, instead we now expose a `VerificationError` (which is much more specific about what it actually does, and avoids allocations). Manual usage of `MessageReceiver::send_message` now no longer need to handle the error case.

Also, errors that `verify_message` catches are now more consistent:
```
# Before
thread 'main' panicked at 'Method initA not found on class NSObject'
thread 'main' panicked at 'Return type code I does not match expected Q for method hash'

# After
thread 'main' panicked at 'invalid message send to -[NSObject initA]: method not found'
thread 'main' panicked at 'invalid message send to -[NSObject hash]: expected return to have type code Q, but found I'
```