### PR TITLE
Expose generic version of extern_class!

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `NSData` and `NSMutableData`.
 * Implemented `Extend` for `NSMutableArray`.
 * Add extra `Extend<&u8>` impl for `NSMutableData`.
+* Exposed generic version of `extern_class!` macro.
 
 ### Fixed
 * Made `Debug` impls for all objects print something useful.

--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -10,11 +10,11 @@ use objc2::Message;
 use objc2::{msg_send, msg_send_id};
 
 use crate::{
-    NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableArray, NSMutableCopying,
-    NSObject, NSRange, __inner_extern_class,
+    extern_class, NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableArray,
+    NSMutableCopying, NSObject, NSRange,
 };
 
-__inner_extern_class! {
+extern_class! {
     /// TODO
     ///
     /// You can have a `Id<NSArray<T, Owned>, Owned>`, which allows mutable access

--- a/objc2-foundation/src/declare_macro.rs
+++ b/objc2-foundation/src/declare_macro.rs
@@ -639,6 +639,8 @@ macro_rules! __inner_declare_class {
 /// ```
 ///
 /// [`extern_class!`]: crate::extern_class
+#[doc(alias = "@interface")]
+#[doc(alias = "@implementation")]
 #[macro_export]
 macro_rules! declare_class {
     {

--- a/objc2-foundation/src/dictionary.rs
+++ b/objc2-foundation/src/dictionary.rs
@@ -9,9 +9,9 @@ use core::ptr;
 use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
 use objc2::{msg_send, msg_send_id, Message};
 
-use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject, __inner_extern_class};
+use super::{extern_class, NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
 
-__inner_extern_class! {
+extern_class! {
     #[derive(PartialEq, Eq, Hash)]
     unsafe pub struct NSDictionary<K, V>: NSObject {
         key: PhantomData<Id<K, Shared>>,

--- a/objc2-foundation/src/mutable_array.rs
+++ b/objc2-foundation/src/mutable_array.rs
@@ -11,11 +11,11 @@ use objc2::{msg_send, msg_send_id};
 
 use crate::array::from_refs;
 use crate::{
-    NSArray, NSComparisonResult, NSCopying, NSFastEnumeration, NSFastEnumerator, NSMutableCopying,
-    NSObject, __inner_extern_class,
+    extern_class, NSArray, NSComparisonResult, NSCopying, NSFastEnumeration, NSFastEnumerator,
+    NSMutableCopying, NSObject,
 };
 
-__inner_extern_class! {
+extern_class! {
     // TODO: Ensure that this deref to NSArray is safe!
     // This "inherits" NSArray, and has the same `Send`/`Sync` impls as that.
     #[derive(PartialEq, Eq, Hash)]

--- a/objc2-foundation/src/value.rs
+++ b/objc2-foundation/src/value.rs
@@ -13,9 +13,9 @@ use objc2::rc::{DefaultId, Id, Shared};
 use objc2::Encode;
 use objc2::{msg_send, msg_send_id};
 
-use super::{NSCopying, NSObject, __inner_extern_class};
+use super::{extern_class, NSCopying, NSObject};
 
-__inner_extern_class! {
+extern_class! {
     // `T: Eq` bound to prevent `NSValue<f32>` from being `Eq`
     // (even though `[NAN isEqual: NAN]` is true in Objective-C).
     #[derive(PartialEq, Eq, Hash)]


### PR DESCRIPTION
I would like to move the macro to `objc2`, and since we use this functionality in `objc2-foundation`, we need to publicly expose it