### PR TITLE
Add `SubclassOf` trait

### DIFF
--- a/crates/objc2/src/class_type.rs
+++ b/crates/objc2/src/class_type.rs
@@ -109,3 +109,32 @@ pub unsafe trait ClassType: Message {
         unsafe { msg_send_id![Self::class(), alloc] }
     }
 }
+
+/// TODO
+pub unsafe trait SubclassOf<Super: ClassType> {}
+
+unsafe impl<T> SubclassOf<T> for T {}
+
+unsafe impl<T: ClassType> SubclassOf<T::Super> for T where T::Super: ClassType {}
+
+unsafe impl<T: ClassType> SubclassOf<<T::Super as ClassType>::Super> for T
+where
+    T::Super: ClassType,
+    <T::Super as ClassType>::Super: ClassType,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::foundation::{NSMutableString, NSObject, NSString};
+
+    fn assert_subclass_of<T: SubclassOf<C>, C: ClassType>() {}
+
+    #[test]
+    fn test_subclass_of() {
+        assert_subclass_of::<NSString, NSObject>();
+        assert_subclass_of::<NSMutableString, NSObject>();
+        assert_subclass_of::<NSMutableString, NSString>();
+    }
+}

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -195,7 +195,7 @@ pub use objc_sys as ffi;
 #[doc(no_inline)]
 pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
-pub use crate::class_type::ClassType;
+pub use crate::class_type::{ClassType, SubclassOf};
 pub use crate::message::{Message, MessageArguments, MessageReceiver};
 pub use crate::protocol::{ConformsTo, ProtocolType};
 pub use crate::verify::VerificationError;


### PR DESCRIPTION
An idea for making a trait to tell whether a specific class is a subclass of another. Basically, the more generic version of the `ClassType` trait.

The need arises on [`NSMeasurement`](https://developer.apple.com/documentation/foundation/nsmeasurement?language=objc), which is defined in the Objective-C header as:
```objective-c
@interface NSMeasurement<UnitType: NSUnit *>
```

With this we could define the generic in Rust as:
```rust
pub struct NSMeasurement<UnitType: SubclassOf<NSUnit>>;
```

Unfortunately, automatically declaring it doesn't work, since we have no way of ensuring in the type-system, that `Super` is not recursive:
```rust
pub struct NSObject;
unsafe impl ClassType {
    type Super = NSObject;
}

// Now there's multiple impls of `SubclassOf<NSObject>`
```

So maybe it'd make sense to add it anyways, and then implement it in `extern_class!` instead? At least if the problem comes up in other places than `NSMeasurement` (`NSUnit` is an "abstract class", meaning it really acts more like a protocol than a class, which is why this case is kinda special).

See also https://github.com/madsmtm/objc2/issues/518.