### PR TITLE
Consistently implement `MethodImplementation` wrt. lifetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ runtime libraries.
 It is recommended that you upgrade in small steps, to decrease the chance of
 making a mistake somewhere. This way, you can under each release review the
 relevant changelogs and run your test suite, to ensure you haven't missed
-something.
+something. For the most common errors, the changelogs will include a helpful
+example on how to upgrade.
 
 As an example, if you want to migrate to `objc2`, you'd start by using it
 instead of `objc` in your `Cargo.toml`:

--- a/objc2-foundation/examples/class_with_lifetime.rs
+++ b/objc2-foundation/examples/class_with_lifetime.rs
@@ -63,8 +63,7 @@ impl<'a> MyObject<'a> {
             }
 
             unsafe {
-                let init_with_ptr: unsafe extern "C" fn(*mut Object, Sel, *mut u8) -> *mut Object =
-                    init_with_ptr;
+                let init_with_ptr: unsafe extern "C" fn(_, _, _) -> _ = init_with_ptr;
                 builder.add_method(sel!(initWithPtr:), init_with_ptr);
             }
 

--- a/objc2-foundation/examples/custom_class.rs
+++ b/objc2-foundation/examples/custom_class.rs
@@ -52,9 +52,9 @@ impl MYObject {
             }
 
             unsafe {
-                let set_number: extern "C" fn(&mut MYObject, Sel, u32) = my_object_set_number;
+                let set_number: extern "C" fn(_, _, _) = my_object_set_number;
                 builder.add_method(sel!(setNumber:), set_number);
-                let get_number: extern "C" fn(&MYObject, Sel) -> u32 = my_object_get_number;
+                let get_number: extern "C" fn(_, _) -> _ = my_object_get_number;
                 builder.add_method(sel!(number), get_number);
             }
 

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -520,7 +520,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
     /// unsafe {
     ///     builder.add_class_method(
     ///         sel!(get),
-    ///         get as extern "C" fn(&Class, Sel) -> *mut Object,
+    ///         get as extern "C" fn(_, _) -> _,
     ///     );
     /// }
     ///

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -118,31 +118,16 @@ impl RcTestObject {
 
             let mut builder = ClassBuilder::new("RcTestObject", class!(NSObject)).unwrap();
             unsafe {
-                builder.add_class_method(
-                    sel!(alloc),
-                    alloc as extern "C" fn(&Class, Sel) -> *mut RcTestObject,
-                );
-                builder.add_method(
-                    sel!(init),
-                    init as extern "C" fn(&mut RcTestObject, Sel) -> _,
-                );
-                builder.add_method(
-                    sel!(retain),
-                    retain as extern "C" fn(&RcTestObject, Sel) -> _,
-                );
+                builder.add_class_method(sel!(alloc), alloc as extern "C" fn(_, _) -> _);
+                builder.add_method(sel!(init), init as extern "C" fn(_, _) -> _);
+                builder.add_method(sel!(retain), retain as extern "C" fn(_, _) -> _);
                 builder.add_method(
                     sel!(_tryRetain),
-                    try_retain as unsafe extern "C" fn(&RcTestObject, Sel) -> Bool,
+                    try_retain as unsafe extern "C" fn(_, _) -> _,
                 );
-                builder.add_method(sel!(release), release as extern "C" fn(&RcTestObject, Sel));
-                builder.add_method(
-                    sel!(autorelease),
-                    autorelease as extern "C" fn(&RcTestObject, Sel) -> _,
-                );
-                builder.add_method(
-                    sel!(dealloc),
-                    dealloc as unsafe extern "C" fn(*mut RcTestObject, Sel),
-                );
+                builder.add_method(sel!(release), release as extern "C" fn(_, _));
+                builder.add_method(sel!(autorelease), autorelease as extern "C" fn(_, _) -> _);
+                builder.add_method(sel!(dealloc), dealloc as unsafe extern "C" fn(_, _));
             }
 
             builder.register();

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -94,7 +94,7 @@ pub(crate) fn custom_class() -> &'static Class {
 
         let mut builder = ClassBuilder::root(
             "CustomObject",
-            custom_obj_class_initialize as extern "C" fn(&Class, Sel),
+            custom_obj_class_initialize as extern "C" fn(_, _),
         )
         .unwrap();
         let proto = custom_protocol();
@@ -113,6 +113,10 @@ pub(crate) fn custom_class() -> &'static Class {
 
         extern "C" fn custom_obj_get_foo(this: &Object, _cmd: Sel) -> u32 {
             unsafe { *this.ivar::<u32>("_foo") }
+        }
+
+        extern "C" fn custom_obj_get_foo_reference(this: &Object, _cmd: Sel) -> &u32 {
+            unsafe { this.ivar::<u32>("_foo") }
         }
 
         extern "C" fn custom_obj_get_struct(_this: &Object, _cmd: Sel) -> CustomStruct {
@@ -144,21 +148,23 @@ pub(crate) fn custom_class() -> &'static Class {
         }
 
         unsafe {
-            let release: unsafe extern "C" fn(*mut Object, Sel) = custom_obj_release;
+            let release: unsafe extern "C" fn(_, _) = custom_obj_release;
             builder.add_method(sel!(release), release);
 
-            let set_foo: extern "C" fn(&mut Object, Sel, u32) = custom_obj_set_foo;
+            let set_foo: extern "C" fn(_, _, _) = custom_obj_set_foo;
             builder.add_method(sel!(setFoo:), set_foo);
-            let get_foo: extern "C" fn(&Object, Sel) -> u32 = custom_obj_get_foo;
+            let get_foo: extern "C" fn(_, _) -> _ = custom_obj_get_foo;
             builder.add_method(sel!(foo), get_foo);
-            let get_struct: extern "C" fn(&Object, Sel) -> CustomStruct = custom_obj_get_struct;
+            let get_foo_reference: extern "C" fn(_, _) -> _ = custom_obj_get_foo_reference;
+            builder.add_method(sel!(fooReference), get_foo_reference);
+            let get_struct: extern "C" fn(_, _) -> CustomStruct = custom_obj_get_struct;
             builder.add_method(sel!(customStruct), get_struct);
-            let class_method: extern "C" fn(&Class, Sel) -> u32 = custom_obj_class_method;
+            let class_method: extern "C" fn(_, _) -> _ = custom_obj_class_method;
             builder.add_class_method(sel!(classFoo), class_method);
 
-            let protocol_instance_method: extern "C" fn(&mut Object, Sel, u32) = custom_obj_set_bar;
+            let protocol_instance_method: extern "C" fn(_, _, _) = custom_obj_set_bar;
             builder.add_method(sel!(setBar:), protocol_instance_method);
-            let protocol_class_method: extern "C" fn(&Class, Sel, i32, i32) -> i32 =
+            let protocol_class_method: extern "C" fn(_, _, _, _) -> _ =
                 custom_obj_add_number_to_number;
             builder.add_class_method(sel!(addNumber:toNumber:), protocol_class_method);
         }
@@ -218,7 +224,7 @@ pub(crate) fn custom_subclass() -> &'static Class {
         }
 
         unsafe {
-            let get_foo: extern "C" fn(&Object, Sel) -> u32 = custom_subclass_get_foo;
+            let get_foo: extern "C" fn(_, _) -> _ = custom_subclass_get_foo;
             builder.add_method(sel!(foo), get_foo);
         }
 

--- a/tests/ui/fn_ptr_reference_method.rs
+++ b/tests/ui/fn_ptr_reference_method.rs
@@ -15,13 +15,13 @@ fn main() {
     let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
     unsafe {
         // Works
-        builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
+        builder.add_method(sel!(none:), my_fn as extern "C" fn(_, _, _));
 
         // Fails
-        builder.add_method(sel!(none:), my_fn as extern "C" fn(_, _, _));
         builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &Object));
 
         // Also fails, properly tested in `fn_ptr_reference_method2`
+        builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, _, &Object));
     }
 }

--- a/tests/ui/fn_ptr_reference_method.stderr
+++ b/tests/ui/fn_ptr_reference_method.stderr
@@ -1,44 +1,20 @@
-error[E0277]: the trait bound `extern "C" fn(_, _, _): MethodImplementation` is not satisfied
-   --> ui/fn_ptr_reference_method.rs:21:41
-    |
-21  |         builder.add_method(sel!(none:), my_fn as extern "C" fn(_, _, _));
-    |                 ----------              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MethodImplementation` is not implemented for `extern "C" fn(_, _, _)`
-    |                 |
-    |                 required by a bound introduced by this call
-    |
-    = help: the following other types implement trait `MethodImplementation`:
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
-            and 109 others
-note: required by a bound in `ClassBuilder::add_method`
-   --> $WORKSPACE/objc2/src/declare.rs
-    |
-    |         F: MethodImplementation<Callee = T>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilder::add_method`
-
 error[E0277]: the trait bound `for<'r> extern "C" fn(_, _, &'r objc2::runtime::Object): MethodImplementation` is not satisfied
-   --> ui/fn_ptr_reference_method.rs:22:42
+   --> ui/fn_ptr_reference_method.rs:21:42
     |
-22  |         builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &Object));
+21  |         builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &Object));
     |                 ----------               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MethodImplementation` is not implemented for `for<'r> extern "C" fn(_, _, &'r objc2::runtime::Object)`
     |                 |
     |                 required by a bound introduced by this call
     |
     = help: the following other types implement trait `MethodImplementation`:
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-              for<'r> extern "C" fn(&'r T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+              extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
             and 109 others
 note: required by a bound in `ClassBuilder::add_method`
    --> $WORKSPACE/objc2/src/declare.rs

--- a/tests/ui/fn_ptr_reference_method2.rs
+++ b/tests/ui/fn_ptr_reference_method2.rs
@@ -9,6 +9,7 @@ extern "C" fn my_fn(_this: &Object, _cmd: Sel, _x: &Object) {}
 fn main() {
     let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
     unsafe {
+        builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
     }
 }

--- a/tests/ui/fn_ptr_reference_method2.stderr
+++ b/tests/ui/fn_ptr_reference_method2.stderr
@@ -1,8 +1,26 @@
 error: implementation of `MethodImplementation` is not general enough
   --> ui/fn_ptr_reference_method2.rs:12:9
    |
-12 |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
+12 |         builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+   |
+   = note: `MethodImplementation` would have to be implemented for the type `for<'r> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`
+   = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`, for some specific lifetime `'0`
+
+error: implementation of `MethodImplementation` is not general enough
+  --> ui/fn_ptr_reference_method2.rs:13:9
+   |
+13 |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
    |
    = note: `MethodImplementation` would have to be implemented for the type `for<'r, 's> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &'s objc2::runtime::Object)`
-   = note: ...but `MethodImplementation` is actually implemented for the type `for<'r> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &'0 objc2::runtime::Object)`, for some specific lifetime `'0`
+   = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`, for some specific lifetime `'0`
+
+error: implementation of `MethodImplementation` is not general enough
+  --> ui/fn_ptr_reference_method2.rs:13:9
+   |
+13 |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+   |
+   = note: `MethodImplementation` would have to be implemented for the type `for<'r, 's> extern "C" fn(&'r objc2::runtime::Object, objc2::runtime::Sel, &'s objc2::runtime::Object)`
+   = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&objc2::runtime::Object, objc2::runtime::Sel, &'0 objc2::runtime::Object)`, for some specific lifetime `'0`


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/30. This is required for https://github.com/madsmtm/objc2/pull/190.

Fixes upstream https://github.com/SSheldon/rust-objc/issues/12, see that for more details.

Previously, the receiver's lifetime was higher-ranked, while the rest of the arguments weren't, which meant that:
- Their type could not be inferred like the other arguments
- Having a return type with a lifetime bound to the receiver was impossible

This is a breaking change (can't avoid that, lest we run into a future-compat error), and is unfortunately difficult for users to know how to fix, not really sure how to improve that situation?