### PR TITLE
Bump objc2 from `v0.3.0-beta.2` to `v0.3.0-beta.3`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+## 0.3.0-beta.3 - 2022-09-01
+
 ### Added
 * Added `Ivar::write`, `Ivar::as_ptr` and `Ivar::as_mut_ptr` for safely
   querying and modifying instance variables inside `init` methods.

--- a/objc2/CHANGELOG_FOUNDATION.md
+++ b/objc2/CHANGELOG_FOUNDATION.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+## objc2 0.3.0-beta.3 - 2022-09-01
+
 ### Added
 * Added `NSSet`.
 * Added `NSMutableSet`.

--- a/objc2/Cargo.toml
+++ b/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.3.0-beta.2" # Remember to update html_root_url in lib.rs
+version = "0.3.0-beta.3" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 

--- a/objc2/src/lib.rs
+++ b/objc2/src/lib.rs
@@ -175,7 +175,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.2")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.3")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");


### PR DESCRIPTION
A few changes in this that are nice for the `winit` and `metal` crates