### PR TITLE
Make traits that `Owned` and `Shared` implement supertraits of `Ownership`

### DIFF
--- a/objc2-foundation/src/array.rs
+++ b/objc2-foundation/src/array.rs
@@ -246,7 +246,7 @@ mod tests {
     use objc2::rc::autoreleasepool;
 
     use super::*;
-    use crate::NSValue;
+    use crate::{NSString, NSValue};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);
@@ -373,5 +373,20 @@ mod tests {
 
         let vec = NSArray::into_vec(array);
         assert_eq!(vec.len(), 4);
+    }
+
+    #[test]
+    fn test_generic_ownership_traits() {
+        fn assert_partialeq<T: PartialEq>() {}
+
+        assert_partialeq::<NSArray<NSString, Shared>>();
+        assert_partialeq::<NSArray<NSString, Owned>>();
+
+        fn test_ownership_implies_partialeq<O: Ownership>() {
+            assert_partialeq::<NSArray<NSString, O>>();
+        }
+
+        test_ownership_implies_partialeq::<Shared>();
+        test_ownership_implies_partialeq::<Owned>();
     }
 }

--- a/objc2/src/rc/ownership.rs
+++ b/objc2/src/rc/ownership.rs
@@ -1,12 +1,25 @@
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+
+use super::AutoreleaseSafe;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+enum Never {}
+
 /// A type used to mark that a struct owns the object(s) it contains,
 /// so it has the sole references to them.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum Owned {}
+pub struct Owned {
+    inner: Never,
+}
 
 /// A type used to mark that the object(s) a struct contains are shared,
 /// so there may be other references to them.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum Shared {}
+pub struct Shared {
+    inner: Never,
+}
 
 mod private {
     pub trait Sealed {}
@@ -20,7 +33,50 @@ mod private {
 ///
 /// This trait is sealed and not meant to be implemented outside of the this
 /// crate.
-pub trait Ownership: private::Sealed + 'static {}
+pub trait Ownership:
+    private::Sealed
+    // Special
+    + 'static
+    + Sized
+    // Auto-traits
+    + Send
+    + Sync
+    + Unpin
+    + UnwindSafe
+    + RefUnwindSafe
+    // Derived
+    + Clone
+    + Copy
+    + PartialEq
+    + Eq
+    + PartialOrd
+    + Ord
+    + Hash
+    + Debug
+    // Custom
+    + AutoreleaseSafe
+{
+}
 
 impl Ownership for Owned {}
 impl Ownership for Shared {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generic_ownership_traits() {
+        fn assert_partialeq<T: PartialEq>() {}
+
+        assert_partialeq::<Shared>();
+        assert_partialeq::<Owned>();
+
+        fn test_ownership_implies_partialeq<O: Ownership>() {
+            assert_partialeq::<O>();
+        }
+
+        test_ownership_implies_partialeq::<Shared>();
+        test_ownership_implies_partialeq::<Owned>();
+    }
+}

--- a/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -100,7 +100,7 @@ error[E0308]: mismatched types
   --> ui/msg_send_id_invalid_return.rs
    |
    |     let _: Id<Object, Owned> = unsafe { msg_send_id![obj, init].unwrap() };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `objc2::rc::Owned`, found enum `Shared`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `objc2::rc::Owned`, found struct `Shared`
    |
    = note: expected struct `Id<_, objc2::rc::Owned>`
               found struct `Id<_, Shared>`

--- a/test-ui/ui/msg_send_id_underspecified.stderr
+++ b/test-ui/ui/msg_send_id_underspecified.stderr
@@ -1,9 +1,11 @@
-error[E0282]: type annotations needed for `Option<Id<objc2::runtime::Object, O>>`
+error[E0283]: type annotations needed for `Option<Id<objc2::runtime::Object, O>>`
  --> ui/msg_send_id_underspecified.rs
   |
   |     let _: &Object = &*unsafe { msg_send_id![obj, description].unwrap() };
-  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type must be known at this point
   |
+  = note: cannot satisfy `_: Ownership`
+  = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Object, Id<objc2::runtime::Object, _>>` for `RetainSemantics<false, false, false, false>`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider giving `result` an explicit type, where the type for type parameter `O` is specified
  --> $WORKSPACE/objc2/src/macros.rs


### PR DESCRIPTION
This helps when using in generic code.

Also make the fact that they are empty enums private.