### PR TITLE
Update UI tests for Rust 1.65 nightly

### DIFF
--- a/test-ui/ui/global_block_not_encode.stderr
+++ b/test-ui/ui/global_block_not_encode.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `Box<i32>: objc2_encode::encode::Encode` is not sa
             *mut c_void
             AtomicBool
           and 152 others
-  = note: required because of the requirements on the impl of `BlockArguments` for `(Box<i32>,)`
-  = note: required because of the requirements on the impl of `Sync` for `GlobalBlock<(Box<i32>,)>`
+  = note: required for `(Box<i32>,)` to implement `BlockArguments`
+  = note: required for `GlobalBlock<(Box<i32>,)>` to implement `Sync`
   = note: shared static variables must have a type that implements `Sync`
   = note: this error originates in the macro `global_block` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -109,5 +109,5 @@ error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiv
    = help: the following other types implement trait `MessageReceiver`:
              &'a Id<T, O>
              &'a mut Id<T, objc2::rc::Owned>
-   = note: required because of the requirements on the impl of `MsgSendId<Id<objc2::runtime::Object, Shared>, _, _>` for `RetainSemantics<false, false, false, true>`
+   = note: required for `RetainSemantics<false, false, false, true>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, _, _>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSException
              NSMutableArray<T, O>
            and 11 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, objc2::runtime::Class, Shared>` for `RetainSemantics<true, false, false, false>`
+   = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<&objc2::runtime::Class, objc2::runtime::Class, Shared>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
@@ -49,7 +49,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSException
              NSMutableArray<T, O>
            and 11 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, objc2::runtime::Class, Shared>` for `RetainSemantics<true, false, false, false>`
+   = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<&objc2::runtime::Class, objc2::runtime::Class, Shared>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap<Allocated<_>, _>` is not satisfied
@@ -84,7 +84,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
              NSException
              NSMutableArray<T, O>
            and 11 others
-   = note: required because of the requirements on the impl of `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>, Shared>` for `RetainSemantics<false, true, false, false>`
+   = note: required for `RetainSemantics<false, true, false, false>` to implement `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>, Shared>`
    = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MaybeUnwrap<Allocated<_>, _>` is not satisfied

--- a/test-ui/ui/msg_send_not_encode.stderr
+++ b/test-ui/ui/msg_send_not_encode.stderr
@@ -37,7 +37,7 @@ error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
               *mut c_void
               AtomicBool
             and 159 others
-    = note: required because of the requirements on the impl of `MessageArguments` for `(Vec<u8>,)`
+    = note: required for `(Vec<u8>,)` to implement `MessageArguments`
 note: required by a bound in `send_message`
    --> $WORKSPACE/objc2/src/message/mod.rs
     |

--- a/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -7,7 +7,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   = help: within `objc2::runtime::Object`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = note: required because it appears within the type `objc_object`
   = note: required because it appears within the type `objc2::runtime::Object`
-  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object>`
+  = note: required for `NSArray<objc2::runtime::Object>` to implement `Sync`
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
   |
@@ -26,7 +26,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   = note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = note: required because it appears within the type `objc_object`
   = note: required because it appears within the type `objc2::runtime::Object`
-  = note: required because of the requirements on the impl of `Sync` for `NSArray<objc2::runtime::Object>`
+  = note: required for `NSArray<objc2::runtime::Object>` to implement `Sync`
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
   |
@@ -42,7 +42,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
    = help: within `objc2::runtime::Object`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
    = note: required because it appears within the type `objc_object`
    = note: required because it appears within the type `objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object>`
+   = note: required for `NSArray<objc2::runtime::Object>` to implement `Send`
 note: required by a bound in `needs_send`
   --> ui/nsarray_bound_not_send_sync.rs
    |
@@ -61,7 +61,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
    = note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
    = note: required because it appears within the type `objc_object`
    = note: required because it appears within the type `objc2::runtime::Object`
-   = note: required because of the requirements on the impl of `Send` for `NSArray<objc2::runtime::Object>`
+   = note: required for `NSArray<objc2::runtime::Object>` to implement `Send`
 note: required by a bound in `needs_send`
   --> ui/nsarray_bound_not_send_sync.rs
    |


### PR DESCRIPTION
Rust 1.65 seems to have updated their error messages for missing trait implementations which caused some UI tests to fail.