### PR TITLE
Macro cleanup

### DIFF
--- a/block2/src/lib.rs
+++ b/block2/src/lib.rs
@@ -106,7 +106,6 @@ pub use block_sys as ffi;
 use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
 mod debug;
-#[macro_use]
 mod global;
 
 pub use global::GlobalBlock;

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -4,10 +4,10 @@ use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut, Range};
 
-use objc2::msg_send;
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
 use objc2::runtime::{Class, Object};
 use objc2::Message;
+use objc2::{msg_send, msg_send_id};
 
 use super::{
     NSComparisonResult, NSCopying, NSEnumerator, NSFastEnumeration, NSMutableCopying, NSObject,
@@ -62,8 +62,8 @@ unsafe fn from_refs<T: Message + ?Sized>(cls: &Class, refs: &[&T]) -> *mut Objec
 }
 
 impl<T: Message> NSArray<T, Shared> {
-    unsafe_def_fn! {
-        pub fn new -> Shared;
+    pub fn new() -> Id<Self, Shared> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 }
 
@@ -220,7 +220,9 @@ impl<T: Message> DefaultId for NSArray<T, Shared> {
 }
 
 impl<T: Message, O: Ownership> NSMutableArray<T, O> {
-    unsafe_def_fn!(pub fn new -> Owned);
+    pub fn new() -> Id<Self, Owned> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
+    }
 
     pub fn from_vec(vec: Vec<Id<T, O>>) -> Id<Self, Owned> {
         unsafe { Id::new(from_refs(Self::class(), vec.as_slice_ref()).cast()).unwrap() }

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -11,7 +11,7 @@ use objc2::{msg_send, msg_send_id};
 
 use super::{
     NSComparisonResult, NSCopying, NSEnumerator, NSFastEnumeration, NSMutableCopying, NSObject,
-    NSRange,
+    NSRange, __inner_extern_class,
 };
 
 __inner_extern_class! {

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -32,9 +32,9 @@ pub type NSAttributedStringKey = NSString;
 
 /// Creating attributed strings.
 impl NSAttributedString {
-    unsafe_def_fn! {
-        /// Construct an empty attributed string.
-        pub fn new -> Shared;
+    /// Construct an empty attributed string.
+    pub fn new() -> Id<Self, Shared> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
     /// Creates a new attributed string from the given string and attributes.

--- a/objc2-foundation/src/attributed_string.rs
+++ b/objc2-foundation/src/attributed_string.rs
@@ -3,7 +3,8 @@ use objc2::runtime::Object;
 use objc2::{msg_send, msg_send_id};
 
 use crate::{
-    NSCopying, NSDictionary, NSMutableAttributedString, NSMutableCopying, NSObject, NSString,
+    extern_class, NSCopying, NSDictionary, NSMutableAttributedString, NSMutableCopying, NSObject,
+    NSString,
 };
 
 extern_class! {

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -9,7 +9,7 @@ use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
 use objc2::{msg_send, msg_send_id};
 
-use super::{NSCopying, NSMutableCopying, NSObject, NSRange};
+use super::{extern_class, NSCopying, NSMutableCopying, NSObject, NSRange};
 
 extern_class! {
     /// A static byte buffer in memory.

--- a/objc2-foundation/src/data.rs
+++ b/objc2-foundation/src/data.rs
@@ -42,7 +42,9 @@ unsafe impl Sync for NSMutableData {}
 unsafe impl Send for NSMutableData {}
 
 impl NSData {
-    unsafe_def_fn!(fn new -> Shared);
+    pub fn new() -> Id<Self, Shared> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
+    }
 
     #[doc(alias = "length")]
     pub fn len(&self) -> usize {
@@ -132,7 +134,9 @@ impl DefaultId for NSData {
 
 /// Creation methods
 impl NSMutableData {
-    unsafe_def_fn!(fn new -> Owned);
+    pub fn new() -> Id<Self, Owned> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
+    }
 
     pub fn with_bytes(bytes: &[u8]) -> Id<Self, Owned> {
         unsafe { Id::new(data_with_bytes(Self::class(), bytes).cast()).unwrap() }

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -637,6 +637,8 @@ macro_rules! __inner_declare_class {
 ///
 /// @end
 /// ```
+///
+/// [`extern_class!`]: crate::extern_class
 #[macro_export]
 macro_rules! declare_class {
     {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -22,7 +22,9 @@ unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}
 unsafe impl<K: Sync + Send, V: Send> Send for NSDictionary<K, V> {}
 
 impl<K: Message, V: Message> NSDictionary<K, V> {
-    unsafe_def_fn!(pub fn new -> Shared);
+    pub fn new() -> Id<Self, Shared> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
+    }
 
     #[doc(alias = "count")]
     pub fn len(&self) -> usize {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -7,7 +7,7 @@ use core::ptr;
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
 use objc2::{msg_send, msg_send_id, Message};
 
-use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
+use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject, __inner_extern_class};
 
 __inner_extern_class! {
     #[derive(Debug, PartialEq, Eq, Hash)]

--- a/objc2-foundation/src/exception.rs
+++ b/objc2-foundation/src/exception.rs
@@ -7,7 +7,7 @@ use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
 use objc2::{msg_send, msg_send_id, sel};
 
-use crate::{NSCopying, NSDictionary, NSObject, NSString};
+use crate::{extern_class, NSCopying, NSDictionary, NSObject, NSString};
 
 extern_class! {
     /// A special condition that interrupts the normal flow of program

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -90,18 +90,17 @@ extern "C" {}
 #[link(name = "gnustep-base", kind = "dylib")]
 extern "C" {}
 
-mod declare_macro;
-mod macros;
-
 mod array;
 mod attributed_string;
 mod comparison_result;
 mod copying;
 mod data;
+mod declare_macro;
 mod dictionary;
 mod enumerator;
 mod exception;
 mod geometry;
+mod macros;
 mod mutable_attributed_string;
 mod mutable_string;
 mod object;

--- a/objc2-foundation/src/lib.rs
+++ b/objc2-foundation/src/lib.rs
@@ -90,10 +90,8 @@ extern "C" {}
 #[link(name = "gnustep-base", kind = "dylib")]
 extern "C" {}
 
-#[macro_use]
-mod macros;
-#[macro_use]
 mod declare_macro;
+mod macros;
 
 mod array;
 mod attributed_string;

--- a/objc2-foundation/src/macros.rs
+++ b/objc2-foundation/src/macros.rs
@@ -292,16 +292,3 @@ macro_rules! __inner_extern_class {
         $crate::__impl_as_ref_borrow!($name<$($t $(: $b)?),*>, $inherits, $($inheritance_rest,)*);
     };
 }
-
-macro_rules! unsafe_def_fn {
-    (
-        $(#[$m:meta])*
-        $v:vis fn new -> $o:ty $(;)?
-    ) => {
-        $(#[$m])*
-        $v fn new() -> Id<Self, $o> {
-            let cls = Self::class();
-            unsafe { $crate::objc2::msg_send_id![cls, new].unwrap() }
-        }
-    };
-}

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -1,7 +1,7 @@
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::{msg_send, msg_send_id};
 
-use crate::{NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
+use crate::{extern_class, NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
 
 extern_class! {
     /// A mutable string that has associated attributes.

--- a/objc2-foundation/src/mutable_attributed_string.rs
+++ b/objc2-foundation/src/mutable_attributed_string.rs
@@ -17,9 +17,9 @@ unsafe impl Send for NSMutableAttributedString {}
 
 /// Creating mutable attributed strings.
 impl NSMutableAttributedString {
-    unsafe_def_fn! {
-        /// Construct an empty mutable attributed string.
-        pub fn new -> Owned;
+    /// Construct an empty mutable attributed string.
+    pub fn new() -> Id<Self, Owned> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
     // TODO: new_with_attributes

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -22,9 +22,9 @@ unsafe impl Send for NSMutableString {}
 
 /// Creating mutable strings.
 impl NSMutableString {
-    unsafe_def_fn! {
-        /// Construct an empty [`NSMutableString`].
-        pub fn new -> Owned;
+    /// Construct an empty [`NSMutableString`].
+    pub fn new() -> Id<Self, Owned> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
     /// Creates a new [`NSMutableString`] by copying the given string slice.

--- a/objc2-foundation/src/mutable_string.rs
+++ b/objc2-foundation/src/mutable_string.rs
@@ -6,7 +6,7 @@ use core::str;
 use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::{msg_send, msg_send_id};
 
-use crate::{NSCopying, NSMutableCopying, NSObject, NSString};
+use crate::{extern_class, NSCopying, NSMutableCopying, NSObject, NSString};
 
 extern_class! {
     /// A dynamic plain-text Unicode string object.

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -21,7 +21,9 @@ impl NSObject {
 }
 
 impl NSObject {
-    unsafe_def_fn!(pub fn new -> Owned);
+    pub fn new() -> Id<Self, Owned> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
+    }
 
     pub fn hash_code(&self) -> usize {
         unsafe { msg_send![self, hash] }

--- a/objc2-foundation/src/object.rs
+++ b/objc2-foundation/src/object.rs
@@ -5,7 +5,7 @@ use objc2::rc::{DefaultId, Id, Owned, Shared};
 use objc2::runtime::{Class, Object};
 use objc2::{class, msg_send, msg_send_bool, msg_send_id};
 
-use super::NSString;
+use crate::{NSString, __inner_extern_class};
 
 __inner_extern_class! {
     @__inner

--- a/objc2-foundation/src/process_info.rs
+++ b/objc2-foundation/src/process_info.rs
@@ -1,7 +1,7 @@
 use objc2::msg_send_id;
 use objc2::rc::{Id, Shared};
 
-use crate::{NSObject, NSString};
+use crate::{extern_class, NSObject, NSString};
 
 extern_class! {
     /// A collection of information about the current process.

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -16,7 +16,9 @@ use objc2::rc::{Id, Shared};
 use objc2::runtime::{Class, Object};
 use objc2::{msg_send, msg_send_bool, msg_send_id};
 
-use crate::{NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject};
+use crate::{
+    extern_class, NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject,
+};
 
 #[cfg(feature = "apple")]
 const UTF8_ENCODING: usize = 4;

--- a/objc2-foundation/src/string.rs
+++ b/objc2-foundation/src/string.rs
@@ -14,7 +14,7 @@ use objc2::rc::DefaultId;
 use objc2::rc::{autoreleasepool, AutoreleasePool};
 use objc2::rc::{Id, Shared};
 use objc2::runtime::{Class, Object};
-use objc2::{msg_send, msg_send_bool};
+use objc2::{msg_send, msg_send_bool, msg_send_id};
 
 use crate::{NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject};
 
@@ -47,9 +47,9 @@ impl UnwindSafe for NSString {}
 impl RefUnwindSafe for NSString {}
 
 impl NSString {
-    unsafe_def_fn! {
-        /// Construct an empty NSString.
-        pub fn new -> Shared;
+    /// Construct an empty NSString.
+    pub fn new() -> Id<Self, Shared> {
+        unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
     /// The number of UTF-8 code units in `self`.

--- a/objc2-foundation/src/thread.rs
+++ b/objc2-foundation/src/thread.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use objc2::rc::{Id, Shared};
 use objc2::{msg_send, msg_send_bool, msg_send_id};
 
-use crate::{NSObject, NSString};
+use crate::{extern_class, NSObject, NSString};
 
 extern_class! {
     /// A thread of execution.

--- a/objc2-foundation/src/uuid.rs
+++ b/objc2-foundation/src/uuid.rs
@@ -1,7 +1,7 @@
 use objc2::rc::{Id, Shared};
 use objc2::{msg_send, msg_send_id, Encode, Encoding, RefEncode};
 
-use super::{NSCopying, NSObject};
+use super::{extern_class, NSCopying, NSObject};
 
 extern_class! {
     /// A universally unique value.

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -12,7 +12,7 @@ use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
 use objc2::{msg_send, msg_send_id};
 
-use super::{NSCopying, NSObject};
+use super::{NSCopying, NSObject, __inner_extern_class};
 
 __inner_extern_class! {
     // `T: Eq` bound correct to prevent `NSValue<f32>` from being `Eq`

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -193,6 +193,7 @@ mod tests {
 
     use crate::rc::{Allocated, Owned, RcTestObject, Shared, ThreadTestData};
     use crate::runtime::Object;
+    use crate::{class, msg_send_id};
     use crate::{Encoding, RefEncode};
 
     #[test]

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -49,6 +49,7 @@ use core::ptr::NonNull;
 use std::ffi::CString;
 
 use crate::runtime::{Bool, Class, Imp, Object, Protocol, Sel};
+use crate::sel;
 use crate::{ffi, Encode, EncodeArguments, Encoding, Message, RefEncode};
 
 pub use ivar::{Ivar, IvarType};
@@ -474,6 +475,7 @@ impl ProtocolBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::msg_send;
     use crate::test_utils;
 
     #[test]

--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -200,7 +200,7 @@ mod tests {
     use core::panic::{RefUnwindSafe, UnwindSafe};
 
     use super::*;
-    use crate::{test_utils, MessageReceiver};
+    use crate::{msg_send, test_utils, MessageReceiver};
 
     struct TestIvar;
 

--- a/objc2/src/exception.rs
+++ b/objc2/src/exception.rs
@@ -42,6 +42,7 @@ use crate::rc::{Id, Shared};
 use crate::runtime::Class;
 use crate::runtime::Object;
 use crate::Message;
+use crate::{msg_send, msg_send_bool, msg_send_id, sel};
 
 /// Unfortunate reimplementation of `objc2_foundation::NSString`.
 ///
@@ -312,6 +313,7 @@ mod tests {
     use alloc::string::ToString;
 
     use super::*;
+    use crate::{class, msg_send_id};
 
     #[test]
     fn test_catch() {

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -203,23 +203,20 @@ pub use crate::message::{Message, MessageArguments, MessageReceiver};
 #[cfg(feature = "malloc")]
 pub use crate::verify::VerificationError;
 
-mod macros;
-
+#[doc(hidden)]
+pub mod __macro_helpers;
 mod bool;
 mod cache;
 pub mod declare;
 pub mod exception;
+mod macros;
 mod message;
 pub mod rc;
 pub mod runtime;
-#[cfg(feature = "malloc")]
-mod verify;
-
 #[cfg(test)]
 mod test_utils;
-
-#[doc(hidden)]
-pub mod __macro_helpers;
+#[cfg(feature = "malloc")]
+mod verify;
 
 /// Hacky way to make GNUStep link properly to Foundation while testing.
 ///

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -203,7 +203,6 @@ pub use crate::message::{Message, MessageArguments, MessageReceiver};
 #[cfg(feature = "malloc")]
 pub use crate::verify::VerificationError;
 
-#[macro_use]
 mod macros;
 
 mod bool;

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -392,6 +392,7 @@ mod tests {
     use super::*;
     use crate::rc::{Id, Owned};
     use crate::test_utils;
+    use crate::{msg_send, msg_send_id};
 
     #[allow(unused)]
     fn test_different_receivers(mut obj: Id<Object, Owned>) {

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -151,16 +151,18 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
     /// Messages" in Apple's [documentation][runtime].
     ///
     /// If the selector is known at compile-time, it is recommended to use the
-    /// [`msg_send!`][`crate::msg_send`] macro rather than this method.
+    /// [`msg_send!`] macro rather than this method.
     ///
     /// [runtime]: https://developer.apple.com/documentation/objectivec/objective-c_runtime?language=objc
     ///
     /// # Safety
     ///
-    /// This shares the same safety requirements as [`msg_send!`][`msg_send`].
+    /// This shares the same safety requirements as [`msg_send!`].
     ///
     /// The added invariant is that the selector must take the same number of
     /// arguments as is given.
+    ///
+    /// [`msg_send!`]: crate::msg_send
     #[inline]
     #[track_caller]
     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> R
@@ -195,17 +197,19 @@ pub unsafe trait MessageReceiver: private::Sealed + Sized {
     /// Messages" in Apple's [documentation][runtime].
     ///
     /// If the selector is known at compile-time, it is recommended to use the
-    /// [`msg_send!(super)`][`crate::msg_send`] macro rather than this method.
+    /// [`msg_send!(super(...), ...)`] macro rather than this method.
     ///
     /// [runtime]: https://developer.apple.com/documentation/objectivec/objective-c_runtime?language=objc
     ///
     /// # Safety
     ///
     /// This shares the same safety requirements as
-    /// [`msg_send!(super(...), ...)`][`msg_send`].
+    /// [`msg_send!(super(...), ...)`].
     ///
     /// The added invariant is that the selector must take the same number of
     /// arguments as is given.
+    ///
+    /// [`msg_send!(super(...), ...)`]: crate::msg_send
     #[inline]
     #[track_caller]
     unsafe fn send_super_message<A, R>(self, superclass: &Class, sel: Sel, args: A) -> R

--- a/objc2/src/rc/autorelease.rs
+++ b/objc2/src/rc/autorelease.rs
@@ -224,6 +224,8 @@ impl !AutoreleaseSafe for AutoreleasePool {}
 /// you can instead, since having to use this function can be quite cumbersome
 /// for your users!
 ///
+/// [`msg_send_id!`]: crate::msg_send_id
+///
 ///
 /// # Examples
 ///

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -353,6 +353,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
     /// be careful not accidentally require instructions between these.
     ///
     /// [mmRules]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html
+    /// [`msg_send!`]: crate::msg_send
     ///
     ///
     /// # Safety

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -5,7 +5,7 @@ use std::sync::Once;
 use super::{Id, Owned};
 use crate::declare::ClassBuilder;
 use crate::runtime::{Bool, Class, Object, Sel};
-use crate::{msg_send, msg_send_bool};
+use crate::{class, msg_send, msg_send_bool, sel};
 use crate::{Encoding, Message, RefEncode};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -799,6 +799,7 @@ mod tests {
     use super::{Bool, Class, Imp, Ivar, Method, Object, Protocol, Sel};
     use crate::test_utils;
     use crate::Encode;
+    use crate::{msg_send, sel};
 
     #[test]
     fn test_selector() {

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -47,6 +47,7 @@ pub const NO: ffi::BOOL = ffi::NO;
 /// This guarantees the null-pointer optimization, namely that `Option<Sel>`
 /// is the same size as `Sel`.
 ///
+/// [`sel!`]: crate::sel
 /// [interned string]: https://en.wikipedia.org/wiki/String_interning
 #[repr(transparent)]
 // ffi::sel_isEqual is just pointer comparison, so we just generate PartialEq
@@ -153,6 +154,9 @@ impl Sel {
     ///
     /// This is the dynamic version of the [`sel!`] macro, prefer to use that
     /// when your selector is static.
+    ///
+    /// [`sel!`]: crate::sel
+    ///
     ///
     /// # Panics
     ///
@@ -625,6 +629,8 @@ fn ivar_offset<T: Encode>(cls: &Class, name: &str) -> isize {
 /// depending on the specific subclass. For example, `NSAutoreleasePool` is
 /// not `Send`, it has to be deallocated on the same thread that it was
 /// created. `NSLock` is not `Send` either.
+///
+/// [`msg_send!`]: crate::msg_send
 #[doc(alias = "id")]
 #[repr(C)]
 pub struct Object(ffi::objc_object);

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -5,6 +5,7 @@ use std::sync::Once;
 
 use crate::declare::{ClassBuilder, ProtocolBuilder};
 use crate::runtime::{Class, Object, Protocol, Sel};
+use crate::{class, msg_send, sel};
 use crate::{ffi, Encode, Encoding, MessageReceiver};
 
 #[derive(Debug)]

--- a/objc2/src/verify.rs
+++ b/objc2/src/verify.rs
@@ -136,6 +136,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sel;
     use crate::test_utils;
     use alloc::string::ToString;
     use core::panic::{RefUnwindSafe, UnwindSafe};
@@ -196,7 +197,7 @@ mod tests {
     #[should_panic = "invalid message send to -[CustomObject foo]: expected return to have type code I, but found i"]
     fn test_send_message_verified() {
         let obj = test_utils::custom_object();
-        let _: i32 = unsafe { msg_send![&obj, foo] };
+        let _: i32 = unsafe { crate::msg_send![&obj, foo] };
     }
 
     #[test]
@@ -204,7 +205,7 @@ mod tests {
     #[should_panic = "invalid message send to +[CustomObject abcDef]: method not found"]
     fn test_send_message_verified_to_class() {
         let cls = test_utils::custom_class();
-        let _: i32 = unsafe { msg_send![cls, abcDef] };
+        let _: i32 = unsafe { crate::msg_send![cls, abcDef] };
     }
 
     #[test]


### PR DESCRIPTION
Remove internal `unsafe_def_fn` macro and all instances of `#[macro_use]`