### PR TITLE
Fix nested encodings

### DIFF
--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Fixed
+* Fixed the encoding output and comparison of structs behind pointers.
+
 
 ## 2.0.0-pre.1 - 2022-07-19
 

--- a/objc2-encode/src/helper.rs
+++ b/objc2-encode/src/helper.rs
@@ -1,6 +1,52 @@
 use crate::Encoding;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum NestingLevel {
+    Top,
+    Within,
+    Bottom,
+}
+
+impl NestingLevel {
+    pub(crate) const fn new() -> Self {
+        Self::Top
+    }
+
+    pub(crate) const fn bitfield(self) -> Self {
+        // TODO: Is this correct?
+        self
+    }
+
+    pub(crate) const fn indirection(self, kind: IndirectionKind) -> Self {
+        match kind {
+            // Move all the way down
+            IndirectionKind::Atomic => Self::Bottom,
+            // Move one step down
+            IndirectionKind::Pointer => match self {
+                Self::Top => Self::Within,
+                Self::Bottom | Self::Within => Self::Bottom,
+            },
+        }
+    }
+
+    pub(crate) const fn array(self) -> Self {
+        // TODO: Is this correct?
+        self
+    }
+
+    pub(crate) const fn container(self) -> Option<Self> {
+        match self {
+            // Move one step down, and output
+            Self::Top => Some(Self::Within),
+            // Output
+            Self::Within => Some(Self::Within),
+            // Don't output
+            Self::Bottom => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub(crate) enum Primitive {
     Char,

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -252,10 +252,10 @@ mod tests {
 
     #[cfg(feature = "objc2-proc-macros")]
     use crate::__hash_idents;
+    use crate::foundation::NSZone;
     use crate::rc::{Allocated, Owned, RcTestObject, Shared, ThreadTestData};
     use crate::runtime::Object;
     use crate::{class, msg_send_id};
-    use crate::{Encoding, RefEncode};
 
     #[test]
     fn test_macro_alloc() {
@@ -273,25 +273,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        all(feature = "gnustep-1-7", feature = "verify_message"),
-        ignore = "NSZone's encoding is quite complex on GNUStep"
-    )]
     fn test_alloc_with_zone() {
-        #[repr(C)]
-        struct _NSZone {
-            _inner: [u8; 0],
-        }
-
-        unsafe impl RefEncode for _NSZone {
-            const ENCODING_REF: Encoding<'static> =
-                Encoding::Pointer(&Encoding::Struct("_NSZone", &[]));
-        }
-
         let expected = ThreadTestData::current();
         let cls = RcTestObject::class();
 
-        let zone: *const _NSZone = ptr::null();
+        let zone: *const NSZone = ptr::null();
         let _obj: Id<Allocated<RcTestObject>, Owned> =
             unsafe { msg_send_id![cls, allocWithZone: zone].unwrap() };
         // `+[NSObject alloc]` delegates to `+[NSObject allocWithZone:]`, but

--- a/tests/extern/encode_utils.m
+++ b/tests/extern/encode_utils.m
@@ -7,14 +7,17 @@
 
 #define ENCODING_INNER(name, type) char* ENCODING_ ## name = @encode(type);
 
-#define ENCODING(name, type) \
+#define ENCODING_NO_ATOMIC(name, type) \
     ENCODING_INNER(name, type); \
     ENCODING_INNER(name ## _POINTER, type*); \
     ENCODING_INNER(name ## _POINTER_POINTER, type**); \
     ENCODING_INNER(name ## _POINTER_POINTER_POINTER, type***); \
-    ENCODING_INNER(name ## _ATOMIC, _Atomic type); \
-    ENCODING_INNER(name ## _ATOMIC_POINTER, _Atomic type*); \
     ENCODING_INNER(name ## _POINTER_ATOMIC, _Atomic (type*));
+
+#define ENCODING(name, type) \
+    ENCODING_NO_ATOMIC(name, type); \
+    ENCODING_INNER(name ## _ATOMIC_POINTER, _Atomic type*); \
+    ENCODING_INNER(name ## _ATOMIC, _Atomic type);
 
 // C types
 
@@ -42,10 +45,8 @@ ENCODING(LONG_DOUBLE_COMPLEX, long double _Complex);
 // ENCODING(DOUBLE_IMAGINARY, double _Imaginary);
 // ENCODING(LONG_DOUBLE_IMAGINARY, long double _Imaginary);
 
-ENCODING_INNER(VOID, void);
-ENCODING_INNER(VOID_POINTER, void*);
+ENCODING_NO_ATOMIC(VOID, void);
 ENCODING_INNER(VOID_POINTER_CONST, const void*);
-ENCODING_INNER(VOID_POINTER_POINTER, void**);
 
 // Struct
 
@@ -81,19 +82,20 @@ struct with_block {
     id b;
     void (*c)(void);
 };
-ENCODING_INNER(STRUCT_WITH_BLOCK, struct with_block); \
-ENCODING_INNER(STRUCT_WITH_BLOCK_POINTER, struct with_block*); \
+ENCODING_NO_ATOMIC(STRUCT_WITH_BLOCK, struct with_block); \
 
 struct with_atomic_inner {
     _Atomic int a;
     _Atomic int* b;
+    _Atomic (int*) c;
 };
 struct with_atomic {
     _Atomic int a;
     _Atomic const int* b;
-    struct with_atomic_inner c;
-    struct with_atomic_inner* d;
-    _Atomic struct with_atomic_inner* e;
+    _Atomic (int*) c;
+    struct with_atomic_inner d;
+    struct with_atomic_inner* e;
+    _Atomic struct with_atomic_inner* f;
 };
 ENCODING(STRUCT_WITH_ATOMIC, struct with_atomic);
 
@@ -118,20 +120,16 @@ ENCODING(UNION, union union_);
 // Also, atomic arrays does not exist
 
 typedef int arr[10];
-ENCODING_INNER(ARRAY_INT, arr);
-ENCODING_INNER(ARRAY_INT_POINTER, arr*);
+ENCODING_NO_ATOMIC(ARRAY_INT, arr);
 
 typedef int* arr_ptr[10];
-ENCODING_INNER(ARRAY_POINTER, arr_ptr);
-ENCODING_INNER(ARRAY_POINTER_POINTER, arr_ptr*);
+ENCODING_NO_ATOMIC(ARRAY_POINTER, arr_ptr);
 
 typedef int arr_nested[10][20];
-ENCODING_INNER(ARRAY_NESTED, arr_nested);
-ENCODING_INNER(ARRAY_NESTED_POINTER, arr_nested*);
+ENCODING_NO_ATOMIC(ARRAY_NESTED, arr_nested);
 
 typedef struct two_items arr_struct[0];
-ENCODING_INNER(ARRAY_STRUCT, arr_struct);
-ENCODING_INNER(ARRAY_STRUCT_POINTER, arr_struct*);
+ENCODING_NO_ATOMIC(ARRAY_STRUCT, arr_struct);
 
 // Objective-C
 
@@ -168,8 +166,7 @@ ENCODING(PTRDIFF_T, ptrdiff_t);
 
 // uuid.h
 
-ENCODING_INNER(UUID_T, uuid_t);
-ENCODING_INNER(UUID_T_POINTER, uuid_t*);
+ENCODING_NO_ATOMIC(UUID_T, uuid_t);
 
 // Possible extras
 

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
-use alloc::format;
 use core::fmt::Display;
+use core::sync::atomic::{AtomicI32, AtomicPtr};
 use objc2::ffi::{NSInteger, NSUInteger};
 use objc2::runtime::{Bool, Class, Object, Sel};
-use objc2::{Encode, Encoding, RefEncode};
+use objc2::{Encode, Encoding};
 use paste::paste;
 use std::ffi::CStr;
 use std::os::raw::*;
@@ -20,6 +20,7 @@ unsafe fn assert_encoding(s: *const c_char, e: Encoding) {
     assert_eq!(e.to_string(), s.trim_start_matches('r'));
 }
 
+#[allow(unused)]
 unsafe fn assert_str<T: Display>(s: *const c_char, expected: T) {
     let s = CStr::from_ptr(s).to_str().unwrap();
     // Exact comparison to ensure we catch regressions (and that they are not
@@ -53,39 +54,51 @@ macro_rules! assert_inner {
 macro_rules! assert_types {
     ($(
         $(#[$m:meta])*
-        $stat:ident => $type:ident $($encoding:expr)?,
+        $stat:ident $($should_atomic:ident)? => $type:ident $($encoding:expr)?,
     )+) => {$(
-        assert_types!(@ $(#[$m])* $stat => $type $($encoding)?);
+        assert_types!(@ $(#[$m])* $stat $($should_atomic)? => $type $($encoding)?);
     )+};
     (@
         $(#[$m:meta])*
-        $stat:ident => enc $encoding:expr
+        $stat:ident $($should_atomic:ident)? => enc $encoding:expr
     ) => {
         paste! {
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat>] => $encoding);
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER>] => Encoding::Pointer(&$encoding));
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_POINTER>] => Encoding::Pointer(&Encoding::Pointer(&$encoding)));
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_POINTER_POINTER>] => Encoding::Pointer(&Encoding::Pointer(&Encoding::Pointer(&$encoding))));
-            assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _ATOMIC>] => Encoding::Atomic(&$encoding));
-            assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _ATOMIC_POINTER>] => Encoding::Pointer(&Encoding::Atomic(&$encoding)));
+            $(assert_types!(#$should_atomic);)?
+            assert_inner!(enc $(#[$m])* $(#[cfg($should_atomic)])? [<ENCODING_ $stat _ATOMIC>] => Encoding::Atomic(&$encoding));
+            assert_inner!(enc $(#[$m])* $(#[cfg($should_atomic)])? [<ENCODING_ $stat _ATOMIC_POINTER>] => Encoding::Pointer(&Encoding::Atomic(&$encoding)));
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_ATOMIC>] => Encoding::Atomic(&Encoding::Pointer(&$encoding)));
         }
     };
     (@
         $(#[$m:meta])*
-        $stat:ident => $type:ident
+        $stat:ident $($should_atomic:ident)? => $type:ident
     ) => {
         paste! {
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat>] => <$type>::ENCODING);
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER>] => <*const $type>::ENCODING);
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_POINTER>] => <*const *const $type>::ENCODING);
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_POINTER_POINTER>] => <*const *const *const $type>::ENCODING);
-            assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _ATOMIC>] => Encoding::Atomic(&<$type>::ENCODING));
-            assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _ATOMIC_POINTER>] => Encoding::Pointer(&Encoding::Atomic(&<$type>::ENCODING)));
+            $(assert_types!(#$should_atomic);)?
+            assert_inner!(enc $(#[$m])* $(#[cfg($should_atomic)])? [<ENCODING_ $stat _ATOMIC>] => Encoding::Atomic(&<$type>::ENCODING));
+            assert_inner!(enc $(#[$m])* $(#[cfg($should_atomic)])? [<ENCODING_ $stat _ATOMIC_POINTER>] => Encoding::Pointer(&Encoding::Atomic(&<$type>::ENCODING)));
             assert_inner!(enc $(#[$m])* [<ENCODING_ $stat _POINTER_ATOMIC>] => Encoding::Atomic(&<*const $type>::ENCODING));
         }
     };
+    (#no_atomic) => {};
 }
+
+const WITH_ATOMIC_INNER: Encoding<'static> = Encoding::Struct(
+    "with_atomic_inner",
+    &[
+        AtomicI32::ENCODING,
+        <*const AtomicI32>::ENCODING,
+        <AtomicPtr<c_int>>::ENCODING,
+    ],
+);
 
 assert_types! {
     // C types
@@ -117,26 +130,72 @@ assert_types! {
     // DOUBLE_IMAGINARY => double _Imaginary,
     // LONG_DOUBLE_IMAGINARY => long double _Imaginary,
 
-    // VOID => void,
+    VOID no_atomic => enc Encoding::Void,
 
     // Struct
 
-    // STRUCT_EMPTY
-    // STRUCT_ONE_ITEM
-    // STRUCT_NESTED
-    // STRUCT_TWO_ITEMS
-    // STRUCT_WITH_ARRAYS
+    STRUCT_EMPTY => enc Encoding::Struct("empty", &[]),
+    STRUCT_ONE_ITEM => enc Encoding::Struct("one_item", &[<*const c_void>::ENCODING]),
+    STRUCT_NESTED => enc Encoding::Struct(
+        "nested",
+        &[
+            Encoding::Struct("one_item", &[<*const c_void>::ENCODING]),
+            Encoding::Pointer(&Encoding::Struct("one_item", &[<*const c_void>::ENCODING]))
+        ]
+    ),
+    STRUCT_TWO_ITEMS => enc Encoding::Struct("two_items", &[f32::ENCODING, c_int::ENCODING]),
+    STRUCT_WITH_ARRAYS => enc Encoding::Struct(
+        "with_arrays",
+        &[
+            <[c_int; 1]>::ENCODING,
+            <[&c_int; 2]>::ENCODING,
+            <&[c_int; 3]>::ENCODING,
+        ],
+    ),
+    STRUCT_WITH_BLOCK no_atomic => enc Encoding::Struct(
+        "with_block",
+        &[
+            Encoding::Block,
+            Encoding::Object,
+            Encoding::Pointer(&Encoding::Unknown),
+        ],
+    ),
+    STRUCT_WITH_ATOMIC => enc Encoding::Struct(
+        "with_atomic",
+        &[
+            AtomicI32::ENCODING,
+            <*const AtomicI32>::ENCODING,
+            <AtomicPtr<c_int>>::ENCODING,
+            WITH_ATOMIC_INNER,
+            Encoding::Pointer(&WITH_ATOMIC_INNER),
+            Encoding::Pointer(&Encoding::Atomic(&WITH_ATOMIC_INNER)),
+        ],
+    ),
 
     // Bitfields
 
-    // BITFIELD
+    #[cfg(feature = "apple")]
+    BITFIELD => enc Encoding::Struct(
+        "bitfield",
+        &[
+            Encoding::BitField(1, &Encoding::UInt),
+            Encoding::BitField(30, &Encoding::UInt),
+        ],
+    ),
+
+    // Unions
+
+    UNION => enc Encoding::Union("union_", &[f32::ENCODING, c_int::ENCODING]),
 
     // Array
 
-    // ARRAY_INT
-    // ARRAY_POINTER
-    // ARRAY_NESTED
-    // ARRAY_STRUCT
+    ARRAY_INT no_atomic => enc <[c_int; 10]>::ENCODING,
+    ARRAY_POINTER no_atomic => enc <[*const c_int; 10]>::ENCODING,
+    ARRAY_NESTED no_atomic => enc <[[c_int; 20]; 10]>::ENCODING,
+    ARRAY_STRUCT no_atomic => enc Encoding::Array(
+        0,
+        &Encoding::Struct("two_items", &[f32::ENCODING, c_int::ENCODING]),
+    ),
 
     // Objective-C
 
@@ -175,92 +234,17 @@ assert_types! {
     SIZE_T => usize,
     PTRDIFF_T => isize,
 
+    // uuid.h
+
+    UUID_T no_atomic => enc Encoding::Array(16, &u8::ENCODING),
+
     // Possible extras; need to be #[cfg]-ed somehow
 
     // SIGNED_INT_128 => i128,
     // UNSIGNED_INT_128 => u128,
 }
 
-// _Atomic void* is not available
-assert_inner!(enc ENCODING_VOID => <()>::ENCODING);
-assert_inner!(enc ENCODING_VOID_POINTER => <*const c_void>::ENCODING);
-assert_inner!(str ENCODING_VOID_POINTER_CONST => format!("r{}", <*const c_void>::ENCODING));
-assert_inner!(enc ENCODING_VOID_POINTER_POINTER => <*const *const c_void>::ENCODING);
-
-// Structs (atomics or double indirection erase type information)
-
-const ENC0: Encoding<'static> = Encoding::Struct("empty", &[]);
-assert_inner!(enc ENCODING_STRUCT_EMPTY => ENC0);
-assert_inner!(enc ENCODING_STRUCT_EMPTY_POINTER => Encoding::Pointer(&ENC0));
-assert_inner!(str ENCODING_STRUCT_EMPTY_POINTER_POINTER => "^^{empty}");
-assert_inner!(str ENCODING_STRUCT_EMPTY_POINTER_POINTER_POINTER => "^^^{empty}");
-assert_inner!(str ENCODING_STRUCT_EMPTY_ATOMIC => "A{empty}");
-
-const ENC1: Encoding<'static> = Encoding::Struct("one_item", &[<*const c_void>::ENCODING]);
-assert_inner!(enc ENCODING_STRUCT_ONE_ITEM => ENC1);
-assert_inner!(enc ENCODING_STRUCT_ONE_ITEM_POINTER => Encoding::Pointer(&ENC1));
-assert_inner!(str ENCODING_STRUCT_ONE_ITEM_POINTER_POINTER => "^^{one_item}");
-assert_inner!(str ENCODING_STRUCT_ONE_ITEM_POINTER_POINTER_POINTER => "^^^{one_item}");
-assert_inner!(str ENCODING_STRUCT_ONE_ITEM_ATOMIC => "A{one_item}");
-
-// const ENC_NESTED: Encoding<'static> = Encoding::Struct("nested", &[ENC1, Encoding::Pointer(&ENC1)]);
-// assert_inner!(enc ENCODING_STRUCT_NESTED => ENC_NESTED);
-// assert_inner!(enc ENCODING_STRUCT_NESTED_POINTER => Encoding::Pointer(&ENC_NESTED));
-assert_inner!(str ENCODING_STRUCT_NESTED => "{nested={one_item=^v}^{one_item}}");
-assert_inner!(str ENCODING_STRUCT_NESTED_POINTER => "^{nested={one_item=^v}^{one_item}}");
-assert_inner!(str ENCODING_STRUCT_NESTED_POINTER_POINTER => "^^{nested}");
-assert_inner!(str ENCODING_STRUCT_NESTED_POINTER_POINTER_POINTER => "^^^{nested}");
-assert_inner!(str ENCODING_STRUCT_NESTED_ATOMIC => "A{nested}");
-
-const ENC2: Encoding<'static> = Encoding::Struct("two_items", &[f32::ENCODING, c_int::ENCODING]);
-assert_inner!(enc ENCODING_STRUCT_TWO_ITEMS => ENC2);
-assert_inner!(enc ENCODING_STRUCT_TWO_ITEMS_POINTER => Encoding::Pointer(&ENC2));
-assert_inner!(str ENCODING_STRUCT_TWO_ITEMS_ATOMIC => "A{two_items}");
-
-const WITH_ARRAYS: Encoding<'static> = Encoding::Struct(
-    "with_arrays",
-    &[
-        <[c_int; 1]>::ENCODING,
-        <[&c_int; 2]>::ENCODING,
-        <&[c_int; 3]>::ENCODING,
-    ],
-);
-assert_inner!(str ENCODING_STRUCT_WITH_ARRAYS => WITH_ARRAYS);
-assert_inner!(str ENCODING_STRUCT_WITH_ARRAYS_POINTER => Encoding::Pointer(&WITH_ARRAYS));
-assert_inner!(str ENCODING_STRUCT_WITH_ARRAYS_ATOMIC => "A{with_arrays}");
-
-const WITH_BLOCK: Encoding<'static> = Encoding::Struct(
-    "with_block",
-    &[
-        Encoding::Block,
-        Encoding::Object,
-        Encoding::Pointer(&Encoding::Unknown),
-    ],
-);
-assert_inner!(str ENCODING_STRUCT_WITH_BLOCK => WITH_BLOCK);
-assert_inner!(str ENCODING_STRUCT_WITH_BLOCK_POINTER => Encoding::Pointer(&WITH_BLOCK));
-
-assert_inner!(str ENCODING_STRUCT_WITH_ATOMIC => "{with_atomic=Ai^Ai{with_atomic_inner=Ai^Ai}^{with_atomic_inner}^A{with_atomic_inner}}");
-assert_inner!(str ENCODING_STRUCT_WITH_ATOMIC_POINTER => "^{with_atomic=Ai^Ai{with_atomic_inner=Ai^Ai}^{with_atomic_inner}^A{with_atomic_inner}}");
-assert_inner!(str ENCODING_STRUCT_WITH_ATOMIC_ATOMIC => "A{with_atomic}");
-
 // Bitfields
-
-#[cfg(feature = "apple")]
-mod bitfields {
-    use super::*;
-
-    const BITFIELD: Encoding<'static> = Encoding::Struct(
-        "bitfield",
-        &[
-            Encoding::BitField(1, &Encoding::UInt),
-            Encoding::BitField(30, &Encoding::UInt),
-        ],
-    );
-    assert_inner!(enc ENCODING_BITFIELD => BITFIELD);
-    assert_inner!(enc ENCODING_BITFIELD_POINTER => Encoding::Pointer(&BITFIELD));
-    assert_inner!(str ENCODING_BITFIELD_ATOMIC => "A{bitfield}");
-}
 
 #[cfg(feature = "gnustep-1-7")]
 mod bitfields {
@@ -270,32 +254,3 @@ mod bitfields {
     assert_inner!(str ENCODING_BITFIELD_POINTER => "^{bitfield=b0I1b1I30}");
     assert_inner!(str ENCODING_BITFIELD_ATOMIC => "A{bitfield}");
 }
-
-// Unions
-
-const UNION: Encoding<'static> = Encoding::Union("union_", &[f32::ENCODING, c_int::ENCODING]);
-assert_inner!(enc ENCODING_UNION => UNION);
-assert_inner!(enc ENCODING_UNION_POINTER => Encoding::Pointer(&UNION));
-assert_inner!(str ENCODING_UNION_ATOMIC => "A(union_)");
-
-// Arrays (atomics are not supported)
-
-type Array = [c_int; 10];
-assert_inner!(enc ENCODING_ARRAY_INT => Array::ENCODING);
-assert_inner!(enc ENCODING_ARRAY_INT_POINTER => Array::ENCODING_REF);
-
-type Pointer = [*const c_int; 10];
-assert_inner!(enc ENCODING_ARRAY_POINTER => Pointer::ENCODING);
-assert_inner!(str ENCODING_ARRAY_POINTER_POINTER => Pointer::ENCODING_REF);
-
-type Nested = [[c_int; 20]; 10];
-assert_inner!(enc ENCODING_ARRAY_NESTED => Nested::ENCODING);
-assert_inner!(str ENCODING_ARRAY_NESTED_POINTER => Nested::ENCODING_REF);
-
-assert_inner!(enc ENCODING_ARRAY_STRUCT => Encoding::Array(0, &ENC2));
-assert_inner!(str ENCODING_ARRAY_STRUCT_POINTER => Encoding::Pointer(&Encoding::Array(0, &ENC2)));
-
-// UUIDs
-
-assert_inner!(enc ENCODING_UUID_T => Encoding::Array(16, &u8::ENCODING));
-assert_inner!(enc ENCODING_UUID_T_POINTER => Encoding::Pointer(&Encoding::Array(16, &u8::ENCODING)));


### PR DESCRIPTION
Structs within two pointer indirections (amongst others) should have their fields stripped from the resulting encoding string; `objc2-encode` doesn't handle this yet (it is context-unaware), this PR is an attempt to fix that.