### PR TITLE
Add `ClassType` trait

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   methods that `extern_class!` and `declare_class!` generated to that. This
   means you'll have to `use objc2::ClassType` whenever you want to use e.g.
   `NSData::class()`.
+* Added `Id::into_superclass`.
 
 ### Changed
 * **BREAKING**: Change selector syntax in `declare_class!` macro to be more Rust-like.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `declare_class!`, `extern_class!` and `ns_string!` macros from
   `objc2-foundation`.
 * Added helper method `ClassBuilder::add_static_ivar`.
+* **BREAKING**: Added `ClassType` trait, and moved the associated `class`
+  methods that `extern_class!` and `declare_class!` generated to that. This
+  means you'll have to `use objc2::ClassType` whenever you want to use e.g.
+  `NSData::class()`.
 
 ### Changed
 * **BREAKING**: Change selector syntax in `declare_class!` macro to be more Rust-like.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 * **BREAKING**: Change selector syntax in `declare_class!` macro to be more Rust-like.
+* **BREAKING**: Renamed `Id::from_owned` to `Id::into_shared`.
 
 
 ## 0.3.0-beta.1 - 2022-07-19

--- a/objc2/CHANGELOG_FOUNDATION.md
+++ b/objc2/CHANGELOG_FOUNDATION.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   type-safety from this, it makes `NSValue` much more useful in the real
   world!
 * **BREAKING**: Made `NSArray::new` generic over ownership.
+* **BREAKING**: Made `NSObject::is_kind_of` take a generic `T: ClassType`
+  instead of a `runtime::Class`.
 
 ### Fixed
 * Made `Debug` impls for all objects print something useful.

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -12,7 +12,7 @@ use objc2::foundation::NSObject;
 use objc2::rc::{Id, Owned};
 use objc2::runtime::{Class, Object, Sel};
 use objc2::{msg_send, msg_send_id, sel};
-use objc2::{Encoding, Message, RefEncode};
+use objc2::{ClassType, Encoding, Message, RefEncode};
 
 /// Helper type for the instance variable
 struct NumberIvar<'a> {
@@ -62,8 +62,10 @@ impl<'a> MyObject<'a> {
     pub fn set(&mut self, number: u8) {
         **self.number = number;
     }
+}
 
-    pub fn class() -> &'static Class {
+unsafe impl<'a> ClassType for MyObject<'a> {
+    fn class() -> &'static Class {
         // TODO: Use std::lazy::LazyCell
         static REGISTER_CLASS: Once = Once::new();
 

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -123,6 +123,10 @@ fn main() {
     let mut number = 54;
     let mut obj = MyObject::new(&mut number);
 
+    // It is not possible to convert to `Id<NSObject, Owned>` since that would
+    // loose the lifetime information that `MyObject` stores
+    // let obj = Id::into_superclass(obj);
+
     println!("Number: {}", obj.get());
 
     obj.set(7);

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -130,7 +130,7 @@ fn main() {
     // println!("Number: {}", number);
     println!("Number: {}", obj.get());
 
-    let obj = Id::from_owned(obj);
+    let obj = Id::into_shared(obj);
     let obj2 = obj.clone();
 
     // We gave up ownership above, so can't edit the number any more!

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -65,6 +65,8 @@ impl<'a> MyObject<'a> {
 }
 
 unsafe impl<'a> ClassType for MyObject<'a> {
+    type Superclass = NSObject;
+
     fn class() -> &'static Class {
         // TODO: Use std::lazy::LazyCell
         static REGISTER_CLASS: Once = Once::new();

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -1,11 +1,8 @@
-#[cfg(all(feature = "apple", target_os = "macos"))]
-use objc2::{
-    declare_class, extern_class,
-    foundation::NSObject,
-    msg_send, msg_send_id,
-    rc::{Id, Shared},
-    runtime::{Bool, Object},
-};
+#![cfg_attr(not(all(feature = "apple", target_os = "macos")), allow(unused))]
+use objc2::foundation::NSObject;
+use objc2::rc::{Id, Shared};
+use objc2::runtime::{Bool, Object};
+use objc2::{declare_class, extern_class, msg_send, msg_send_id, ClassType};
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
 #[link(name = "AppKit", kind = "framework")]

--- a/objc2/examples/introspection.rs
+++ b/objc2/examples/introspection.rs
@@ -1,7 +1,6 @@
 use objc2::foundation::NSObject;
 use objc2::runtime::Class;
-use objc2::sel;
-use objc2::Encode;
+use objc2::{sel, ClassType, Encode};
 
 fn main() {
     // Get the class representing `NSObject`

--- a/objc2/examples/nspasteboard.rs
+++ b/objc2/examples/nspasteboard.rs
@@ -9,7 +9,7 @@ use std::mem::ManuallyDrop;
 use objc2::foundation::{NSArray, NSDictionary, NSInteger, NSObject, NSString};
 use objc2::rc::{Id, Shared};
 use objc2::runtime::{Class, Object};
-use objc2::{extern_class, msg_send, msg_send_bool, msg_send_id};
+use objc2::{extern_class, msg_send, msg_send_bool, msg_send_id, ClassType};
 
 type NSPasteboardType = NSString;
 type NSPasteboardReadingOptionKey = NSString;

--- a/objc2/examples/speech_synthethis.rs
+++ b/objc2/examples/speech_synthethis.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use objc2::foundation::{NSObject, NSString};
 use objc2::rc::{Id, Owned};
-use objc2::{extern_class, msg_send, msg_send_bool, msg_send_id, ns_string};
+use objc2::{extern_class, msg_send, msg_send_bool, msg_send_id, ns_string, ClassType};
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
 mod appkit {

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -255,6 +255,7 @@ mod tests {
     use crate::foundation::NSZone;
     use crate::rc::{Allocated, Owned, RcTestObject, Shared, ThreadTestData};
     use crate::runtime::Object;
+    use crate::ClassType;
     use crate::{class, msg_send_id};
 
     #[test]

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -1,0 +1,60 @@
+use crate::runtime::Class;
+use crate::Message;
+
+/// Marks types that represent specific classes.
+///
+/// Usually it is enough to generically know that a type is messageable, e.g.
+/// [`rc::Id`][crate::rc::Id] works with any type that implements the
+/// [`Message`] trait. But often, you have an object that you know represents
+/// a specific Objective-C class - this trait allows you to communicate that
+/// to the rest of the type-system.
+///
+/// This is implemented automatically by the
+/// [`declare_class!`][crate::declare_class] and
+/// [`extern_class!`][crate::extern_class] macros.
+///
+///
+/// # Safety
+///
+/// TODO
+///
+///
+/// # Examples
+///
+/// Use the trait to access the [`Class`] of different objects.
+///
+/// ```
+/// # #[cfg(feature = "gnustep-1-7")]
+/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
+/// use objc2::ClassType;
+/// use objc2::foundation::NSObject;
+/// // Get a class object representing `NSObject`
+/// let cls = <NSObject as ClassType>::class(); // Or just `NSObject::class()`
+/// ```
+///
+/// Use the [`extern_class!`][crate::extern_class] macro to implement this
+/// trait for a type.
+///
+/// ```ignore
+/// use objc2::{extern_class, ClassType};
+///
+/// extern_class! {
+///     unsafe struct MyClass: NSObject;
+/// }
+///
+/// let cls = MyClass::class();
+/// ```
+// TODO: Figure out if we should use `Deref`, or an associated type.
+pub unsafe trait ClassType: Message {
+    /// Get a reference to the Objective-C class that this type represents.
+    ///
+    /// May register the class with the runtime if it wasn't already.
+    ///
+    ///
+    /// # Panics
+    ///
+    /// This may panic if something went wrong with getting or declaring the
+    /// class, e.g. if the program is not properly linked to the framework
+    /// that defines the class.
+    fn class() -> &'static Class;
+}

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -16,7 +16,13 @@ use crate::Message;
 ///
 /// # Safety
 ///
-/// TODO
+/// The class returned by [`Self::class`] must be a subclass of the class that
+/// [`Self::Superclass`] represents.
+///
+/// In pseudocode:
+/// ```ignore
+/// Self::class().superclass() == <Self::Superclass as ClassType>::class()
+/// ```
 ///
 ///
 /// # Examples
@@ -44,8 +50,19 @@ use crate::Message;
 ///
 /// let cls = MyClass::class();
 /// ```
-// TODO: Figure out if we should use `Deref`, or an associated type.
 pub unsafe trait ClassType: Message {
+    /// The superclass of this class.
+    ///
+    /// If you have implemented [`Deref`] for your type, it is highly
+    /// recommended that this is equal to [`Deref::Target`].
+    ///
+    /// This may be [`runtime::Object`] if the class is a root class.
+    ///
+    /// [`Deref`]: std::ops::Deref
+    /// [`Deref::Target`]: std::ops::Deref::Target
+    /// [`runtime::Object`]: crate::runtime::Object
+    type Superclass: Message;
+
     /// Get a reference to the Objective-C class that this type represents.
     ///
     /// May register the class with the runtime if it wasn't already.

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -15,11 +15,11 @@
 //! methods and methods for interfacing with the number.
 //!
 //! ```
-//! use objc2::{class, sel, msg_send, msg_send_id};
 //! use objc2::declare::ClassBuilder;
 //! use objc2::foundation::NSObject;
 //! use objc2::rc::{Id, Owned};
 //! use objc2::runtime::{Class, Object, Sel};
+//! use objc2::{class, sel, msg_send, msg_send_id, ClassType};
 //! # #[cfg(feature = "gnustep-1-7")]
 //! # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 //!

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -10,8 +10,7 @@ use super::{
 };
 use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
 use crate::runtime::{Class, Object};
-use crate::Message;
-use crate::{__inner_extern_class, msg_send, msg_send_id};
+use crate::{ClassType, Message, __inner_extern_class, msg_send, msg_send_id};
 
 __inner_extern_class! {
     /// An immutable ordered collection of objects.

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_retains_stored() {
-        let obj = Id::from_owned(RcTestObject::new());
+        let obj = Id::into_shared(RcTestObject::new());
         let mut expected = ThreadTestData::current();
 
         let input = [obj.clone(), obj.clone()];
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_nscopying_uses_retain() {
-        let obj = Id::from_owned(RcTestObject::new());
+        let obj = Id::into_shared(RcTestObject::new());
         let array = NSArray::from_slice(&[obj]);
         let mut expected = ThreadTestData::current();
 
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_iter_no_retain() {
-        let obj = Id::from_owned(RcTestObject::new());
+        let obj = Id::into_shared(RcTestObject::new());
         let array = NSArray::from_slice(&[obj]);
         let mut expected = ThreadTestData::current();
 

--- a/objc2/src/foundation/attributed_string.rs
+++ b/objc2/src/foundation/attributed_string.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::rc::{DefaultId, Id, Shared};
 use crate::runtime::Object;
-use crate::{extern_class, msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// A string that has associated attributes for portions of its text.

--- a/objc2/src/foundation/attributed_string.rs
+++ b/objc2/src/foundation/attributed_string.rs
@@ -176,11 +176,11 @@ mod tests {
         // NSAttributedString performs this optimization in GNUStep's runtime,
         // but not in Apple's; so we don't test for it!
         // assert_eq!(Id::as_ptr(&s1), Id::as_ptr(&s2));
-        assert!(s2.is_kind_of(NSAttributedString::class()));
+        assert!(s2.is_kind_of::<NSAttributedString>());
 
         let s3 = s1.mutable_copy();
         assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3).cast());
-        assert!(s3.is_kind_of(NSMutableAttributedString::class()));
+        assert!(s3.is_kind_of::<NSMutableAttributedString>());
     }
 
     #[test]

--- a/objc2/src/foundation/data.rs
+++ b/objc2/src/foundation/data.rs
@@ -9,7 +9,7 @@ use core::slice::{self, SliceIndex};
 use super::{NSCopying, NSMutableCopying, NSMutableData, NSObject};
 use crate::rc::{DefaultId, Id, Shared};
 use crate::runtime::{Class, Object};
-use crate::{extern_class, msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// A static byte buffer in memory.

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -8,7 +8,7 @@ use core::ptr;
 
 use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
 use crate::rc::{DefaultId, Id, Owned, Shared, SliceId};
-use crate::{__inner_extern_class, msg_send, msg_send_id, Message};
+use crate::{ClassType, __inner_extern_class, msg_send, msg_send_id, Message};
 
 __inner_extern_class! {
     #[derive(PartialEq, Eq, Hash)]

--- a/objc2/src/foundation/error.rs
+++ b/objc2/src/foundation/error.rs
@@ -2,10 +2,9 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSDictionary, NSObject, NSString};
-use crate::extern_class;
 use crate::ffi::NSInteger;
 use crate::rc::{Id, Shared};
-use crate::{msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// Information about an error condition including a domain, a

--- a/objc2/src/foundation/exception.rs
+++ b/objc2/src/foundation/exception.rs
@@ -6,7 +6,7 @@ use super::{NSCopying, NSDictionary, NSObject, NSString};
 use crate::exception::Exception;
 use crate::rc::{Id, Shared};
 use crate::runtime::Object;
-use crate::{extern_class, msg_send, msg_send_id, sel};
+use crate::{extern_class, msg_send, msg_send_id, sel, ClassType};
 
 extern_class! {
     /// A special condition that interrupts the normal flow of program

--- a/objc2/src/foundation/exception.rs
+++ b/objc2/src/foundation/exception.rs
@@ -94,7 +94,7 @@ impl NSException {
             // SAFETY: We only use `isKindOfClass:` on NSObject
             let obj: *const Exception = obj;
             let obj = unsafe { obj.cast::<NSObject>().as_ref().unwrap() };
-            obj.is_kind_of(Self::class())
+            obj.is_kind_of::<Self>()
         } else {
             false
         }

--- a/objc2/src/foundation/mod.rs
+++ b/objc2/src/foundation/mod.rs
@@ -21,6 +21,31 @@
 //! [pull requests]: https://github.com/madsmtm/objc2/pulls
 //! [`Message`]: crate::Message
 //! [`msg_send!`]: crate::msg_send
+//!
+//!
+//! # Use of `Deref`
+//!
+//! `objc2::foundation` uses the [`Deref`] trait in a bit special way: All
+//! objects deref to their superclasses. For example, `NSMutableArray` derefs
+//! to `NSArray`, which in turn derefs to `NSObject`.
+//!
+//! Note that this is explicitly recommended against in [the
+//! documentation][`Deref`] and [the Rust Design patterns
+//! book][anti-pattern-deref] (see those links for details).
+//!
+//! Due to Objective-C objects only ever being accessible behind pointers in
+//! the first place, the problems stated there are less severe, and having the
+//! implementation just means that everything is much nicer when you actually
+//! want to use the objects!
+//!
+//! All objects also implement [`AsRef`] and [`AsMut`] to their superclass,
+//! and can be used in [`Id::into_superclass`], so if you favour explicit
+//! conversion, that is a possibility too.
+//!
+//! [`Deref`]: std::ops::Deref
+//! [`ClassType`]: crate::ClassType
+//! [anti-pattern-deref]: https://rust-unofficial.github.io/patterns/anti_patterns/deref.html
+//! [`Id::into_superclass`]: crate::rc::Id::into_superclass
 
 // TODO: Remove these
 #![allow(missing_docs)]

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -11,8 +11,7 @@ use super::{
     NSObject,
 };
 use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::Message;
-use crate::{__inner_extern_class, msg_send, msg_send_id};
+use crate::{ClassType, Message, __inner_extern_class, msg_send, msg_send_id};
 
 __inner_extern_class! {
     /// A growable ordered collection of objects.

--- a/objc2/src/foundation/mutable_attributed_string.rs
+++ b/objc2/src/foundation/mutable_attributed_string.rs
@@ -100,10 +100,10 @@ mod tests {
         let s1 = NSMutableAttributedString::from_nsstring(&NSString::from_str("abc"));
         let s2 = s1.copy();
         assert_ne!(Id::as_ptr(&s1).cast(), Id::as_ptr(&s2));
-        assert!(s2.is_kind_of(NSAttributedString::class()));
+        assert!(s2.is_kind_of::<NSAttributedString>());
 
         let s3 = s1.mutable_copy();
         assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3));
-        assert!(s3.is_kind_of(NSMutableAttributedString::class()));
+        assert!(s3.is_kind_of::<NSMutableAttributedString>());
     }
 }

--- a/objc2/src/foundation/mutable_attributed_string.rs
+++ b/objc2/src/foundation/mutable_attributed_string.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use super::{NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
 use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// A mutable string that has associated attributes.

--- a/objc2/src/foundation/mutable_data.rs
+++ b/objc2/src/foundation/mutable_data.rs
@@ -9,7 +9,7 @@ use std::io;
 use super::data::with_slice;
 use super::{NSCopying, NSData, NSMutableCopying, NSObject, NSRange};
 use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// A dynamic byte buffer in memory.

--- a/objc2/src/foundation/mutable_string.rs
+++ b/objc2/src/foundation/mutable_string.rs
@@ -218,10 +218,10 @@ mod tests {
         let s1 = NSMutableString::from_str("abc");
         let s2 = s1.copy();
         assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s2).cast());
-        assert!(s2.is_kind_of(NSString::class()));
+        assert!(s2.is_kind_of::<NSString>());
 
         let s3 = s1.mutable_copy();
         assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3));
-        assert!(s3.is_kind_of(NSMutableString::class()));
+        assert!(s3.is_kind_of::<NSMutableString>());
     }
 }

--- a/objc2/src/foundation/mutable_string.rs
+++ b/objc2/src/foundation/mutable_string.rs
@@ -5,7 +5,7 @@ use core::str;
 
 use super::{NSCopying, NSMutableCopying, NSObject, NSString};
 use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, msg_send, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_id, ClassType};
 
 extern_class! {
     /// A dynamic plain-text Unicode string object.

--- a/objc2/src/foundation/number.rs
+++ b/objc2/src/foundation/number.rs
@@ -11,8 +11,7 @@ use super::{
 };
 use crate::rc::{Id, Shared};
 use crate::runtime::Bool;
-use crate::Encoding;
-use crate::{extern_class, msg_send, msg_send_bool, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_bool, msg_send_id, ClassType, Encoding};
 
 extern_class! {
     /// An object wrapper for primitive scalars.

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -12,6 +12,8 @@ __inner_extern_class! {
 }
 
 unsafe impl ClassType for NSObject {
+    type Superclass = Object;
+
     #[inline]
     fn class() -> &'static Class {
         class!(NSObject)

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -4,17 +4,16 @@ use core::hash;
 use super::NSString;
 use crate::rc::{DefaultId, Id, Owned, Shared};
 use crate::runtime::{Class, Object};
-use crate::{__inner_extern_class, class, msg_send, msg_send_bool, msg_send_id};
+use crate::{ClassType, __inner_extern_class, class, msg_send, msg_send_bool, msg_send_id};
 
 __inner_extern_class! {
     @__inner
     unsafe pub struct NSObject<>: Object {}
 }
 
-impl NSObject {
-    /// Get a reference to the Objective-C class `NSObject`.
+unsafe impl ClassType for NSObject {
     #[inline]
-    pub fn class() -> &'static Class {
+    fn class() -> &'static Class {
         class!(NSObject)
     }
 }

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -25,9 +25,28 @@ impl NSObject {
         unsafe { msg_send_id![Self::class(), new].unwrap() }
     }
 
-    pub fn is_kind_of(&self, cls: &Class) -> bool {
+    fn is_kind_of_inner(&self, cls: &Class) -> bool {
         unsafe { msg_send_bool![self, isKindOfClass: cls] }
     }
+
+    /// Check if the object is an instance of the class, or one of it's
+    /// subclasses.
+    ///
+    /// See [Apple's documentation][apple-doc] for more details on what you
+    /// may (and what you may not) do with this information.
+    ///
+    /// [apple-doc]: https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418511-iskindofclass
+    #[doc(alias = "isKindOfClass:")]
+    pub fn is_kind_of<T: ClassType>(&self) -> bool {
+        self.is_kind_of_inner(T::class())
+    }
+
+    // Note: We don't provide a method to convert `NSObject` to `T` based on
+    // `is_kind_of`, since that is not possible to do in general!
+    //
+    // For example, something may have a return type of `NSString`, while
+    // behind the scenes they really return `NSMutableString` and expect it to
+    // not be modified.
 }
 
 /// Objective-C equality has approximately the same semantics as Rust
@@ -161,7 +180,7 @@ mod tests {
     #[test]
     fn test_is_kind_of() {
         let obj = NSObject::new();
-        assert!(obj.is_kind_of(NSObject::class()));
-        assert!(!obj.is_kind_of(NSString::class()));
+        assert!(obj.is_kind_of::<NSObject>());
+        assert!(!obj.is_kind_of::<NSString>());
     }
 }

--- a/objc2/src/foundation/process_info.rs
+++ b/objc2/src/foundation/process_info.rs
@@ -3,7 +3,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSObject, NSString};
 use crate::rc::{Id, Shared};
-use crate::{extern_class, msg_send_id};
+use crate::{extern_class, msg_send_id, ClassType};
 
 extern_class! {
     /// A collection of information about the current process.

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -11,11 +11,9 @@ use std::os::raw::c_char;
 
 use super::{NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject};
 use crate::ffi;
-use crate::rc::DefaultId;
-use crate::rc::{autoreleasepool, AutoreleasePool};
-use crate::rc::{Id, Shared};
+use crate::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
 use crate::runtime::{Class, Object};
-use crate::{extern_class, msg_send, msg_send_bool, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_bool, msg_send_id, ClassType};
 
 #[cfg(feature = "apple")]
 const UTF8_ENCODING: usize = 4;

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -375,11 +375,11 @@ mod tests {
         let s2 = s1.copy();
         // An optimization that NSString makes, since it is immutable
         assert_eq!(Id::as_ptr(&s1), Id::as_ptr(&s2));
-        assert!(s2.is_kind_of(NSString::class()));
+        assert!(s2.is_kind_of::<NSString>());
 
         let s3 = s1.mutable_copy();
         assert_ne!(Id::as_ptr(&s1), Id::as_ptr(&s3).cast());
-        assert!(s3.is_kind_of(NSMutableString::class()));
+        assert!(s3.is_kind_of::<NSMutableString>());
     }
 
     #[test]

--- a/objc2/src/foundation/thread.rs
+++ b/objc2/src/foundation/thread.rs
@@ -4,7 +4,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSObject, NSString};
 use crate::rc::{Id, Shared};
-use crate::{extern_class, msg_send, msg_send_bool, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_bool, msg_send_id, ClassType};
 
 extern_class! {
     /// A thread of execution.

--- a/objc2/src/foundation/uuid.rs
+++ b/objc2/src/foundation/uuid.rs
@@ -2,9 +2,8 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSObject, NSString};
-use crate::rc::DefaultId;
-use crate::rc::{Id, Shared};
-use crate::{extern_class, msg_send, msg_send_id, Encode, Encoding, RefEncode};
+use crate::rc::{DefaultId, Id, Shared};
+use crate::{extern_class, msg_send, msg_send_id, ClassType, Encode, Encoding, RefEncode};
 
 extern_class! {
     /// A universally unique value.

--- a/objc2/src/foundation/value.rs
+++ b/objc2/src/foundation/value.rs
@@ -10,8 +10,7 @@ use std::os::raw::c_char;
 
 use super::{NSCopying, NSObject, NSPoint, NSRange, NSRect, NSSize};
 use crate::rc::{Id, Shared};
-use crate::Encode;
-use crate::{extern_class, msg_send, msg_send_bool, msg_send_id};
+use crate::{extern_class, msg_send, msg_send_bool, msg_send_id, ClassType, Encode};
 
 extern_class! {
     /// A container wrapping any encodable type as an Obective-C object.

--- a/objc2/src/foundation/zone.rs
+++ b/objc2/src/foundation/zone.rs
@@ -1,9 +1,10 @@
 use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
+use crate::ffi;
 #[cfg(feature = "gnustep-1-7")]
 use crate::Encode;
-use crate::{ffi, Encoding, RefEncode};
+use crate::{Encoding, RefEncode};
 
 /// A type used to identify and manage memory zones.
 ///
@@ -68,6 +69,7 @@ mod tests {
     use crate::foundation::NSObject;
     use crate::msg_send_id;
     use crate::rc::{Allocated, Id, Owned};
+    use crate::ClassType;
 
     #[test]
     fn alloc_with_zone() {

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -199,6 +199,7 @@ pub use objc_sys as ffi;
 #[doc(no_inline)]
 pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
+pub use crate::class_type::ClassType;
 pub use crate::message::{Message, MessageArguments, MessageReceiver};
 #[cfg(feature = "malloc")]
 pub use crate::verify::VerificationError;
@@ -219,6 +220,7 @@ macro_rules! __hash_idents {
 pub mod __macro_helpers;
 mod bool;
 mod cache;
+mod class_type;
 pub mod declare;
 pub mod exception;
 #[cfg(feature = "foundation")]

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -504,6 +504,8 @@ macro_rules! declare_class {
 
         // Creation
         unsafe impl $crate::ClassType for $name {
+            type Superclass = $inherits;
+
             fn class() -> &'static $crate::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`
                 use $crate::__macro_helpers::Once;

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -323,10 +323,10 @@ macro_rules! __inner_declare_class {
 ///
 /// ```
 /// use std::os::raw::c_int;
-/// use objc2::{declare_class, msg_send, msg_send_bool, msg_send_id};
 /// use objc2::rc::{Id, Owned};
 /// use objc2::foundation::{NSCopying, NSObject, NSZone};
 /// use objc2::runtime::Bool;
+/// use objc2::{declare_class, msg_send, msg_send_bool, msg_send_id, ClassType};
 /// #
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
@@ -503,22 +503,15 @@ macro_rules! declare_class {
         }
 
         // Creation
-        impl $name {
-            #[doc = concat!(
-                "Get a reference to the Objective-C class `",
-                stringify!($name),
-                "`.",
-                "\n\n",
-                "May register the class if it wasn't already.",
-            )]
-            // TODO: Allow users to configure this?
-            $v fn class() -> &'static $crate::runtime::Class {
+        unsafe impl $crate::ClassType for $name {
+            fn class() -> &'static $crate::runtime::Class {
+                // TODO: Use `core::cell::LazyCell`
                 use $crate::__macro_helpers::Once;
 
                 static REGISTER_CLASS: Once = Once::new();
 
                 REGISTER_CLASS.call_once(|| {
-                    let superclass = <$inherits>::class();
+                    let superclass = <$inherits as $crate::ClassType>::class();
                     let err_str = concat!(
                         "could not create new class ",
                         stringify!($name),

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -189,19 +189,21 @@ macro_rules! __inner_extern_class {
     // TODO: Expose this variant in the `object` macro.
     (
         $(#[$m:meta])*
-        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident $(= $default:ty)?)?),*>: $($inheritance_chain:ty),+ {
+        unsafe $v:vis struct $name:ident<$($t:ident $(: $b:ident $(= $default:ty)?)?),*>: $superclass:ty $(, $inheritance_rest:ty)* {
             $($field_vis:vis $field:ident: $field_ty:ty,)*
         }
     ) => {
         $crate::__inner_extern_class! {
             @__inner
             $(#[$m])*
-            unsafe $v struct $name<$($t $(: $b $(= $default)?)?),*>: $($inheritance_chain,)+ $crate::runtime::Object {
+            unsafe $v struct $name<$($t $(: $b $(= $default)?)?),*>: $superclass, $($inheritance_rest,)* $crate::runtime::Object {
                 $($field_vis $field: $field_ty,)*
             }
         }
 
         unsafe impl<$($t $(: $b)?),*> $crate::ClassType for $name<$($t),*> {
+            type Superclass = $superclass;
+
             #[inline]
             fn class() -> &'static $crate::runtime::Class {
                 $crate::class!($name)

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -57,7 +57,7 @@
 /// ```
 /// use objc2::foundation::NSObject;
 /// use objc2::rc::{Id, Shared};
-/// use objc2::{extern_class, msg_send_id};
+/// use objc2::{ClassType, extern_class, msg_send_id};
 /// #
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
@@ -70,7 +70,7 @@
 ///     unsafe pub struct NSFormatter: NSObject;
 /// }
 ///
-/// // Provided by the macro
+/// // Provided by the macro (it implements `ClassType`)
 /// let cls = NSFormatter::class();
 ///
 /// // `NSFormatter` implements `Message`:
@@ -201,15 +201,9 @@ macro_rules! __inner_extern_class {
             }
         }
 
-        impl<$($t $(: $b)?),*> $name<$($t),*> {
-            #[doc = concat!(
-                "Get a reference to the Objective-C class `",
-                stringify!($name),
-                "`.",
-            )]
+        unsafe impl<$($t $(: $b)?),*> $crate::ClassType for $name<$($t),*> {
             #[inline]
-            // TODO: Allow users to configure this?
-            $v fn class() -> &'static $crate::runtime::Class {
+            fn class() -> &'static $crate::runtime::Class {
                 $crate::class!($name)
             }
         }

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -175,11 +175,13 @@ impl<T: Message + ?Sized, O: Ownership> Id<T, O> {
     ///
     /// Returns `None` if the pointer was null.
     ///
+    ///
     /// # Safety
     ///
     /// The caller must ensure the given object has +1 retain count, and that
     /// the object pointer otherwise follows the same safety requirements as
     /// in [`Id::retain`].
+    ///
     ///
     /// # Example
     ///
@@ -309,6 +311,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
     ///
     /// Returns `None` if the pointer was null.
     ///
+    ///
     /// # Safety
     ///
     /// The caller must ensure that the ownership is correct; that is, there
@@ -319,6 +322,10 @@ impl<T: Message, O: Ownership> Id<T, O> {
     /// Additionally, the pointer must be valid as a reference (aligned,
     /// dereferencable and initialized, see the [`std::ptr`] module for more
     /// information).
+    ///
+    /// Finally, if you do not know the concrete type of `T`, it may not be
+    /// `'static`, and hence you must ensure that the data that `T` references
+    /// lives for as long as `T`.
     ///
     /// [`std::ptr`]: core::ptr
     //
@@ -580,6 +587,7 @@ impl<T: Message> Id<T, Owned> {
 
     /// Promote a shared [`Id`] to an owned one, allowing it to be mutated.
     ///
+    ///
     /// # Safety
     ///
     /// The caller must ensure that there are no other pointers (including
@@ -587,6 +595,9 @@ impl<T: Message> Id<T, Owned> {
     ///
     /// This also means that the given [`Id`] should have a retain count of
     /// exactly 1 (except when autoreleases are involved).
+    ///
+    /// In general, this is wildly unsafe, do see if you can find a different
+    /// solution!
     #[inline]
     pub unsafe fn from_shared(obj: Id<T, Shared>) -> Self {
         // Note: We can't debug_assert retainCount because of autoreleases

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -5,7 +5,7 @@ use core::ptr;
 use super::{Id, Owned};
 use crate::foundation::{NSObject, NSZone};
 use crate::runtime::Bool;
-use crate::{declare_class, msg_send, msg_send_bool};
+use crate::{declare_class, msg_send, msg_send_bool, ClassType};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ThreadTestData {

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -7,7 +7,7 @@ use objc2::runtime::{Bool, Class, Object, Protocol};
 #[cfg(feature = "malloc")]
 use objc2::sel;
 use objc2::{class, msg_send, msg_send_bool, msg_send_id};
-use objc2::{Encoding, Message, RefEncode};
+use objc2::{ClassType, Encoding, Message, RefEncode};
 
 #[repr(C)]
 struct MyTestObject {
@@ -20,11 +20,13 @@ unsafe impl RefEncode for MyTestObject {
     const ENCODING_REF: Encoding<'static> = Encoding::Object;
 }
 
-impl MyTestObject {
+unsafe impl ClassType for MyTestObject {
     fn class() -> &'static Class {
         class!(MyTestObject)
     }
+}
 
+impl MyTestObject {
     fn new() -> Id<Self, Owned> {
         let cls = Self::class();
         unsafe { msg_send_id![cls, new].unwrap() }

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -21,6 +21,8 @@ unsafe impl RefEncode for MyTestObject {
 }
 
 unsafe impl ClassType for MyTestObject {
+    type Superclass = NSObject;
+
     fn class() -> &'static Class {
         class!(MyTestObject)
     }


### PR DESCRIPTION
Replaces https://github.com/madsmtm/objc2/pull/197.
Closes https://github.com/madsmtm/objc2/issues/58 (finally!).

Add `ClassType` trait that should be implemented for all types that describe a concrete class (e.g. `NSString` and `NSObject`, but not `runtime::Object`). I've been thinking about adding this for a _long_ time, but have been hesitant to do it because more traits = more for the user to learn. In the end though, I think it is worth it.

Also add `Id::into_superclass` that uses this trait to convert an object to it's superclass.