### PR TITLE
Any receiver in `msg_send_id!` new

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 * Allow directly specifying class name in `extern_class!` macro.
 
+### Changed
+* Allow other types than `&Class` as the receiver in `msg_send_id!` methods
+  of the `new` family.
+
 
 ## 0.3.0-beta.3 - 2022-09-01
 

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -863,8 +863,9 @@ macro_rules! msg_send_bool {
 /// families][sel-families] the selector belongs to (here `T: Message` and
 /// `O: Ownership`):
 ///
-/// - The `new` family: The receiver must be `&Class`, and the return type
-///   is a generic `Id<T, O>` or `Option<Id<T, O>>`.
+/// - The `new` family: The receiver may be anything that implements
+///   [`MessageReceiver`] (though often you'll want to use `&Class`). The
+///   return type is a generic `Id<T, O>` or `Option<Id<T, O>>`.
 ///
 /// - The `alloc` family: The receiver must be `&Class`, and the return type
 ///   is a generic `Id<Allocated<T>, O>` or `Option<Id<Allocated<T>, O>>`.

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -63,6 +63,16 @@ declare_class!(
             ptr::null_mut()
         }
 
+        #[sel(newMethodOnInstance)]
+        fn new_method_on_instance(&self) -> *mut Self {
+            Id::consume_as_ptr(ManuallyDrop::new(Self::new()))
+        }
+
+        #[sel(newMethodOnInstanceNull)]
+        fn new_method_on_instance_null(&self) -> *mut Self {
+            ptr::null_mut()
+        }
+
         #[sel(alloc)]
         fn alloc() -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().alloc += 1);

--- a/test-ui/ui/msg_send_id_invalid_receiver.rs
+++ b/test-ui/ui/msg_send_id_invalid_receiver.rs
@@ -5,7 +5,6 @@ use objc2::runtime::{Class, Object};
 
 fn main() {
     let obj: &Object;
-    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new] };
     let _: Id<Allocated<Object>, Shared> = unsafe { msg_send_id![obj, alloc] };
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init] };
 
@@ -16,6 +15,8 @@ fn main() {
     let obj: Option<Id<Object, Shared>>;
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, init] };
 
+    let obj: Id<Object, Shared>;
+    let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new] };
     let obj: Id<Object, Shared>;
     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, copy] };
 }

--- a/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -1,23 +1,6 @@
 error[E0308]: mismatched types
   --> ui/msg_send_id_invalid_receiver.rs
    |
-   |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new] };
-   |                                          -------------^^^------
-   |                                          |            |
-   |                                          |            expected struct `objc2::runtime::Class`, found struct `objc2::runtime::Object`
-   |                                          arguments to this function are incorrect
-   |
-   = note: expected reference `&objc2::runtime::Class`
-              found reference `&objc2::runtime::Object`
-note: associated function defined here
-  --> $WORKSPACE/objc2/src/__macro_helpers.rs
-   |
-   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<U, O>>(
-   |               ^^^^^^^^^^^^^^^
-
-error[E0308]: mismatched types
-  --> ui/msg_send_id_invalid_receiver.rs
-   |
    |     let _: Id<Allocated<Object>, Shared> = unsafe { msg_send_id![obj, alloc] };
    |                                                     -------------^^^--------
    |                                                     |            |
@@ -99,6 +82,20 @@ note: associated function defined here
    |
    |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<U, O>>(
    |               ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
+  --> ui/msg_send_id_invalid_receiver.rs
+   |
+   |     let _: Id<Object, Shared> = unsafe { msg_send_id![obj, new] };
+   |                                          -------------^^^------
+   |                                          |            |
+   |                                          |            the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object, Shared>`
+   |                                          required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `MessageReceiver`:
+             &'a Id<T, O>
+             &'a mut Id<T, objc2::rc::Owned>
+   = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, _, _>`
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
   --> ui/msg_send_id_invalid_receiver.rs


### PR DESCRIPTION
Allow other types than `&Class` as the receiver in `msg_send_id!` methods of the `new` family.

This is useful in `metal`, for example [`-[MTLDevice newTextureWithDescriptor:]`](https://developer.apple.com/documentation/metal/mtldevice/1433425-newtexturewithdescriptor?language=objc).