### PR TITLE
Allow `Drop` types in ivars

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -8,8 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 ### Added
-* `Ivar::write`, `Ivar::as_ptr` and `Ivar::as_mut_ptr` for querying/modifying
-  the instance variable inside `init` methods.
+* Added `Ivar::write`, `Ivar::as_ptr` and `Ivar::as_mut_ptr` for safely
+  querying and modifying instance variables inside `init` methods.
+* Added `IvarDrop<T>` to allow storing complex `Drop` values in ivars
+  (currently `rc::Id<T, O>`, `Box<T>`, `Option<rc::Id<T, O>>` or
+  `Option<Box<T>>`).
 
 ### Removed
 * **BREAKING**: `MaybeUninit` no longer implements `IvarType` directly; use

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(not(all(feature = "apple", target_os = "macos")), allow(unused))]
-use objc2::declare::Ivar;
-use objc2::foundation::NSObject;
+use objc2::declare::{Ivar, IvarDrop};
+use objc2::foundation::{NSCopying, NSObject, NSString};
 use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
-use objc2::{declare_class, extern_class, msg_send, msg_send_id, ClassType};
+use objc2::{declare_class, extern_class, msg_send, msg_send_id, ns_string, ClassType};
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
 #[link(name = "AppKit", kind = "framework")]
@@ -23,6 +23,10 @@ declare_class!(
     struct CustomAppDelegate {
         pub ivar: u8,
         another_ivar: bool,
+        box_ivar: IvarDrop<Box<i32>>,
+        maybe_box_ivar: IvarDrop<Option<Box<i32>>>,
+        id_ivar: IvarDrop<Id<NSString, Shared>>,
+        maybe_id_ivar: IvarDrop<Option<Id<NSString, Shared>>>,
     }
 
     unsafe impl ClassType for CustomAppDelegate {
@@ -34,18 +38,17 @@ declare_class!(
         #[sel(initWith:another:)]
         fn init_with(self: &mut Self, ivar: u8, another_ivar: bool) -> Option<&mut Self> {
             let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
+
+            // TODO: `ns_string` can't be used inside closures; investigate!
+            let s = ns_string!("def");
+
             this.map(|this| {
                 Ivar::write(&mut this.ivar, ivar);
-                Ivar::write(&mut this.another_ivar, another_ivar);
-                // Note that we could have done this with just:
-                // *this.ivar = ivar;
-                // *this.another_ivar = another_ivar;
-                //
-                // Since these two ivar types (`u8` and `bool`) are safe to
-                // initialize from all zeroes; but for this example, we chose
-                // to be explicit.
-
-                // SAFETY: All the instance variables have been initialized
+                *this.another_ivar = another_ivar;
+                *this.maybe_box_ivar = None;
+                *this.maybe_id_ivar = Some(s.copy());
+                Ivar::write(&mut this.box_ivar, Box::new(2));
+                Ivar::write(&mut this.id_ivar, NSString::from_str("abc"));
                 this
             })
         }
@@ -97,8 +100,12 @@ impl CustomAppDelegate {
 fn main() {
     let delegate = CustomAppDelegate::new(42, true);
 
-    println!("{}", delegate.ivar);
-    println!("{}", delegate.another_ivar);
+    println!("{:?}", delegate.ivar);
+    println!("{:?}", delegate.another_ivar);
+    println!("{:?}", delegate.box_ivar);
+    println!("{:?}", delegate.maybe_box_ivar);
+    println!("{:?}", delegate.id_ivar);
+    println!("{:?}", delegate.maybe_id_ivar);
 }
 
 #[cfg(not(all(feature = "apple", target_os = "macos")))]

--- a/objc2/src/__macro_helpers.rs
+++ b/objc2/src/__macro_helpers.rs
@@ -13,6 +13,7 @@ pub use core::mem::size_of;
 pub use core::ops::{Deref, DerefMut};
 pub use core::option::Option::{self, None, Some};
 pub use core::primitive::{bool, str, u8};
+pub use core::ptr::drop_in_place;
 pub use core::{compile_error, concat, panic, stringify};
 // TODO: Use `core::cell::LazyCell`
 pub use std::sync::Once;

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -410,12 +410,13 @@ impl ClassBuilder {
     /// If the ivar wasn't successfully added for some reason - this usually
     /// happens if there already was an ivar with that name.
     pub fn add_ivar<T: Encode>(&mut self, name: &str) {
-        self.add_ivar_inner::<T>(name)
+        // SAFETY: The encoding is correct
+        unsafe { self.add_ivar_inner::<T>(name, &T::ENCODING) }
     }
 
-    fn add_ivar_inner<T: EncodeConvert>(&mut self, name: &str) {
+    unsafe fn add_ivar_inner<T>(&mut self, name: &str, encoding: &Encoding) {
         let c_name = CString::new(name).unwrap();
-        let encoding = CString::new(T::__ENCODING.to_string()).unwrap();
+        let encoding = CString::new(encoding.to_string()).unwrap();
         let size = mem::size_of::<T>();
         let align = log2_align_of::<T>();
         let success = Bool::from_raw(unsafe {
@@ -437,7 +438,8 @@ impl ClassBuilder {
     ///
     /// Same as [`ClassBuilder::add_ivar`].
     pub fn add_static_ivar<T: IvarType>(&mut self) {
-        self.add_ivar_inner::<T::Type>(T::NAME)
+        // SAFETY: The encoding is correct
+        unsafe { self.add_ivar_inner::<T::Type>(T::NAME, &T::Type::__ENCODING) }
     }
 
     /// Adds the given protocol to self.

--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -2,10 +2,84 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
-use core::ptr::NonNull;
+use core::ptr::{self, NonNull};
 
-use crate::encode::EncodeConvert;
+use crate::encode::{EncodeConvert, Encoding};
 use crate::runtime::{ivar_offset, Object};
+
+pub(crate) mod private {
+    pub trait Sealed {}
+}
+
+/// Types that may be used in ivars.
+///
+/// This may be either:
+/// - [`bool`].
+/// - [`IvarDrop<T>`][super::IvarDrop].
+/// - Something that implements [`Encode`][crate::Encode].
+///
+/// This is a sealed trait, and should not need to be implemented. Open an
+/// issue if you know a use-case where this restrition should be lifted!
+///
+///
+/// # Safety
+///
+/// You cannot rely on any safety guarantees from this.
+pub unsafe trait InnerIvarType: private::Sealed {
+    #[doc(hidden)]
+    const __ENCODING: Encoding;
+
+    // SAFETY: It must be safe to transmute from `__Inner` to `Output`.
+    #[doc(hidden)]
+    type __Inner;
+
+    /// The type that an `Ivar` containing this will dereference to.
+    ///
+    /// E.g. `Ivar<IvarDrop<Box<u8>>>` will deref to `Box<u8>`.
+    type Output;
+
+    // SAFETY: The __Inner type must be safe to drop even if zero-initialized.
+    #[doc(hidden)]
+    const __MAY_DROP: bool;
+
+    #[doc(hidden)]
+    unsafe fn __to_ref(inner: &Self::__Inner) -> &Self::Output;
+
+    #[doc(hidden)]
+    unsafe fn __to_mut(inner: &mut Self::__Inner) -> &mut Self::Output;
+
+    #[doc(hidden)]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output>;
+}
+
+impl<T: EncodeConvert> private::Sealed for T {}
+unsafe impl<T: EncodeConvert> InnerIvarType for T {
+    const __ENCODING: Encoding = <Self as EncodeConvert>::__ENCODING;
+    type __Inner = Self;
+    type Output = Self;
+    // Note: We explicitly tell `Ivar` that it shouldn't do anything to drop,
+    // since if the object was deallocated before an `init` method was called,
+    // the ivar would not have been initialized properly!
+    //
+    // For example in the case of `NonNull<u8>`, it would be zero-initialized
+    // which is an invalid state for that.
+    const __MAY_DROP: bool = false;
+
+    #[inline]
+    unsafe fn __to_ref(inner: &Self::__Inner) -> &Self::Output {
+        inner
+    }
+
+    #[inline]
+    unsafe fn __to_mut(inner: &mut Self::__Inner) -> &mut Self::Output {
+        inner
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner
+    }
+}
 
 /// Helper trait for defining instance variables.
 ///
@@ -39,7 +113,7 @@ use crate::runtime::{ivar_offset, Object};
 /// ```
 pub unsafe trait IvarType {
     /// The type of the instance variable.
-    type Type: EncodeConvert;
+    type Type: InnerIvarType;
     /// The name of the instance variable.
     const NAME: &'static str;
 
@@ -132,7 +206,18 @@ pub struct Ivar<T: IvarType> {
     /// Make this type allowed in `repr(C)`
     inner: [u8; 0],
     /// For proper variance and auto traits
-    item: PhantomData<T::Type>,
+    item: PhantomData<<T::Type as InnerIvarType>::Output>,
+}
+
+impl<T: IvarType> Drop for Ivar<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if <T::Type as InnerIvarType>::__MAY_DROP {
+            // SAFETY: We drop the inner type, which is guaranteed by
+            // `__MAY_DROP` to always be safe to drop.
+            unsafe { ptr::drop_in_place(self.as_inner_mut_ptr().as_ptr()) }
+        }
+    }
 }
 
 impl<T: IvarType> Ivar<T> {
@@ -143,8 +228,12 @@ impl<T: IvarType> Ivar<T> {
     ///
     /// This is similar to [`MaybeUninit::as_ptr`], see that for usage
     /// instructions.
-    pub fn as_ptr(this: &Self) -> *const T::Type {
-        let ptr: NonNull<Object> = NonNull::from(this).cast();
+    pub fn as_ptr(this: &Self) -> *const <T::Type as InnerIvarType>::Output {
+        T::Type::__to_ptr(this.as_inner_ptr()).as_ptr()
+    }
+
+    fn as_inner_ptr(&self) -> NonNull<<T::Type as InnerIvarType>::__Inner> {
+        let ptr: NonNull<Object> = NonNull::from(self).cast();
 
         // SAFETY: The user ensures that this is placed in a struct that can
         // be reinterpreted as an `Object`. Since `Ivar` can never be
@@ -159,9 +248,7 @@ impl<T: IvarType> Ivar<T> {
         // so that is fine.
         let offset = unsafe { T::__offset(ptr) };
         // SAFETY: The offset is valid
-        let ptr = unsafe { Object::ivar_at_offset::<T::Type>(ptr, offset) };
-
-        ptr.as_ptr()
+        unsafe { Object::ivar_at_offset::<<T::Type as InnerIvarType>::__Inner>(ptr, offset) }
     }
 
     /// Get a mutable pointer to the instance variable.
@@ -174,16 +261,17 @@ impl<T: IvarType> Ivar<T> {
     ///
     /// This is similar to [`MaybeUninit::as_mut_ptr`], see that for usage
     /// instructions.
-    fn as_mut_ptr(this: &mut Self) -> *mut T::Type {
-        let ptr: NonNull<Object> = NonNull::from(this).cast();
+    pub fn as_mut_ptr(this: &mut Self) -> *mut <T::Type as InnerIvarType>::Output {
+        T::Type::__to_ptr(this.as_inner_mut_ptr()).as_ptr()
+    }
 
-        // SAFETY: Same as `as_ptr`
+    fn as_inner_mut_ptr(&mut self) -> NonNull<<T::Type as InnerIvarType>::__Inner> {
+        let ptr: NonNull<Object> = NonNull::from(self).cast();
+
+        // SAFETY: Same as `as_inner_ptr`
         let offset = unsafe { T::__offset(ptr) };
         // SAFETY: The offset is valid
-        let ptr = unsafe { Object::ivar_at_offset::<T::Type>(ptr, offset) };
-
-        // Safe as *mut T because it came from `&mut Self`
-        ptr.as_ptr()
+        unsafe { Object::ivar_at_offset::<<T::Type as InnerIvarType>::__Inner>(ptr, offset) }
     }
 
     /// Sets the value of the instance variable.
@@ -193,15 +281,19 @@ impl<T: IvarType> Ivar<T> {
     ///
     /// This is similar to [`MaybeUninit::write`], see that for usage
     /// instructions.
-    pub fn write(this: &mut Self, val: T::Type) -> &mut T::Type {
-        let ptr: *mut MaybeUninit<T::Type> = Self::as_mut_ptr(this).cast();
+    pub fn write(
+        this: &mut Self,
+        val: <T::Type as InnerIvarType>::Output,
+    ) -> &mut <T::Type as InnerIvarType>::Output {
+        let ptr: *mut MaybeUninit<<T::Type as InnerIvarType>::Output> =
+            Self::as_mut_ptr(this).cast();
         let ivar = unsafe { ptr.as_mut().unwrap_unchecked() };
         ivar.write(val)
     }
 }
 
 impl<T: IvarType> Deref for Ivar<T> {
-    type Target = T::Type;
+    type Target = <T::Type as InnerIvarType>::Output;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -210,7 +302,7 @@ impl<T: IvarType> Deref for Ivar<T> {
         //
         // Since all accesses to a particular ivar only goes through one
         // `Ivar`, if we have `&Ivar` we know that `&T` is safe.
-        unsafe { Self::as_ptr(self).as_ref().unwrap_unchecked() }
+        unsafe { T::Type::__to_ref(self.as_inner_ptr().as_ref()) }
     }
 }
 
@@ -241,15 +333,14 @@ impl<T: IvarType> DerefMut for Ivar<T> {
         //
         // And using `mut` would create aliasing mutable reference to the
         // object.
-        unsafe { Self::as_mut_ptr(self).as_mut().unwrap_unchecked() }
+        unsafe { T::Type::__to_mut(self.as_inner_mut_ptr().as_mut()) }
     }
 }
 
 /// Format as a pointer to the instance variable.
 impl<T: IvarType> fmt::Pointer for Ivar<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ptr: *const T::Type = &**self;
-        fmt::Pointer::fmt(&ptr, f)
+        fmt::Pointer::fmt(&Self::as_ptr(self), f)
     }
 }
 
@@ -257,9 +348,12 @@ impl<T: IvarType> fmt::Pointer for Ivar<T> {
 mod tests {
     use core::mem;
     use core::panic::{RefUnwindSafe, UnwindSafe};
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
-    use crate::{msg_send, test_utils, MessageReceiver};
+    use crate::foundation::NSObject;
+    use crate::rc::{Id, Owned};
+    use crate::{declare_class, msg_send, msg_send_id, test_utils, ClassType, MessageReceiver};
 
     struct TestIvar;
 
@@ -296,5 +390,32 @@ mod tests {
                 .unwrap()
         };
         assert_eq!(*obj.foo, 42);
+    }
+
+    #[test]
+    fn ensure_custom_drop_is_possible() {
+        static HAS_RUN_DEALLOC: AtomicBool = AtomicBool::new(false);
+
+        declare_class!(
+            #[derive(Debug, PartialEq)]
+            struct CustomDrop {
+                ivar: u8,
+            }
+
+            unsafe impl ClassType for CustomDrop {
+                type Super = NSObject;
+            }
+
+            unsafe impl CustomDrop {
+                #[sel(dealloc)]
+                fn dealloc(&mut self) {
+                    HAS_RUN_DEALLOC.store(true, Ordering::SeqCst);
+                }
+            }
+        );
+
+        let _: Id<CustomDrop, Owned> = unsafe { msg_send_id![CustomDrop::class(), new] };
+
+        assert!(HAS_RUN_DEALLOC.load(Ordering::SeqCst));
     }
 }

--- a/objc2/src/declare/ivar_drop.rs
+++ b/objc2/src/declare/ivar_drop.rs
@@ -1,0 +1,333 @@
+use alloc::boxed::Box;
+use core::ffi::c_void;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+use crate::encode::{EncodeConvert, Encoding};
+use crate::rc::{Id, Ownership};
+use crate::Message;
+
+use super::InnerIvarType;
+
+/// A helper type to allow putting certain types that may drop into ivars.
+///
+/// This is used to work around current limitations in the type system.
+/// Consider this type "temporary" in the sense that one day it may just
+/// become `type IvarDrop<T> = T`.
+///
+/// This currently works with the following types:
+/// - `Box<T>`
+/// - `Option<Box<T>>`
+/// - `Id<T, O>`
+/// - `Option<Id<T, O>>`
+///
+/// Further may be added when the standard library guarantees their layout.
+///
+/// See `examples/delegate.rs` for usage.
+pub struct IvarDrop<T> {
+    /// For proper variance and auto traits.
+    p: PhantomData<T>,
+}
+
+impl<T: Sized> super::ivar::private::Sealed for IvarDrop<Box<T>> {}
+// SAFETY: The memory layout of `Box<T: Sized>` is guaranteed to be a pointer:
+// <https://doc.rust-lang.org/1.62.1/std/boxed/index.html#memory-layout>
+//
+// The user ensures that the Box has been initialized in an `init` method
+// before being used.
+unsafe impl<T: Sized> InnerIvarType for IvarDrop<Box<T>> {
+    // Note that we use `*const c_void` and not `*const T` to allow _any_
+    // type, not just types that can be encoded by Objective-C
+    const __ENCODING: Encoding = <*const c_void as EncodeConvert>::__ENCODING;
+
+    type __Inner = Option<Box<T>>;
+    type Output = Box<T>;
+
+    const __MAY_DROP: bool = true;
+
+    #[inline]
+    unsafe fn __to_ref(inner: &Self::__Inner) -> &Self::Output {
+        match inner {
+            Some(inner) => inner,
+            None => unsafe { box_unreachable() },
+        }
+    }
+
+    #[inline]
+    unsafe fn __to_mut(inner: &mut Self::__Inner) -> &mut Self::Output {
+        match inner {
+            Some(inner) => inner,
+            None => unsafe { box_unreachable() },
+        }
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner.cast()
+    }
+}
+
+impl<T: Sized> super::ivar::private::Sealed for IvarDrop<Option<Box<T>>> {}
+// SAFETY: `Option<Box<T>>` guarantees the null-pointer optimization, so for
+// `T: Sized` the layout is just a pointer:
+// <https://doc.rust-lang.org/1.62.1/std/option/index.html#representation>
+//
+// This is valid to initialize as all-zeroes, so the user doesn't have to do
+// anything to initialize it.
+unsafe impl<T: Sized> InnerIvarType for IvarDrop<Option<Box<T>>> {
+    const __ENCODING: Encoding = <*const c_void as EncodeConvert>::__ENCODING;
+
+    type __Inner = Option<Box<T>>;
+    type Output = Option<Box<T>>;
+
+    const __MAY_DROP: bool = true;
+
+    #[inline]
+    unsafe fn __to_ref(this: &Self::__Inner) -> &Self::Output {
+        this
+    }
+
+    #[inline]
+    unsafe fn __to_mut(this: &mut Self::__Inner) -> &mut Self::Output {
+        this
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner.cast()
+    }
+}
+
+impl<T: Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Id<T, O>> {}
+// SAFETY: `Id` is `NonNull<T>`, and hence safe to store as a pointer.
+//
+// The user ensures that the Id has been initialized in an `init` method
+// before being used.
+//
+// Note: We could technically do `impl InnerIvarType for Ivar<Id<T, O>>`
+// directly today, but since we can't do so for `Box` (because that is
+// `#[fundamental]`), I think it makes sense to handle them similarly.
+unsafe impl<T: Message, O: Ownership> InnerIvarType for IvarDrop<Id<T, O>> {
+    const __ENCODING: Encoding = <*const T as EncodeConvert>::__ENCODING;
+
+    type __Inner = Option<Id<T, O>>;
+    type Output = Id<T, O>;
+
+    const __MAY_DROP: bool = true;
+
+    #[inline]
+    unsafe fn __to_ref(inner: &Self::__Inner) -> &Self::Output {
+        match inner {
+            Some(inner) => inner,
+            None => unsafe { id_unreachable() },
+        }
+    }
+
+    #[inline]
+    unsafe fn __to_mut(inner: &mut Self::__Inner) -> &mut Self::Output {
+        match inner {
+            Some(inner) => inner,
+            None => unsafe { id_unreachable() },
+        }
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner.cast()
+    }
+}
+
+impl<T: Message, O: Ownership> super::ivar::private::Sealed for IvarDrop<Option<Id<T, O>>> {}
+// SAFETY: `Id<T, O>` guarantees the null-pointer optimization.
+//
+// This is valid to initialize as all-zeroes, so the user doesn't have to do
+// anything to initialize it.
+unsafe impl<T: Message, O: Ownership> InnerIvarType for IvarDrop<Option<Id<T, O>>> {
+    const __ENCODING: Encoding = <*const T as EncodeConvert>::__ENCODING;
+
+    type __Inner = Option<Id<T, O>>;
+    type Output = Option<Id<T, O>>;
+
+    const __MAY_DROP: bool = true;
+
+    #[inline]
+    unsafe fn __to_ref(this: &Self::__Inner) -> &Self::Output {
+        this
+    }
+
+    #[inline]
+    unsafe fn __to_mut(this: &mut Self::__Inner) -> &mut Self::Output {
+        this
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner.cast()
+    }
+}
+
+// TODO: Allow the following once their layout is guaranteed by `std`:
+// - Arc<T>
+// - Option<Arc<T>>
+// - sync::Weak<T>
+// - Rc<T>
+// - Option<Rc<T>>
+// - rc::Weak<T>
+// - Vec<T>
+// - String
+
+// TODO: Allow `WeakId` once we figure out how to allow it being initialized
+// by default.
+
+#[inline]
+unsafe fn id_unreachable() -> ! {
+    #[cfg(debug_assertions)]
+    {
+        unreachable!("an Id in instance variables must always be initialized before use!")
+    }
+    // SAFETY: Checked by caller
+    #[cfg(not(debug_assertions))]
+    unsafe {
+        core::hint::unreachable_unchecked()
+    }
+}
+
+#[inline]
+unsafe fn box_unreachable() -> ! {
+    #[cfg(debug_assertions)]
+    {
+        unreachable!("a Box in instance variables must always be initialized before use!")
+    }
+    // SAFETY: Checked by caller
+    #[cfg(not(debug_assertions))]
+    unsafe {
+        core::hint::unreachable_unchecked()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::declare::{Ivar, IvarType};
+    use crate::foundation::NSObject;
+    use crate::rc::{Allocated, Owned, RcTestObject, Shared, ThreadTestData};
+    use crate::runtime::Object;
+    use crate::{declare_class, msg_send, msg_send_id, ClassType};
+
+    struct TestIvar1;
+    unsafe impl IvarType for TestIvar1 {
+        type Type = IvarDrop<Box<u8>>;
+        const NAME: &'static str = "_abc";
+    }
+
+    struct TestIvar2;
+    unsafe impl IvarType for TestIvar2 {
+        type Type = IvarDrop<Option<Box<u8>>>;
+        const NAME: &'static str = "_abc";
+    }
+
+    struct TestIvar3;
+    unsafe impl IvarType for TestIvar3 {
+        type Type = IvarDrop<Id<Object, Shared>>;
+        const NAME: &'static str = "_abc";
+    }
+
+    struct TestIvar4;
+    unsafe impl IvarType for TestIvar4 {
+        type Type = IvarDrop<Option<Id<Object, Owned>>>;
+        const NAME: &'static str = "_abc";
+    }
+
+    declare_class!(
+        #[derive(Debug, PartialEq)]
+        struct IvarTester {
+            ivar1: IvarDrop<Id<RcTestObject, Shared>>,
+            ivar2: IvarDrop<Option<Id<RcTestObject, Owned>>>,
+            ivar3: IvarDrop<Box<Id<RcTestObject, Owned>>>,
+            ivar4: IvarDrop<Option<Box<Id<RcTestObject, Owned>>>>,
+        }
+
+        unsafe impl ClassType for IvarTester {
+            type Super = NSObject;
+        }
+
+        unsafe impl IvarTester {
+            #[sel(init)]
+            fn init(&mut self) -> Option<&mut Self> {
+                let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
+                this.map(|this| {
+                    Ivar::write(&mut this.ivar1, Id::into_shared(RcTestObject::new()));
+                    *this.ivar2 = Some(RcTestObject::new());
+                    Ivar::write(&mut this.ivar3, Box::new(RcTestObject::new()));
+                    *this.ivar4 = Some(Box::new(RcTestObject::new()));
+                    this
+                })
+            }
+
+            #[sel(initInvalid)]
+            fn init_invalid(&mut self) -> Option<&mut Self> {
+                // Don't actually initialize anything here; this creates an
+                // invalid instance, where accessing the two ivars `ivar1`
+                // and `ivar3` is UB
+                unsafe { msg_send![super(self), init] }
+            }
+        }
+    );
+
+    #[test]
+    fn test_alloc_dealloc() {
+        let expected = ThreadTestData::current();
+
+        let obj: Id<Allocated<IvarTester>, Owned> =
+            unsafe { msg_send_id![IvarTester::class(), alloc] };
+        expected.assert_current();
+
+        drop(obj);
+        expected.assert_current();
+    }
+
+    #[test]
+    fn test_init_drop() {
+        let mut expected = ThreadTestData::current();
+
+        let mut obj: Id<IvarTester, Owned> = unsafe { msg_send_id![IvarTester::class(), new] };
+        expected.alloc += 4;
+        expected.init += 4;
+        expected.assert_current();
+
+        *obj.ivar1 = (*obj.ivar1).clone();
+        expected.retain += 1;
+        expected.release += 1;
+        expected.assert_current();
+
+        *obj.ivar2 = None;
+        expected.release += 1;
+        expected.dealloc += 1;
+        expected.assert_current();
+
+        drop(obj);
+        expected.release += 3;
+        expected.dealloc += 3;
+        expected.assert_current();
+    }
+
+    #[test]
+    #[cfg_attr(not(debug_assertions), ignore = "only panics in debug mode")]
+    #[should_panic = "an Id in instance variables must always be initialized before use"]
+    fn test_init_invalid_ref() {
+        let obj: Id<IvarTester, Owned> =
+            unsafe { msg_send_id![msg_send_id![IvarTester::class(), alloc], initInvalid] };
+
+        std::println!("{:?}", obj.ivar1);
+    }
+
+    #[test]
+    #[cfg_attr(not(debug_assertions), ignore = "only panics in debug mode")]
+    #[should_panic = "an Id in instance variables must always be initialized before use"]
+    fn test_init_invalid_mut() {
+        let mut obj: Id<IvarTester, Owned> =
+            unsafe { msg_send_id![msg_send_id![IvarTester::class(), alloc], initInvalid] };
+
+        *obj.ivar1 = RcTestObject::new().into();
+    }
+}

--- a/objc2/src/declare/ivar_forwarding_impls.rs
+++ b/objc2/src/declare/ivar_forwarding_impls.rs
@@ -24,7 +24,7 @@ use super::{Ivar, IvarType};
 
 impl<T: IvarType> PartialEq for Ivar<T>
 where
-    T::Type: PartialEq,
+    <Self as Deref>::Target: PartialEq,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -38,11 +38,11 @@ where
     }
 }
 
-impl<T: IvarType> Eq for Ivar<T> where T::Type: Eq {}
+impl<T: IvarType> Eq for Ivar<T> where <Self as Deref>::Target: Eq {}
 
 impl<T: IvarType> PartialOrd for Ivar<T>
 where
-    T::Type: PartialOrd,
+    <Self as Deref>::Target: PartialOrd,
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -68,7 +68,7 @@ where
 
 impl<T: IvarType> Ord for Ivar<T>
 where
-    T::Type: Ord,
+    <Self as Deref>::Target: Ord,
 {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
@@ -78,7 +78,7 @@ where
 
 impl<T: IvarType> hash::Hash for Ivar<T>
 where
-    T::Type: hash::Hash,
+    <Self as Deref>::Target: hash::Hash,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state)
@@ -87,7 +87,7 @@ where
 
 impl<T: IvarType> hash::Hasher for Ivar<T>
 where
-    T::Type: hash::Hasher,
+    <Self as Deref>::Target: hash::Hasher,
 {
     fn finish(&self) -> u64 {
         (**self).finish()
@@ -135,7 +135,7 @@ where
 
 impl<T: IvarType> fmt::Display for Ivar<T>
 where
-    T::Type: fmt::Display,
+    <Self as Deref>::Target: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
@@ -144,7 +144,7 @@ where
 
 impl<T: IvarType> fmt::Debug for Ivar<T>
 where
-    T::Type: fmt::Debug,
+    <Self as Deref>::Target: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
@@ -153,70 +153,70 @@ where
 
 impl<I: IvarType> Iterator for Ivar<I>
 where
-    I::Type: Iterator,
+    <Self as Deref>::Target: Iterator,
 {
-    type Item = <I::Type as Iterator>::Item;
-    fn next(&mut self) -> Option<<I::Type as Iterator>::Item> {
+    type Item = <<Self as Deref>::Target as Iterator>::Item;
+    fn next(&mut self) -> Option<<<Self as Deref>::Target as Iterator>::Item> {
         (**self).next()
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         (**self).size_hint()
     }
-    fn nth(&mut self, n: usize) -> Option<<I::Type as Iterator>::Item> {
+    fn nth(&mut self, n: usize) -> Option<<<Self as Deref>::Target as Iterator>::Item> {
         (**self).nth(n)
     }
 }
 
 impl<I: IvarType> DoubleEndedIterator for Ivar<I>
 where
-    I::Type: DoubleEndedIterator,
+    <Self as Deref>::Target: DoubleEndedIterator,
 {
-    fn next_back(&mut self) -> Option<<I::Type as Iterator>::Item> {
+    fn next_back(&mut self) -> Option<<<Self as Deref>::Target as Iterator>::Item> {
         (**self).next_back()
     }
-    fn nth_back(&mut self, n: usize) -> Option<<I::Type as Iterator>::Item> {
+    fn nth_back(&mut self, n: usize) -> Option<<<Self as Deref>::Target as Iterator>::Item> {
         (**self).nth_back(n)
     }
 }
 
 impl<I: IvarType> ExactSizeIterator for Ivar<I>
 where
-    I::Type: ExactSizeIterator,
+    <Self as Deref>::Target: ExactSizeIterator,
 {
     fn len(&self) -> usize {
         (**self).len()
     }
 }
 
-impl<I: IvarType> FusedIterator for Ivar<I> where I::Type: FusedIterator {}
+impl<I: IvarType> FusedIterator for Ivar<I> where <Self as Deref>::Target: FusedIterator {}
 
-// impl<T: IvarType> borrow::Borrow<T::Type> for Ivar<T> {
-//     fn borrow(&self) -> &T::Type {
+// impl<T: IvarType> borrow::Borrow<<Self as Deref>::Target> for Ivar<T> {
+//     fn borrow(&self) -> &<Self as Deref>::Target {
 //         Deref::deref(self)
 //     }
 // }
 //
-// impl<T: IvarType> borrow::BorrowMut<T::Type> for Ivar<T> {
-//     fn borrow_mut(&mut self) -> &mut T::Type {
+// impl<T: IvarType> borrow::BorrowMut<<Self as Deref>::Target> for Ivar<T> {
+//     fn borrow_mut(&mut self) -> &mut <Self as Deref>::Target {
 //         DerefMut::deref_mut(self)
 //     }
 // }
 
-impl<T: IvarType> AsRef<T::Type> for Ivar<T> {
-    fn as_ref(&self) -> &T::Type {
+impl<T: IvarType> AsRef<<Self as Deref>::Target> for Ivar<T> {
+    fn as_ref(&self) -> &<Self as Deref>::Target {
         Deref::deref(self)
     }
 }
 
-impl<T: IvarType> AsMut<T::Type> for Ivar<T> {
-    fn as_mut(&mut self) -> &mut T::Type {
+impl<T: IvarType> AsMut<<Self as Deref>::Target> for Ivar<T> {
+    fn as_mut(&mut self) -> &mut <Self as Deref>::Target {
         DerefMut::deref_mut(self)
     }
 }
 
 impl<T: IvarType> Error for Ivar<T>
 where
-    T::Type: Error,
+    <Self as Deref>::Target: Error,
 {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         (**self).source()
@@ -225,7 +225,7 @@ where
 
 impl<T: IvarType> io::Read for Ivar<T>
 where
-    T::Type: io::Read,
+    <Self as Deref>::Target: io::Read,
 {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -255,7 +255,7 @@ where
 
 impl<T: IvarType> io::Write for Ivar<T>
 where
-    T::Type: io::Write,
+    <Self as Deref>::Target: io::Write,
 {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -285,7 +285,7 @@ where
 
 impl<T: IvarType> io::Seek for Ivar<T>
 where
-    T::Type: io::Seek,
+    <Self as Deref>::Target: io::Seek,
 {
     #[inline]
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
@@ -300,7 +300,7 @@ where
 
 impl<T: IvarType> io::BufRead for Ivar<T>
 where
-    T::Type: io::BufRead,
+    <Self as Deref>::Target: io::BufRead,
 {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
@@ -325,12 +325,12 @@ where
 
 impl<T: IvarType> Future for Ivar<T>
 where
-    T::Type: Future + Unpin,
+    <Self as Deref>::Target: Future + Unpin,
 {
-    type Output = <T::Type as Future>::Output;
+    type Output = <<Self as Deref>::Target as Future>::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        <T::Type as Future>::poll(Pin::new(&mut *self), cx)
+        <<Self as Deref>::Target as Future>::poll(Pin::new(&mut *self), cx)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/30.

The desire is to allow using `Box`, `Id` and `WeakId` (and at some point `Arc`, `Rc` and the corresponding `Weak`) inside instance variables.

This is accomplished using a new user-facing type `IvarDrop<T>` (because of current coherence limitations in how `Box`/`#[fundamental]` types work).

Usage:
```rust
use objc2::foundation::NSObject;
use objc2::declare::IvarDrop;
use objc2::{declare_class, ClassType};

declare_class!(
    struct MyObject {
        ivar: IvarDrop<Box<i32>>,
    }

    unsafe impl ClassType for MyObject {
        type Super = NSObject;
    }

    // Later on, initialize it with `Ivar::write`

    // A `dealloc` method is generated automatically
);
```