### PR TITLE
Add `Id::autorelease_return`

### DIFF
--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -9,10 +9,13 @@
 //! has one ivar, a `u32` named `_number` and a `number` method that returns
 //! it:
 //!
-//! ```no_run
+//! ```
 //! use objc2::{class, sel};
 //! use objc2::declare::ClassBuilder;
 //! use objc2::runtime::{Class, Object, Sel};
+//! #
+//! # #[cfg(feature = "gnustep-1-7")]
+//! # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 //!
 //! let superclass = class!(NSObject);
 //! let mut decl = ClassBuilder::new("MyNumber", superclass).unwrap();


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/30.

Calls `objc_autoreleaseReturnValue`. Required for most custom declared methods that return objects.