### PR TITLE
`declare_class!` macro

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `NSException` object.
 * Added `extern_class!` macro to help with defining other classes.
 * Expose the `objc2` version that this uses in the crate root.
+* Added `NSZone`.
 
 ### Changed
 * Changed a few `Debug` impls.

--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `MainThreadMarker` to help with designing APIs where a method is only
   safe to call on the main thread.
 * Added `NSException` object.
-* Added `extern_class!` macro to help with defining other classes.
+* Added `extern_class!` macro to help with defining interfaces to classes.
+* Added `declare_class!` macro to help with declaring custom classes.
 * Expose the `objc2` version that this uses in the crate root.
 * Added `NSZone`.
 

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -1,17 +1,22 @@
 use std::sync::Once;
 
-use objc2::declare::ClassBuilder;
+use objc2::declare::{ClassBuilder, Ivar, IvarType};
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{msg_send, msg_send_id, sel};
 use objc2::{Encoding, Message, RefEncode};
 use objc2_foundation::NSObject;
 
-/// In the future this should be an `extern type`, if that gets stabilized,
-/// see [RFC-1861](https://rust-lang.github.io/rfcs/1861-extern-types.html).
+struct NumberIvar;
+unsafe impl IvarType for NumberIvar {
+    type Type = u32;
+    const NAME: &'static str = "_number";
+}
+
 #[repr(C)]
 pub struct MYObject {
     inner: Object,
+    number: Ivar<NumberIvar>,
 }
 
 unsafe impl RefEncode for MYObject {
@@ -28,27 +33,19 @@ impl MYObject {
         unsafe { msg_send_id![cls, new].unwrap() }
     }
 
-    fn number(&self) -> u32 {
-        unsafe { *self.inner.ivar("_number") }
-    }
-
-    fn set_number(&mut self, number: u32) {
-        unsafe { self.inner.set_ivar("_number", number) };
-    }
-
     fn class() -> &'static Class {
         MYOBJECT_REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();
             let mut builder = ClassBuilder::new("MYObject", superclass).unwrap();
-            builder.add_ivar::<u32>("_number");
+            builder.add_ivar::<<NumberIvar as IvarType>::Type>(<NumberIvar as IvarType>::NAME);
 
             // Add ObjC methods for getting and setting the number
             extern "C" fn my_object_set_number(this: &mut MYObject, _cmd: Sel, number: u32) {
-                this.set_number(number);
+                *this.number = number;
             }
 
             extern "C" fn my_object_get_number(this: &MYObject, _cmd: Sel) -> u32 {
-                this.number()
+                *this.number
             }
 
             unsafe {
@@ -68,7 +65,7 @@ impl MYObject {
 fn main() {
     let mut obj = MYObject::new();
 
-    obj.set_number(7);
+    *obj.number = 7;
     println!("Number: {}", unsafe {
         let number: u32 = msg_send![&obj, number];
         number
@@ -77,5 +74,5 @@ fn main() {
     unsafe {
         let _: () = msg_send![&mut obj, setNumber: 12u32];
     }
-    println!("Number: {}", obj.number());
+    println!("Number: {}", obj.number);
 }

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -74,8 +74,6 @@ impl CustomAppDelegate {
 }
 
 fn main() {
-    let _cls = CustomAppDelegate::create_class(); // TMP
-
     let delegate = CustomAppDelegate::new(42, true);
 
     println!("{}", delegate.ivar);

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -25,7 +25,7 @@ declare_class! {
     }
 
     unsafe impl {
-        // #[selector(initWith:another:)]
+        @sel(initWith:another:)
         fn init_with(
             self: &mut Self,
             ivar: u8,
@@ -42,20 +42,20 @@ declare_class! {
             this
         }
 
-        // #[selector(applicationDidFinishLaunching:)]
         #[allow(unused)] // TMP
+        @sel(applicationDidFinishLaunching:)
         fn did_finish_launching(&self, _sender: *mut Object) {
             println!("Did finish launching!");
         }
 
-        // #[selector(applicationWillTerminate:)]
         #[allow(unused)] // TMP
+        @sel(applicationWillTerminate:)
         fn will_terminate(&self, _sender: *mut Object) {
             println!("Will terminate!");
         }
 
-        // #[selector(myClassMethod)]
         #[allow(unused)] // TMP
+        @sel(myClassMethod)
         fn my_class_method() {
             println!("A class method!");
         }

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -37,16 +37,6 @@ declare_class! {
             this
         }
 
-        @sel(applicationDidFinishLaunching:)
-        fn did_finish_launching(&self, _sender: *mut Object) {
-            println!("Did finish launching!");
-        }
-
-        @sel(applicationWillTerminate:)
-        fn will_terminate(&self, _: *mut Object) {
-            println!("Will terminate!");
-        }
-
         @sel(myClassMethod)
         fn my_class_method() {
             println!("A class method!");
@@ -58,6 +48,17 @@ declare_class! {
     // `clang` only when used in Objective-C...
     //
     // TODO: Investigate this!
+    unsafe impl {
+        @sel(applicationDidFinishLaunching:)
+        fn did_finish_launching(&self, _sender: *mut Object) {
+            println!("Did finish launching!");
+        }
+
+        @sel(applicationWillTerminate:)
+        fn will_terminate(&self, _: *mut Object) {
+            println!("Will terminate!");
+        }
+    }
 }
 
 impl CustomAppDelegate {

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -14,7 +14,11 @@ extern_class! {
 }
 
 declare_class! {
-    // TODO: Protocol NSApplicationDelegate
+    // For some reason, `NSApplicationDelegate` is not a "real" protocol we
+    // can retrieve using `objc_getProtocol` - it seems it is created by
+    // `clang` only when used in Objective-C...
+    //
+    // TODO: Investigate this!
     unsafe struct CustomAppDelegate: NSResponder, NSObject {
         pub ivar: u8,
         another_ivar: Bool,

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -27,12 +27,12 @@ declare_class! {
     unsafe impl {
         // #[selector(initWith:another:)]
         fn init_with(
-            this: &mut Self,
+            self: &mut Self,
             ivar: u8,
             another_ivar: Bool,
         ) -> *mut Self {
             let this: *mut Self = unsafe {
-                msg_send![super(this, NSResponder::class()), init]
+                msg_send![super(self, NSResponder::class()), init]
             };
             if let Some(this) = unsafe { this.as_mut() } {
                 // TODO: Allow initialization through MaybeUninit
@@ -52,6 +52,12 @@ declare_class! {
         #[allow(unused)] // TMP
         fn will_terminate(&self, _sender: *mut Object) {
             println!("Will terminate!");
+        }
+
+        // #[selector(myClassMethod)]
+        #[allow(unused)] // TMP
+        fn my_class_method() {
+            println!("A class method!");
         }
     }
 }

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -43,7 +43,7 @@ declare_class! {
         }
 
         @sel(applicationWillTerminate:)
-        fn will_terminate(&self, _sender: *mut Object) {
+        fn will_terminate(&self, _: *mut Object) {
             println!("Will terminate!");
         }
 

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -42,19 +42,16 @@ declare_class! {
             this
         }
 
-        #[allow(unused)] // TMP
         @sel(applicationDidFinishLaunching:)
         fn did_finish_launching(&self, _sender: *mut Object) {
             println!("Did finish launching!");
         }
 
-        #[allow(unused)] // TMP
         @sel(applicationWillTerminate:)
         fn will_terminate(&self, _sender: *mut Object) {
             println!("Will terminate!");
         }
 
-        #[allow(unused)] // TMP
         @sel(myClassMethod)
         fn my_class_method() {
             println!("A class method!");

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -1,0 +1,76 @@
+use objc2::{
+    msg_send, msg_send_id,
+    rc::{Id, Shared},
+    runtime::{Bool, Object},
+};
+use objc2_foundation::{declare_class, extern_class, NSObject};
+
+#[cfg(all(feature = "apple", target_os = "macos"))]
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {}
+
+extern_class! {
+    unsafe struct NSResponder: NSObject;
+}
+
+declare_class! {
+    // TODO: Protocol NSApplicationDelegate
+    unsafe struct CustomAppDelegate: NSResponder, NSObject {
+        pub ivar: u8,
+        another_ivar: Bool,
+    }
+
+    unsafe impl {
+        // #[selector(initWith:another:)]
+        fn init_with(
+            this: &mut Self,
+            ivar: u8,
+            another_ivar: Bool,
+        ) -> *mut Self {
+            let this: *mut Self = unsafe {
+                msg_send![super(this, NSResponder::class()), init]
+            };
+            if let Some(this) = unsafe { this.as_mut() } {
+                // TODO: Allow initialization through MaybeUninit
+                *this.ivar = ivar;
+                *this.another_ivar = another_ivar;
+            }
+            this
+        }
+
+        // #[selector(applicationDidFinishLaunching:)]
+        #[allow(unused)] // TMP
+        fn did_finish_launching(&self, _sender: *mut Object) {
+            println!("Did finish launching!");
+        }
+
+        // #[selector(applicationWillTerminate:)]
+        #[allow(unused)] // TMP
+        fn will_terminate(&self, _sender: *mut Object) {
+            println!("Will terminate!");
+        }
+    }
+}
+
+impl CustomAppDelegate {
+    pub fn new(ivar: u8, another_ivar: bool) -> Id<Self, Shared> {
+        let cls = Self::class();
+        unsafe {
+            msg_send_id![
+                msg_send_id![cls, alloc],
+                initWith: ivar,
+                another: Bool::from(another_ivar),
+            ]
+            .unwrap()
+        }
+    }
+}
+
+fn main() {
+    let _cls = CustomAppDelegate::create_class(); // TMP
+
+    let delegate = CustomAppDelegate::new(42, true);
+
+    println!("{}", delegate.ivar);
+    println!("{}", delegate.another_ivar.as_bool());
+}

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -14,11 +14,6 @@ extern_class! {
 }
 
 declare_class! {
-    // For some reason, `NSApplicationDelegate` is not a "real" protocol we
-    // can retrieve using `objc_getProtocol` - it seems it is created by
-    // `clang` only when used in Objective-C...
-    //
-    // TODO: Investigate this!
     unsafe struct CustomAppDelegate: NSResponder, NSObject {
         pub ivar: u8,
         another_ivar: Bool,
@@ -57,6 +52,12 @@ declare_class! {
             println!("A class method!");
         }
     }
+
+    // For some reason, `NSApplicationDelegate` is not a "real" protocol we
+    // can retrieve using `objc_getProtocol` - it seems it is created by
+    // `clang` only when used in Objective-C...
+    //
+    // TODO: Investigate this!
 }
 
 impl CustomAppDelegate {

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -1,0 +1,76 @@
+/// TODO
+#[macro_export]
+macro_rules! declare_class {
+    {
+        $(#[$m:meta])*
+        unsafe $v:vis struct $name:ident: $inherits:ty $(, $inheritance_rest:ty)* {
+            $($ivar_v:vis $ivar:ident: $ivar_ty:ty,)*
+        }
+
+        $(#[$impl_m:meta])*
+        unsafe impl {
+            $(
+                $s:item
+            )*
+        }
+    } => {
+        $(
+            #[allow(non_camel_case_types)]
+            $ivar_v struct $ivar {
+                __priv: (),
+            }
+
+            unsafe impl $crate::objc2::declare::IvarType for $ivar {
+                type Type = $ivar_ty;
+                const NAME: &'static str = stringify!($ivar);
+            }
+        )*
+
+        $crate::__inner_extern_class! {
+            @__inner
+            $(#[$m])*
+            unsafe $v struct $name<>: $inherits, $($inheritance_rest,)* $crate::objc2::runtime::Object {
+                $($ivar_v $ivar: $crate::objc2::declare::Ivar<$ivar>,)*
+            }
+        }
+
+        // Creation
+        impl $name {
+            fn create_class() -> &'static $crate::objc2::runtime::Class {
+                let superclass = <$inherits>::class();
+                let mut builder = $crate::objc2::declare::ClassBuilder::new(stringify!($name), superclass).unwrap();
+
+                $(
+                    builder.add_ivar::<$ivar_ty>(stringify!($ivar));
+                )*
+
+                // TODO: Fix shim
+                extern "C" fn init_with(
+                    this: &mut CustomAppDelegate,
+                    _cmd: $crate::objc2::runtime::Sel,
+                    ivar: u8,
+                    another_ivar: Bool,
+                ) -> *mut CustomAppDelegate {
+                    CustomAppDelegate::init_with(this, ivar, another_ivar)
+                }
+
+                unsafe {
+                    builder.add_method(
+                        $crate::objc2::sel!(initWith:another:),
+                        init_with as unsafe extern "C" fn(_, _, _, _) -> _,
+                    );
+                }
+
+                builder.register()
+            }
+        }
+
+        // Methods
+        $(#[$impl_m])*
+        impl $name {
+            $(
+                $s
+            )*
+        }
+    };
+}

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -255,7 +255,7 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _) -> _
     };
@@ -263,8 +263,8 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _) -> _
     };
@@ -272,9 +272,9 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _) -> _
     };
@@ -282,10 +282,10 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _) -> _
     };
@@ -293,11 +293,11 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _) -> _
     };
@@ -305,12 +305,12 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _) -> _
     };
@@ -318,13 +318,13 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _) -> _
     };
@@ -332,14 +332,14 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty,
-        $param8:ident: $param8_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty,
+        $($param8:ident)? $(_)?: $param8_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _, _) -> _
     };
@@ -347,15 +347,15 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty,
-        $param8:ident: $param8_ty:ty,
-        $param9:ident: $param9_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty,
+        $($param8:ident)? $(_)?: $param8_ty:ty,
+        $($param9:ident)? $(_)?: $param9_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _, _, _) -> _
     };
@@ -363,16 +363,16 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty,
-        $param8:ident: $param8_ty:ty,
-        $param9:ident: $param9_ty:ty,
-        $param10:ident: $param10_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty,
+        $($param8:ident)? $(_)?: $param8_ty:ty,
+        $($param9:ident)? $(_)?: $param9_ty:ty,
+        $($param10:ident)? $(_)?: $param10_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _, _, _, _) -> _
     };
@@ -380,17 +380,17 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty,
-        $param8:ident: $param8_ty:ty,
-        $param9:ident: $param9_ty:ty,
-        $param10:ident: $param10_ty:ty,
-        $param11:ident: $param11_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty,
+        $($param8:ident)? $(_)?: $param8_ty:ty,
+        $($param9:ident)? $(_)?: $param9_ty:ty,
+        $($param10:ident)? $(_)?: $param10_ty:ty,
+        $($param11:ident)? $(_)?: $param11_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _, _, _, _, _) -> _
     };
@@ -398,18 +398,18 @@ macro_rules! __inner_declare_class {
         @cast_extern_fn
         @$name:ident
 
-        $param1:ident: $param1_ty:ty,
-        $param2:ident: $param2_ty:ty,
-        $param3:ident: $param3_ty:ty,
-        $param4:ident: $param4_ty:ty,
-        $param5:ident: $param5_ty:ty,
-        $param6:ident: $param6_ty:ty,
-        $param7:ident: $param7_ty:ty,
-        $param8:ident: $param8_ty:ty,
-        $param9:ident: $param9_ty:ty,
-        $param10:ident: $param10_ty:ty,
-        $param11:ident: $param11_ty:ty,
-        $param12:ident: $param12_ty:ty $(,)?
+        $($param1:ident)? $(_)?: $param1_ty:ty,
+        $($param2:ident)? $(_)?: $param2_ty:ty,
+        $($param3:ident)? $(_)?: $param3_ty:ty,
+        $($param4:ident)? $(_)?: $param4_ty:ty,
+        $($param5:ident)? $(_)?: $param5_ty:ty,
+        $($param6:ident)? $(_)?: $param6_ty:ty,
+        $($param7:ident)? $(_)?: $param7_ty:ty,
+        $($param8:ident)? $(_)?: $param8_ty:ty,
+        $($param9:ident)? $(_)?: $param9_ty:ty,
+        $($param10:ident)? $(_)?: $param10_ty:ty,
+        $($param11:ident)? $(_)?: $param11_ty:ty,
+        $($param12:ident)? $(_)?: $param12_ty:ty $(,)?
     } => {
         Self::$name as extern "C" fn(_, _, _, _, _, _, _, _, _, _, _, _, _, _) -> _
     };

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -9,7 +9,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
 
         $($rest:tt)*
     } => {
@@ -23,7 +23,7 @@ macro_rules! __inner_declare_class {
 
             $(#[$m])*
             @sel($($sel)+)
-            $v fn $name($($args)*) $(-> $ret)? $body
+            fn $name($($args)*) $(-> $ret)? $body
         }
 
         $crate::__inner_declare_class! {
@@ -44,7 +44,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident(
+        fn $name:ident(
             &mut $self:ident
             $(, $($rest_args:tt)*)?
         ) $(-> $ret:ty)? $body:block
@@ -58,7 +58,7 @@ macro_rules! __inner_declare_class {
             @($($($rest_args)*)?)
 
             $(#[$m])*
-            $v extern "C" fn $name(
+            extern "C" fn $name(
                 &mut $self,
                 _cmd: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
@@ -73,7 +73,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident(
+        fn $name:ident(
             &$self:ident
             $(, $($rest_args:tt)*)?
         ) $(-> $ret:ty)? $body:block
@@ -87,7 +87,7 @@ macro_rules! __inner_declare_class {
             @($($($rest_args)*)?)
 
             $(#[$m])*
-            $v extern "C" fn $name(
+            extern "C" fn $name(
                 &$self,
                 _cmd: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
@@ -105,7 +105,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident(
+        fn $name:ident(
             mut $self:ident: $self_ty:ty
             $(, $($rest_args:tt)*)?
         ) $(-> $ret:ty)? $body:block
@@ -119,7 +119,7 @@ macro_rules! __inner_declare_class {
             @($($($rest_args)*)?)
 
             $(#[$m])*
-            $v extern "C" fn $name(
+            extern "C" fn $name(
                 mut $self: $self_ty,
                 _cmd: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
@@ -137,7 +137,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident(
+        fn $name:ident(
             $self:ident: $self_ty:ty
             $(, $($rest_args:tt)*)?
         ) $(-> $ret:ty)? $body:block
@@ -151,7 +151,7 @@ macro_rules! __inner_declare_class {
             @($($($rest_args)*)?)
 
             $(#[$m])*
-            $v extern "C" fn $name(
+            extern "C" fn $name(
                 $self: $self_ty,
                 _cmd: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
@@ -168,7 +168,7 @@ macro_rules! __inner_declare_class {
 
         $(#[$m:meta])*
         @sel($($sel:tt)+)
-        $v:vis fn $name:ident(
+        fn $name:ident(
             $($args:tt)*
         ) $(-> $ret:ty)? $body:block
     } => {
@@ -181,7 +181,7 @@ macro_rules! __inner_declare_class {
             @($($args)*)
 
             $(#[$m])*
-            $v extern "C" fn $name(
+            extern "C" fn $name(
                 _cls: &$crate::objc2::runtime::Class,
                 _cmd: $crate::objc2::runtime::Sel,
                 $($args)*
@@ -416,6 +416,12 @@ macro_rules! __inner_declare_class {
 }
 
 /// TODO
+///
+/// This macro is limited in a few spots, in particular:
+/// - A transformation step is performed on the methods, and hence they should
+///   not be called manually, only through a `msg_send!` (they can't be marked
+///   `pub` nor `unsafe` for the same reason).
+/// - ...
 #[macro_export]
 macro_rules! declare_class {
     {

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -3,7 +3,7 @@
 macro_rules! declare_class {
     {
         $(#[$m:meta])*
-        unsafe $v:vis struct $name:ident: $inherits:ty $(, $inheritance_rest:ty)* {
+        unsafe $v:vis struct $name:ident: $inherits:ident $(, $inheritance_rest:ident)* $(<$($protocols:ident),+ $(,)?>)? {
             $($ivar_v:vis $ivar:ident: $ivar_ty:ty,)*
         }
 
@@ -39,6 +39,13 @@ macro_rules! declare_class {
             fn create_class() -> &'static $crate::objc2::runtime::Class {
                 let superclass = <$inherits>::class();
                 let mut builder = $crate::objc2::declare::ClassBuilder::new(stringify!($name), superclass).unwrap();
+
+                // Implement protocols
+                $(
+                    $(
+                        builder.add_protocol($crate::objc2::runtime::Protocol::get(stringify!($protocols)).unwrap());
+                    )+
+                )?
 
                 $(
                     builder.add_ivar::<$ivar_ty>(stringify!($ivar));

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -682,7 +682,7 @@ macro_rules! declare_class {
 
         // Creation
         impl $name {
-            fn class() -> &'static $crate::objc2::runtime::Class {
+            $v fn class() -> &'static $crate::objc2::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`
                 use $crate::__std::sync::Once;
 

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -681,6 +681,14 @@ macro_rules! declare_class {
 
         // Creation
         impl $name {
+            #[doc = concat!(
+                "Get a reference to the Objective-C class `",
+                stringify!($name),
+                "`.",
+                "\n\n",
+                "May register the class if it wasn't already.",
+            )]
+            // TODO: Allow users to configure this?
             $v fn class() -> &'static $crate::objc2::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`
                 use $crate::__std::sync::Once;

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -6,6 +6,7 @@ macro_rules! __inner_declare_class {
         @rewrite_methods
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
 
         $($rest:tt)*
@@ -18,6 +19,7 @@ macro_rules! __inner_declare_class {
             ($($args)*)
 
             $(#[$m])*
+            @sel($($sel)+)
             $v fn $name($($args)*) $(-> $ret)? $body
         }
 
@@ -35,6 +37,7 @@ macro_rules! __inner_declare_class {
         (&mut self $($__rest_args:tt)*)
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident(
             &mut $self:ident
             $($rest_args:tt)*
@@ -53,6 +56,7 @@ macro_rules! __inner_declare_class {
         (&self $($__rest_args:tt)*)
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident(
             &$self:ident
             $($rest_args:tt)*
@@ -74,6 +78,7 @@ macro_rules! __inner_declare_class {
         )
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident(
             mut $self:ident: $self_ty:ty
             $(, $($rest_args:tt)*)?
@@ -95,6 +100,7 @@ macro_rules! __inner_declare_class {
         )
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident(
             $self:ident: $self_ty:ty
             $(, $($rest_args:tt)*)?
@@ -115,6 +121,7 @@ macro_rules! __inner_declare_class {
         ($($__args:tt)*)
 
         $(#[$m:meta])*
+        @sel($($sel:tt)+)
         $v:vis fn $name:ident(
             $($args:tt)*
         ) $(-> $ret:ty)? $body:block

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -60,7 +60,7 @@ macro_rules! __inner_declare_class {
             $(#[$m])*
             extern "C" fn $name(
                 &mut $self,
-                _cmd: $crate::objc2::runtime::Sel,
+                _: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
             ) $(-> $ret)? $body
         }
@@ -89,7 +89,7 @@ macro_rules! __inner_declare_class {
             $(#[$m])*
             extern "C" fn $name(
                 &$self,
-                _cmd: $crate::objc2::runtime::Sel,
+                _: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
             ) $(-> $ret)? $body
         }
@@ -121,7 +121,7 @@ macro_rules! __inner_declare_class {
             $(#[$m])*
             extern "C" fn $name(
                 mut $self: $self_ty,
-                _cmd: $crate::objc2::runtime::Sel,
+                _: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
             ) $(-> $ret)? $body
         }
@@ -153,7 +153,7 @@ macro_rules! __inner_declare_class {
             $(#[$m])*
             extern "C" fn $name(
                 $self: $self_ty,
-                _cmd: $crate::objc2::runtime::Sel,
+                _: $crate::objc2::runtime::Sel,
                 $($($rest_args)*)?
             ) $(-> $ret)? $body
         }
@@ -182,8 +182,8 @@ macro_rules! __inner_declare_class {
 
             $(#[$m])*
             extern "C" fn $name(
-                _cls: &$crate::objc2::runtime::Class,
-                _cmd: $crate::objc2::runtime::Sel,
+                _: &$crate::objc2::runtime::Class,
+                _: $crate::objc2::runtime::Sel,
                 $($args)*
             ) $(-> $ret)? $body
         }

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -692,7 +692,12 @@ macro_rules! declare_class {
 
                 REGISTER_CLASS.call_once(|| {
                     let superclass = <$inherits>::class();
-                    let mut builder = ClassBuilder::new(stringify!($name), superclass).unwrap();
+                    let err_str = concat!(
+                        "could not create new class ",
+                        stringify!($name),
+                        ". Perhaps a class with that name already exists?",
+                    );
+                    let mut builder = ClassBuilder::new(stringify!($name), superclass).expect(err_str);
 
                     $(
                         builder.add_ivar::<<$ivar as $crate::objc2::declare::IvarType>::Type>(
@@ -713,7 +718,8 @@ macro_rules! declare_class {
 
                     // Implement protocols
                     $(
-                        builder.add_protocol(Protocol::get(stringify!($protocols)).unwrap());
+                        let err_str = concat!("could not find protocol ", stringify!($protocols));
+                        builder.add_protocol(Protocol::get(stringify!($protocols)).expect(err_str));
 
                         // SAFETY: Upheld by caller
                         unsafe {

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -71,8 +71,11 @@ pub use self::value::NSValue;
 #[doc(no_inline)]
 pub use objc2::ffi::{NSInteger, NSUInteger};
 
+// For macros
 #[doc(hidden)]
 pub use core as __core;
+#[doc(hidden)]
+pub extern crate std as __std;
 
 // Expose the version of objc2 that this crate uses
 pub use objc2;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -87,6 +87,8 @@ extern "C" {}
 
 #[macro_use]
 mod macros;
+#[macro_use]
+mod declare_macro;
 
 mod array;
 mod attributed_string;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -65,6 +65,7 @@ pub use self::string::NSString;
 pub use self::thread::{is_main_thread, is_multi_threaded, MainThreadMarker, NSThread};
 pub use self::uuid::NSUUID;
 pub use self::value::NSValue;
+pub use self::zone::NSZone;
 
 // Available under Foundation, so makes sense here as well:
 // https://developer.apple.com/documentation/foundation/numbers_data_and_basic_values?language=objc
@@ -111,3 +112,4 @@ mod string;
 mod thread;
 mod uuid;
 mod value;
+mod zone;

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -166,7 +166,7 @@ macro_rules! __inner_extern_class {
         @__inner
         $(#[$m:meta])*
         unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident)?),*>: $inherits:ty $(, $inheritance_rest:ty)* {
-            $($p:ident: $pty:ty,)*
+            $($p_v:vis $p:ident: $pty:ty,)*
         }
     ) => {
         $(#[$m])*
@@ -174,8 +174,8 @@ macro_rules! __inner_extern_class {
         #[repr(C)]
         $v struct $name<$($t $(: $b)?),*> {
             __inner: $inherits,
-            // Additional fields (should only be zero-sized PhantomData).
-            $($p: $pty),*
+            // Additional fields (should only be zero-sized PhantomData or ivars).
+            $($p_v $p: $pty),*
         }
 
         unsafe impl<$($t $(: $b)?),*> $crate::objc2::Message for $name<$($t),*> { }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -13,6 +13,10 @@
 /// The traits [`objc2::RefEncode`] and [`objc2::Message`] are implemented to
 /// allow sending messages to the object and using it in [`objc2::rc::Id`].
 ///
+/// An associated function `class` is created on the object as a convenient
+/// shorthand so that you can do `MyObject::class()` instead of
+/// `class!(MyObject)`.
+///
 /// [`Deref`] and [`DerefMut`] are implemented and delegate to the first
 /// superclass (direct parent). Auto traits are inherited from this superclass
 /// as well (this macro effectively just creates a newtype wrapper around the
@@ -96,6 +100,13 @@ macro_rules! extern_class {
         }
 
         impl $name {
+            #[doc = concat!(
+                "Get a reference to the Objective-C class `",
+                stringify!($name),
+                "`.",
+            )]
+            #[inline]
+            // TODO: Allow users to configure this?
             $v fn class() -> &'static $crate::objc2::runtime::Class {
                 $crate::objc2::class!($name)
             }
@@ -169,6 +180,13 @@ macro_rules! __inner_extern_class {
         }
 
         impl<$($t $(: $b)?),*> $name<$($t),*> {
+            #[doc = concat!(
+                "Get a reference to the Objective-C class `",
+                stringify!($name),
+                "`.",
+            )]
+            #[inline]
+            // TODO: Allow users to configure this?
             $v fn class() -> &'static $crate::objc2::runtime::Class {
                 $crate::objc2::class!($name)
             }

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -94,6 +94,12 @@ macro_rules! extern_class {
             $(#[$m])*
             unsafe $v struct $name<>: $($inheritance_chain,)+ $crate::objc2::runtime::Object {}
         }
+
+        impl $name {
+            $v fn class() -> &'static $crate::objc2::runtime::Class {
+                $crate::objc2::class!($name)
+            }
+        }
     };
 }
 
@@ -161,6 +167,12 @@ macro_rules! __inner_extern_class {
                 $($p: $pty,)*
             }
         }
+
+        impl<$($t $(: $b)?),*> $name<$($t),*> {
+            $v fn class() -> &'static $crate::objc2::runtime::Class {
+                $crate::objc2::class!($name)
+            }
+        }
     };
     (
         @__inner
@@ -183,12 +195,6 @@ macro_rules! __inner_extern_class {
         unsafe impl<$($t $(: $b)?),*> $crate::objc2::RefEncode for $name<$($t),*> {
             const ENCODING_REF: $crate::objc2::Encoding<'static>
                 = <$inherits as $crate::objc2::RefEncode>::ENCODING_REF;
-        }
-
-        impl<$($t $(: $b)?),*> $name<$($t),*> {
-            $v fn class() -> &'static $crate::objc2::runtime::Class {
-                $crate::objc2::class!($name)
-            }
         }
 
         // SAFETY: An instance can always be _used_ in exactly the same way as

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -13,6 +13,8 @@ __inner_extern_class! {
 }
 
 impl NSObject {
+    /// Get a reference to the Objective-C class `NSObject`.
+    #[inline]
     pub fn class() -> &'static Class {
         class!(NSObject)
     }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -3,13 +3,19 @@ use core::hash;
 
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
-use objc2::{msg_send, msg_send_bool, msg_send_id};
+use objc2::{class, msg_send, msg_send_bool, msg_send_id};
 
 use super::NSString;
 
 __inner_extern_class! {
     @__inner
     unsafe pub struct NSObject<>: Object {}
+}
+
+impl NSObject {
+    pub fn class() -> &'static Class {
+        class!(NSObject)
+    }
 }
 
 impl NSObject {

--- a/objc2-foundation/src/zone.rs
+++ b/objc2-foundation/src/zone.rs
@@ -5,7 +5,8 @@ use objc2::{Encoding, RefEncode};
 /// A type used to identify and manage memory zones.
 ///
 /// Zones are ignored on all newer platforms, you should very rarely need to
-/// use this.
+/// use this, but may be useful if you need to implement `copyWithZone:` or
+/// `allocWithZone:`.
 ///
 /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nszone?language=objc).
 #[derive(Debug)]

--- a/objc2-foundation/src/zone.rs
+++ b/objc2-foundation/src/zone.rs
@@ -1,0 +1,61 @@
+#[cfg(feature = "gnustep-1-7")]
+use objc2::Encode;
+use objc2::{Encoding, RefEncode};
+
+/// A type used to identify and manage memory zones.
+///
+/// Zones are ignored on all newer platforms, you should very rarely need to
+/// use this.
+///
+/// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nszone?language=objc).
+#[derive(Debug)]
+pub struct NSZone {
+    _inner: [u8; 0],
+}
+
+unsafe impl RefEncode for NSZone {
+    #[cfg(feature = "apple")]
+    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Encoding::Struct("_NSZone", &[]));
+    #[cfg(feature = "gnustep-1-7")]
+    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Encoding::Struct(
+        "_NSZone",
+        &[
+            // Functions
+            Encoding::Pointer(&Encoding::Unknown),
+            Encoding::Pointer(&Encoding::Unknown),
+            Encoding::Pointer(&Encoding::Unknown),
+            Encoding::Pointer(&Encoding::Unknown),
+            Encoding::Pointer(&Encoding::Unknown),
+            Encoding::Pointer(&Encoding::Unknown),
+            // Stats
+            Encoding::Pointer(&Encoding::Unknown),
+            // Zone granularity
+            usize::ENCODING,
+            // Name of zone
+            Encoding::Object,
+            // Next zone
+            Encoding::Pointer(&Encoding::Struct("_NSZone", &[])),
+        ],
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::NSObject;
+    use core::ptr;
+    use objc2::msg_send_id;
+    use objc2::rc::{Allocated, Id, Owned};
+
+    use super::*;
+
+    #[test]
+    #[cfg_attr(
+        feature = "gnustep-1-7",
+        ignore = "The encoding is not really correct yet!"
+    )]
+    fn alloc_with_zone() {
+        let zone: *const NSZone = ptr::null();
+        let _obj: Id<Allocated<NSObject>, Owned> =
+            unsafe { msg_send_id![NSObject::class(), allocWithZone: zone].unwrap() };
+    }
+}

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `Class::responds_to`.
 * Added `exception::Exception` object to improve error messages from caught
   exceptions.
+* Added `declare::Ivar<T>` helper struct. This is useful for building safe
+  abstractions that access instance variables.
 
 ### Changed
 * **BREAKING**: `Sel` is now required to be non-null, which means that you

--- a/objc2/examples/declare_ivar.rs
+++ b/objc2/examples/declare_ivar.rs
@@ -1,0 +1,86 @@
+use std::mem::MaybeUninit;
+
+use objc2::declare::{ClassBuilder, Ivar, IvarType};
+use objc2::rc::{Id, Owned};
+use objc2::runtime::{Bool, Class, Object, Sel};
+use objc2::{class, msg_send, msg_send_id, sel, Encoding, Message, RefEncode};
+
+// Helper types for the two instance variables
+
+struct CustomIvar1;
+unsafe impl IvarType for CustomIvar1 {
+    type Type = i32;
+    const NAME: &'static str = "ivar1";
+}
+
+struct CustomIvar2;
+unsafe impl IvarType for CustomIvar2 {
+    type Type = Bool;
+    const NAME: &'static str = "ivar2";
+}
+
+/// Struct that represents the desired object
+#[repr(C)]
+pub struct CustomObject {
+    inner: Object,
+    // SAFETY: The instance variables are used within an object, and they are
+    // correctly declared in `create_class`.
+    ivar1: Ivar<CustomIvar1>,
+    ivar2: Ivar<CustomIvar2>,
+}
+
+// SAFETY: `Ivar<T>` is zero-sized, so it can be ignored
+unsafe impl RefEncode for CustomObject {
+    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+}
+unsafe impl Message for CustomObject {}
+
+pub fn create_class() -> &'static Class {
+    let superclass = class!(NSObject);
+    let mut builder = ClassBuilder::new("CustomObject", superclass).unwrap();
+
+    builder.add_ivar::<<CustomIvar1 as IvarType>::Type>(CustomIvar1::NAME);
+    builder.add_ivar::<<CustomIvar2 as IvarType>::Type>(CustomIvar2::NAME);
+
+    #[repr(C)]
+    pub struct PartialInit {
+        inner: Object,
+        ivar1: Ivar<MaybeUninit<CustomIvar1>>,
+        ivar2: Ivar<MaybeUninit<CustomIvar2>>,
+    }
+    unsafe impl RefEncode for PartialInit {
+        const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    }
+    unsafe impl Message for PartialInit {}
+
+    impl PartialInit {
+        extern "C" fn init(&mut self, _cmd: Sel) -> Option<&mut Self> {
+            let this: Option<&mut Self> = unsafe { msg_send![super(self, class!(NSObject)), init] };
+            this.map(|this| {
+                this.ivar1.write(42);
+                this.ivar2.write(Bool::from(true));
+                this
+            })
+        }
+    }
+
+    unsafe {
+        builder.add_method(sel!(init), PartialInit::init as extern "C" fn(_, _) -> _);
+    }
+
+    builder.register()
+}
+
+fn main() {
+    let cls = create_class();
+    let mut obj: Id<CustomObject, Owned> = unsafe { msg_send_id![cls, new].unwrap() };
+
+    println!("Ivar1: {:?}", obj.ivar1);
+    println!("Ivar2: {:?}", obj.ivar2);
+
+    *obj.ivar1 += 1;
+    *obj.ivar2 = Bool::from(false);
+
+    println!("Ivar1: {:?}", obj.ivar1);
+    println!("Ivar2: {:?}", obj.ivar2);
+}

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -265,7 +265,8 @@ impl ClassBuilder {
         assert_eq!(
             sel_args,
             encs.len(),
-            "Selector accepts {} arguments, but function accepts {}",
+            "Selector {:?} accepts {} arguments, but function accepts {}",
+            sel,
             sel_args,
             encs.len(),
         );
@@ -306,7 +307,8 @@ impl ClassBuilder {
         assert_eq!(
             sel_args,
             encs.len(),
-            "Selector accepts {} arguments, but function accepts {}",
+            "Selector {:?} accepts {} arguments, but function accepts {}",
+            sel,
             sel_args,
             encs.len(),
         );
@@ -417,7 +419,8 @@ impl ProtocolBuilder {
         assert_eq!(
             sel_args,
             encs.len(),
-            "Selector accepts {} arguments, but function accepts {}",
+            "Selector {:?} accepts {} arguments, but function accepts {}",
+            sel,
             sel_args,
             encs.len(),
         );

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -37,6 +37,9 @@
 //! decl.register();
 //! ```
 
+mod ivar;
+mod ivar_forwarding_impls;
+
 use alloc::format;
 use alloc::string::ToString;
 use core::mem;
@@ -47,6 +50,8 @@ use std::ffi::CString;
 
 use crate::runtime::{Bool, Class, Imp, Object, Protocol, Sel};
 use crate::{ffi, Encode, EncodeArguments, Encoding, Message, RefEncode};
+
+pub use ivar::{Ivar, IvarType};
 
 pub(crate) mod private {
     pub trait Sealed {}

--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -1,0 +1,241 @@
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
+
+use crate::runtime::Object;
+use crate::Encode;
+
+/// Helper trait for defining instance variables.
+///
+/// This should be implemented for an empty marker type, which can then be
+/// used within [`Ivar`] to refer to the instance variable.
+///
+///
+/// # Safety
+///
+/// Really, [`Ivar`] should be marked as `unsafe`, but since we can't do that
+/// we'll mark this trait as `unsafe` instead. See [`Ivar`] for safety
+/// requirements.
+///
+///
+/// # Examples
+///
+/// Create an instance variable `myCustomIvar` with type `i32`.
+///
+/// ```
+/// use objc2::declare::IvarType;
+///
+/// // Helper type
+/// struct MyCustomIvar;
+///
+/// unsafe impl IvarType for MyCustomIvar {
+///     type Type = i32;
+///     const NAME: &'static str = "myCustomIvar";
+/// }
+///
+/// // `Ivar<MyCustomIvar>` can now be used
+/// ```
+pub unsafe trait IvarType {
+    /// The type of the instance variable.
+    type Type: Encode;
+    /// The name of the instance variable.
+    const NAME: &'static str;
+}
+
+unsafe impl<T: IvarType> IvarType for MaybeUninit<T> {
+    type Type = MaybeUninit<T::Type>;
+    const NAME: &'static str = T::NAME;
+}
+
+/// A wrapper type over a custom instance variable.
+///
+/// This type is not meant to be constructed by itself, it must reside within
+/// another struct meant to represent an Objective-C object.
+///
+/// On [`Deref`] it then uses the [`IvarType::NAME`] string to access the ivar
+/// of the containing object.
+///
+/// Note that this is not ([currently][zst-hack]) allowed by [stacked
+/// borrows][sb], but due to [`Object`] being a zero-sized type such that we
+/// don't have provenance over the ivars anyhow, this should be just as sound
+/// as normal instance variable access.
+///
+/// [sb]: https://github.com/rust-lang/unsafe-code-guidelines/blob/e21202c60c7be03dd2ab016ada92fb5305d40438/wip/stacked-borrows.md
+/// [zst-hack]: https://github.com/rust-lang/unsafe-code-guidelines/issues/305
+///
+///
+/// # Safety
+///
+/// This must be used within a type that act as an Objective-C object. In
+/// particular, this is never safe to have on the stack by itself.
+///
+/// Additionally, the instance variable described by `T` must be available on
+/// the specific instance, and be of the exact same type.
+///
+/// Finally, two ivars with the same name must not be used on the same object.
+///
+///
+/// # Examples
+///
+/// ```
+/// use objc2::declare::{Ivar, IvarType};
+/// use objc2::runtime::Object;
+/// #
+/// # #[cfg(feature = "gnustep-1-7")]
+/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
+///
+/// // Declare ivar with given type and name
+/// struct MyCustomIvar;
+/// unsafe impl IvarType for MyCustomIvar {
+///     type Type = i32;
+///     const NAME: &'static str = "myCustomIvar";
+/// }
+///
+/// // Custom object
+/// #[repr(C)]
+/// pub struct MyObject {
+///     inner: Object,
+///     // SAFETY: The instance variable is used within an object, and it is
+///     // properly declared below.
+///     my_ivar: Ivar<MyCustomIvar>,
+/// }
+///
+/// # use objc2::class;
+/// # use objc2::declare::ClassBuilder;
+/// # let mut builder = ClassBuilder::new("MyObject", class!(NSObject)).unwrap();
+/// // Declare the class and add the instance variable to it
+/// builder.add_ivar::<<MyCustomIvar as IvarType>::Type>(MyCustomIvar::NAME);
+/// # let _cls = builder.register();
+///
+/// let obj: MyObject;
+/// // You can now access `obj.my_ivar`
+/// ```
+///
+/// See also the `declare_ivar.rs` example.
+#[repr(C)]
+// Must not be `Copy` nor `Clone`!
+pub struct Ivar<T: IvarType> {
+    /// Make this type allowed in `repr(C)`
+    inner: [u8; 0],
+    /// For proper variance and auto traits
+    item: PhantomData<T::Type>,
+}
+
+impl<T: IvarType> Deref for Ivar<T> {
+    type Target = T::Type;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The user ensures that this is placed in a struct that can
+        // be reinterpreted as an `Object`. Since `Ivar` can never be
+        // constructed by itself (and is neither Copy nor Clone), we know that
+        // it is guaranteed to _stay_ in said struct.
+        //
+        // Even if the user were to do `mem::swap`, the `Ivar` has a unique
+        // type (and does not hold any data), so that wouldn't break anything.
+        //
+        // Note: We technically don't have provenance over the object, nor the
+        // ivar, but the object doesn't have provenance over the ivar either,
+        // so that is fine.
+        let ptr = NonNull::from(self).cast::<Object>();
+        let obj = unsafe { ptr.as_ref() };
+
+        // SAFETY: User ensures that the `Ivar<T>` is only used when the ivar
+        // exists and has the correct type
+        unsafe { obj.ivar::<T::Type>(T::NAME) }
+    }
+}
+
+impl<T: IvarType> DerefMut for Ivar<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let ptr = NonNull::from(self).cast::<Object>();
+        // SAFETY: Same as `deref`.
+        //
+        // Note: We don't use `mut` because the user might have two mutable
+        // references to different ivars, as such:
+        //
+        // ```
+        // #[repr(C)]
+        // struct X {
+        //     inner: Object,
+        //     ivar1: Ivar<Ivar1>,
+        //     ivar2: Ivar<Ivar2>,
+        // }
+        //
+        // let mut x: X;
+        // let ivar1: &mut Ivar<Ivar1> = &mut x.ivar1;
+        // let ivar2: &mut Ivar<Ivar2> = &mut x.ivar2;
+        // ```
+        //
+        // And using `mut` would create aliasing mutable reference to the
+        // object.
+        //
+        // TODO: Not entirely sure, it might be safe to just do `as_mut`, but
+        // this is definitely safe.
+        let obj = unsafe { ptr.as_ref() };
+
+        // SAFETY: Same as `deref`
+        //
+        // Safe as mutable because there is only one access to a particular
+        // ivar at a time (since we have `&mut self`). `Object` is
+        // `UnsafeCell`, so mutable access through `&Object` is allowed.
+        unsafe { obj.ivar_ptr::<T::Type>(T::NAME).as_mut().unwrap_unchecked() }
+    }
+}
+
+/// Format as a pointer to the instance variable.
+impl<T: IvarType> fmt::Pointer for Ivar<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ptr: *const T::Type = &**self;
+        fmt::Pointer::fmt(&ptr, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem;
+    use core::panic::{RefUnwindSafe, UnwindSafe};
+
+    use super::*;
+    use crate::{test_utils, MessageReceiver};
+
+    struct TestIvar;
+
+    unsafe impl IvarType for TestIvar {
+        type Type = u32;
+        const NAME: &'static str = "_foo";
+    }
+
+    #[repr(C)]
+    struct IvarTestObject {
+        inner: Object,
+        foo: Ivar<TestIvar>,
+    }
+
+    #[test]
+    fn auto_traits() {
+        fn assert_auto_traits<T: Unpin + UnwindSafe + RefUnwindSafe + Sized + Send + Sync>() {}
+        assert_auto_traits::<Ivar<TestIvar>>();
+
+        // Ensure that `Ivar` is zero-sized
+        assert_eq!(mem::size_of::<Ivar<TestIvar>>(), 0);
+        assert_eq!(mem::align_of::<Ivar<TestIvar>>(), 1);
+    }
+
+    #[test]
+    fn access_ivar() {
+        let mut obj = test_utils::custom_object();
+        let _: () = unsafe { msg_send![&mut obj, setFoo: 42u32] };
+
+        let obj = unsafe {
+            obj.__as_raw_receiver()
+                .cast::<IvarTestObject>()
+                .as_ref()
+                .unwrap()
+        };
+        assert_eq!(*obj.foo, 42);
+    }
+}

--- a/objc2/src/declare/ivar_forwarding_impls.rs
+++ b/objc2/src/declare/ivar_forwarding_impls.rs
@@ -1,0 +1,337 @@
+//! Trivial forwarding impls on `Ivar`.
+//!
+//! Kept here to keep `ivar.rs` free from this boilerplate.
+//!
+//! `#[inline]` is used where the standard library `Box` uses it.
+
+#![forbid(unsafe_code)]
+
+// use alloc::borrow;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt;
+use core::future::Future;
+use core::hash;
+use core::iter::FusedIterator;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::error::Error;
+use std::io;
+
+use super::{Ivar, IvarType};
+
+impl<T: IvarType> PartialEq for Ivar<T>
+where
+    T::Type: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        (**self).eq(&**other)
+    }
+
+    #[inline]
+    #[allow(clippy::partialeq_ne_impl)]
+    fn ne(&self, other: &Self) -> bool {
+        (**self).ne(&**other)
+    }
+}
+
+impl<T: IvarType> Eq for Ivar<T> where T::Type: Eq {}
+
+impl<T: IvarType> PartialOrd for Ivar<T>
+where
+    T::Type: PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+    #[inline]
+    fn lt(&self, other: &Self) -> bool {
+        (**self).lt(&**other)
+    }
+    #[inline]
+    fn le(&self, other: &Self) -> bool {
+        (**self).le(&**other)
+    }
+    #[inline]
+    fn ge(&self, other: &Self) -> bool {
+        (**self).ge(&**other)
+    }
+    #[inline]
+    fn gt(&self, other: &Self) -> bool {
+        (**self).gt(&**other)
+    }
+}
+
+impl<T: IvarType> Ord for Ivar<T>
+where
+    T::Type: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
+impl<T: IvarType> hash::Hash for Ivar<T>
+where
+    T::Type: hash::Hash,
+{
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        (**self).hash(state)
+    }
+}
+
+impl<T: IvarType> hash::Hasher for Ivar<T>
+where
+    T::Type: hash::Hasher,
+{
+    fn finish(&self) -> u64 {
+        (**self).finish()
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        (**self).write(bytes)
+    }
+    fn write_u8(&mut self, i: u8) {
+        (**self).write_u8(i)
+    }
+    fn write_u16(&mut self, i: u16) {
+        (**self).write_u16(i)
+    }
+    fn write_u32(&mut self, i: u32) {
+        (**self).write_u32(i)
+    }
+    fn write_u64(&mut self, i: u64) {
+        (**self).write_u64(i)
+    }
+    fn write_u128(&mut self, i: u128) {
+        (**self).write_u128(i)
+    }
+    fn write_usize(&mut self, i: usize) {
+        (**self).write_usize(i)
+    }
+    fn write_i8(&mut self, i: i8) {
+        (**self).write_i8(i)
+    }
+    fn write_i16(&mut self, i: i16) {
+        (**self).write_i16(i)
+    }
+    fn write_i32(&mut self, i: i32) {
+        (**self).write_i32(i)
+    }
+    fn write_i64(&mut self, i: i64) {
+        (**self).write_i64(i)
+    }
+    fn write_i128(&mut self, i: i128) {
+        (**self).write_i128(i)
+    }
+    fn write_isize(&mut self, i: isize) {
+        (**self).write_isize(i)
+    }
+}
+
+impl<T: IvarType> fmt::Display for Ivar<T>
+where
+    T::Type: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<T: IvarType> fmt::Debug for Ivar<T>
+where
+    T::Type: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<I: IvarType> Iterator for Ivar<I>
+where
+    I::Type: Iterator,
+{
+    type Item = <I::Type as Iterator>::Item;
+    fn next(&mut self) -> Option<<I::Type as Iterator>::Item> {
+        (**self).next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
+    fn nth(&mut self, n: usize) -> Option<<I::Type as Iterator>::Item> {
+        (**self).nth(n)
+    }
+}
+
+impl<I: IvarType> DoubleEndedIterator for Ivar<I>
+where
+    I::Type: DoubleEndedIterator,
+{
+    fn next_back(&mut self) -> Option<<I::Type as Iterator>::Item> {
+        (**self).next_back()
+    }
+    fn nth_back(&mut self, n: usize) -> Option<<I::Type as Iterator>::Item> {
+        (**self).nth_back(n)
+    }
+}
+
+impl<I: IvarType> ExactSizeIterator for Ivar<I>
+where
+    I::Type: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+}
+
+impl<I: IvarType> FusedIterator for Ivar<I> where I::Type: FusedIterator {}
+
+// impl<T: IvarType> borrow::Borrow<T::Type> for Ivar<T> {
+//     fn borrow(&self) -> &T::Type {
+//         Deref::deref(self)
+//     }
+// }
+//
+// impl<T: IvarType> borrow::BorrowMut<T::Type> for Ivar<T> {
+//     fn borrow_mut(&mut self) -> &mut T::Type {
+//         DerefMut::deref_mut(self)
+//     }
+// }
+
+impl<T: IvarType> AsRef<T::Type> for Ivar<T> {
+    fn as_ref(&self) -> &T::Type {
+        Deref::deref(self)
+    }
+}
+
+impl<T: IvarType> AsMut<T::Type> for Ivar<T> {
+    fn as_mut(&mut self) -> &mut T::Type {
+        DerefMut::deref_mut(self)
+    }
+}
+
+impl<T: IvarType> Error for Ivar<T>
+where
+    T::Type: Error,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        (**self).source()
+    }
+}
+
+impl<T: IvarType> io::Read for Ivar<T>
+where
+    T::Type: io::Read,
+{
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        (**self).read_vectored(bufs)
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        (**self).read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        (**self).read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+impl<T: IvarType> io::Write for Ivar<T>
+where
+    T::Type: io::Write,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (**self).write(buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        (**self).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        (**self).flush()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (**self).write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        (**self).write_fmt(fmt)
+    }
+}
+
+impl<T: IvarType> io::Seek for Ivar<T>
+where
+    T::Type: io::Seek,
+{
+    #[inline]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        (**self).seek(pos)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (**self).stream_position()
+    }
+}
+
+impl<T: IvarType> io::BufRead for Ivar<T>
+where
+    T::Type: io::BufRead,
+{
+    #[inline]
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        (**self).fill_buf()
+    }
+
+    #[inline]
+    fn consume(&mut self, amt: usize) {
+        (**self).consume(amt)
+    }
+
+    #[inline]
+    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<usize> {
+        (**self).read_until(byte, buf)
+    }
+
+    #[inline]
+    fn read_line(&mut self, buf: &mut String) -> io::Result<usize> {
+        (**self).read_line(buf)
+    }
+}
+
+impl<T: IvarType> Future for Ivar<T>
+where
+    T::Type: Future + Unpin,
+{
+    type Output = <T::Type as Future>::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        <T::Type as Future>::poll(Pin::new(&mut *self), cx)
+    }
+}
+
+// TODO: impl Fn traits, CoerceUnsized, Stream and so on when stabilized


### PR DESCRIPTION
~Blocked on https://github.com/madsmtm/objc2/pull/193.~

Solves a big part of https://github.com/madsmtm/objc2/issues/30. Fixes upstream https://github.com/SSheldon/rust-objc/issues/74.

Related to https://github.com/madsmtm/objc2/pull/161, and has a few of the same limitations when it comes to defining methods.

Syntax:
```rust
declare_class! {
    // Similar to `extern_class!`
    // Implements protocol `NSApplicationDelegate`
    unsafe struct CustomAppDelegate: NSResponder, NSObject <NSApplicationDelegate> {
        pub ivar: u8,
        another_ivar: Bool,
    }

    unsafe impl {
        @sel(abc:defGhi:)
        fn abc_def_ghi(&self, arg1: &Object, arg2: i32) {
            println!("{}", self.ivar + arg2);
        }
    }
}

// Generates

pub struct ivar;
unsafe impl objc2::declare::IvarType for ivar {
    type Type = u8;
    const NAME: &'static str = "ivar";
}

struct another_ivar;
unsafe impl objc2::declare::IvarType for another_ivar {
    type Type = Bool;
    const NAME: &'static str = "another_ivar";
}

struct CustomAppDelegate: NSResponder, NSObject <NSApplicationDelegate> {
    pub ivar: objc2::declare::Ivar<ivar>,
    another_ivar: objc2::declare::Ivar<another_ivar>,
}

impl CustomAppDelegate {
    // Added `extern "C"` and `Sel` argument
    extern "C" fn abc_def_ghi(&self, _: Sel, arg1: &Object, arg2: i32) {
        println!("{}", self.ivar + arg2);
    }
}

impl CustomAppDelegate {
    fn __create_class() -> &'static Class {
        let superclass = NSResponder::class(); // Subclasses `NSResponder`
        let mut builder = ClassBuilder::new("CustomAppDelegate", superclass).unwrap();

        // Implement protocols
        builder.add_protocol(Protocol::get("NSApplicationDelegate"));

        // Declare ivars
        builder.add_ivar::<<ivar as IvarType>::Type>(<ivar as IvarType>::NAME);
        builder.add_ivar::<<another_ivar as IvarType>::Type>(<another_ivar as IvarType>::NAME);

        // Declare methods
        unsafe {
            builder.add_method(
                sel!(abc:defGhi:),
                CustomAppDelegate::abc_def_ghi as extern "C" fn(_, _, _, _) -> _,
            );
        }

        builder.register()
    }

    pub fn class() -> &'static Class {
        static REGISTER: Once = Once::new();
        REGISTER.call_once(Self::__create_class);
        Class::get("CustomAppDelegate").unwrap()
    }
}
```

The really cool thing here is the instance variable setup, with that, users can just do `self.ivar` in a completely hassle-free manner!