### PR TITLE
Clean up block traits

### DIFF
--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * **BREAKING**: Cleaned up `BlockArguments` trait, it is now sealed and a
   subtrait of `EncodeArguments`.
+* **BREAKING**: Cleaned up `IntoConcreteBlock` trait, it is now sealed and the
+  associated output type has been renamed to `Output`.
 
 ## 0.2.0-alpha.5 - 2022-07-19
 

--- a/block2/CHANGELOG.md
+++ b/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Fixed
+* **BREAKING**: Cleaned up `BlockArguments` trait, it is now sealed and a
+  subtrait of `EncodeArguments`.
 
 ## 0.2.0-alpha.5 - 2022-07-19
 

--- a/block2/src/concrete_block.rs
+++ b/block2/src/concrete_block.rs
@@ -9,13 +9,26 @@ use objc2_encode::{Encode, Encoding, RefEncode};
 
 use crate::{ffi, Block, BlockArguments, RcBlock};
 
-/// Types that may be converted into a `ConcreteBlock`.
-pub trait IntoConcreteBlock<A: BlockArguments>: Sized {
-    /// The return type of the resulting `ConcreteBlock`.
-    type Ret: Encode;
+mod private {
+    pub trait Sealed<A> {}
+}
 
-    /// Consumes self to create a `ConcreteBlock`.
-    fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
+/// Types that may be converted into a [`ConcreteBlock`].
+///
+/// This is implemented for [`Fn`] closures of up to 12 arguments, where each
+/// argument and the return type implements [`Encode`].
+///
+///
+/// # Safety
+///
+/// This is a sealed trait, and should not need to be implemented. Open an
+/// issue if you know a use-case where this restrition should be lifted!
+pub unsafe trait IntoConcreteBlock<A: BlockArguments>: private::Sealed<A> + Sized {
+    /// The return type of the resulting `ConcreteBlock`.
+    type Output: Encode;
+
+    #[doc(hidden)]
+    fn __into_concrete_block(self) -> ConcreteBlock<A, Self::Output, Self>;
 }
 
 macro_rules! concrete_block_impl {
@@ -23,13 +36,18 @@ macro_rules! concrete_block_impl {
         concrete_block_impl!($f,);
     );
     ($f:ident, $($a:ident : $t:ident),*) => (
-        impl<$($t: Encode,)* R: Encode, X> IntoConcreteBlock<($($t,)*)> for X
+        impl<$($t: Encode,)* R: Encode, X> private::Sealed<($($t,)*)> for X
+        where
+            X: Fn($($t,)*) -> R,
+        {}
+
+        unsafe impl<$($t: Encode,)* R: Encode, X> IntoConcreteBlock<($($t,)*)> for X
         where
             X: Fn($($t,)*) -> R,
         {
-            type Ret = R;
+            type Output = R;
 
-            fn into_concrete_block(self) -> ConcreteBlock<($($t,)*), R, X> {
+            fn __into_concrete_block(self) -> ConcreteBlock<($($t,)*), R, X> {
                 extern "C" fn $f<$($t,)* R, X>(
                     block: &ConcreteBlock<($($t,)*), R, X>,
                     $($a: $t,)*
@@ -156,13 +174,13 @@ impl<A, R, F> ConcreteBlock<A, R, F>
 where
     A: BlockArguments,
     R: Encode,
-    F: IntoConcreteBlock<A, Ret = R>,
+    F: IntoConcreteBlock<A, Output = R>,
 {
     /// Constructs a `ConcreteBlock` with the given closure.
     /// When the block is called, it will return the value that results from
     /// calling the closure.
     pub fn new(closure: F) -> Self {
-        closure.into_concrete_block()
+        closure.__into_concrete_block()
     }
 }
 

--- a/block2/src/concrete_block.rs
+++ b/block2/src/concrete_block.rs
@@ -5,12 +5,12 @@ use core::ops::Deref;
 use core::ptr;
 use std::os::raw::c_ulong;
 
-use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
+use objc2_encode::{Encode, Encoding, RefEncode};
 
 use crate::{ffi, Block, BlockArguments, RcBlock};
 
 /// Types that may be converted into a `ConcreteBlock`.
-pub trait IntoConcreteBlock<A: BlockArguments + EncodeArguments>: Sized {
+pub trait IntoConcreteBlock<A: BlockArguments>: Sized {
     /// The return type of the resulting `ConcreteBlock`.
     type Ret: Encode;
 
@@ -148,15 +148,13 @@ pub struct ConcreteBlock<A, R, F> {
     pub(crate) closure: F,
 }
 
-unsafe impl<A: BlockArguments + EncodeArguments, R: Encode, F> RefEncode
-    for ConcreteBlock<A, R, F>
-{
+unsafe impl<A: BlockArguments, R: Encode, F> RefEncode for ConcreteBlock<A, R, F> {
     const ENCODING_REF: Encoding<'static> = Encoding::Block;
 }
 
 impl<A, R, F> ConcreteBlock<A, R, F>
 where
-    A: BlockArguments + EncodeArguments,
+    A: BlockArguments,
     R: Encode,
     F: IntoConcreteBlock<A, Ret = R>,
 {

--- a/block2/src/global.rs
+++ b/block2/src/global.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 use core::ptr;
 use std::os::raw::c_ulong;
 
-use objc2_encode::{Encode, EncodeArguments};
+use objc2_encode::Encode;
 
 use super::{ffi, Block};
 use crate::BlockArguments;
@@ -34,13 +34,13 @@ pub struct GlobalBlock<A, R = ()> {
 
 unsafe impl<A, R> Sync for GlobalBlock<A, R>
 where
-    A: BlockArguments + EncodeArguments,
+    A: BlockArguments,
     R: Encode,
 {
 }
 unsafe impl<A, R> Send for GlobalBlock<A, R>
 where
-    A: BlockArguments + EncodeArguments,
+    A: BlockArguments,
     R: Encode,
 {
 }
@@ -77,7 +77,7 @@ impl<A, R> GlobalBlock<A, R> {
 
 impl<A, R> Deref for GlobalBlock<A, R>
 where
-    A: BlockArguments + EncodeArguments,
+    A: BlockArguments,
     R: Encode,
 {
     type Target = Block<A, R>;

--- a/test-ui/ui/global_block_not_encode.stderr
+++ b/test-ui/ui/global_block_not_encode.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `Box<i32>: objc2_encode::encode::Encode` is not sa
             *mut c_void
             AtomicBool
           and 152 others
-  = note: required because of the requirements on the impl of `objc2_encode::encode::EncodeArguments` for `(Box<i32>,)`
+  = note: required because of the requirements on the impl of `BlockArguments` for `(Box<i32>,)`
   = note: required because of the requirements on the impl of `Sync` for `GlobalBlock<(Box<i32>,)>`
   = note: shared static variables must have a type that implements `Sync`
   = note: this error originates in the macro `global_block` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/168.

Required for the soundness of #239 (`EncodeArguments` will be relaxed to `EncodeConvert`, while `block2` relied on it being `Encode`)