### PR TITLE
Allow returning `Id` from `extern_methods!`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added the ability to specify an extra parameter at the end of the selector
   in methods declared with `extern_methods!`, and let that be the `NSError**`
   parameter.
+* Added `#[method_id(...)]` attribute to `extern_methods!`.
 
 ### Changed
 * Allow other types than `&Class` as the receiver in `msg_send_id!` methods

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -46,6 +46,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   associated functions whoose first parameter is called `this`, is treated as
   instance methods instead of class methods.
 
+### Fixed
+* Fixed duplicate selector extraction in `extern_methods!`.
+
 
 ## 0.3.0-beta.3 - 2022-09-01
 

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -90,15 +90,14 @@ extern_methods!(
     /// Generic creation methods.
     unsafe impl<T: Message, O: Ownership> NSArray<T, O> {
         /// Get an empty array.
-        pub fn new() -> Id<Self, Shared> {
-            // SAFETY:
-            // - `new` may not create a new object, but instead return a shared
-            //   instance. We remedy this by returning `Id<Self, Shared>`.
-            // - `O` don't actually matter here! E.g. `NSArray<T, Owned>` is
-            //   perfectly legal, since the array doesn't have any elements, and
-            //   hence the notion of ownership over the elements is void.
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        // SAFETY:
+        // - `new` may not create a new object, but instead return a shared
+        //   instance. We remedy this by returning `Id<Self, Shared>`.
+        // - `O` don't actually matter here! E.g. `NSArray<T, Owned>` is
+        //   perfectly legal, since the array doesn't have any elements, and
+        //   hence the notion of ownership over the elements is void.
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Shared>;
 
         pub fn from_vec(vec: Vec<Id<T, O>>) -> Id<Self, O> {
             // SAFETY:

--- a/objc2/src/foundation/bundle.rs
+++ b/objc2/src/foundation/bundle.rs
@@ -3,7 +3,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSDictionary, NSObject, NSString};
 use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use crate::{extern_class, extern_methods, ClassType};
 
 extern_class!(
     /// A representation of the code and resources stored in a bundle
@@ -27,13 +27,11 @@ impl RefUnwindSafe for NSBundle {}
 
 extern_methods!(
     unsafe impl NSBundle {
-        pub fn main() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), mainBundle] }
-        }
+        #[method_id(mainBundle)]
+        pub fn main() -> Id<Self, Shared>;
 
-        pub fn info(&self) -> Id<NSDictionary<NSString, NSObject>, Shared> {
-            unsafe { msg_send_id![self, infoDictionary] }
-        }
+        #[method_id(infoDictionary)]
+        pub fn info(&self) -> Id<NSDictionary<NSString, NSObject>, Shared>;
 
         pub fn name(&self) -> Option<Id<NSString, Shared>> {
             // TODO: Use ns_string!

--- a/objc2/src/foundation/data.rs
+++ b/objc2/src/foundation/data.rs
@@ -36,9 +36,8 @@ impl RefUnwindSafe for NSData {}
 extern_methods!(
     /// Creation methods.
     unsafe impl NSData {
-        pub fn new() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Shared>;
 
         pub fn with_bytes(bytes: &[u8]) -> Id<Self, Shared> {
             unsafe { Id::cast(with_slice(Self::class(), bytes)) }

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -32,9 +32,8 @@ impl<K: Message + UnwindSafe, V: Message + UnwindSafe> UnwindSafe for NSDictiona
 impl<K: Message + RefUnwindSafe, V: Message + RefUnwindSafe> RefUnwindSafe for NSDictionary<K, V> {}
 extern_methods!(
     unsafe impl<K: Message, V: Message> NSDictionary<K, V> {
-        pub fn new() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Shared>;
 
         #[doc(alias = "count")]
         #[method(count)]
@@ -102,9 +101,8 @@ extern_methods!(
             }
         }
 
-        pub fn keys_array(&self) -> Id<NSArray<K, Shared>, Shared> {
-            unsafe { msg_send_id![self, allKeys] }
-        }
+        #[method_id(allKeys)]
+        pub fn keys_array(&self) -> Id<NSArray<K, Shared>, Shared>;
 
         pub fn from_keys_and_objects<T>(keys: &[&T], vals: Vec<Id<V, Owned>>) -> Id<Self, Shared>
         where

--- a/objc2/src/foundation/error.rs
+++ b/objc2/src/foundation/error.rs
@@ -63,16 +63,14 @@ extern_methods!(
 
     /// Accessor methods.
     unsafe impl NSError {
-        pub fn domain(&self) -> Id<NSString, Shared> {
-            unsafe { msg_send_id![self, domain] }
-        }
+        #[method_id(domain)]
+        pub fn domain(&self) -> Id<NSString, Shared>;
 
         #[method(code)]
         pub fn code(&self) -> NSInteger;
 
-        pub fn user_info(&self) -> Option<Id<NSDictionary<NSErrorUserInfoKey, NSObject>, Shared>> {
-            unsafe { msg_send_id![self, userInfo] }
-        }
+        #[method_id(userInfo)]
+        pub fn user_info(&self) -> Option<Id<NSDictionary<NSErrorUserInfoKey, NSObject>, Shared>>;
 
         pub fn localized_description(&self) -> Id<NSString, Shared> {
             // TODO: For some reason this leaks a lot?

--- a/objc2/src/foundation/exception.rs
+++ b/objc2/src/foundation/exception.rs
@@ -83,20 +83,17 @@ extern_methods!(
         /// can take.
         ///
         /// [doc]: https://developer.apple.com/documentation/foundation/nsexceptionname?language=objc
-        pub fn name(&self) -> Id<NSExceptionName, Shared> {
-            // Nullability not documented, but a name is expected in most places.
-            unsafe { msg_send_id![self, name] }
-        }
+        #[method_id(name)]
+        // Nullability not documented, but a name is expected in most places.
+        pub fn name(&self) -> Id<NSExceptionName, Shared>;
 
         /// A human-readable message summarizing the reason for the exception.
-        pub fn reason(&self) -> Option<Id<NSString, Shared>> {
-            unsafe { msg_send_id![self, reason] }
-        }
+        #[method_id(reason)]
+        pub fn reason(&self) -> Option<Id<NSString, Shared>>;
 
         /// Application-specific data pertaining to the exception.
-        pub fn user_info(&self) -> Option<Id<NSDictionary<Object, Object>, Shared>> {
-            unsafe { msg_send_id![self, userInfo] }
-        }
+        #[method_id(userInfo)]
+        pub fn user_info(&self) -> Option<Id<NSDictionary<Object, Object>, Shared>>;
 
         /// Convert this into an [`Exception`] object.
         pub fn into_exception(this: Id<Self, Shared>) -> Id<Exception, Shared> {

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -11,7 +11,7 @@ use super::{
     NSObject,
 };
 use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
+use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send};
 
 __inner_extern_class!(
     /// A growable ordered collection of objects.
@@ -42,11 +42,10 @@ unsafe impl<T: Message + Send> Send for NSMutableArray<T, Owned> {}
 extern_methods!(
     /// Generic creation methods.
     unsafe impl<T: Message, O: Ownership> NSMutableArray<T, O> {
-        pub fn new() -> Id<Self, Owned> {
-            // SAFETY: Same as `NSArray::new`, except mutable arrays are always
-            // unique.
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        // SAFETY: Same as `NSArray::new`, except mutable arrays are always
+        // unique.
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         pub fn from_vec(vec: Vec<Id<T, O>>) -> Id<Self, Owned> {
             // SAFETY: Same as `NSArray::from_vec`, except mutable arrays are

--- a/objc2/src/foundation/mutable_attributed_string.rs
+++ b/objc2/src/foundation/mutable_attributed_string.rs
@@ -21,9 +21,8 @@ extern_methods!(
     /// Creating mutable attributed strings.
     unsafe impl NSMutableAttributedString {
         /// Construct an empty mutable attributed string.
-        pub fn new() -> Id<Self, Owned> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         // TODO: new_with_attributes
 

--- a/objc2/src/foundation/mutable_data.rs
+++ b/objc2/src/foundation/mutable_data.rs
@@ -31,9 +31,8 @@ extern_class!(
 extern_methods!(
     /// Creation methods
     unsafe impl NSMutableData {
-        pub fn new() -> Id<Self, Owned> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         pub fn with_bytes(bytes: &[u8]) -> Id<Self, Owned> {
             unsafe { Id::from_shared(Id::cast(with_slice(Self::class(), bytes))) }

--- a/objc2/src/foundation/mutable_dictionary.rs
+++ b/objc2/src/foundation/mutable_dictionary.rs
@@ -52,12 +52,11 @@ extern_methods!(
         ///
         /// let dict = NSMutableDictionary::<NSString, NSObject>::new();
         /// ```
-        pub fn new() -> Id<Self, Owned> {
-            // SAFETY:
-            // Mutable dictionaries are always unique, so it's safe to return
-            // `Id<Self, Owned>`
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        // SAFETY:
+        // Mutable dictionaries are always unique, so it's safe to return
+        // `Id<Self, Owned>`
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         #[method(setDictionary:)]
         fn set_dictionary(&mut self, dict: &NSDictionary<K, V>);

--- a/objc2/src/foundation/mutable_set.rs
+++ b/objc2/src/foundation/mutable_set.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use super::set::with_objects;
 use super::{NSCopying, NSFastEnumeration, NSFastEnumerator, NSMutableCopying, NSObject, NSSet};
 use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send_id};
+use crate::{ClassType, Message, __inner_extern_class, extern_methods};
 
 __inner_extern_class!(
     /// A growable unordered collection of unique objects.
@@ -44,11 +44,10 @@ extern_methods!(
         ///
         /// let set = NSMutableSet::<NSString>::new();
         /// ```
-        pub fn new() -> Id<Self, Owned> {
-            // SAFETY:
-            // Same as `NSSet::new`, except mutable sets are always unique.
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        // SAFETY:
+        // Same as `NSSet::new`, except mutable sets are always unique.
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         /// Creates an [`NSMutableSet`] from a vector.
         ///

--- a/objc2/src/foundation/mutable_string.rs
+++ b/objc2/src/foundation/mutable_string.rs
@@ -24,9 +24,8 @@ extern_methods!(
     /// Creating mutable strings.
     unsafe impl NSMutableString {
         /// Construct an empty [`NSMutableString`].
-        pub fn new() -> Id<Self, Owned> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         /// Creates a new [`NSMutableString`] by copying the given string slice.
         #[doc(alias = "initWithBytes:length:encoding:")]

--- a/objc2/src/foundation/number.rs
+++ b/objc2/src/foundation/number.rs
@@ -244,9 +244,8 @@ extern_methods!(
         #[method(isEqualToNumber:)]
         fn is_equal_to_number(&self, other: &Self) -> bool;
 
-        fn string(&self) -> Id<NSString, Shared> {
-            unsafe { msg_send_id![self, stringValue] }
-        }
+        #[method_id(stringValue)]
+        fn string(&self) -> Id<NSString, Shared>;
     }
 );
 

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -35,9 +35,8 @@ unsafe impl ClassType for NSObject {
 
 extern_methods!(
     unsafe impl NSObject {
-        pub fn new() -> Id<Self, Owned> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Owned>;
 
         #[method(isKindOfClass:)]
         fn is_kind_of_inner(&self, cls: &Class) -> bool;

--- a/objc2/src/foundation/process_info.rs
+++ b/objc2/src/foundation/process_info.rs
@@ -3,7 +3,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSObject, NSString};
 use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use crate::{extern_class, extern_methods, ClassType};
 
 extern_class!(
     /// A collection of information about the current process.
@@ -27,13 +27,11 @@ impl RefUnwindSafe for NSProcessInfo {}
 
 extern_methods!(
     unsafe impl NSProcessInfo {
-        pub fn process_info() -> Id<NSProcessInfo, Shared> {
-            unsafe { msg_send_id![Self::class(), processInfo] }
-        }
+        #[method_id(processInfo)]
+        pub fn process_info() -> Id<NSProcessInfo, Shared>;
 
-        pub fn process_name(&self) -> Id<NSString, Shared> {
-            unsafe { msg_send_id![self, processName] }
-        }
+        #[method_id(processName)]
+        pub fn process_name(&self) -> Id<NSString, Shared>;
 
         // TODO: This contains a lot more important functionality!
     }

--- a/objc2/src/foundation/set.rs
+++ b/objc2/src/foundation/set.rs
@@ -64,15 +64,14 @@ extern_methods!(
         ///
         /// let set = NSSet::<NSString>::new();
         /// ```
-        pub fn new() -> Id<Self, Shared> {
-            // SAFETY:
-            // - `new` may not create a new object, but instead return a shared
-            //   instance. We remedy this by returning `Id<Self, Shared>`.
-            // - `O` don't actually matter here! E.g. `NSSet<T, Owned>` is
-            //   perfectly legal, since the set doesn't have any elements, and
-            //   hence the notion of ownership over the elements is void.
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        // SAFETY:
+        // - `new` may not create a new object, but instead return a shared
+        //   instance. We remedy this by returning `Id<Self, Shared>`.
+        // - `O` don't actually matter here! E.g. `NSSet<T, Owned>` is
+        //   perfectly legal, since the set doesn't have any elements, and
+        //   hence the notion of ownership over the elements is void.
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Shared>;
 
         /// Creates an [`NSSet`] from a vector.
         ///
@@ -234,13 +233,12 @@ extern_methods!(
         /// assert_eq!(set.to_array().len(), 3);
         /// assert!(set.to_array().iter().all(|i| nums.contains(&i.as_i32())));
         /// ```
+        // SAFETY:
+        // We only define this method for sets with shared elements
+        // because we can't return copies of owned elements.
+        #[method_id(allObjects)]
         #[doc(alias = "allObjects")]
-        pub fn to_array(&self) -> Id<NSArray<T, Shared>, Shared> {
-            // SAFETY:
-            // We only define this method for sets with shared elements
-            // because we can't return copies of owned elements.
-            unsafe { msg_send_id![self, allObjects] }
-        }
+        pub fn to_array(&self) -> Id<NSArray<T, Shared>, Shared>;
     }
 
     // We're explicit about `T` being `PartialEq` for these methods because the

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -12,7 +12,7 @@ use std::os::raw::c_char;
 use super::{NSComparisonResult, NSCopying, NSError, NSMutableCopying, NSMutableString, NSObject};
 use crate::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
 use crate::runtime::{Class, Object};
-use crate::{extern_class, extern_methods, msg_send, msg_send_id, ClassType};
+use crate::{extern_class, extern_methods, msg_send, ClassType};
 
 #[cfg(feature = "apple")]
 const UTF8_ENCODING: usize = 4;
@@ -52,9 +52,8 @@ impl RefUnwindSafe for NSString {}
 extern_methods!(
     unsafe impl NSString {
         /// Construct an empty NSString.
-        pub fn new() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new() -> Id<Self, Shared>;
 
         /// Create a new string by appending the given string to self.
         ///
@@ -70,13 +69,12 @@ extern_methods!(
         /// let error_message = error_tag.concat(error_string);
         /// assert_eq!(&*error_message, ns_string!("Error: premature end of file."));
         /// ```
+        // SAFETY: The other string is non-null, and won't be retained by the
+        // function.
+        #[method_id(stringByAppendingString:)]
         #[doc(alias = "stringByAppendingString")]
         #[doc(alias = "stringByAppendingString:")]
-        pub fn concat(&self, other: &Self) -> Id<Self, Shared> {
-            // SAFETY: The other string is non-null, and won't be retained
-            // by the function.
-            unsafe { msg_send_id![self, stringByAppendingString: other] }
-        }
+        pub fn concat(&self, other: &Self) -> Id<Self, Shared>;
 
         /// Create a new string by appending the given string, separated by
         /// a path separator.
@@ -100,12 +98,11 @@ extern_methods!(
         /// assert_eq!(&*ns_string!("/").join_path(extension), ns_string!("/scratch.tiff"));
         /// assert_eq!(&*ns_string!("").join_path(extension), ns_string!("scratch.tiff"));
         /// ```
+        // SAFETY: Same as `Self::concat`.
+        #[method_id(stringByAppendingPathComponent:)]
         #[doc(alias = "stringByAppendingPathComponent")]
         #[doc(alias = "stringByAppendingPathComponent:")]
-        pub fn join_path(&self, other: &Self) -> Id<Self, Shared> {
-            // SAFETY: Same as `Self::concat`.
-            unsafe { msg_send_id![self, stringByAppendingPathComponent: other] }
-        }
+        pub fn join_path(&self, other: &Self) -> Id<Self, Shared>;
 
         /// The number of UTF-8 code units in `self`.
         #[doc(alias = "lengthOfBytesUsingEncoding")]

--- a/objc2/src/foundation/thread.rs
+++ b/objc2/src/foundation/thread.rs
@@ -27,9 +27,8 @@ impl RefUnwindSafe for NSThread {}
 extern_methods!(
     unsafe impl NSThread {
         /// Returns the [`NSThread`] object representing the current thread.
-        pub fn current() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), currentThread] }
-        }
+        #[method_id(currentThread)]
+        pub fn current() -> Id<Self, Shared>;
 
         /// Returns the [`NSThread`] object representing the main thread.
         pub fn main() -> Id<NSThread, Shared> {
@@ -44,13 +43,11 @@ extern_methods!(
         pub fn is_main(&self) -> bool;
 
         /// The name of the thread.
-        pub fn name(&self) -> Option<Id<NSString, Shared>> {
-            unsafe { msg_send_id![self, name] }
-        }
+        #[method_id(name)]
+        pub fn name(&self) -> Option<Id<NSString, Shared>>;
 
-        unsafe fn new() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        unsafe fn new() -> Id<Self, Shared>;
 
         #[method(start)]
         unsafe fn start(&self);

--- a/objc2/src/foundation/uuid.rs
+++ b/objc2/src/foundation/uuid.rs
@@ -45,9 +45,8 @@ impl RefUnwindSafe for NSUUID {}
 
 extern_methods!(
     unsafe impl NSUUID {
-        pub fn new_v4() -> Id<Self, Shared> {
-            unsafe { msg_send_id![Self::class(), new] }
-        }
+        #[method_id(new)]
+        pub fn new_v4() -> Id<Self, Shared>;
 
         /// The 'nil UUID'.
         pub fn nil() -> Id<Self, Shared> {
@@ -72,9 +71,8 @@ extern_methods!(
             bytes.0
         }
 
-        pub fn string(&self) -> Id<NSString, Shared> {
-            unsafe { msg_send_id![self, UUIDString] }
-        }
+        #[method_id(UUIDString)]
+        pub fn string(&self) -> Id<NSString, Shared>;
     }
 );
 

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -828,6 +828,10 @@ macro_rules! __declare_class_register_out {
                 ($crate::__declare_class_register_out)
                 ($(#[$($m)*])*)
                 @call_sel
+
+                // Will add
+                // @(sel)
+                // @(output macro)
             },
             Self::$name as $crate::__fn_ptr! {
                 @($($qualifiers)*) $($args_start)* $($args_rest)*
@@ -853,6 +857,10 @@ macro_rules! __declare_class_register_out {
                 ($crate::__declare_class_register_out)
                 ($(#[$($m)*])*)
                 @call_sel
+
+                // Will add
+                // @(sel)
+                // @(output macro)
             },
             Self::$name as $crate::__fn_ptr! {
                 @($($qualifiers)*) $($args_start)* $($args_rest)*
@@ -863,8 +871,17 @@ macro_rules! __declare_class_register_out {
     {
         @call_sel
         @($($sel:tt)*)
+        @(msg_send)
     } => {
         $crate::sel!($($sel)*)
+    };
+
+    {
+        @call_sel
+        @($($sel:tt)*)
+        @(msg_send_id)
+    } => {
+        compile_error!("`#[method_id(...)]` is not supported in `declare_class!` yet");
     };
 }
 

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -559,7 +559,7 @@ macro_rules! __attribute_helper {
     } => {
         $crate::__attribute_helper! {
             @extract_sel_duplicate
-            ($($rest:tt)*)
+            ($($rest)*)
             $($output)*
         }
     };

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -397,7 +397,9 @@ macro_rules! __inner_extern_class {
 #[macro_export]
 macro_rules! __attribute_helper {
     // Convert a set of attributes described with `@[...]` to `#[...]`, while
-    // parsing out the `method(...)` attribute.
+    // parsing out the `method(...)` or `method_id(...)` attribute.
+
+    // method
     {
         @strip_sel
         @[method($($_sel_args:tt)*)]
@@ -414,6 +416,24 @@ macro_rules! __attribute_helper {
             ($($fn)*)
         }
     };
+    // method_id
+    {
+        @strip_sel
+        @[method_id($($_sel_args:tt)*)]
+        $(@[$($m_rest:tt)*])*
+
+        $(#[$($m:tt)*])*
+        ($($fn:tt)*)
+    } => {
+        $crate::__attribute_helper! {
+            @strip_sel
+            $(@[$($m_rest)*])*
+
+            $(#[$($m)*])*
+            ($($fn)*)
+        }
+    };
+    // Others
     {
         @strip_sel
         @[$($m_checked:tt)*]
@@ -431,6 +451,7 @@ macro_rules! __attribute_helper {
             ($($fn)*)
         }
     };
+    // Final output
     {
         @strip_sel
         $(#[$($m:tt)*])*
@@ -440,7 +461,8 @@ macro_rules! __attribute_helper {
         $($fn)*
     };
 
-    // Extract the `#[method(...)]` attribute and send it to another macro
+    // Extract the `#[method(...)]` and `#[method_id(...)]` attribute and send
+    // it to another macro
     {
         @extract_sel
         ($out_macro:path)
@@ -455,8 +477,29 @@ macro_rules! __attribute_helper {
             ($($rest)*)
             $out_macro!(
                 $($macro_args)*
-                // Append selector to the end of the macro arguments
+                // Append selector and macro name to the end of the macro arguments
                 @($($sel)*)
+                @(msg_send)
+            )
+        }
+    };
+    {
+        @extract_sel
+        ($out_macro:path)
+        (
+            #[method_id($($sel:tt)*)]
+            $($rest:tt)*
+        )
+        $($macro_args:tt)*
+    } => {
+        $crate::__attribute_helper! {
+            @extract_sel_duplicate
+            ($($rest)*)
+            $out_macro!(
+                $($macro_args)*
+
+                @($($sel)*)
+                @(msg_send_id)
             )
         }
     };
@@ -482,13 +525,24 @@ macro_rules! __attribute_helper {
         ()
         $($macro_args:tt)*
     } => {{
-        compile_error!("Must specify the desired selector using `#[method(...)]`");
+        compile_error!("Must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`");
     }};
 
+    // Duplicate checking
     {
         @extract_sel_duplicate
         (
             #[method($($_sel_args:tt)*)]
+            $($rest:tt)*
+        )
+        $($output:tt)*
+    } => {{
+        compile_error!("Cannot not specify a selector twice!");
+    }};
+    {
+        @extract_sel_duplicate
+        (
+            #[method_id($($_sel_args:tt)*)]
             $($rest:tt)*
         )
         $($output:tt)*

--- a/test-ui/ui/extern_methods_invalid_type.rs
+++ b/test-ui/ui/extern_methods_invalid_type.rs
@@ -1,0 +1,34 @@
+use objc2::{extern_class, extern_methods, ClassType};
+use objc2::foundation::NSObject;
+use objc2::rc::{Id, Owned};
+
+extern_class!(
+    pub struct MyObject;
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(a)]
+        fn a(&self) -> Id<Self, Owned>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method_id(b)]
+        fn b(&self) -> i32;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method_id(init)]
+        fn init(&mut self) -> Option<Id<Self, Owned>>;
+    }
+);
+
+fn main() {}

--- a/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/test-ui/ui/extern_methods_invalid_type.stderr
@@ -1,0 +1,74 @@
+error[E0277]: the trait bound `Id<MyObject, objc2::rc::Owned>: Encode` is not satisfied
+ --> ui/extern_methods_invalid_type.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(a)]
+  | |         fn a(&self) -> Id<Self, Owned>;
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Id<MyObject, objc2::rc::Owned>`
+  |
+  = help: the following other types implement trait `Encode`:
+            &'a T
+            &'a mut T
+            ()
+            *const T
+            *const c_void
+            *mut T
+            *mut c_void
+            AtomicI16
+          and $N others
+  = note: required for `Id<MyObject, objc2::rc::Owned>` to implement `EncodeConvert`
+note: required by a bound in `send_message`
+ --> $WORKSPACE/objc2/src/message/mod.rs
+  |
+  |         R: EncodeConvert,
+  |            ^^^^^^^^^^^^^ required by this bound in `send_message`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `i32: MaybeUnwrap` is not satisfied
+ --> ui/extern_methods_invalid_type.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method_id(b)]
+  | |         fn b(&self) -> i32;
+  | |     }
+  | | );
+  | |_^ the trait `MaybeUnwrap` is not implemented for `i32`
+  |
+  = help: the following other types implement trait `MaybeUnwrap`:
+            Allocated<T>
+            Id<T, O>
+            Option<Allocated<T>>
+            Option<Id<T, O>>
+note: required by a bound in `send_message_id`
+ --> $WORKSPACE/objc2/src/__macro_helpers.rs
+  |
+  |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
+  |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `send_message_id`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_invalid_type.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method_id(init)]
+  | |         fn init(&mut self) -> Option<Id<Self, Owned>>;
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected enum `Option`, found `&mut MyObject`
+  |   arguments to this function are incorrect
+  |
+  = note:           expected enum `Option<Allocated<_>>`
+          found mutable reference `&mut MyObject`
+note: associated function defined here
+ --> $WORKSPACE/objc2/src/__macro_helpers.rs
+  |
+  |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
+  |               ^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `$crate::__inner_extern_methods` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/extern_methods_missing_method.stderr
+++ b/test-ui/ui/extern_methods_missing_method.stderr
@@ -1,4 +1,4 @@
-error: Must specify the desired selector using `#[method(...)]`
+error: Must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`
  --> ui/extern_methods_missing_method.rs
   |
   | / extern_methods!(

--- a/test-ui/ui/extern_methods_selector_twice.rs
+++ b/test-ui/ui/extern_methods_selector_twice.rs
@@ -1,0 +1,28 @@
+use objc2::{extern_class, extern_methods, ClassType};
+use objc2::foundation::NSObject;
+
+extern_class!(
+    pub struct MyObject;
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(a)]
+        #[method(a)]
+        fn a();
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(b)]
+        #[method_id(b)]
+        fn b();
+    }
+);
+
+fn main() {}

--- a/test-ui/ui/extern_methods_selector_twice.stderr
+++ b/test-ui/ui/extern_methods_selector_twice.stderr
@@ -1,0 +1,27 @@
+error: Cannot not specify a selector twice!
+ --> ui/extern_methods_selector_twice.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(a)]
+  | |         #[method(a)]
+  | |         fn a();
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__attribute_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Cannot not specify a selector twice!
+ --> ui/extern_methods_selector_twice.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(b)]
+  | |         #[method_id(b)]
+  | |         fn b();
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__attribute_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Initial example syntax:
```rust
extern_methods!(
    unsafe impl MyObject {
        #[sel_id(init)]
        fn new() -> Id<Self, Owned>;

        #[sel_id(description)]
        fn get(&self) -> Id<NSString, Owned>;
    }
);

// Becomes
impl MyObject {
    fn new() -> Id<Self, Owned> {
        // Automatic allocation?
        unsafe { msg_send_id![msg_send_id![Self::class(), alloc], init] }
    }

    fn get(&self) -> Id<NSString, Owned> {
        unsafe { msg_send_id![self, description] }
    }
}
```