### PR TITLE
Add `ClassBuilder::add_static_ivar`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (default) feature flag `"foundation"`.
 * Added `declare_class!`, `extern_class!` and `ns_string!` macros from
   `objc2-foundation`.
+* Added helper method `ClassBuilder::add_static_ivar`.
 
 ### Changed
 * **BREAKING**: Change selector syntax in `declare_class!` macro to be more Rust-like.

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -71,7 +71,7 @@ impl<'a> MyObject<'a> {
             let superclass = NSObject::class();
             let mut builder = ClassBuilder::new("MyObject", superclass).unwrap();
 
-            builder.add_ivar::<<NumberIvar<'a> as IvarType>::Type>(<NumberIvar<'a>>::NAME);
+            builder.add_static_ivar::<NumberIvar<'a>>();
 
             /// Helper struct since we can't access the instance variable
             /// from inside MyObject, since it hasn't been initialized yet!

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -402,9 +402,11 @@ impl ClassBuilder {
 
     /// Adds an ivar with type `T` and the provided name.
     ///
+    ///
     /// # Panics
     ///
-    /// If the ivar wasn't successfully added.
+    /// If the ivar wasn't successfully added for some reason - this usually
+    /// happens if there already was an ivar with that name.
     pub fn add_ivar<T: Encode>(&mut self, name: &str) {
         let c_name = CString::new(name).unwrap();
         let encoding = CString::new(T::ENCODING.to_string()).unwrap();
@@ -420,6 +422,16 @@ impl ClassBuilder {
             )
         });
         assert!(success.as_bool(), "Failed to add ivar {}", name);
+    }
+
+    /// Adds an instance variable from an [`IvarType`].
+    ///
+    ///
+    /// # Panics
+    ///
+    /// Same as [`ClassBuilder::add_ivar`].
+    pub fn add_static_ivar<T: IvarType>(&mut self) {
+        self.add_ivar::<T::Type>(T::NAME);
     }
 
     /// Adds the given protocol to self.

--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -72,9 +72,13 @@ unsafe impl<T: IvarType> IvarType for MaybeUninit<T> {
 /// particular, this is never safe to have on the stack by itself.
 ///
 /// Additionally, the instance variable described by `T` must be available on
-/// the specific instance, and be of the exact same type.
+/// the specific instance, and be of the exact same type. When declaring the
+/// object yourself, you can ensure this using
+/// [`ClassBuilder::add_static_ivar`].
 ///
 /// Finally, two ivars with the same name must not be used on the same object.
+///
+/// [`ClassBuilder::add_static_ivar`]: crate::declare::ClassBuilder::add_static_ivar
 ///
 ///
 /// # Examples
@@ -106,7 +110,7 @@ unsafe impl<T: IvarType> IvarType for MaybeUninit<T> {
 /// # use objc2::declare::ClassBuilder;
 /// # let mut builder = ClassBuilder::new("MyObject", class!(NSObject)).unwrap();
 /// // Declare the class and add the instance variable to it
-/// builder.add_ivar::<<MyCustomIvar as IvarType>::Type>(MyCustomIvar::NAME);
+/// builder.add_static_ivar::<MyCustomIvar>();
 /// # let _cls = builder.register();
 ///
 /// let obj: MyObject;

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -495,8 +495,7 @@ macro_rules! declare_class {
             unsafe $v struct $name<>: $inherits, $($inheritance_rest,)* $crate::runtime::Object {
                 // SAFETY:
                 // - The ivars are in a type used as an Objective-C object.
-                // - The instance variable is defined in the exact same manner
-                //   in `class` below.
+                // - The ivar is added to the class below.
                 // - Rust prevents having two fields with the same name.
                 // - Caller upholds that the ivars are properly initialized.
                 $($ivar_v $ivar: $crate::declare::Ivar<$ivar>,)*
@@ -527,10 +526,9 @@ macro_rules! declare_class {
                     );
                     let mut builder = $crate::declare::ClassBuilder::new(stringify!($name), superclass).expect(err_str);
 
+                    // Ivars
                     $(
-                        builder.add_ivar::<<$ivar as $crate::declare::IvarType>::Type>(
-                            <$ivar as $crate::declare::IvarType>::NAME
-                        );
+                        builder.add_static_ivar::<$ivar>();
                     )*
 
                     $(


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/30.

Helper method for adding an `declare::Ivar<T>` to a class. Simplifies manual usage of ivars a bit.