### PR TITLE
Improve message sending to superclasses

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `NSData::class()`.
 * Added `Id::into_super`.
 * Added `extern_methods!` macro.
+* Added ability to call `msg_send![super(obj), ...]` without explicitly
+  specifying the superclass.
 
 ### Changed
 * **BREAKING**: Change syntax in `extern_class!` macro to be more Rust-like.

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   methods that `extern_class!` and `declare_class!` generated to that. This
   means you'll have to `use objc2::ClassType` whenever you want to use e.g.
   `NSData::class()`.
-* Added `Id::into_superclass`.
+* Added `Id::into_super`.
 * Added `extern_methods!` macro.
 
 ### Changed

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -117,6 +117,14 @@ unsafe impl<'a> ClassType for MyObject<'a> {
 
         Class::get("MyObject").unwrap()
     }
+
+    fn as_super(&self) -> &Self::Super {
+        &self.superclass
+    }
+
+    fn as_super_mut(&mut self) -> &mut Self::Super {
+        &mut self.superclass
+    }
 }
 
 fn main() {

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -65,7 +65,7 @@ impl<'a> MyObject<'a> {
 }
 
 unsafe impl<'a> ClassType for MyObject<'a> {
-    type Superclass = NSObject;
+    type Super = NSObject;
 
     fn class() -> &'static Class {
         // TODO: Use std::lazy::LazyCell
@@ -125,7 +125,7 @@ fn main() {
 
     // It is not possible to convert to `Id<NSObject, Owned>` since that would
     // loose the lifetime information that `MyObject` stores
-    // let obj = Id::into_superclass(obj);
+    // let obj = Id::into_super(obj);
 
     println!("Number: {}", obj.get());
 

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -32,7 +32,7 @@ declare_class!(
     unsafe impl CustomAppDelegate {
         #[sel(initWith:another:)]
         fn init_with(self: &mut Self, ivar: u8, another_ivar: Bool) -> *mut Self {
-            let this: *mut Self = unsafe { msg_send![super(self, NSResponder::class()), init] };
+            let this: *mut Self = unsafe { msg_send![super(self), init] };
             if let Some(this) = unsafe { this.as_mut() } {
                 // TODO: Allow initialization through MaybeUninit
                 *this.ivar = ivar;

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -13,7 +13,7 @@ extern_class!(
     struct NSResponder;
 
     unsafe impl ClassType for NSResponder {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 
@@ -26,7 +26,7 @@ declare_class!(
 
     unsafe impl ClassType for CustomAppDelegate {
         #[inherits(NSObject)]
-        type Superclass = NSResponder;
+        type Super = NSResponder;
     }
 
     unsafe impl CustomAppDelegate {

--- a/objc2/examples/nspasteboard.rs
+++ b/objc2/examples/nspasteboard.rs
@@ -28,7 +28,7 @@ extern_class!(
 
     // SAFETY: NSPasteboard actually inherits from NSObject.
     unsafe impl ClassType for NSPasteboard {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/examples/speech_synthethis.rs
+++ b/objc2/examples/speech_synthethis.rs
@@ -31,7 +31,7 @@ mod appkit {
         pub struct NSSpeechSynthesizer;
 
         unsafe impl ClassType for NSSpeechSynthesizer {
-            type Superclass = NSObject;
+            type Super = NSObject;
         }
     );
 
@@ -110,7 +110,7 @@ mod avfaudio {
         pub struct AVSpeechSynthesizer;
 
         unsafe impl ClassType for AVSpeechSynthesizer {
-            type Superclass = NSObject;
+            type Super = NSObject;
         }
     );
 
@@ -136,7 +136,7 @@ mod avfaudio {
         pub struct AVSpeechUtterance;
 
         unsafe impl ClassType for AVSpeechUtterance {
-            type Superclass = NSObject;
+            type Super = NSObject;
         }
     );
 

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -17,11 +17,11 @@ use crate::Message;
 /// # Safety
 ///
 /// The class returned by [`Self::class`] must be a subclass of the class that
-/// [`Self::Superclass`] represents.
+/// [`Self::Super`] represents.
 ///
 /// In pseudocode:
 /// ```ignore
-/// Self::class().superclass() == <Self::Superclass as ClassType>::class()
+/// Self::class().superclass() == <Self::Super as ClassType>::class()
 /// ```
 ///
 ///
@@ -48,7 +48,7 @@ use crate::Message;
 ///     struct MyClass;
 ///
 ///     unsafe impl ClassType for MyClass {
-///         type Superclass = NSObject;
+///         type Super = NSObject;
 ///     }
 /// );
 ///
@@ -65,7 +65,7 @@ pub unsafe trait ClassType: Message {
     /// [`Deref`]: std::ops::Deref
     /// [`Deref::Target`]: std::ops::Deref::Target
     /// [`runtime::Object`]: crate::runtime::Object
-    type Superclass: Message;
+    type Super: Message;
 
     /// Get a reference to the Objective-C class that this type represents.
     ///

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -17,7 +17,8 @@ use crate::Message;
 /// # Safety
 ///
 /// The class returned by [`Self::class`] must be a subclass of the class that
-/// [`Self::Super`] represents.
+/// [`Self::Super`] represents, and `as_super`/`as_super_mut` must be
+/// implemented correctly.
 ///
 /// In pseudocode:
 /// ```ignore
@@ -78,4 +79,12 @@ pub unsafe trait ClassType: Message {
     /// class, e.g. if the program is not properly linked to the framework
     /// that defines the class.
     fn class() -> &'static Class;
+
+    /// Get an immutable reference to the superclass.
+    // Note: It'd be safe to provide a default impl using transmute here if
+    // we wanted to!
+    fn as_super(&self) -> &Self::Super;
+
+    /// Get a mutable reference to the superclass.
+    fn as_super_mut(&mut self) -> &mut Self::Super;
 }

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -58,7 +58,7 @@ __inner_extern_class!(
     }
 
     unsafe impl<T: Message, O: Ownership> ClassType for NSArray<T, O> {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/attributed_string.rs
+++ b/objc2/src/foundation/attributed_string.rs
@@ -25,7 +25,7 @@ extern_class!(
     pub struct NSAttributedString;
 
     unsafe impl ClassType for NSAttributedString {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/data.rs
+++ b/objc2/src/foundation/data.rs
@@ -21,7 +21,7 @@ extern_class!(
     pub struct NSData;
 
     unsafe impl ClassType for NSData {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -18,7 +18,7 @@ __inner_extern_class!(
     }
 
     unsafe impl<K: Message, V: Message> ClassType for NSDictionary<K, V> {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/error.rs
+++ b/objc2/src/foundation/error.rs
@@ -19,7 +19,7 @@ extern_class!(
     pub struct NSError;
 
     unsafe impl ClassType for NSError {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/exception.rs
+++ b/objc2/src/foundation/exception.rs
@@ -22,7 +22,7 @@ extern_class!(
     pub struct NSException;
 
     unsafe impl ClassType for NSException {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/mod.rs
+++ b/objc2/src/foundation/mod.rs
@@ -39,13 +39,13 @@
 //! want to use the objects!
 //!
 //! All objects also implement [`AsRef`] and [`AsMut`] to their superclass,
-//! and can be used in [`Id::into_superclass`], so if you favour explicit
+//! and can be used in [`Id::into_super`], so if you favour explicit
 //! conversion, that is a possibility too.
 //!
 //! [`Deref`]: std::ops::Deref
 //! [`ClassType`]: crate::ClassType
 //! [anti-pattern-deref]: https://rust-unofficial.github.io/patterns/anti_patterns/deref.html
-//! [`Id::into_superclass`]: crate::rc::Id::into_superclass
+//! [`Id::into_super`]: crate::rc::Id::into_super
 
 // TODO: Remove these
 #![allow(missing_docs)]

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -27,7 +27,7 @@ __inner_extern_class!(
 
     unsafe impl<T: Message, O: Ownership> ClassType for NSMutableArray<T, O> {
         #[inherits(NSObject)]
-        type Superclass = NSArray<T, O>;
+        type Super = NSArray<T, O>;
     }
 );
 

--- a/objc2/src/foundation/mutable_attributed_string.rs
+++ b/objc2/src/foundation/mutable_attributed_string.rs
@@ -13,7 +13,7 @@ extern_class!(
 
     unsafe impl ClassType for NSMutableAttributedString {
         #[inherits(NSObject)]
-        type Superclass = NSAttributedString;
+        type Super = NSAttributedString;
     }
 );
 

--- a/objc2/src/foundation/mutable_data.rs
+++ b/objc2/src/foundation/mutable_data.rs
@@ -24,7 +24,7 @@ extern_class!(
 
     unsafe impl ClassType for NSMutableData {
         #[inherits(NSObject)]
-        type Superclass = NSData;
+        type Super = NSData;
     }
 );
 

--- a/objc2/src/foundation/mutable_string.rs
+++ b/objc2/src/foundation/mutable_string.rs
@@ -16,7 +16,7 @@ extern_class!(
 
     unsafe impl ClassType for NSMutableString {
         #[inherits(NSObject)]
-        type Superclass = NSString;
+        type Super = NSString;
     }
 );
 

--- a/objc2/src/foundation/number.rs
+++ b/objc2/src/foundation/number.rs
@@ -43,7 +43,7 @@ extern_class!(
 
     unsafe impl ClassType for NSNumber {
         #[inherits(NSObject)]
-        type Superclass = NSValue;
+        type Super = NSValue;
     }
 );
 

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -16,7 +16,7 @@ __inner_extern_class! {
 }
 
 unsafe impl ClassType for NSObject {
-    type Superclass = Object;
+    type Super = Object;
 
     #[inline]
     fn class() -> &'static Class {

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -22,6 +22,14 @@ unsafe impl ClassType for NSObject {
     fn class() -> &'static Class {
         class!(NSObject)
     }
+
+    fn as_super(&self) -> &Self::Super {
+        &self.__inner
+    }
+
+    fn as_super_mut(&mut self) -> &mut Self::Super {
+        &mut self.__inner
+    }
 }
 
 extern_methods!(

--- a/objc2/src/foundation/process_info.rs
+++ b/objc2/src/foundation/process_info.rs
@@ -13,7 +13,7 @@ extern_class!(
     pub struct NSProcessInfo;
 
     unsafe impl ClassType for NSProcessInfo {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -40,7 +40,7 @@ extern_class!(
     // TODO: Check if performance of NSSelectorFromString is worthwhile
 
     unsafe impl ClassType for NSString {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/thread.rs
+++ b/objc2/src/foundation/thread.rs
@@ -14,7 +14,7 @@ extern_class!(
     pub struct NSThread;
 
     unsafe impl ClassType for NSThread {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/uuid.rs
+++ b/objc2/src/foundation/uuid.rs
@@ -20,7 +20,7 @@ extern_class!(
     pub struct NSUUID;
 
     unsafe impl ClassType for NSUUID {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/foundation/value.rs
+++ b/objc2/src/foundation/value.rs
@@ -35,7 +35,7 @@ extern_class!(
     pub struct NSValue;
 
     unsafe impl ClassType for NSValue {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -253,7 +253,7 @@ macro_rules! __inner_declare_class {
 ///         #[sel(initWithFoo:)]
 ///         fn init_with(&mut self, foo: u8) -> Option<&mut Self> {
 ///             let this: Option<&mut Self> = unsafe {
-///                 msg_send![super(self, NSObject::class()), init]
+///                 msg_send![super(self), init]
 ///             };
 ///             this.map(|this| {
 ///                 // TODO: Initialization through MaybeUninit

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -454,6 +454,16 @@ macro_rules! declare_class {
                 // We just registered the class, so it should be available
                 $crate::runtime::Class::get(stringify!($name)).unwrap()
             }
+
+            #[inline]
+            fn as_super(&self) -> &Self::Super {
+                &self.__inner
+            }
+
+            #[inline]
+            fn as_super_mut(&mut self) -> &mut Self::Super {
+                &mut self.__inner
+            }
         }
 
         // Methods

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -246,7 +246,7 @@ macro_rules! __inner_declare_class {
 ///     }
 ///
 ///     unsafe impl ClassType for MyCustomObject {
-///         type Superclass = NSObject;
+///         type Super = NSObject;
 ///     }
 ///
 ///     unsafe impl MyCustomObject {
@@ -383,7 +383,7 @@ macro_rules! declare_class {
 
         unsafe impl ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
-            type Superclass = $superclass:ty;
+            type Super = $superclass:ty;
         }
 
         $($methods:tt)*
@@ -420,7 +420,7 @@ macro_rules! declare_class {
 
         // Creation
         unsafe impl ClassType for $for {
-            type Superclass = $superclass;
+            type Super = $superclass;
 
             fn class() -> &'static $crate::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -74,7 +74,7 @@
 ///
 ///     // Specify the superclass, in this case `NSObject`
 ///     unsafe impl ClassType for NSFormatter {
-///         type Superclass = NSObject;
+///         type Super = NSObject;
 ///     }
 /// );
 ///
@@ -97,7 +97,7 @@
 /// #     pub struct NSFormatter;
 /// #
 /// #     unsafe impl ClassType for NSFormatter {
-/// #         type Superclass = NSObject;
+/// #         type Super = NSObject;
 /// #     }
 /// # );
 ///
@@ -108,7 +108,7 @@
 ///     unsafe impl ClassType for NSDateFormatter {
 ///         // Specify the correct inheritance chain
 ///         #[inherits(NSObject)]
-///         type Superclass = NSFormatter;
+///         type Super = NSFormatter;
 ///     }
 /// );
 /// ```
@@ -123,7 +123,7 @@ macro_rules! extern_class {
 
         unsafe impl ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
-            type Superclass = $superclass:ty;
+            type Super = $superclass:ty;
         }
     ) => {
         // Just shorthand syntax for the following
@@ -133,7 +133,7 @@ macro_rules! extern_class {
 
             unsafe impl ClassType for $for {
                 $(#[inherits($($inheritance_rest),+)])?
-                type Superclass = $superclass;
+                type Super = $superclass;
             }
         );
     };
@@ -145,7 +145,7 @@ macro_rules! extern_class {
 
         unsafe impl ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
-            type Superclass = $superclass:ty;
+            type Super = $superclass:ty;
         }
     ) => {
         $crate::__inner_extern_class!(
@@ -156,7 +156,7 @@ macro_rules! extern_class {
 
             unsafe impl<> ClassType for $for {
                 $(#[inherits($($inheritance_rest),+)])?
-                type Superclass = $superclass;
+                type Super = $superclass;
             }
         );
 
@@ -237,7 +237,7 @@ macro_rules! __inner_extern_class {
 
         unsafe impl<$($t_for:ident $(: $b_for:ident)?),*> ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
-            type Superclass = $superclass:ty;
+            type Super = $superclass:ty;
         }
     ) => {
         $crate::__inner_extern_class! {
@@ -253,7 +253,7 @@ macro_rules! __inner_extern_class {
         }
 
         unsafe impl<$($t_for $(: $b_for)?),*> ClassType for $for {
-            type Superclass = $superclass;
+            type Super = $superclass;
 
             #[inline]
             fn class() -> &'static $crate::runtime::Class {

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -259,6 +259,16 @@ macro_rules! __inner_extern_class {
             fn class() -> &'static $crate::runtime::Class {
                 $crate::class!($name)
             }
+
+            #[inline]
+            fn as_super(&self) -> &Self::Super {
+                &self.__inner
+            }
+
+            #[inline]
+            fn as_super_mut(&mut self) -> &mut Self::Super {
+                &mut self.__inner
+            }
         }
     };
     (

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -50,7 +50,7 @@
 ///     pub struct NSCalendar;
 ///
 ///     unsafe impl ClassType for NSCalendar {
-///         type Superclass = NSObject;
+///         type Super = NSObject;
 ///     }
 /// );
 ///
@@ -130,7 +130,7 @@
 /// #     pub struct NSCalendar;
 /// #
 /// #     unsafe impl ClassType for NSCalendar {
-/// #         type Superclass = NSObject;
+/// #         type Super = NSObject;
 /// #     }
 /// # );
 /// #

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -266,7 +266,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
     ///
     /// This is equivalent to a `cast` between two pointers.
     ///
-    /// See [`Id::into_superclass`] for a safe alternative.
+    /// See [`Id::into_super`] for a safe alternative.
     ///
     /// This is common to do when you know that an object is a subclass of
     /// a specific class (e.g. casting an instance of `NSString` to `NSObject`
@@ -639,16 +639,16 @@ impl<T: Message> Id<T, Shared> {
 
 impl<T: ClassType + 'static, O: Ownership> Id<T, O>
 where
-    T::Superclass: 'static,
+    T::Super: 'static,
 {
     /// Convert the object into it's superclass.
     #[inline]
-    pub fn into_superclass(this: Self) -> Id<T::Superclass, O> {
+    pub fn into_super(this: Self) -> Id<T::Super, O> {
         // SAFETY:
         // - The casted-to type is a superclass of the type.
         // - Both types are `'static` (this could maybe be relaxed a bit, but
         //   let's just be on the safe side)!
-        unsafe { Self::cast::<T::Superclass>(this) }
+        unsafe { Self::cast::<T::Super>(this) }
     }
 }
 

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -77,25 +77,25 @@ declare_class!(
         #[sel(init)]
         fn init(&mut self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().init += 1);
-            unsafe { msg_send![super(self, NSObject::class()), init] }
+            unsafe { msg_send![super(self), init] }
         }
 
         #[sel(retain)]
         fn retain(&self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().retain += 1);
-            unsafe { msg_send![super(self, NSObject::class()), retain] }
+            unsafe { msg_send![super(self), retain] }
         }
 
         #[sel(release)]
         fn release(&self) {
             TEST_DATA.with(|data| data.borrow_mut().release += 1);
-            unsafe { msg_send![super(self, NSObject::class()), release] }
+            unsafe { msg_send![super(self), release] }
         }
 
         #[sel(autorelease)]
         fn autorelease(&self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().autorelease += 1);
-            unsafe { msg_send![super(self, NSObject::class()), autorelease] }
+            unsafe { msg_send![super(self), autorelease] }
         }
 
         #[sel(dealloc)]
@@ -107,7 +107,7 @@ declare_class!(
         #[sel(_tryRetain)]
         unsafe fn try_retain(&self) -> Bool {
             TEST_DATA.with(|data| data.borrow_mut().try_retain += 1);
-            let res = unsafe { msg_send_bool![super(self, NSObject::class()), _tryRetain] };
+            let res = unsafe { msg_send_bool![super(self), _tryRetain] };
             if !res {
                 TEST_DATA.with(|data| data.borrow_mut().try_retain -= 1);
                 TEST_DATA.with(|data| data.borrow_mut().try_retain_fail += 1);

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -55,7 +55,7 @@ declare_class!(
     pub(crate) struct RcTestObject {}
 
     unsafe impl ClassType for RcTestObject {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 
     unsafe impl RcTestObject {

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -27,6 +27,8 @@ impl crate::message::private::Sealed for &mut CustomObject {}
 impl crate::message::private::Sealed for ManuallyDrop<CustomObject> {}
 
 unsafe impl MessageReceiver for &CustomObject {
+    type __Inner = Object;
+
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
         self.obj
@@ -34,6 +36,8 @@ unsafe impl MessageReceiver for &CustomObject {
 }
 
 unsafe impl MessageReceiver for &mut CustomObject {
+    type __Inner = Object;
+
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
         self.obj
@@ -41,6 +45,8 @@ unsafe impl MessageReceiver for &mut CustomObject {
 }
 
 unsafe impl MessageReceiver for ManuallyDrop<CustomObject> {
+    type __Inner = Object;
+
     #[inline]
     fn __as_raw_receiver(self) -> *mut Object {
         self.obj

--- a/objc2/tests/no_prelude.rs
+++ b/objc2/tests/no_prelude.rs
@@ -95,18 +95,22 @@ pub fn test_class() {
     let _class = new_objc2::class!(NSObject);
 }
 
-pub fn test_msg_send(obj: &new_objc2::runtime::Object) {
+pub fn test_msg_send(obj: &new_objc2::foundation::NSString) {
     let superclass = obj.class().superclass().unwrap();
     let _: () = unsafe { new_objc2::msg_send![obj, a] };
     let _: () = unsafe { new_objc2::msg_send![obj, a: obj, b: obj] };
+    let _: () = unsafe { new_objc2::msg_send![super(obj), a] };
+    let _: () = unsafe { new_objc2::msg_send![super(obj), a: obj, b: obj] };
     let _: () = unsafe { new_objc2::msg_send![super(obj, superclass), a] };
     let _: () = unsafe { new_objc2::msg_send![super(obj, superclass), a: obj, b: obj] };
 }
 
-pub fn test_msg_send_bool(obj: &new_objc2::runtime::Object) {
+pub fn test_msg_send_bool(obj: &new_objc2::foundation::NSString) {
     let superclass = obj.class().superclass().unwrap();
     unsafe { new_objc2::msg_send_bool![obj, a] };
     unsafe { new_objc2::msg_send_bool![obj, a: obj, b: obj] };
+    unsafe { new_objc2::msg_send_bool![super(obj), a] };
+    unsafe { new_objc2::msg_send_bool![super(obj), a: obj, b: obj] };
     unsafe { new_objc2::msg_send_bool![super(obj, superclass), a] };
     unsafe { new_objc2::msg_send_bool![super(obj, superclass), a: obj, b: obj] };
 }

--- a/objc2/tests/use_macros.rs
+++ b/objc2/tests/use_macros.rs
@@ -1,3 +1,4 @@
+use objc2::foundation::NSString;
 use objc2::runtime::{Class, Object};
 use objc2::{class, msg_send, sel};
 
@@ -24,7 +25,7 @@ fn use_sel() {
 }
 
 #[allow(unused)]
-fn test_msg_send_comma_handling(obj: &Object, superclass: &Class) {
+fn test_msg_send_comma_handling(obj: &NSString, superclass: &Class) {
     unsafe {
         let _: () = msg_send![obj, a];
         let _: () = msg_send![obj, a,];
@@ -45,5 +46,14 @@ fn test_msg_send_comma_handling(obj: &Object, superclass: &Class) {
         let _: () = msg_send![super(obj, superclass), a: 32i32 b: 32i32,];
         let _: () = msg_send![super(obj, superclass), a: 32i32, b: 32i32];
         let _: () = msg_send![super(obj, superclass), a: 32i32, b: 32i32,];
+    }
+
+    unsafe {
+        let _: () = msg_send![super(obj), a];
+        let _: () = msg_send![super(obj), a,];
+        let _: () = msg_send![super(obj), a: 32i32];
+        let _: () = msg_send![super(obj), a: 32i32,];
+        let _: () = msg_send![super(obj), a: 32i32, b: 32i32];
+        let _: () = msg_send![super(obj), a: 32i32, b: 32i32,];
     }
 }

--- a/test-ui/ui/extern_class_not_zst.rs
+++ b/test-ui/ui/extern_class_not_zst.rs
@@ -7,7 +7,7 @@ extern_class!(
     }
 
     unsafe impl ClassType for NSNumber {
-        type Superclass = NSObject;
+        type Super = NSObject;
     }
 );
 

--- a/test-ui/ui/invalid_msg_send_super.rs
+++ b/test-ui/ui/invalid_msg_send_super.rs
@@ -8,7 +8,6 @@ fn main() {
 
     let _: () = unsafe { msg_send![super, init] };
     let _: () = unsafe { msg_send![super(), init] };
-    let _: () = unsafe { msg_send![super(obj), init] };
     let _: () = unsafe { msg_send![super(obj,), init] };
     let _: () = unsafe { msg_send![super(obj, superclass,), init] };
 }

--- a/test-ui/ui/invalid_msg_send_super.stderr
+++ b/test-ui/ui/invalid_msg_send_super.stderr
@@ -13,12 +13,6 @@ error[E0433]: failed to resolve: there are too many leading `super` keywords
 error[E0433]: failed to resolve: there are too many leading `super` keywords
   --> ui/invalid_msg_send_super.rs
    |
-   |     let _: () = unsafe { msg_send![super(obj), init] };
-   |                                    ^^^^^ there are too many leading `super` keywords
-
-error[E0433]: failed to resolve: there are too many leading `super` keywords
-  --> ui/invalid_msg_send_super.rs
-   |
    |     let _: () = unsafe { msg_send![super(obj,), init] };
    |                                    ^^^^^ there are too many leading `super` keywords
 

--- a/test-ui/ui/msg_send_super_not_classtype.rs
+++ b/test-ui/ui/msg_send_super_not_classtype.rs
@@ -1,0 +1,12 @@
+//! Invalid receiver to msg_send![super(obj), ...], missing ClassType impl.
+use objc2::msg_send;
+use objc2::foundation::NSObject;
+use objc2::runtime::Object;
+
+fn main() {
+    let obj: &Object;
+    let _: () = unsafe { msg_send![super(obj), method] };
+
+    let obj: &NSObject; // impls ClassType, but it's superclass does not
+    let _: () = unsafe { msg_send![super(obj), method] };
+}

--- a/test-ui/ui/msg_send_super_not_classtype.stderr
+++ b/test-ui/ui/msg_send_super_not_classtype.stderr
@@ -1,0 +1,45 @@
+error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfied
+   --> ui/msg_send_super_not_classtype.rs
+    |
+    |     let _: () = unsafe { msg_send![super(obj), method] };
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ClassType` is not implemented for `objc2::runtime::Object`
+    |
+    = help: the following other types implement trait `ClassType`:
+              NSArray<T, O>
+              NSAttributedString
+              NSData
+              NSDictionary<K, V>
+              NSError
+              NSException
+              NSMutableArray<T, O>
+              NSMutableAttributedString
+            and 9 others
+note: required by a bound in `__send_super_message_static`
+   --> $WORKSPACE/objc2/src/message/mod.rs
+    |
+    |         Self::__Inner: ClassType,
+    |                        ^^^^^^^^^ required by this bound in `__send_super_message_static`
+    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfied
+   --> ui/msg_send_super_not_classtype.rs
+    |
+    |     let _: () = unsafe { msg_send![super(obj), method] };
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ClassType` is not implemented for `objc2::runtime::Object`
+    |
+    = help: the following other types implement trait `ClassType`:
+              NSArray<T, O>
+              NSAttributedString
+              NSData
+              NSDictionary<K, V>
+              NSError
+              NSException
+              NSMutableArray<T, O>
+              NSMutableAttributedString
+            and 9 others
+note: required by a bound in `__send_super_message_static`
+   --> $WORKSPACE/objc2/src/message/mod.rs
+    |
+    |         <Self::__Inner as ClassType>::Super: ClassType,
+    |                                              ^^^^^^^^^ required by this bound in `__send_super_message_static`
+    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -21,7 +21,7 @@ unsafe impl RefEncode for MyTestObject {
 }
 
 unsafe impl ClassType for MyTestObject {
-    type Superclass = NSObject;
+    type Super = NSObject;
 
     fn class() -> &'static Class {
         class!(MyTestObject)

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -26,6 +26,14 @@ unsafe impl ClassType for MyTestObject {
     fn class() -> &'static Class {
         class!(MyTestObject)
     }
+
+    fn as_super(&self) -> &Self::Super {
+        &self.inner
+    }
+
+    fn as_super_mut(&mut self) -> &mut Self::Super {
+        &mut self.inner
+    }
 }
 
 impl MyTestObject {


### PR DESCRIPTION
Now `msg_send![super(self), init]` is possible, which is a nice improvement as it is easy to accidentally send a message to the wrong superclass!