### PR TITLE
Remove lifetime from `Encoding`

### DIFF
--- a/block2/src/block.rs
+++ b/block2/src/block.rs
@@ -94,7 +94,7 @@ pub struct Block<A, R> {
 }
 
 unsafe impl<A: BlockArguments, R: Encode> RefEncode for Block<A, R> {
-    const ENCODING_REF: Encoding<'static> = Encoding::Block;
+    const ENCODING_REF: Encoding = Encoding::Block;
 }
 
 impl<A: BlockArguments, R: Encode> Block<A, R> {

--- a/block2/src/concrete_block.rs
+++ b/block2/src/concrete_block.rs
@@ -167,7 +167,7 @@ pub struct ConcreteBlock<A, R, F> {
 }
 
 unsafe impl<A: BlockArguments, R: Encode, F> RefEncode for ConcreteBlock<A, R, F> {
-    const ENCODING_REF: Encoding<'static> = Encoding::Block;
+    const ENCODING_REF: Encoding = Encoding::Block;
 }
 
 impl<A, R, F> ConcreteBlock<A, R, F>

--- a/objc2-encode/CHANGELOG.md
+++ b/objc2-encode/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Remove the lifetime specifier from `Encoding`, since the non
+  -`'static` version was essentially useless.
+
 ### Fixed
 * Fixed the encoding output and comparison of structs behind pointers.
 

--- a/objc2-encode/examples/core_graphics.rs
+++ b/objc2-encode/examples/core_graphics.rs
@@ -13,8 +13,7 @@ struct CGPoint {
 }
 
 unsafe impl Encode for CGPoint {
-    const ENCODING: Encoding<'static> =
-        Encoding::Struct("CGPoint", &[CGFloat::ENCODING, CGFloat::ENCODING]);
+    const ENCODING: Encoding = Encoding::Struct("CGPoint", &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 #[repr(C)]
@@ -24,8 +23,7 @@ struct CGSize {
 }
 
 unsafe impl Encode for CGSize {
-    const ENCODING: Encoding<'static> =
-        Encoding::Struct("CGSize", &[CGFloat::ENCODING, CGFloat::ENCODING]);
+    const ENCODING: Encoding = Encoding::Struct("CGSize", &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 #[repr(C)]
@@ -35,8 +33,7 @@ struct CGRect {
 }
 
 unsafe impl Encode for CGRect {
-    const ENCODING: Encoding<'static> =
-        Encoding::Struct("CGRect", &[CGPoint::ENCODING, CGSize::ENCODING]);
+    const ENCODING: Encoding = Encoding::Struct("CGRect", &[CGPoint::ENCODING, CGSize::ENCODING]);
 }
 
 fn main() {

--- a/objc2-encode/examples/ns_string.rs
+++ b/objc2-encode/examples/ns_string.rs
@@ -12,7 +12,7 @@ struct NSString {
 
 /// Implement `RefEncode` for pointers and references to the string.
 unsafe impl RefEncode for NSString {
-    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    const ENCODING_REF: Encoding = Encoding::Object;
 }
 
 fn main() {

--- a/objc2-encode/examples/ns_uinteger.rs
+++ b/objc2-encode/examples/ns_uinteger.rs
@@ -14,7 +14,7 @@ unsafe impl Encode for NSUInteger {
     /// Running `@encode(NSUInteger)` gives `Q` on 64-bit systems and `I` on
     /// 32-bit systems. This corresponds exactly to `usize`, which is also how
     /// we've defined our struct.
-    const ENCODING: Encoding<'static> = usize::ENCODING;
+    const ENCODING: Encoding = usize::ENCODING;
 }
 
 // SAFETY: `&NSUInteger` has the same representation as `&usize`.
@@ -22,7 +22,7 @@ unsafe impl RefEncode for NSUInteger {
     /// Running `@encode(NSUInteger*)` gives `^Q` on 64-bit systems and `^I`
     /// on 32-bit systems. So implementing `RefEncode` as a plain pointer is
     /// correct.
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&NSUInteger::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&NSUInteger::ENCODING);
 }
 
 fn main() {

--- a/objc2-encode/examples/opaque_type.rs
+++ b/objc2-encode/examples/opaque_type.rs
@@ -15,7 +15,7 @@ struct NSDecimal {
 // SAFETY: `&NSDecimal` is a pointer.
 unsafe impl RefEncode for NSDecimal {
     // Running `@encode` on `NSDecimal*` on my 64-bit system gives `^{?=cCCC[38C]}`.
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Encoding::Struct(
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct(
         "?",
         &[
             Encoding::Char,

--- a/objc2-encode/src/helper.rs
+++ b/objc2-encode/src/helper.rs
@@ -167,7 +167,7 @@ pub(crate) enum Helper<'a> {
 }
 
 impl<'a> Helper<'a> {
-    pub(crate) const fn new(encoding: Encoding<'a>) -> Self {
+    pub(crate) const fn new(encoding: &Encoding<'a>) -> Self {
         use Encoding::*;
         match encoding {
             Char => Self::Primitive(Primitive::Char),
@@ -194,10 +194,10 @@ impl<'a> Helper<'a> {
             Class => Self::Primitive(Primitive::Class),
             Sel => Self::Primitive(Primitive::Sel),
             Unknown => Self::Primitive(Primitive::Unknown),
-            BitField(b, t) => Self::BitField(b, t),
+            BitField(b, t) => Self::BitField(*b, t),
             Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t),
             Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t),
-            Array(len, item) => Self::Array(len, item),
+            Array(len, item) => Self::Array(*len, item),
             Struct(name, fields) => Self::Container(ContainerKind::Struct, name, fields),
             Union(name, members) => Self::Container(ContainerKind::Union, name, members),
         }

--- a/objc2-encode/src/helper.rs
+++ b/objc2-encode/src/helper.rs
@@ -160,14 +160,14 @@ impl ContainerKind {
 #[non_exhaustive]
 pub(crate) enum Helper<'a> {
     Primitive(Primitive),
-    BitField(u8, &'a Encoding<'a>),
-    Indirection(IndirectionKind, &'a Encoding<'a>),
-    Array(usize, &'a Encoding<'a>),
-    Container(ContainerKind, &'a str, &'a [Encoding<'a>]),
+    BitField(u8, &'a Encoding),
+    Indirection(IndirectionKind, &'a Encoding),
+    Array(usize, &'a Encoding),
+    Container(ContainerKind, &'a str, &'a [Encoding]),
 }
 
 impl<'a> Helper<'a> {
-    pub(crate) const fn new(encoding: &Encoding<'a>) -> Self {
+    pub(crate) const fn new(encoding: &'a Encoding) -> Self {
         use Encoding::*;
         match encoding {
             Char => Self::Primitive(Primitive::Char),

--- a/objc2-encode/src/lib.rs
+++ b/objc2-encode/src/lib.rs
@@ -34,7 +34,7 @@
 //! }
 //!
 //! unsafe impl Encode for MyStruct {
-//!     const ENCODING: Encoding<'static> = Encoding::Struct(
+//!     const ENCODING: Encoding = Encoding::Struct(
 //!         "MyStruct", // Must use the same name as defined in C header files
 //!         &[
 //!             f32::ENCODING, // Same as Encoding::Float
@@ -49,7 +49,7 @@
 //! unsafe impl RefEncode for MyStruct {
 //!     // Note that if `MyStruct` is an Objective-C instance, this should
 //!     // be `Encoding::Object`.
-//!     const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+//!     const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 //! }
 //!
 //! // @encode(MyStruct*) -> "^{MyStruct=fs}"

--- a/objc2-encode/src/parse.rs
+++ b/objc2-encode/src/parse.rs
@@ -20,7 +20,7 @@ pub(crate) fn rm_enc_prefix<'a>(
     level: NestingLevel,
 ) -> Option<&'a str> {
     use Helper::*;
-    match Helper::new(*enc) {
+    match Helper::new(enc) {
         Primitive(primitive) => s.strip_prefix(primitive.to_str()),
         BitField(b, _type) => {
             // TODO: Use the type on GNUStep (nesting level?)

--- a/objc2-encode/src/parse.rs
+++ b/objc2-encode/src/parse.rs
@@ -16,7 +16,7 @@ pub(crate) const QUALIFIERS: &[char] = &[
 
 pub(crate) fn rm_enc_prefix<'a>(
     s: &'a str,
-    enc: &Encoding<'_>,
+    enc: &Encoding,
     level: NestingLevel,
 ) -> Option<&'a str> {
     use Helper::*;

--- a/objc2-encode/src/static_str.rs
+++ b/objc2-encode/src/static_str.rs
@@ -38,7 +38,7 @@ pub(crate) const fn static_int_str_array<const RES: usize>(mut n: u128) -> [u8; 
     rev
 }
 
-pub(crate) const fn static_encoding_str_len(encoding: Encoding<'_>, level: NestingLevel) -> usize {
+pub(crate) const fn static_encoding_str_len(encoding: &Encoding<'_>, level: NestingLevel) -> usize {
     use Helper::*;
 
     match Helper::new(encoding) {
@@ -47,8 +47,8 @@ pub(crate) const fn static_encoding_str_len(encoding: Encoding<'_>, level: Nesti
             // TODO: Use the type on GNUStep (nesting level?)
             1 + static_int_str_len(b as u128)
         }
-        Indirection(kind, &t) => 1 + static_encoding_str_len(t, level.indirection(kind)),
-        Array(len, &item) => {
+        Indirection(kind, t) => 1 + static_encoding_str_len(t, level.indirection(kind)),
+        Array(len, item) => {
             1 + static_int_str_len(len as u128) + static_encoding_str_len(item, level.array()) + 1
         }
         Container(_, name, items) => {
@@ -57,7 +57,7 @@ pub(crate) const fn static_encoding_str_len(encoding: Encoding<'_>, level: Nesti
                 res += 1;
                 let mut i = 0;
                 while i < items.len() {
-                    res += static_encoding_str_len(items[i], level);
+                    res += static_encoding_str_len(&items[i], level);
                     i += 1;
                 }
             }
@@ -67,7 +67,7 @@ pub(crate) const fn static_encoding_str_len(encoding: Encoding<'_>, level: Nesti
 }
 
 pub(crate) const fn static_encoding_str_array<const LEN: usize>(
-    encoding: Encoding<'_>,
+    encoding: &Encoding<'_>,
     level: NestingLevel,
 ) -> [u8; LEN] {
     use Helper::*;
@@ -84,7 +84,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        BitField(b, &_type) => {
+        BitField(b, _type) => {
             // TODO: Use the type on GNUStep (nesting level?)
             res[res_i] = b'b';
             res_i += 1;
@@ -98,7 +98,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        Indirection(kind, &t) => {
+        Indirection(kind, t) => {
             res[res_i] = kind.prefix_byte();
             res_i += 1;
 
@@ -111,7 +111,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        Array(len, &item) => {
+        Array(len, item) => {
             let mut res_i = 0;
 
             res[res_i] = b'[';
@@ -158,10 +158,10 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 let mut items_i = 0;
                 while items_i < items.len() {
                     // We use LEN even though it creates an oversized array
-                    let field_res = static_encoding_str_array::<LEN>(items[items_i], level);
+                    let field_res = static_encoding_str_array::<LEN>(&items[items_i], level);
 
                     let mut item_res_i = 0;
-                    while item_res_i < static_encoding_str_len(items[items_i], level) {
+                    while item_res_i < static_encoding_str_len(&items[items_i], level) {
                         res[res_i] = field_res[item_res_i];
                         res_i += 1;
                         item_res_i += 1;

--- a/objc2-encode/src/static_str.rs
+++ b/objc2-encode/src/static_str.rs
@@ -38,7 +38,7 @@ pub(crate) const fn static_int_str_array<const RES: usize>(mut n: u128) -> [u8; 
     rev
 }
 
-pub(crate) const fn static_encoding_str_len(encoding: &Encoding<'_>, level: NestingLevel) -> usize {
+pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingLevel) -> usize {
     use Helper::*;
 
     match Helper::new(encoding) {
@@ -67,7 +67,7 @@ pub(crate) const fn static_encoding_str_len(encoding: &Encoding<'_>, level: Nest
 }
 
 pub(crate) const fn static_encoding_str_array<const LEN: usize>(
-    encoding: &Encoding<'_>,
+    encoding: &Encoding,
     level: NestingLevel,
 ) -> [u8; LEN] {
     use Helper::*;

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -40,7 +40,7 @@ pub struct MyObject<'a> {
 }
 
 unsafe impl RefEncode for MyObject<'_> {
-    const ENCODING_REF: Encoding<'static> = Object::ENCODING_REF;
+    const ENCODING_REF: Encoding = Object::ENCODING_REF;
 }
 
 unsafe impl Message for MyObject<'_> {}
@@ -85,7 +85,7 @@ unsafe impl<'a> ClassType for MyObject<'a> {
                 number: Ivar<MaybeUninit<NumberIvar<'a>>>,
             }
             unsafe impl RefEncode for PartialInit<'_> {
-                const ENCODING_REF: Encoding<'static> = Encoding::Object;
+                const ENCODING_REF: Encoding = Encoding::Object;
             }
             unsafe impl Message for PartialInit<'_> {}
 

--- a/objc2/src/bool.rs
+++ b/objc2/src/bool.rs
@@ -113,7 +113,7 @@ impl fmt::Debug for Bool {
 
 // SAFETY: `Bool` is `repr(transparent)`.
 unsafe impl Encode for Bool {
-    const ENCODING: Encoding<'static> = ffi::BOOL::ENCODING;
+    const ENCODING: Encoding = ffi::BOOL::ENCODING;
 }
 
 // Note that we shouldn't delegate to `BOOL`'s  `ENCODING_REF` since `BOOL` is
@@ -127,7 +127,7 @@ unsafe impl Encode for Bool {
 // @encode(char*); // -> "*"
 // ```
 unsafe impl RefEncode for Bool {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 #[cfg(test)]

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -230,7 +230,7 @@ fn count_args(sel: Sel) -> usize {
     sel.name().chars().filter(|&c| c == ':').count()
 }
 
-fn method_type_encoding(ret: &Encoding<'_>, args: &[Encoding<'_>]) -> CString {
+fn method_type_encoding(ret: &Encoding, args: &[Encoding]) -> CString {
     // First two arguments are always self and the selector
     let mut types = format!("{}{}{}", ret, <*mut Object>::ENCODING, Sel::ENCODING);
     for enc in args {

--- a/objc2/src/exception.rs
+++ b/objc2/src/exception.rs
@@ -51,7 +51,7 @@ use crate::Message;
 pub struct Exception(Object);
 
 unsafe impl RefEncode for Exception {
-    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    const ENCODING_REF: Encoding = Encoding::Object;
 }
 
 unsafe impl Message for Exception {}

--- a/objc2/src/foundation/comparison_result.rs
+++ b/objc2/src/foundation/comparison_result.rs
@@ -24,11 +24,11 @@ impl Default for NSComparisonResult {
 }
 
 unsafe impl Encode for NSComparisonResult {
-    const ENCODING: Encoding<'static> = isize::ENCODING;
+    const ENCODING: Encoding = isize::ENCODING;
 }
 
 unsafe impl RefEncode for NSComparisonResult {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 impl From<Ordering> for NSComparisonResult {

--- a/objc2/src/foundation/enumerator.rs
+++ b/objc2/src/foundation/enumerator.rs
@@ -54,7 +54,7 @@ struct NSFastEnumerationState<T: Message> {
 }
 
 unsafe impl<T: Message> Encode for NSFastEnumerationState<T> {
-    const ENCODING: Encoding<'static> = Encoding::Struct(
+    const ENCODING: Encoding = Encoding::Struct(
         "?",
         &[
             Encoding::C_ULONG,
@@ -66,7 +66,7 @@ unsafe impl<T: Message> Encode for NSFastEnumerationState<T> {
 }
 
 unsafe impl<T: Message> RefEncode for NSFastEnumerationState<T> {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 fn enumerate<'a, 'b: 'a, C: NSFastEnumeration + ?Sized>(

--- a/objc2/src/foundation/geometry.rs
+++ b/objc2/src/foundation/geometry.rs
@@ -57,12 +57,12 @@ pub struct NSPoint {
 }
 
 unsafe impl Encode for NSPoint {
-    const ENCODING: Encoding<'static> =
+    const ENCODING: Encoding =
         Encoding::Struct(names::POINT, &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 unsafe impl RefEncode for NSPoint {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 impl NSPoint {
@@ -115,12 +115,12 @@ pub struct NSSize {
 }
 
 unsafe impl Encode for NSSize {
-    const ENCODING: Encoding<'static> =
+    const ENCODING: Encoding =
         Encoding::Struct(names::SIZE, &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 unsafe impl RefEncode for NSSize {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 impl NSSize {
@@ -200,12 +200,12 @@ pub struct NSRect {
 }
 
 unsafe impl Encode for NSRect {
-    const ENCODING: Encoding<'static> =
+    const ENCODING: Encoding =
         Encoding::Struct(names::RECT, &[NSPoint::ENCODING, NSSize::ENCODING]);
 }
 
 unsafe impl RefEncode for NSRect {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 impl NSRect {

--- a/objc2/src/foundation/number.rs
+++ b/objc2/src/foundation/number.rs
@@ -218,7 +218,7 @@ impl NSNumber {
     ///     }
     /// }
     /// ```
-    pub fn encoding(&self) -> Encoding<'static> {
+    pub fn encoding(&self) -> Encoding {
         // Use NSValue::encoding
         let enc = (**self)
             .encoding()

--- a/objc2/src/foundation/range.rs
+++ b/objc2/src/foundation/range.rs
@@ -121,12 +121,11 @@ impl From<NSRange> for Range<usize> {
 }
 
 unsafe impl Encode for NSRange {
-    const ENCODING: Encoding<'static> =
-        Encoding::Struct("_NSRange", &[usize::ENCODING, usize::ENCODING]);
+    const ENCODING: Encoding = Encoding::Struct("_NSRange", &[usize::ENCODING, usize::ENCODING]);
 }
 
 unsafe impl RefEncode for NSRange {
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Self::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
 #[cfg(test)]

--- a/objc2/src/foundation/uuid.rs
+++ b/objc2/src/foundation/uuid.rs
@@ -33,7 +33,7 @@ extern_class!(
 struct UuidBytes([u8; 16]);
 
 unsafe impl RefEncode for UuidBytes {
-    const ENCODING_REF: Encoding<'static> = Encoding::Array(16, &u8::ENCODING);
+    const ENCODING_REF: Encoding = Encoding::Array(16, &u8::ENCODING);
 }
 
 // SAFETY: `NSUUID` is immutable.

--- a/objc2/src/foundation/zone.rs
+++ b/objc2/src/foundation/zone.rs
@@ -34,9 +34,9 @@ impl RefUnwindSafe for NSZone {}
 
 unsafe impl RefEncode for NSZone {
     #[cfg(feature = "apple")]
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Encoding::Struct("_NSZone", &[]));
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("_NSZone", &[]));
     #[cfg(feature = "gnustep-1-7")]
-    const ENCODING_REF: Encoding<'static> = Encoding::Pointer(&Encoding::Struct(
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct(
         "_NSZone",
         &[
             // Functions

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -299,7 +299,7 @@ macro_rules! __inner_extern_class {
         // - The rest of the struct's fields are ZSTs, so they don't influence
         //   the layout.
         unsafe impl<$($t)*> $crate::RefEncode for $for {
-            const ENCODING_REF: $crate::Encoding<'static>
+            const ENCODING_REF: $crate::Encoding
                 = <$superclass as $crate::RefEncode>::ENCODING_REF;
         }
 

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -65,7 +65,7 @@
 /// }
 ///
 /// unsafe impl Encode for NSCalendarUnit {
-///     const ENCODING: Encoding<'static> = usize::ENCODING;
+///     const ENCODING: Encoding = usize::ENCODING;
 /// }
 ///
 /// extern_methods!(
@@ -144,7 +144,7 @@
 /// # }
 /// #
 /// # unsafe impl Encode for NSCalendarUnit {
-/// #     const ENCODING: Encoding<'static> = usize::ENCODING;
+/// #     const ENCODING: Encoding = usize::ENCODING;
 /// # }
 /// #
 /// # use objc2::msg_send;

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -89,7 +89,7 @@ use self::platform::{send_super_unverified, send_unverified};
 /// }
 ///
 /// unsafe impl RefEncode for MyObject {
-///     const ENCODING_REF: Encoding<'static> = Encoding::Object;
+///     const ENCODING_REF: Encoding = Encoding::Object;
 /// }
 ///
 /// unsafe impl Message for MyObject {}

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -189,7 +189,7 @@ impl Sel {
 
 // SAFETY: `Sel` is FFI compatible, and the encoding is of course `Sel`.
 unsafe impl Encode for Sel {
-    const ENCODING: Encoding<'static> = Encoding::Sel;
+    const ENCODING: Encoding = Encoding::Sel;
 }
 
 // RefEncode is not implemented for Sel, because there is literally no API
@@ -509,7 +509,7 @@ impl RefUnwindSafe for Class {}
 // Note that Unpin is not applicable.
 
 unsafe impl RefEncode for Class {
-    const ENCODING_REF: Encoding<'static> = Encoding::Class;
+    const ENCODING_REF: Encoding = Encoding::Class;
 }
 
 impl fmt::Debug for Class {
@@ -583,7 +583,7 @@ impl PartialEq for Protocol {
 
 unsafe impl RefEncode for Protocol {
     // Protocol is an object internally
-    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    const ENCODING_REF: Encoding = Encoding::Object;
 }
 
 impl Eq for Protocol {}
@@ -636,7 +636,7 @@ fn ivar_offset<T: Encode>(cls: &Class, name: &str) -> isize {
 pub struct Object(ffi::objc_object);
 
 unsafe impl RefEncode for Object {
-    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    const ENCODING_REF: Encoding = Encoding::Object;
 }
 
 impl Object {

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -86,7 +86,7 @@ pub(crate) struct CustomStruct {
 }
 
 unsafe impl Encode for CustomStruct {
-    const ENCODING: Encoding<'static> = Encoding::Struct(
+    const ENCODING: Encoding = Encoding::Struct(
         "CustomStruct",
         &[u64::ENCODING, u64::ENCODING, u64::ENCODING, u64::ENCODING],
     );

--- a/objc2/src/verify.rs
+++ b/objc2/src/verify.rs
@@ -37,9 +37,9 @@ impl fmt::Display for MallocEncoding {
 #[derive(Debug, PartialEq, Eq, Hash)]
 enum Inner {
     MethodNotFound,
-    MismatchedReturn(MallocEncoding, Encoding<'static>),
+    MismatchedReturn(MallocEncoding, Encoding),
     MismatchedArgumentsCount(usize, usize),
-    MismatchedArgument(usize, MallocEncoding, Encoding<'static>),
+    MismatchedArgument(usize, MallocEncoding, Encoding),
 }
 
 impl fmt::Display for Inner {

--- a/tests/src/ffi.rs
+++ b/tests/src/ffi.rs
@@ -36,7 +36,7 @@ impl LargeStruct {
 }
 
 unsafe impl Encode for LargeStruct {
-    const ENCODING: Encoding<'static> =
+    const ENCODING: Encoding =
         Encoding::Struct("LargeStruct", &[f32::ENCODING, <[u8; 100]>::ENCODING]);
 }
 

--- a/tests/src/test_encode_utils.rs
+++ b/tests/src/test_encode_utils.rs
@@ -91,7 +91,7 @@ macro_rules! assert_types {
     (#no_atomic) => {};
 }
 
-const WITH_ATOMIC_INNER: Encoding<'static> = Encoding::Struct(
+const WITH_ATOMIC_INNER: Encoding = Encoding::Struct(
     "with_atomic_inner",
     &[
         AtomicI32::ENCODING,

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -17,7 +17,7 @@ struct MyTestObject {
 unsafe impl Message for MyTestObject {}
 
 unsafe impl RefEncode for MyTestObject {
-    const ENCODING_REF: Encoding<'static> = Encoding::Object;
+    const ENCODING_REF: Encoding = Encoding::Object;
 }
 
 unsafe impl ClassType for MyTestObject {


### PR DESCRIPTION
Seems to make things easier to read without any real downsides, since encodings are almost always statically constructed anyway.

Still unsure if I want to do this though.