### PR TITLE
Allow specifying `ClassType::NAME` in `extern_class!` macro

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Allow directly specifying class name in `extern_class!` macro.
+
+
 ## 0.3.0-beta.3 - 2022-09-01
 
 ### Added
@@ -17,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `Option<Box<T>>`).
 * **BREAKING**: Added required `ClassType::NAME` constant for statically
   determining the name of a specific class.
-* Allow directly specifying class name in declare_class! macro.
+* Allow directly specifying class name in `declare_class!` macro.
 
 ### Removed
 * **BREAKING**: `MaybeUninit` no longer implements `IvarType` directly; use

--- a/objc2/examples/speech_synthethis.rs
+++ b/objc2/examples/speech_synthethis.rs
@@ -28,14 +28,15 @@ mod appkit {
 
     extern_class!(
         /// <https://developer.apple.com/documentation/appkit/nsspeechsynthesizer?language=objc>
-        pub struct NSSpeechSynthesizer;
+        pub struct Synthesizer;
 
-        unsafe impl ClassType for NSSpeechSynthesizer {
+        unsafe impl ClassType for Synthesizer {
             type Super = NSObject;
+            const NAME: &'static str = "NSSpeechSynthesizer";
         }
     );
 
-    impl NSSpeechSynthesizer {
+    impl Synthesizer {
         // Uses default voice
         pub fn new() -> Id<Self, Owned> {
             unsafe { msg_send_id![Self::class(), new] }
@@ -105,19 +106,20 @@ mod avfaudio {
     extern_class!(
         /// <https://developer.apple.com/documentation/avfaudio/avspeechsynthesizer?language=objc>
         #[derive(Debug)]
-        pub struct AVSpeechSynthesizer;
+        pub struct Synthesizer;
 
-        unsafe impl ClassType for AVSpeechSynthesizer {
+        unsafe impl ClassType for Synthesizer {
             type Super = NSObject;
+            const NAME: &'static str = "AVSpeechSynthesizer";
         }
     );
 
-    impl AVSpeechSynthesizer {
+    impl Synthesizer {
         pub fn new() -> Id<Self, Owned> {
             unsafe { msg_send_id![Self::class(), new] }
         }
 
-        pub fn speak(&mut self, utterance: &AVSpeechUtterance) {
+        pub fn speak(&mut self, utterance: &Utterance) {
             unsafe { msg_send![self, speakUtterance: utterance] }
         }
 
@@ -129,14 +131,15 @@ mod avfaudio {
     extern_class!(
         /// <https://developer.apple.com/documentation/avfaudio/avspeechutterance?language=objc>
         #[derive(Debug)]
-        pub struct AVSpeechUtterance;
+        pub struct Utterance;
 
-        unsafe impl ClassType for AVSpeechUtterance {
+        unsafe impl ClassType for Utterance {
             type Super = NSObject;
+            const NAME: &'static str = "AVSpeechUtterance";
         }
     );
 
-    impl AVSpeechUtterance {
+    impl Utterance {
         pub fn new(string: &NSString) -> Id<Self, Owned> {
             unsafe { msg_send_id![msg_send_id![Self::class(), alloc], initWithString: string] }
         }
@@ -152,9 +155,9 @@ mod avfaudio {
 }
 
 #[cfg(all(feature = "apple", target_os = "macos"))]
-use appkit::{NSSpeechSynthesizer as Synthesizer, Utterance};
+use appkit::{Synthesizer, Utterance};
 #[cfg(all(feature = "apple", not(target_os = "macos")))]
-use avfaudio::{AVSpeechSynthesizer as Synthesizer, AVSpeechUtterance as Utterance};
+use avfaudio::{Synthesizer, Utterance};
 
 #[cfg(feature = "apple")]
 fn main() {

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -8,7 +8,7 @@ use crate::{ClassType, __inner_extern_class, class, extern_methods, msg_send_id}
 
 __inner_extern_class! {
     @__inner
-    pub struct NSObject () {}
+    pub struct (NSObject) {}
 
     unsafe impl () for NSObject {
         INHERITS = [Object];

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -599,7 +599,7 @@ macro_rules! declare_class {
             @__inner
             $(#[$m])*
             // SAFETY: Upheld by caller
-            $v struct $name () {
+            $v struct ($name) {
                 // SAFETY:
                 // - The ivars are in a type used as an Objective-C object.
                 // - The ivar is added to the class below.

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -626,12 +626,12 @@ macro_rules! declare_class {
 
                 REGISTER_CLASS.call_once(|| {
                     let superclass = <$superclass as $crate::ClassType>::class();
-                    let err_str = concat!(
-                        "could not create new class ",
-                        $crate::__select_name!($name; $($name_const)?),
-                        ". Perhaps a class with that name already exists?",
-                    );
-                    let mut builder = $crate::declare::ClassBuilder::new(Self::NAME, superclass).expect(err_str);
+                    let mut builder = $crate::declare::ClassBuilder::new(Self::NAME, superclass).unwrap_or_else(|| {
+                        $crate::__macro_helpers::panic!(
+                            "could not create new class {}. Perhaps a class with that name already exists?",
+                            Self::NAME,
+                        )
+                    });
 
                     // Ivars
                     $(
@@ -773,8 +773,14 @@ macro_rules! __declare_class_methods {
         $($rest:tt)*
     ) => {
         // Implement protocol
-        let err_str = concat!("could not find protocol ", stringify!($protocol));
-        $builder.add_protocol($crate::runtime::Protocol::get(stringify!($protocol)).expect(err_str));
+        $builder.add_protocol(
+            $crate::runtime::Protocol::get(stringify!($protocol)).unwrap_or_else(|| {
+                $crate::__macro_helpers::panic!(
+                    "could not find protocol {}",
+                    $crate::__macro_helpers::stringify!($protocol),
+                )
+            })
+        );
 
         // SAFETY: Upheld by caller
         unsafe {


### PR DESCRIPTION
Similar to https://github.com/madsmtm/objc2/pull/259.

Personally, I'd always name the type the same thing, but I can see the utility in allowing the user control over this (and `metal` wants to control this with `extern_protocol!` from #250)