### PR TITLE
Run AddressSanitizer and fix leak

### DIFF
--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -410,6 +410,7 @@ mod tests {
                 #[sel(dealloc)]
                 fn dealloc(&mut self) {
                     HAS_RUN_DEALLOC.store(true, Ordering::SeqCst);
+                    unsafe { msg_send![super(self), dealloc] }
                 }
             }
         );

--- a/objc2/src/foundation/error.rs
+++ b/objc2/src/foundation/error.rs
@@ -75,6 +75,7 @@ extern_methods!(
         }
 
         pub fn localized_description(&self) -> Id<NSString, Shared> {
+            // TODO: For some reason this leaks a lot?
             let obj: Option<_> = unsafe { msg_send_id![self, localizedDescription] };
             obj.expect(
                 "unexpected NULL localized description; a default should have been generated!",

--- a/objc2/src/foundation/thread.rs
+++ b/objc2/src/foundation/thread.rs
@@ -214,14 +214,18 @@ mod tests {
         let thread = NSThread::main();
 
         let actual = format!("{:?}", thread);
-        let expected_macos_11 = format!("<NSThread: {:p}>{{number = 1, name = (null)}}", thread);
-        let expected_macos_12 =
-            format!("<_NSMainThread: {:p}>{{number = 1, name = (null)}}", thread);
+        let expected = [
+            // macOS 11
+            format!("<NSThread: {:p}>{{number = 1, name = (null)}}", thread),
+            format!("<NSThread: {:p}>{{number = 1, name = main}}", thread),
+            // macOS 12
+            format!("<_NSMainThread: {:p}>{{number = 1, name = (null)}}", thread),
+            format!("<_NSMainThread: {:p}>{{number = 1, name = main}}", thread),
+        ];
         assert!(
-            actual == expected_macos_11 || actual == expected_macos_12,
-            "Expected one of {:?} or {:?}, got {:?}",
-            expected_macos_11,
-            expected_macos_12,
+            expected.contains(&actual),
+            "Expected one of {:?}, got {:?}",
+            expected,
             actual,
         );
 

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -101,6 +101,7 @@ declare_class!(
 
         #[sel(initReturningNull)]
         fn init_returning_null(&mut self) -> *mut Self {
+            let _: () = unsafe { msg_send![self, release] };
             ptr::null_mut()
         }
 
@@ -125,7 +126,7 @@ declare_class!(
         #[sel(dealloc)]
         unsafe fn dealloc(&mut self) {
             TEST_DATA.with(|data| data.borrow_mut().dealloc += 1);
-            // Don't call superclass
+            unsafe { msg_send![super(self), dealloc] }
         }
 
         #[sel(_tryRetain)]

--- a/objc2/src/rc/weak_id.rs
+++ b/objc2/src/rc/weak_id.rs
@@ -175,7 +175,6 @@ mod tests {
         if cfg!(not(feature = "gnustep-1-7")) {
             // This loads the object on GNUStep for some reason??
             assert!(weak.load().is_none());
-            expected.try_retain_fail += 1;
             expected.assert_current();
         }
 


### PR DESCRIPTION
Run with:
```bash
ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS="-Zsanitizer=address" cargo +nightly test --target=x86_64-apple-darwin -Zbuild-std --tests -- --skip=foundation::error::tests --skip=test_weak
```

Notably, I incorrectly assumed that the super class' `dealloc` method is called in custom `dealloc` methods, but this is only true in Objective-C with ARC enabled!

~Builds upon https://github.com/madsmtm/objc2/pull/273.~