### PR TITLE
Re-enable fail-fast in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
     name: ${{ matrix.name }}
 
     strategy:
-      fail-fast: false
+      # MacOS instances are rate-limited, which means that whenever we can
+      # avoid do some work, we should!
+      fail-fast: true
       matrix:
         include:
           - name: Test macOS 11


### PR DESCRIPTION
This was disabled in #99 with the reasoning:

> It's annoying to not get full feedback the first time around, and it prevents the other builds from finishing their caching

While this is still true, I find myself often manually cancelling CI runs when I've seen something fail, because that will free up some macOS instances for my account, and thus enabling the next run to complete much faster.