### PR TITLE
Improve safety in foundation collection types wrt. ownership

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `objc2-foundation`.
 
 ### Changed
-* Change selector syntax in `declare_class!` macro to be more Rust-like.
+* **BREAKING**: Change selector syntax in `declare_class!` macro to be more Rust-like.
 
 
 ## 0.3.0-beta.1 - 2022-07-19

--- a/objc2/CHANGELOG_FOUNDATION.md
+++ b/objc2/CHANGELOG_FOUNDATION.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of the `NSValue` matches the encoding of the given type.
 * Added functions `get_range`, `get_point`, `get_size` and `get_rect` to
   `NSValue` to help safely returning various types it will commonly contain.
+* `NSArray` and `NSMutableArray` now have sensible defaults for the ownership
+  of the objects they contain.
 
 ### Changed
 * **BREAKING**: Moved from external crate `objc2_foundation` into

--- a/objc2/CHANGELOG_FOUNDATION.md
+++ b/objc2/CHANGELOG_FOUNDATION.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Made `NSValue` not generic any more. While we loose some
   type-safety from this, it makes `NSValue` much more useful in the real
   world!
+* **BREAKING**: Made `NSArray::new` generic over ownership.
 
 ### Fixed
 * Made `Debug` impls for all objects print something useful.

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -53,7 +53,7 @@ __inner_extern_class! {
     // `T: PartialEq` bound correct because `NSArray` does deep (instead of
     // shallow) equality comparisons.
     #[derive(PartialEq, Eq, Hash)]
-    unsafe pub struct NSArray<T: Message, O: Ownership>: NSObject {
+    unsafe pub struct NSArray<T: Message, O: Ownership = Shared>: NSObject {
         item: PhantomData<Id<T, O>>,
         notunwindsafe: PhantomData<&'static mut ()>,
     }
@@ -324,13 +324,13 @@ mod tests {
 
     #[test]
     fn test_two_empty() {
-        let _empty_array1 = NSArray::<NSObject, Shared>::new();
-        let _empty_array2 = NSArray::<NSObject, Shared>::new();
+        let _empty_array1 = NSArray::<NSObject>::new();
+        let _empty_array2 = NSArray::<NSObject>::new();
     }
 
     #[test]
     fn test_len() {
-        let empty_array = NSArray::<NSObject, Shared>::new();
+        let empty_array = NSArray::<NSObject>::new();
         assert_eq!(empty_array.len(), 0);
 
         let array = sample_array(4);
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(array.first(), array.get(0));
         assert_eq!(array.last(), array.get(3));
 
-        let empty_array = <NSArray<NSObject, Shared>>::new();
+        let empty_array = <NSArray<NSObject>>::new();
         assert!(empty_array.first().is_none());
         assert!(empty_array.last().is_none());
     }

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -27,7 +27,7 @@ __inner_extern_class! {
     // `T: PartialEq` bound correct because `NSArray` does deep (instead of
     // shallow) equality comparisons.
     #[derive(PartialEq, Eq, Hash)]
-    unsafe pub struct NSArray<T, O: Ownership>: NSObject {
+    unsafe pub struct NSArray<T: Message, O: Ownership>: NSObject {
         item: PhantomData<Id<T, O>>,
         notunwindsafe: PhantomData<&'static mut ()>,
     }
@@ -36,15 +36,15 @@ __inner_extern_class! {
 // SAFETY: Same as Id<T, O> (which is what NSArray effectively stores).
 //
 // TODO: Properly verify this
-unsafe impl<T: Sync + Send> Sync for NSArray<T, Shared> {}
-unsafe impl<T: Sync + Send> Send for NSArray<T, Shared> {}
-unsafe impl<T: Sync> Sync for NSArray<T, Owned> {}
-unsafe impl<T: Send> Send for NSArray<T, Owned> {}
+unsafe impl<T: Message + Sync + Send> Sync for NSArray<T, Shared> {}
+unsafe impl<T: Message + Sync + Send> Send for NSArray<T, Shared> {}
+unsafe impl<T: Message + Sync> Sync for NSArray<T, Owned> {}
+unsafe impl<T: Message + Send> Send for NSArray<T, Owned> {}
 
 // Also same as Id<T, O>
-impl<T: RefUnwindSafe, O: Ownership> RefUnwindSafe for NSArray<T, O> {}
-impl<T: RefUnwindSafe> UnwindSafe for NSArray<T, Shared> {}
-impl<T: UnwindSafe> UnwindSafe for NSArray<T, Owned> {}
+impl<T: Message + RefUnwindSafe, O: Ownership> RefUnwindSafe for NSArray<T, O> {}
+impl<T: Message + RefUnwindSafe> UnwindSafe for NSArray<T, Shared> {}
+impl<T: Message + UnwindSafe> UnwindSafe for NSArray<T, Owned> {}
 
 pub(crate) unsafe fn from_refs<T: Message + ?Sized>(cls: &Class, refs: &[&T]) -> *mut Object {
     let obj: *mut Object = unsafe { msg_send![cls, alloc] };

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -12,7 +12,7 @@ use crate::{__inner_extern_class, msg_send, msg_send_id, Message};
 
 __inner_extern_class! {
     #[derive(PartialEq, Eq, Hash)]
-    unsafe pub struct NSDictionary<K, V>: NSObject {
+    unsafe pub struct NSDictionary<K: Message, V: Message>: NSObject {
         key: PhantomData<Id<K, Shared>>,
         obj: PhantomData<Id<V, Owned>>,
     }
@@ -20,12 +20,12 @@ __inner_extern_class! {
 
 // TODO: SAFETY
 // Approximately same as `NSArray<T, Shared>`
-unsafe impl<K: Sync + Send, V: Sync> Sync for NSDictionary<K, V> {}
-unsafe impl<K: Sync + Send, V: Send> Send for NSDictionary<K, V> {}
+unsafe impl<K: Message + Sync + Send, V: Message + Sync> Sync for NSDictionary<K, V> {}
+unsafe impl<K: Message + Sync + Send, V: Message + Send> Send for NSDictionary<K, V> {}
 
 // Approximately same as `NSArray<T, Shared>`
-impl<K: UnwindSafe, V: UnwindSafe> UnwindSafe for NSDictionary<K, V> {}
-impl<K: RefUnwindSafe, V: RefUnwindSafe> RefUnwindSafe for NSDictionary<K, V> {}
+impl<K: Message + UnwindSafe, V: Message + UnwindSafe> UnwindSafe for NSDictionary<K, V> {}
+impl<K: Message + RefUnwindSafe, V: Message + RefUnwindSafe> RefUnwindSafe for NSDictionary<K, V> {}
 
 impl<K: Message, V: Message> NSDictionary<K, V> {
     pub fn new() -> Id<Self, Shared> {

--- a/objc2/src/foundation/mod.rs
+++ b/objc2/src/foundation/mod.rs
@@ -132,7 +132,7 @@ mod tests {
         assert_auto_traits::<NSAttributedString>();
         assert_auto_traits::<NSComparisonResult>();
         assert_auto_traits::<NSData>();
-        assert_auto_traits::<NSDictionary<NSString, Shared>>();
+        assert_auto_traits::<NSDictionary<NSString, NSString>>();
         // TODO: Figure out if Send + Sync is safe?
         // assert_auto_traits::<NSEnumerator<NSString>>();
         // assert_auto_traits::<NSFastEnumerator<NSArray<NSString, Shared>>>();

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 
-use super::array::from_refs;
+use super::array::with_objects;
 use super::{
     NSArray, NSComparisonResult, NSCopying, NSFastEnumeration, NSFastEnumerator, NSMutableCopying,
     NSObject,
@@ -41,13 +41,13 @@ impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     }
 
     pub fn from_vec(vec: Vec<Id<T, O>>) -> Id<Self, Owned> {
-        unsafe { Id::new(from_refs(Self::class(), vec.as_slice_ref()).cast()).unwrap() }
+        unsafe { with_objects(Self::class(), vec.as_slice_ref()) }
     }
 }
 
 impl<T: Message> NSMutableArray<T, Shared> {
     pub fn from_slice(slice: &[Id<T, Shared>]) -> Id<Self, Owned> {
-        unsafe { Id::new(from_refs(Self::class(), slice.as_slice_ref()).cast()).unwrap() }
+        unsafe { with_objects(Self::class(), slice.as_slice_ref()) }
     }
 }
 

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -18,7 +18,7 @@ __inner_extern_class! {
     // TODO: Ensure that this deref to NSArray is safe!
     // This "inherits" NSArray, and has the same `Send`/`Sync` impls as that.
     #[derive(PartialEq, Eq, Hash)]
-    unsafe pub struct NSMutableArray<T, O: Ownership>: NSArray<T, O>, NSObject {
+    unsafe pub struct NSMutableArray<T: Message, O: Ownership>: NSArray<T, O>, NSObject {
         p: PhantomData<*mut ()>,
     }
 }
@@ -26,10 +26,10 @@ __inner_extern_class! {
 // SAFETY: Same as NSArray<T, O>
 //
 // Put here because rustdoc doesn't show these otherwise
-unsafe impl<T: Sync + Send> Sync for NSMutableArray<T, Shared> {}
-unsafe impl<T: Sync + Send> Send for NSMutableArray<T, Shared> {}
-unsafe impl<T: Sync> Sync for NSMutableArray<T, Owned> {}
-unsafe impl<T: Send> Send for NSMutableArray<T, Owned> {}
+unsafe impl<T: Message + Sync + Send> Sync for NSMutableArray<T, Shared> {}
+unsafe impl<T: Message + Sync + Send> Send for NSMutableArray<T, Shared> {}
+unsafe impl<T: Message + Sync> Sync for NSMutableArray<T, Owned> {}
+unsafe impl<T: Message + Send> Send for NSMutableArray<T, Owned> {}
 
 impl<T: Message, O: Ownership> NSMutableArray<T, O> {
     pub fn new() -> Id<Self, Owned> {

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -22,7 +22,7 @@ __inner_extern_class! {
     ///
     /// [apple-doc]: https://developer.apple.com/documentation/foundation/nsmutablearray?language=objc
     #[derive(PartialEq, Eq, Hash)]
-    unsafe pub struct NSMutableArray<T: Message, O: Ownership>: NSArray<T, O>, NSObject {
+    unsafe pub struct NSMutableArray<T: Message, O: Ownership = Owned>: NSArray<T, O>, NSObject {
         p: PhantomData<*mut ()>,
     }
 }

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -15,8 +15,12 @@ use crate::Message;
 use crate::{__inner_extern_class, msg_send, msg_send_id};
 
 __inner_extern_class! {
-    // TODO: Ensure that this deref to NSArray is safe!
-    // This "inherits" NSArray, and has the same `Send`/`Sync` impls as that.
+    /// A growable ordered collection of objects.
+    ///
+    /// See the documentation for [`NSArray`] and/or [Apple's
+    /// documentation][apple-doc] for more information.
+    ///
+    /// [apple-doc]: https://developer.apple.com/documentation/foundation/nsmutablearray?language=objc
     #[derive(PartialEq, Eq, Hash)]
     unsafe pub struct NSMutableArray<T: Message, O: Ownership>: NSArray<T, O>, NSObject {
         p: PhantomData<*mut ()>,

--- a/objc2/src/foundation/mutable_data.rs
+++ b/objc2/src/foundation/mutable_data.rs
@@ -6,7 +6,7 @@ use core::ops::{Index, IndexMut, Range};
 use core::slice::{self, SliceIndex};
 use std::io;
 
-use super::data::data_with_bytes;
+use super::data::with_slice;
 use super::{NSCopying, NSData, NSMutableCopying, NSObject, NSRange};
 use crate::rc::{DefaultId, Id, Owned, Shared};
 use crate::{extern_class, msg_send, msg_send_id};
@@ -30,12 +30,12 @@ impl NSMutableData {
     }
 
     pub fn with_bytes(bytes: &[u8]) -> Id<Self, Owned> {
-        unsafe { Id::new(data_with_bytes(Self::class(), bytes).cast()).unwrap() }
+        unsafe { Id::from_shared(Id::cast(with_slice(Self::class(), bytes))) }
     }
 
     #[cfg(feature = "block")]
     pub fn from_vec(bytes: Vec<u8>) -> Id<Self, Owned> {
-        unsafe { Id::new(super::data::data_from_vec(Self::class(), bytes).cast()).unwrap() }
+        unsafe { Id::from_shared(Id::cast(super::data::with_vec(Self::class(), bytes))) }
     }
 
     // TODO: Use malloc_buf/mbox and `initWithBytesNoCopy:...`?

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -516,8 +516,6 @@ macro_rules! declare_class {
             $v fn class() -> &'static $crate::runtime::Class {
                 use $crate::__macro_helpers::Once;
 
-                use $crate::declare::ClassBuilder;
-                use $crate::runtime::{Class, Protocol};
                 static REGISTER_CLASS: Once = Once::new();
 
                 REGISTER_CLASS.call_once(|| {
@@ -527,7 +525,7 @@ macro_rules! declare_class {
                         stringify!($name),
                         ". Perhaps a class with that name already exists?",
                     );
-                    let mut builder = ClassBuilder::new(stringify!($name), superclass).expect(err_str);
+                    let mut builder = $crate::declare::ClassBuilder::new(stringify!($name), superclass).expect(err_str);
 
                     $(
                         builder.add_ivar::<<$ivar as $crate::declare::IvarType>::Type>(
@@ -539,7 +537,7 @@ macro_rules! declare_class {
                         // Implement protocol if any specified
                         $(
                             let err_str = concat!("could not find protocol ", stringify!($protocol));
-                            builder.add_protocol(Protocol::get(stringify!($protocol)).expect(err_str));
+                            builder.add_protocol($crate::runtime::Protocol::get(stringify!($protocol)).expect(err_str));
                         )?
 
                         // Implement methods
@@ -558,7 +556,7 @@ macro_rules! declare_class {
                 });
 
                 // We just registered the class, so it should be available
-                Class::get(stringify!($name)).unwrap()
+                $crate::runtime::Class::get(stringify!($name)).unwrap()
             }
         }
 

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -189,14 +189,14 @@ macro_rules! __inner_extern_class {
     // TODO: Expose this variant in the `object` macro.
     (
         $(#[$m:meta])*
-        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident)?),*>: $($inheritance_chain:ty),+ {
+        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident $(= $default:ty)?)?),*>: $($inheritance_chain:ty),+ {
             $($field_vis:vis $field:ident: $field_ty:ty,)*
         }
     ) => {
         $crate::__inner_extern_class! {
             @__inner
             $(#[$m])*
-            unsafe $v struct $name<$($t $(: $b)?),*>: $($inheritance_chain,)+ $crate::runtime::Object {
+            unsafe $v struct $name<$($t $(: $b $(= $default)?)?),*>: $($inheritance_chain,)+ $crate::runtime::Object {
                 $($field_vis $field: $field_ty,)*
             }
         }
@@ -217,14 +217,14 @@ macro_rules! __inner_extern_class {
     (
         @__inner
         $(#[$m:meta])*
-        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident)?),*>: $superclass:ty $(, $inheritance_rest:ty)* {
+        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident $(= $default:ty)?)?),*>: $superclass:ty $(, $inheritance_rest:ty)* {
             $($field_vis:vis $field:ident: $field_ty:ty,)*
         }
     ) => {
         $(#[$m])*
         // TODO: repr(transparent) when the inner pointer is no longer a ZST.
         #[repr(C)]
-        $v struct $name<$($t $(: $b)?),*> {
+        $v struct $name<$($t $(: $b $(= $default)?)?),*> {
             __inner: $superclass,
             // Additional fields (should only be zero-sized PhantomData or ivars).
             $($field_vis $field: $field_ty,)*

--- a/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -7,7 +7,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   = help: within `objc2::runtime::Object`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = note: required because it appears within the type `objc_object`
   = note: required because it appears within the type `objc2::runtime::Object`
-  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object, Shared>`
+  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object>`
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
   |
@@ -26,7 +26,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   = note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = note: required because it appears within the type `objc_object`
   = note: required because it appears within the type `objc2::runtime::Object`
-  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object, Shared>`
+  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object>`
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
   |
@@ -42,7 +42,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
    = help: within `objc2::runtime::Object`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
    = note: required because it appears within the type `objc_object`
    = note: required because it appears within the type `objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object, Shared>`
+   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object>`
 note: required by a bound in `needs_send`
   --> ui/nsarray_bound_not_send_sync.rs
    |
@@ -61,7 +61,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
    = note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
    = note: required because it appears within the type `objc_object`
    = note: required because it appears within the type `objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object, Shared>`
+   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object>`
 note: required by a bound in `needs_send`
   --> ui/nsarray_bound_not_send_sync.rs
    |

--- a/tests/src/exception.rs
+++ b/tests/src/exception.rs
@@ -3,7 +3,7 @@ use alloc::format;
 use objc2::exception::{catch, throw};
 use objc2::foundation::{NSArray, NSException, NSString};
 use objc2::msg_send;
-use objc2::rc::{autoreleasepool, Id};
+use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::Object;
 
 #[track_caller]
@@ -122,7 +122,7 @@ fn raise_catch() {
 fn catch_actual() {
     let res = unsafe {
         catch(|| {
-            let arr: Id<NSArray<Object, _>, _> = NSArray::new();
+            let arr: Id<NSArray<Object, Shared>, Shared> = NSArray::new();
             let _obj: *mut Object = msg_send![&arr, objectAtIndex: 0usize];
         })
     };


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/67.

I took a look at how we do arrays again, and while a bit confusing with the double-ownership (e.g. `Id<Array<T, O1>, O2>`), I'm now fairly confident that it is sound.