### PR TITLE
Implement `AutoreleaseSafe` for `fmt::Formatter`

### DIFF
--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -204,16 +204,10 @@ macro_rules! object {
         // TODO: Consider T: Debug bound
         impl<$($t $(: $b)?),*> ::core::fmt::Debug for $name<$($t),*> {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                use ::alloc::borrow::ToOwned;
-                use $crate::NSObject;
-                // "downgrading" to  NSObject and calling `to_owned` to work
-                // around `f` and Self not being AutoreleaseSafe.
-                // TODO: Fix this!
-                let this: &NSObject = self.as_ref();
-                let s = ::objc2::rc::autoreleasepool(|pool| {
-                    this.description().as_str(pool).to_owned()
-                });
-                ::core::fmt::Debug::fmt(&s, f)
+                let description = self.description();
+                ::objc2::rc::autoreleasepool(|pool| {
+                    ::core::fmt::Debug::fmt(description.as_str(pool), f)
+                })
             }
         }
     };

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -265,11 +265,7 @@ impl ToOwned for NSString {
 
 impl fmt::Display for NSString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The call to `to_owned` is unfortunate, but is required to work
-        // around `f` not being AutoreleaseSafe.
-        // TODO: Fix this!
-        let s = autoreleasepool(|pool| self.as_str(pool).to_owned());
-        fmt::Display::fmt(&s, f)
+        autoreleasepool(|pool| fmt::Display::fmt(self.as_str(pool), f))
     }
 }
 

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -204,6 +204,11 @@ unsafe impl<T: ?Sized> AutoreleaseSafe for T {}
 #[cfg(feature = "unstable-autoreleasesafe")]
 impl !AutoreleaseSafe for AutoreleasePool {}
 
+// SAFETY: This is not strictly correct, it contains a `dyn Write` which may
+// come from the user (e.g. via. `fmt::write`).
+#[cfg(feature = "unstable-autoreleasesafe")]
+unsafe impl AutoreleaseSafe for fmt::Formatter<'_> {}
+
 /// Execute `f` in the context of a new autorelease pool. The pool is
 /// drained after the execution of `f` completes.
 ///
@@ -311,9 +316,9 @@ where
     f(&pool)
 }
 
-#[cfg(all(test, feature = "unstable-autoreleasesafe"))]
+#[cfg(test)]
 mod tests {
-    use super::AutoreleaseSafe;
+    use super::*;
     use crate::runtime::Object;
 
     fn requires_autoreleasesafe<T: AutoreleaseSafe>() {}
@@ -323,5 +328,8 @@ mod tests {
         requires_autoreleasesafe::<usize>();
         requires_autoreleasesafe::<*mut Object>();
         requires_autoreleasesafe::<&mut Object>();
+        requires_autoreleasesafe::<Id<Object, Shared>>();
+        requires_autoreleasesafe::<fmt::Result>();
+        requires_autoreleasesafe::<&mut fmt::Formatter<'_>>();
     }
 }


### PR DESCRIPTION
Opened to keep the code around, but I think this is the wrong workaround - it is not strictly correct! `fmt::Formatter` contains a `dyn Write` which may come from the user via. `fmt::write`. The type could contain an outer AutoreleasePool, that it could wrongly assume was innermost when attempting a write.