### PR TITLE
Deduplicate common selectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ members = [
     "test-ui",
 ]
 resolver = "2"
+
+[profile.assembly-tests]
+inherits = "release"
+# Enable LTO to allow testing the `unstable-static-sel-inlined` feature
+lto = true

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -1,3 +1,4 @@
+use crate::__sel_inner;
 use crate::rc::{Allocated, Id, Ownership};
 use crate::runtime::{Class, Sel};
 use crate::{Message, MessageArguments, MessageReceiver};
@@ -11,6 +12,31 @@ pub use core::primitive::{bool, str, u8};
 pub use core::{compile_error, concat, panic, stringify};
 #[cfg(feature = "objc2-proc-macros")]
 pub use objc2_proc_macros::__hash_idents;
+
+// Common selectors.
+//
+// These are put here to deduplicate the cached selector, and when using
+// `unstable-static-sel`, the statics.
+//
+// Note that our assembly tests of `unstable-static-sel-inlined` output a GOT
+// entry for such accesses, but that is just a limitation of our tests - the
+// actual assembly is as one would expect.
+
+#[inline]
+pub fn alloc() -> Sel {
+    // SAFETY: Must have NUL byte
+    __sel_inner!("alloc\0", uniqueIdent)
+}
+#[inline]
+pub fn init() -> Sel {
+    // SAFETY: Must have NUL byte
+    __sel_inner!("init\0", uniqueIdent)
+}
+#[inline]
+pub fn new() -> Sel {
+    // SAFETY: Must have NUL byte
+    __sel_inner!("new\0", uniqueIdent)
+}
 
 /// Helper for specifying the retain semantics for a given selector family.
 ///

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
@@ -16,21 +16,24 @@ _handle_alloc_init:
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
 Lloh2:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32@GOTPAGE
 Lloh3:
-	ldr	x19, [x8, L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328@PAGEOFF]
+	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32@GOTPAGEOFF]
 Lloh4:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_dcb825748735621d@PAGE
+	ldr	x19, [x8]
 Lloh5:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_dcb825748735621d@PAGEOFF]
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPAGE
+Lloh6:
+	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPAGEOFF]
+Lloh7:
+	ldr	x1, [x8]
 	bl	_objc_msgSend
 	mov	x1, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_msgSend
-	.loh AdrpLdr	Lloh4, Lloh5
-	.loh AdrpAdrp	Lloh2, Lloh4
-	.loh AdrpLdr	Lloh2, Lloh3
+	.loh AdrpLdrGotLdr	Lloh5, Lloh6, Lloh7
+	.loh AdrpLdrGotLdr	Lloh2, Lloh3, Lloh4
 
 	.globl	_use_generic
 	.p2align	2
@@ -39,32 +42,32 @@ _use_generic:
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
 	mov	x19, x0
-Lloh6:
+Lloh8:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_f16064a6f68ca673@PAGE
-Lloh7:
+Lloh9:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_f16064a6f68ca673@PAGEOFF]
 	adrp	x20, L_OBJC_SELECTOR_REFERENCES_457d234345d46cbe@PAGE
 	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_457d234345d46cbe@PAGEOFF]
 	bl	_objc_msgSend
-Lloh8:
+Lloh10:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_9f134b97cb598446@PAGE
-Lloh9:
+Lloh11:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_9f134b97cb598446@PAGEOFF]
 	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_457d234345d46cbe@PAGEOFF]
 	mov	x0, x19
 	bl	_objc_msgSend
-Lloh10:
+Lloh12:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d@PAGE
-Lloh11:
+Lloh13:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d@PAGEOFF]
 	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_457d234345d46cbe@PAGEOFF]
 	mov	x0, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_msgSend
+	.loh AdrpLdr	Lloh12, Lloh13
 	.loh AdrpLdr	Lloh10, Lloh11
 	.loh AdrpLdr	Lloh8, Lloh9
-	.loh AdrpLdr	Lloh6, Lloh7
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_044375a4329d08dc
@@ -82,40 +85,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	3
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.quad	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.quad	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.quad	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
@@ -16,14 +16,16 @@ LPC0_0:
 _handle_alloc_init:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-(LPC1_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-(LPC1_0+8))
+	movw	r1, :lower16:(LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-(LPC1_0+8))
+	movt	r1, :upper16:(LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-(LPC1_0+8))
+	movw	r2, :lower16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC1_1+8))
+	movt	r2, :upper16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC1_1+8))
 LPC1_0:
 	ldr	r1, [pc, r1]
-	movw	r4, :lower16:(L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-(LPC1_1+8))
-	movt	r4, :upper16:(L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-(LPC1_1+8))
 LPC1_1:
-	ldr	r4, [pc, r4]
+	ldr	r2, [pc, r2]
+	ldr	r4, [r1]
+	ldr	r1, [r2]
 	bl	_objc_msgSend
 	mov	r1, r4
 	pop	{r4, r7, lr}
@@ -83,40 +85,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.long	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.long	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.long	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe
@@ -185,5 +153,14 @@ L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d:
 	.long	L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2
+LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32
+	.long	0
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -19,14 +19,16 @@ LPC0_0:
 _handle_alloc_init:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-(LPC1_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-(LPC1_0+8))
+	movw	r1, :lower16:(LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-(LPC1_0+8))
+	movt	r1, :upper16:(LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-(LPC1_0+8))
+	movw	r2, :lower16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC1_1+8))
+	movt	r2, :upper16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC1_1+8))
 LPC1_0:
 	ldr	r1, [pc, r1]
-	movw	r4, :lower16:(L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-(LPC1_1+8))
-	movt	r4, :upper16:(L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-(LPC1_1+8))
 LPC1_1:
-	ldr	r4, [pc, r4]
+	ldr	r2, [pc, r2]
+	ldr	r4, [r1]
+	ldr	r1, [r2]
 	bl	_objc_msgSend
 	mov	r1, r4
 	bl	_objc_msgSend
@@ -86,40 +88,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.long	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.long	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.long	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe
@@ -188,5 +156,14 @@ L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d:
 	.long	L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2
+LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32
+	.long	0
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
@@ -27,9 +27,11 @@ _handle_alloc_init:
 	call	L1$pb
 L1$pb:
 	pop	eax
-	mov	esi, dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-L1$pb]
+	mov	ecx, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-L1$pb]
+	mov	esi, dword ptr [ecx]
+	mov	eax, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-L1$pb]
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-L1$pb]
+	push	dword ptr [eax]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 8
@@ -89,40 +91,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.long	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.long	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.long	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__OBJC,__image_info
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe
@@ -191,5 +159,13 @@ L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d:
 	.long	L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d
+
+	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
+LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32
+	.long	0
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
@@ -27,9 +27,11 @@ _handle_alloc_init:
 	call	L1$pb
 L1$pb:
 	pop	eax
-	mov	esi, dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328-L1$pb]
+	mov	ecx, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr-L1$pb]
+	mov	esi, dword ptr [ecx]
+	mov	eax, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-L1$pb]
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_dcb825748735621d-L1$pb]
+	push	dword ptr [eax]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 8
@@ -89,40 +91,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.long	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.long	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.long	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe
@@ -191,5 +159,13 @@ L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_e76e01e8b2327e5d:
 	.long	L_OBJC_METH_VAR_NAME_e76e01e8b2327e5d
+
+	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
+LL_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32
+	.long	0
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
@@ -16,8 +16,10 @@ _handle_alloc_init:
 	mov	rbp, rsp
 	push	rbx
 	push	rax
-	mov	rbx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328]
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_dcb825748735621d]
+	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_0ea0a15a3d108c32@GOTPCREL]
+	mov	rbx, qword ptr [rax]
+	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPCREL]
+	mov	rsi, qword ptr [rax]
 	call	_objc_msgSend
 	mov	rdi, rax
 	mov	rsi, rbx
@@ -65,40 +67,6 @@ L_OBJC_METH_VAR_NAME_044375a4329d08dc:
 	.p2align	3
 L_OBJC_SELECTOR_REFERENCES_044375a4329d08dc:
 	.quad	L_OBJC_METH_VAR_NAME_044375a4329d08dc
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_cb49b9ab1b00e328
-	.p2align	2
-L_OBJC_IMAGE_INFO_cb49b9ab1b00e328:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328:
-	.asciz	"init"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_cb49b9ab1b00e328:
-	.quad	L_OBJC_METH_VAR_NAME_cb49b9ab1b00e328
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dcb825748735621d
-	.p2align	2
-L_OBJC_IMAGE_INFO_dcb825748735621d:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_dcb825748735621d
-L_OBJC_METH_VAR_NAME_dcb825748735621d:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_dcb825748735621d
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_dcb825748735621d:
-	.quad	L_OBJC_METH_VAR_NAME_dcb825748735621d
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_457d234345d46cbe

--- a/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
@@ -23,27 +23,24 @@ Lloh3:
 	.p2align	2
 _get_common_twice:
 Lloh4:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPAGE
 Lloh5:
-	ldr	x0, [x8, L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013@PAGEOFF]
+	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPAGEOFF]
 Lloh6:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1@PAGE
-Lloh7:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1@PAGEOFF]
+	ldr	x0, [x8]
+	mov	x1, x0
 	ret
-	.loh AdrpLdr	Lloh6, Lloh7
-	.loh AdrpAdrp	Lloh4, Lloh6
-	.loh AdrpLdr	Lloh4, Lloh5
+	.loh AdrpLdrGotLdr	Lloh4, Lloh5, Lloh6
 
 	.globl	_get_different_sel
 	.p2align	2
 _get_different_sel:
-Lloh8:
+Lloh7:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_25911857653c680c@PAGE
-Lloh9:
+Lloh8:
 	ldr	x0, [x8, L_OBJC_SELECTOR_REFERENCES_25911857653c680c@PAGEOFF]
 	ret
-	.loh AdrpLdr	Lloh8, Lloh9
+	.loh AdrpLdr	Lloh7, Lloh8
 
 	.globl	_unused_sel
 	.p2align	2
@@ -53,40 +50,40 @@ _unused_sel:
 	.globl	_use_fns
 	.p2align	2
 _use_fns:
-Lloh10:
+Lloh9:
 	adrp	x9, L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0@PAGE
-Lloh11:
+Lloh10:
 	ldr	x9, [x9, L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0@PAGEOFF]
-Lloh12:
+Lloh11:
 	adrp	x10, L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83@PAGE
-Lloh13:
+Lloh12:
 	ldr	x10, [x10, L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83@PAGEOFF]
-Lloh14:
+Lloh13:
 	adrp	x11, L_OBJC_SELECTOR_REFERENCES_25911857653c680c@PAGE
-Lloh15:
+Lloh14:
 	ldr	x11, [x11, L_OBJC_SELECTOR_REFERENCES_25911857653c680c@PAGEOFF]
-Lloh16:
+Lloh15:
 	adrp	x12, L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534@PAGE
-Lloh17:
+Lloh16:
 	ldr	x12, [x12, L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534@PAGEOFF]
 	stp	x9, x10, [x8]
 	stp	x11, x12, [x8, #16]
 	ret
-	.loh AdrpLdr	Lloh16, Lloh17
-	.loh AdrpLdr	Lloh14, Lloh15
-	.loh AdrpLdr	Lloh12, Lloh13
-	.loh AdrpLdr	Lloh10, Lloh11
+	.loh AdrpLdr	Lloh15, Lloh16
+	.loh AdrpLdr	Lloh13, Lloh14
+	.loh AdrpLdr	Lloh11, Lloh12
+	.loh AdrpLdr	Lloh9, Lloh10
 
 	.globl	_use_same_twice
 	.p2align	2
 _use_same_twice:
-Lloh18:
+Lloh17:
 	adrp	x9, L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0@PAGE
-Lloh19:
+Lloh18:
 	ldr	x9, [x9, L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0@PAGEOFF]
 	stp	x9, x9, [x8]
 	ret
-	.loh AdrpLdr	Lloh18, Lloh19
+	.loh AdrpLdr	Lloh17, Lloh18
 
 	.globl	_use_in_loop
 	.p2align	2
@@ -126,40 +123,6 @@ L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83:
 	.p2align	3
 L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.quad	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.quad	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.quad	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c

--- a/test-assembly/crates/test_static_sel/expected/apple-armv7.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-armv7.s
@@ -24,14 +24,12 @@ LPC1_0:
 	.p2align	2
 	.code	32
 _get_common_twice:
-	movw	r0, :lower16:(L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-(LPC2_0+8))
-	movt	r0, :upper16:(L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-(LPC2_0+8))
+	movw	r0, :lower16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC2_0+8))
+	movt	r0, :upper16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC2_0+8))
 LPC2_0:
 	ldr	r0, [pc, r0]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-(LPC2_1+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-(LPC2_1+8))
-LPC2_1:
-	ldr	r1, [pc, r1]
+	ldr	r0, [r0]
+	mov	r1, r0
 	bx	lr
 
 	.globl	_get_different_sel
@@ -128,40 +126,6 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.long	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.long	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2
 L_OBJC_IMAGE_INFO_25911857653c680c:
@@ -228,5 +192,11 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
@@ -24,14 +24,12 @@ LPC1_0:
 	.p2align	2
 	.code	32
 _get_common_twice:
-	movw	r0, :lower16:(L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-(LPC2_0+8))
-	movt	r0, :upper16:(L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-(LPC2_0+8))
+	movw	r0, :lower16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC2_0+8))
+	movt	r0, :upper16:(LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-(LPC2_0+8))
 LPC2_0:
 	ldr	r0, [pc, r0]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-(LPC2_1+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-(LPC2_1+8))
-LPC2_1:
-	ldr	r1, [pc, r1]
+	ldr	r0, [r0]
+	mov	r1, r0
 	bx	lr
 
 	.globl	_get_different_sel
@@ -128,40 +126,6 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.long	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.long	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2
 L_OBJC_IMAGE_INFO_25911857653c680c:
@@ -228,5 +192,11 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
@@ -31,9 +31,10 @@ _get_common_twice:
 	mov	ebp, esp
 	call	L2$pb
 L2$pb:
-	pop	ecx
-	mov	eax, dword ptr [ecx + L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-L2$pb]
-	mov	edx, dword ptr [ecx + L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-L2$pb]
+	pop	eax
+	mov	eax, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-L2$pb]
+	mov	eax, dword ptr [eax]
+	mov	edx, eax
 	pop	ebp
 	ret
 
@@ -139,40 +140,6 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.long	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.long	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-
-	.section	__OBJC,__image_info
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2
 L_OBJC_IMAGE_INFO_25911857653c680c:
@@ -239,5 +206,10 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_static_sel/expected/apple-x86.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-x86.s
@@ -31,9 +31,10 @@ _get_common_twice:
 	mov	ebp, esp
 	call	L2$pb
 L2$pb:
-	pop	ecx
-	mov	eax, dword ptr [ecx + L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013-L2$pb]
-	mov	edx, dword ptr [ecx + L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1-L2$pb]
+	pop	eax
+	mov	eax, dword ptr [eax + LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr-L2$pb]
+	mov	eax, dword ptr [eax]
+	mov	edx, eax
 	pop	ebp
 	ret
 
@@ -139,40 +140,6 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.long	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.long	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2
 L_OBJC_IMAGE_INFO_25911857653c680c:
@@ -239,5 +206,10 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
+LL_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2$non_lazy_ptr:
+	.indirect_symbol	L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2
+	.long	0
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
+++ b/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
@@ -23,8 +23,9 @@ _get_same_sel:
 _get_common_twice:
 	push	rbp
 	mov	rbp, rsp
-	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013]
-	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1]
+	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_1678d2f7468155d2@GOTPCREL]
+	mov	rax, qword ptr [rax]
+	mov	rdx, rax
 	pop	rbp
 	ret
 
@@ -115,40 +116,6 @@ L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83:
 	.p2align	3
 L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.quad	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_b3892a38c2415013
-	.p2align	2
-L_OBJC_IMAGE_INFO_b3892a38c2415013:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-L_OBJC_METH_VAR_NAME_b3892a38c2415013:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_b3892a38c2415013:
-	.quad	L_OBJC_METH_VAR_NAME_b3892a38c2415013
-
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9a8b70db451c67b1
-	.p2align	2
-L_OBJC_IMAGE_INFO_9a8b70db451c67b1:
-	.asciz	"\000\000\000\000@\000\000"
-
-	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
-L_OBJC_METH_VAR_NAME_9a8b70db451c67b1:
-	.asciz	"alloc"
-
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1
-	.p2align	3
-L_OBJC_SELECTOR_REFERENCES_9a8b70db451c67b1:
-	.quad	L_OBJC_METH_VAR_NAME_9a8b70db451c67b1
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
 	.globl	L_OBJC_IMAGE_INFO_25911857653c680c

--- a/test-assembly/src/main.rs
+++ b/test-assembly/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
             .arg("rustc")
             .arg(format!("--package={package}"))
             .args(args().skip(1))
-            .arg("--release")
+            .arg("--profile=assembly-tests")
             .arg("--message-format=json-render-diagnostics")
             .arg("--features=assembly-features")
             .arg("--")


### PR DESCRIPTION
Deduplicate selectors `alloc`, `init` and `new`, both when generating statics for these, and when caching said selectors.