### PR TITLE
Add `ClassType::NAME`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `Option<Box<T>>`).
 * **BREAKING**: Added required `ClassType::NAME` constant for statically
   determining the name of a specific class.
+* Allow directly specifying class name in declare_class! macro.
 
 ### Removed
 * **BREAKING**: `MaybeUninit` no longer implements `IvarType` directly; use

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -13,10 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `IvarDrop<T>` to allow storing complex `Drop` values in ivars
   (currently `rc::Id<T, O>`, `Box<T>`, `Option<rc::Id<T, O>>` or
   `Option<Box<T>>`).
+* **BREAKING**: Added required `ClassType::NAME` constant for statically
+  determining the name of a specific class.
 
 ### Removed
 * **BREAKING**: `MaybeUninit` no longer implements `IvarType` directly; use
   `Ivar::write` instead.
+
 
 ## 0.3.0-beta.2 - 2022-08-28
 

--- a/objc2/examples/class_with_lifetime.rs
+++ b/objc2/examples/class_with_lifetime.rs
@@ -78,6 +78,7 @@ impl<'a> MyObject<'a> {
 
 unsafe impl<'a> ClassType for MyObject<'a> {
     type Super = NSObject;
+    const NAME: &'static str = "MyObject";
 
     fn class() -> &'static Class {
         // TODO: Use std::lazy::LazyCell
@@ -85,7 +86,7 @@ unsafe impl<'a> ClassType for MyObject<'a> {
 
         REGISTER_CLASS.call_once(|| {
             let superclass = NSObject::class();
-            let mut builder = ClassBuilder::new("MyObject", superclass).unwrap();
+            let mut builder = ClassBuilder::new(Self::NAME, superclass).unwrap();
 
             builder.add_static_ivar::<NumberIvar<'a>>();
 

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -11,6 +11,7 @@ extern "C" {}
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
 extern_class!(
+    #[derive(Debug)]
     struct NSResponder;
 
     unsafe impl ClassType for NSResponder {
@@ -20,6 +21,7 @@ extern_class!(
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
 declare_class!(
+    #[derive(Debug)]
     struct CustomAppDelegate {
         pub ivar: u8,
         another_ivar: bool,
@@ -32,6 +34,7 @@ declare_class!(
     unsafe impl ClassType for CustomAppDelegate {
         #[inherits(NSObject)]
         type Super = NSResponder;
+        const NAME: &'static str = "MyCustomAppDelegate";
     }
 
     unsafe impl CustomAppDelegate {
@@ -100,6 +103,7 @@ impl CustomAppDelegate {
 fn main() {
     let delegate = CustomAppDelegate::new(42, true);
 
+    println!("{:?}", delegate);
     println!("{:?}", delegate.ivar);
     println!("{:?}", delegate.another_ivar);
     println!("{:?}", delegate.box_ivar);

--- a/objc2/src/class_type.rs
+++ b/objc2/src/class_type.rs
@@ -18,11 +18,12 @@ use crate::Message;
 ///
 /// The class returned by [`Self::class`] must be a subclass of the class that
 /// [`Self::Super`] represents, and `as_super`/`as_super_mut` must be
-/// implemented correctly.
+/// implemented correctly. Finally [`Self::NAME`] must be correct.
 ///
 /// In pseudocode:
 /// ```ignore
 /// Self::class().superclass() == <Self::Super as ClassType>::class()
+/// Self::class().name() == Self::NAME
 /// ```
 ///
 ///
@@ -67,6 +68,9 @@ pub unsafe trait ClassType: Message {
     /// [`Deref::Target`]: std::ops::Deref::Target
     /// [`runtime::Object`]: crate::runtime::Object
     type Super: Message;
+
+    /// The name of the Objective-C class that this type represents.
+    const NAME: &'static str;
 
     /// Get a reference to the Objective-C class that this type represents.
     ///

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -17,6 +17,7 @@ __inner_extern_class! {
 
 unsafe impl ClassType for NSObject {
     type Super = Object;
+    const NAME: &'static str = "NSObject";
 
     #[inline]
     fn class() -> &'static Class {

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -612,6 +612,7 @@ macro_rules! declare_class {
         // Creation
         unsafe impl ClassType for $for {
             type Super = $superclass;
+            const NAME: &'static str = stringify!($name);
 
             fn class() -> &'static $crate::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`
@@ -626,7 +627,7 @@ macro_rules! declare_class {
                         stringify!($name),
                         ". Perhaps a class with that name already exists?",
                     );
-                    let mut builder = $crate::declare::ClassBuilder::new(stringify!($name), superclass).expect(err_str);
+                    let mut builder = $crate::declare::ClassBuilder::new(Self::NAME, superclass).expect(err_str);
 
                     // Ivars
                     $(

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -307,9 +307,9 @@ macro_rules! __fn_args {
 /// Rust struct).
 ///
 /// Note that the class name should be unique across the entire application!
-/// As a tip, you can declare the class with the desired unique name like
-/// `MyCrateCustomObject` using this macro, and then expose a renamed type
-/// alias like `pub type CustomObject = MyCrateCustomObject;` instead.
+/// You can declare the class with the desired unique name like
+/// `"MyCrateCustomObject"` by specifying it in `ClassType::NAME`, and then
+/// give the exposed type a different name like `CustomObject`.
 ///
 /// The class is guaranteed to have been created and registered with the
 /// Objective-C runtime after the [`ClassType::class`] function has been
@@ -406,6 +406,8 @@ macro_rules! __fn_args {
 ///
 ///     unsafe impl ClassType for MyCustomObject {
 ///         type Super = NSObject;
+///         // Optionally specify a different name
+///         // const NAME: &'static str = "MyCustomObject";
 ///     }
 ///
 ///     unsafe impl MyCustomObject {
@@ -575,6 +577,8 @@ macro_rules! declare_class {
         unsafe impl ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+)])?
             type Super = $superclass:ty;
+
+            $(const NAME: &'static str = $name_const:literal;)?
         }
 
         $($methods:tt)*
@@ -612,7 +616,7 @@ macro_rules! declare_class {
         // Creation
         unsafe impl ClassType for $for {
             type Super = $superclass;
-            const NAME: &'static str = stringify!($name);
+            const NAME: &'static str = $crate::__select_name!($name; $($name_const)?);
 
             fn class() -> &'static $crate::runtime::Class {
                 // TODO: Use `core::cell::LazyCell`
@@ -624,7 +628,7 @@ macro_rules! declare_class {
                     let superclass = <$superclass as $crate::ClassType>::class();
                     let err_str = concat!(
                         "could not create new class ",
-                        stringify!($name),
+                        $crate::__select_name!($name; $($name_const)?),
                         ". Perhaps a class with that name already exists?",
                     );
                     let mut builder = $crate::declare::ClassBuilder::new(Self::NAME, superclass).expect(err_str);
@@ -656,7 +660,7 @@ macro_rules! declare_class {
                 });
 
                 // We just registered the class, so it should be available
-                $crate::runtime::Class::get(stringify!($name)).unwrap()
+                $crate::runtime::Class::get(Self::NAME).unwrap()
             }
 
             #[inline]
@@ -687,6 +691,17 @@ macro_rules! declare_class {
             @method_out
             $($methods)*
         );
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_name {
+    ($_name:ident; $name_const:literal) => {
+        $name_const
+    };
+    ($name:ident;) => {
+        $crate::__macro_helpers::stringify!($name)
     };
 }
 

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -254,6 +254,7 @@ macro_rules! __inner_extern_class {
 
         unsafe impl<$($t_for $(: $b_for)?),*> ClassType for $for {
             type Super = $superclass;
+            const NAME: &'static str = stringify!($name);
 
             #[inline]
             fn class() -> &'static $crate::runtime::Class {

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -162,3 +162,13 @@ impl RcTestObject {
         unsafe { Id::new(msg_send![Self::class(), new]) }.unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_declared_name() {
+        assert_eq!(RcTestObject::class().name(), RcTestObject::NAME);
+    }
+}

--- a/tests/src/test_object.rs
+++ b/tests/src/test_object.rs
@@ -22,6 +22,7 @@ unsafe impl RefEncode for MyTestObject {
 
 unsafe impl ClassType for MyTestObject {
     type Super = NSObject;
+    const NAME: &'static str = "MyTestObject";
 
     fn class() -> &'static Class {
         class!(MyTestObject)


### PR DESCRIPTION
Allow directly specifying class name in `declare_class!` macro using `ClassType::NAME`.