### PR TITLE
Change selector syntax in `declare_class!` macro

### DIFF
--- a/objc2-foundation/CHANGELOG.md
+++ b/objc2-foundation/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Implemented `Extend` for `NSMutableArray`.
 * Add extra `Extend<&u8>` impl for `NSMutableData`.
 
+### Changed
+* Change selector syntax in `declare_class!` macro to be more Rust-like.
+
 ### Fixed
 * Made `Debug` impls for all objects print something useful.
 

--- a/objc2-foundation/examples/declaration.rs
+++ b/objc2-foundation/examples/declaration.rs
@@ -20,7 +20,7 @@ declare_class! {
     }
 
     unsafe impl {
-        @sel(initWith:another:)
+        #[sel(initWith:another:)]
         fn init_with(
             self: &mut Self,
             ivar: u8,
@@ -37,7 +37,7 @@ declare_class! {
             this
         }
 
-        @sel(myClassMethod)
+        #[sel(myClassMethod)]
         fn my_class_method() {
             println!("A class method!");
         }
@@ -49,12 +49,14 @@ declare_class! {
     //
     // TODO: Investigate this!
     unsafe impl {
-        @sel(applicationDidFinishLaunching:)
+        #[sel(applicationDidFinishLaunching:)]
         fn did_finish_launching(&self, _sender: *mut Object) {
             println!("Did finish launching!");
         }
 
-        @sel(applicationWillTerminate:)
+        /// Some comment before `sel`.
+        #[sel(applicationWillTerminate:)]
+        /// Some comment after `sel`.
         fn will_terminate(&self, _: *mut Object) {
             println!("Will terminate!");
         }


### PR DESCRIPTION
I found a way to make it look like ordinary Rust attributes, without using a proc macro, so yay!