### PR TITLE
Verify class declaration

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   instead of `Id<Allocated<T>, O>`.
 * Verify the message signature of overriden methods when declaring classes if
   the `verify_message` feature is enabled.
+* Verify in `declare_class!` that protocols are implemented correctly.
 
 
 ## 0.3.0-beta.3 - 2022-09-01

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
       msg_send_id![NSObject::alloc(), init]
   };
   ```
+* Add `Class::class_method`.
 
 ### Changed
 * Allow other types than `&Class` as the receiver in `msg_send_id!` methods

--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of the `new` family.
 * **BREAKING**: Changed the `Allocated` struct to be used as `Allocated<T>`
   instead of `Id<Allocated<T>, O>`.
+* Verify the message signature of overriden methods when declaring classes if
+  the `verify_message` feature is enabled.
 
 
 ## 0.3.0-beta.3 - 2022-09-01

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -377,6 +377,16 @@ macro_rules! __fn_args {
 /// definition to make things easier to read.
 ///
 ///
+/// # Panics
+///
+/// The implemented `ClassType::class` method may panic in a few cases, such
+/// as if:
+/// - A class with the name specified with `const NAME` already exists.
+/// - One of the
+/// - The `verify_message` feature is enabled, and an overriden method's
+///   signature is not equal to the superclass'.
+///
+///
 /// # Safety
 ///
 /// Using this macro requires writing a few `unsafe` markers:
@@ -800,6 +810,7 @@ macro_rules! __declare_class_methods {
         );
 
         // SAFETY: Upheld by caller
+        #[allow(unused_unsafe)]
         unsafe {
             $crate::__declare_class_rewrite_methods! {
                 @($crate::__declare_class_register_out)
@@ -826,6 +837,7 @@ macro_rules! __declare_class_methods {
         $($rest:tt)*
     ) => {
         // SAFETY: Upheld by caller
+        #[allow(unused_unsafe)]
         unsafe {
             $crate::__declare_class_rewrite_methods! {
                 @($crate::__declare_class_register_out)

--- a/objc2/src/message/mod.rs
+++ b/objc2/src/message/mod.rs
@@ -533,6 +533,24 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        feature = "gnustep-1-7",
+        ignore = "GNUStep deadlocks here for some reason"
+    )]
+    fn test_send_message_class_super() {
+        let cls = test_utils::custom_subclass();
+        let superclass = test_utils::custom_class();
+        unsafe {
+            let foo: u32 = msg_send![super(cls, superclass.metaclass()), classFoo];
+            assert_eq!(foo, 7);
+
+            // The subclass is overriden to return + 2
+            let foo: u32 = msg_send![cls, classFoo];
+            assert_eq!(foo, 9);
+        }
+    }
+
+    #[test]
     fn test_send_message_manuallydrop() {
         let obj = ManuallyDrop::new(test_utils::custom_object());
         unsafe {

--- a/objc2/src/runtime.rs
+++ b/objc2/src/runtime.rs
@@ -22,7 +22,7 @@ use crate::ffi;
 #[cfg(feature = "malloc")]
 use crate::{
     encode::{EncodeArguments, EncodeConvert},
-    verify::verify_message_signature,
+    verify::{verify_method_signature, Inner},
     VerificationError,
 };
 
@@ -514,7 +514,8 @@ impl Class {
         A: EncodeArguments,
         R: EncodeConvert,
     {
-        verify_message_signature::<A, R>(self, sel)
+        let method = self.instance_method(sel).ok_or(Inner::MethodNotFound)?;
+        verify_method_signature::<A, R>(method)
     }
 }
 

--- a/objc2/src/test_utils.rs
+++ b/objc2/src/test_utils.rs
@@ -231,9 +231,15 @@ pub(crate) fn custom_subclass() -> &'static Class {
             foo + 2
         }
 
+        extern "C" fn custom_subclass_class_method(_cls: &Class, _cmd: Sel) -> u32 {
+            9
+        }
+
         unsafe {
             let get_foo: extern "C" fn(_, _) -> _ = custom_subclass_get_foo;
             builder.add_method(sel!(foo), get_foo);
+            let class_method: extern "C" fn(_, _) -> _ = custom_subclass_class_method;
+            builder.add_class_method(sel!(classFoo), class_method);
         }
 
         builder.register();


### PR DESCRIPTION
Add extra verification in `declare_class!`.

This would help even more if I knew why some protocols like `NSWindowDelegate` are not available at runtime.

Verify:
- [x] Signature of overridden methods
- [x] Protocols are implemented correctly
- [ ] ~Protocol method signatures are correct~ postponed, requires stuff from #198
