### PR TITLE
Better error handling in `msg_send!` and `msg_send_id!`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -23,7 +23,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
       msg_send_id![NSObject::alloc(), init]
   };
   ```
-* Add `Class::class_method`.
+* Added `Class::class_method`.
+* Added the ability to specify `error: _`, `somethingReturningError: _` and
+  so on at the end of `msg_send!`/`msg_send_id!`, and have it automatically
+  return a `Result<..., Id<NSError, Shared>>`.
+* Added the ability to specify an extra parameter at the end of the selector
+  in methods declared with `extern_methods!`, and let that be the `NSError**`
+  parameter.
 
 ### Changed
 * Allow other types than `&Class` as the receiver in `msg_send_id!` methods

--- a/objc2/CHANGELOG_FOUNDATION.md
+++ b/objc2/CHANGELOG_FOUNDATION.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `NSString::concat` and `NSString::join_path`.
 * Added `CGSize`, `CGPoint` and `CGRect` (just aliases to equivalent
   `NS`-types, but helps readability).
+* Added `NSString::write_to_file`.
 
 ### Changed
 * **BREAKING**: `NSSize::new` no longer requires it's arguments to be

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -9,7 +9,7 @@ use core::slice;
 use core::str;
 use std::os::raw::c_char;
 
-use super::{NSComparisonResult, NSCopying, NSMutableCopying, NSMutableString, NSObject};
+use super::{NSComparisonResult, NSCopying, NSError, NSMutableCopying, NSMutableString, NSObject};
 use crate::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
 use crate::runtime::{Class, Object};
 use crate::{extern_class, extern_methods, msg_send, msg_send_id, ClassType};
@@ -272,6 +272,15 @@ extern_methods!(
 
         // pub fn from_nsrange(range: NSRange) -> Id<Self, Shared>
         // https://developer.apple.com/documentation/foundation/1415155-nsstringfromrange?language=objc
+
+        // TODO: Safety
+        #[sel(writeToFile:atomically:encoding:error:)]
+        pub unsafe fn write_to_file(
+            &self,
+            path: &NSString,
+            atomically: bool,
+            encoding: usize,
+        ) -> Result<(), Id<NSError, Shared>>;
     }
 );
 

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -876,7 +876,9 @@ macro_rules! __msg_send_helper {
         let result;
         // Always add trailing comma after each argument, so that we get a
         // 1-tuple if there is only one.
-        result = $crate::MessageReceiver::$fn($($fn_args)+, $crate::sel!($($selector)*), ($($argument,)*));
+        //
+        // And use `::<_, _>` for better UI
+        result = $crate::MessageReceiver::$fn::<_, _>($($fn_args)+, $crate::sel!($($selector)*), ($($argument,)*));
         result
     });
 }
@@ -1135,7 +1137,7 @@ macro_rules! __msg_send_id_helper {
         let result;
         result = <$crate::__macro_helpers::RetainSemantics<{
             $crate::__macro_helpers::retain_semantics(__SELECTOR_DATA)
-        }> as $crate::__macro_helpers::MsgSendId<_, _>>::$fn(
+        }> as $crate::__macro_helpers::MsgSendId<_, _>>::$fn::<_, _>(
             $obj,
             $crate::__sel_inner!(
                 __SELECTOR_DATA,

--- a/objc2/src/macros.rs
+++ b/objc2/src/macros.rs
@@ -1,3 +1,4 @@
+mod __msg_send_parse;
 mod __rewrite_self_arg;
 mod declare_class;
 mod extern_class;
@@ -641,6 +642,9 @@ macro_rules! __class_inner {
 ///
 /// All arguments, and the return type, must implement [`Encode`].
 ///
+/// If the last argument is the special marker `_`, the macro will return a
+/// `Result<(), Id<E, Shared>>`, see below.
+///
 /// This macro translates into a call to [`sel!`], and afterwards a fully
 /// qualified call to [`MessageReceiver::send_message`]. Note that this means
 /// that auto-dereferencing of the receiver is not supported, and that the
@@ -675,6 +679,33 @@ macro_rules! __class_inner {
 /// [`runtime::Bool`]: crate::runtime::Bool
 ///
 ///
+/// # Errors
+///
+/// Many methods take an `NSError**` as their last parameter, which is used to
+/// communicate errors to the caller, see [Error Handling Programming Guide
+/// For Cocoa][cocoa-error].
+///
+/// Similar to Swift's [importing of error parameters][swift-error], this
+/// macro supports transforming methods whose last parameter is `NSError**`
+/// and returns `BOOL`, into the Rust equivalent, the [`Result`] type.
+///
+/// In particular, you can make the last argument the special marker `_`, and
+/// then the macro will return a `Result<(), Id<E, Shared>>` (where you must
+/// specify `E` yourself, usually you'd use [`foundation::NSError`]).
+///
+/// At runtime, a temporary error variable is created on the stack and sent as
+/// the last parameter. If the message send then returns `NO`/`false` (or in
+/// the case of `msg_send_id!`, `NULL`), the error variable is loaded and
+/// returned in [`Err`].
+///
+/// Do beware that this is only valid on methods that return `BOOL`, see
+/// [`msg_send_id!`] for methods that return instance types.
+///
+/// [cocoa-error]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorHandling/ErrorHandling.html
+/// [swift-error]: https://developer.apple.com/documentation/swift/about-imported-cocoa-error-parameters
+/// [`foundation::NSError`]: crate::foundation::NSError
+///
+///
 /// # Panics
 ///
 /// Panics if the `"catch-all"` feature is enabled and the Objective-C method
@@ -684,6 +715,9 @@ macro_rules! __class_inner {
 /// Panics if the `"verify_message"` feature is enabled and the Objective-C
 /// method's argument's encoding does not match the encoding of the given
 /// arguments. This is highly recommended to enable while testing!
+///
+/// And panics if the `NSError**` handling functionality described above is
+/// used, and the error object was unexpectedly `NULL`.
 ///
 /// [RFC-2945]: https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html
 ///
@@ -770,45 +804,79 @@ macro_rules! __class_inner {
 /// # superclass = class!(NSObject);
 /// let arg3: u32 = unsafe { msg_send![super(obj, superclass), getArg3] };
 /// ```
+///
+/// Sending a message with automatic error handling.
+///
+/// ```no_run
+/// use objc2::msg_send;
+/// use objc2::runtime::Object;
+/// use objc2::rc::{Id, Shared};
+///
+/// let obj: *mut Object; // Let's assume an instance of `NSBundle`
+/// # obj = 0 as *mut Object;
+/// // The `_` tells the macro that the return type should be `Result`.
+/// let res: Result<(), Id<Object, Shared>> = unsafe {
+///     msg_send![obj, preflightAndReturnError: _]
+/// };
+/// ```
 #[macro_export]
 macro_rules! msg_send {
-    [super($obj:expr), $selector:ident $(,)?] => ({
-        let sel = $crate::sel!($selector);
+    [super($obj:expr), $($selector_and_arguments:tt)+] => {
+        $crate::__msg_send_parse! {
+            ($crate::__msg_send_helper)
+            @(__send_super_message_static_error)
+            @()
+            @()
+            @($($selector_and_arguments)+)
+            @(__send_super_message_static)
+
+            @($obj)
+        }
+    };
+    [super($obj:expr, $superclass:expr), $($selector_and_arguments:tt)+] => {
+        $crate::__msg_send_parse! {
+            ($crate::__msg_send_helper)
+            @(__send_super_message_error)
+            @()
+            @()
+            @($($selector_and_arguments)+)
+            @(send_super_message)
+
+            @($obj, $superclass)
+        }
+    };
+    [$obj:expr, $($selector_and_arguments:tt)+] => {
+        $crate::__msg_send_parse! {
+            ($crate::__msg_send_helper)
+            @(__send_message_error)
+            @()
+            @()
+            @($($selector_and_arguments)+)
+            @(send_message)
+
+            @($obj)
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __msg_send_helper {
+    {
+        @($fn:ident)
+        @($($fn_args:tt)+)
+        @($($selector:tt)*)
+        @($($argument:expr,)*)
+    } => ({
+        // Assign to intermediary variable for better UI, and to prevent
+        // miscompilation on older Rust versions.
+        //
+        // Note: This can be accessed from any expression in `fn_args` and
+        // `arguments` - we won't (yet) bother with preventing that though.
         let result;
-        // Note: `sel` and `result` can be accessed from the `obj` and
-        // `superclass` expressions - we won't (yet) bother with preventing
-        // that though.
-        result = $crate::MessageReceiver::__send_super_message_static($obj, sel, ());
-        result
-    });
-    [super($obj:expr), $($selector:ident : $argument:expr),+ $(,)?] => ({
-        let sel = $crate::sel!($($selector :)+);
-        let result;
-        result = $crate::MessageReceiver::__send_super_message_static($obj, sel, ($($argument,)+));
-        result
-    });
-    [super($obj:expr, $superclass:expr), $selector:ident $(,)?] => ({
-        let sel = $crate::sel!($selector);
-        let result;
-        result = $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ());
-        result
-    });
-    [super($obj:expr, $superclass:expr), $($selector:ident : $argument:expr $(,)?)+] => ({
-        let sel = $crate::sel!($($selector :)+);
-        let result;
-        result = $crate::MessageReceiver::send_super_message($obj, $superclass, sel, ($($argument,)+));
-        result
-    });
-    [$obj:expr, $selector:ident $(,)?] => ({
-        let sel = $crate::sel!($selector);
-        let result;
-        result = $crate::MessageReceiver::send_message($obj, sel, ());
-        result
-    });
-    [$obj:expr, $($selector:ident : $argument:expr $(,)?)+] => ({
-        let sel = $crate::sel!($($selector :)+);
-        let result;
-        result = $crate::MessageReceiver::send_message($obj, sel, ($($argument,)+));
+        // Always add trailing comma after each argument, so that we get a
+        // 1-tuple if there is only one.
+        result = $crate::MessageReceiver::$fn($($fn_args)+, $crate::sel!($($selector)*), ($($argument,)*));
         result
     });
 }
@@ -910,6 +978,9 @@ macro_rules! msg_send_bool {
 /// `Id / Allocated` this macro will automatically unwrap the object, or panic
 /// with an error message if it couldn't be retrieved.
 ///
+/// Though as a special case, if the last argument is the marker `_`, the
+/// macro will return a `Result<Id<T, O>, Id<E, Shared>>`, see below.
+///
 /// This macro doesn't support super methods yet, see [#173].
 /// The `retain`, `release` and `autorelease` selectors are not supported, use
 /// [`Id::retain`], [`Id::drop`] and [`Id::autorelease`] for that.
@@ -922,6 +993,19 @@ macro_rules! msg_send_bool {
 /// [`Id::retain`]: crate::rc::Id::retain
 /// [`Id::drop`]: crate::rc::Id::drop
 /// [`Id::autorelease`]: crate::rc::Id::autorelease
+///
+///
+/// # Errors
+///
+/// Very similarly to [`msg_send!`], this macro supports transforming the
+/// return type of methods whose last parameter is `NSError**` into the Rust
+/// equivalent, the [`Result`] type.
+///
+/// In particular, you can make the last argument the special marker `_`, and
+/// then the macro will return a `Result<Id<T, O>, Id<E, Shared>>` (where you
+/// must specify `E` yourself, usually you'd use [`foundation::NSError`]).
+///
+/// [`foundation::NSError`]: crate::foundation::NSError
 ///
 ///
 /// # Panics
@@ -992,46 +1076,73 @@ macro_rules! msg_send_id {
         result = <$crate::__macro_helpers::Init as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ());
         result
     });
-    [$obj:expr, $selector:ident $(,)?] => ({
-        $crate::__msg_send_id_helper!(@verify $selector);
-        let sel = $crate::sel!($selector);
-        const NAME: &$crate::__macro_helpers::str = $crate::__macro_helpers::stringify!($selector);
-        let result;
-        result = <$crate::__macro_helpers::RetainSemantics<{
-            $crate::__macro_helpers::retain_semantics(NAME)
-        }> as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ());
-        result
-    });
-    [$obj:expr, $($selector:ident : $argument:expr),+ $(,)?] => ({
-        let sel = $crate::sel!($($selector:)+);
-        const NAME: &$crate::__macro_helpers::str =
-            $crate::__macro_helpers::concat!($($crate::__macro_helpers::stringify!($selector), ':'),+);
-        let result;
-        result = <$crate::__macro_helpers::RetainSemantics<{
-            $crate::__macro_helpers::retain_semantics(NAME)
-        }> as $crate::__macro_helpers::MsgSendId<_, _>>::send_message_id($obj, sel, ($($argument,)+));
-        result
-    });
+    [$obj:expr, $($selector_and_arguments:tt)+] => {
+        $crate::__msg_send_parse! {
+            ($crate::__msg_send_id_helper)
+            @(send_message_id_error)
+            @()
+            @()
+            @($($selector_and_arguments)+)
+            @(send_message_id)
+
+            @($obj)
+        }
+    };
 }
 
 /// Helper macro to avoid exposing these in the docs for [`msg_send_id!`].
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __msg_send_id_helper {
-    (@verify retain) => {{
+    {
+        @($fn:ident)
+        @($obj:expr)
+        @(retain)
+        @()
+    } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, retain] is not supported. Use `Id::retain` instead"
         )
     }};
-    (@verify release) => {{
+    {
+        @($fn:ident)
+        @($obj:expr)
+        @(release)
+        @()
+    } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, release] is not supported. Drop an `Id` instead"
         )
     }};
-    (@verify autorelease) => {{
+    {
+        @($fn:ident)
+        @($obj:expr)
+        @(autorelease)
+        @()
+    } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, autorelease] is not supported. Use `Id::autorelease`"
         )
     }};
-    (@verify $selector:ident) => {{}};
+    {
+        @($fn:ident)
+        @($obj:expr)
+        @($sel_first:ident $(: $($sel_rest:ident :)*)?)
+        @($($argument:expr,)*)
+    } => ({
+        // Don't use `sel!`, otherwise we'd end up with defining this data twice.
+        const __SELECTOR_DATA: &$crate::__macro_helpers::str = $crate::__sel_data!($sel_first $(: $($sel_rest :)*)?);
+        let result;
+        result = <$crate::__macro_helpers::RetainSemantics<{
+            $crate::__macro_helpers::retain_semantics(__SELECTOR_DATA)
+        }> as $crate::__macro_helpers::MsgSendId<_, _>>::$fn(
+            $obj,
+            $crate::__sel_inner!(
+                __SELECTOR_DATA,
+                $crate::__hash_idents!($sel_first $($($sel_rest)*)?)
+            ),
+            ($($argument,)*),
+        );
+        result
+    });
 }

--- a/objc2/src/macros/__msg_send_parse.rs
+++ b/objc2/src/macros/__msg_send_parse.rs
@@ -1,0 +1,100 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __msg_send_parse {
+    // No arguments
+    {
+        ($out_macro:path)
+        @($error_fn:ident)
+        // Intentionally empty
+        @()
+        @()
+        @($selector:ident $(,)?)
+        $($macro_args:tt)*
+    } => {
+        $crate::__msg_send_parse! {
+            ($out_macro)
+            @($error_fn)
+            @($selector)
+            @()
+            @()
+            $($macro_args)*
+        }
+    };
+
+    // tt-munch remaining `selector: argument` pairs, looking for a pattern
+    // that ends with `sel: _`.
+    {
+        ($out_macro:path)
+        @($_error_fn:ident)
+        @($($selector_output:tt)*)
+        @($($argument_output:tt)*)
+        @()
+        $($macro_args:tt)*
+    } => ({
+        $out_macro! {
+            $($macro_args)*
+            @($($selector_output)*)
+            @($($argument_output)*)
+        }
+    });
+    {
+        ($out_macro:path)
+        @($error_fn:ident)
+        @($($selector_output:tt)*)
+        @($($argument_output:tt)*)
+        @($selector:ident: _ $(,)?)
+        @($fn:ident)
+        $($macro_args:tt)*
+    } => {
+        $crate::__msg_send_parse! {
+            ($out_macro)
+            @($error_fn)
+            @($($selector_output)* $selector:)
+            // Don't pass an argument
+            @($($argument_output)*)
+            @()
+
+            // Instead, we change the called function to the error function.
+            @($error_fn)
+            $($macro_args)*
+        }
+    };
+    {
+        ($out_macro:path)
+        @($error_fn:ident)
+        @($($selector_output:tt)*)
+        @($($argument_output:tt)*)
+        @($selector:ident : $argument:expr $(, $($rest:tt)*)?)
+        $($macro_args:tt)*
+    } => {
+        $crate::__msg_send_parse! {
+            ($out_macro)
+            @($error_fn)
+            @($($selector_output)* $selector:)
+            @($($argument_output)* $argument,)
+            @($($($rest)*)?)
+            $($macro_args)*
+        }
+    };
+
+    // Handle calls without comma between `selector: argument` pair.
+    // TODO: Deprecate this
+    {
+        ($out_macro:path)
+        @($error_fn:ident)
+        // Intentionally empty
+        @()
+        @()
+        @($($selector:ident : $argument:expr)*)
+        $($macro_args:tt)*
+    } => {
+        $crate::__msg_send_parse! {
+            ($out_macro)
+            @($error_fn)
+            @()
+            @()
+            @($($selector : $argument),*)
+            $($macro_args)*
+        }
+    };
+}

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -449,17 +449,17 @@ macro_rules! __attribute_helper {
             $($rest:tt)*
         )
         $($macro_args:tt)*
-    } => {{
+    } => {
         $crate::__attribute_helper! {
             @extract_sel_duplicate
-            $($rest)*
+            ($($rest)*)
+            $out_macro!(
+                $($macro_args)*
+                // Append selector to the end of the macro arguments
+                @($($sel)*)
+            )
         }
-
-        $out_macro!(
-            $($macro_args)*
-            @($($sel)*)
-        )
-    }};
+    };
     {
         @extract_sel
         ($out_macro:path)
@@ -468,14 +468,14 @@ macro_rules! __attribute_helper {
             $($rest:tt)*
         )
         $($macro_args:tt)*
-    } => {{
+    } => {
         $crate::__attribute_helper! {
             @extract_sel
             ($out_macro)
             ($($rest)*)
             $($macro_args)*
         }
-    }};
+    };
     {
         @extract_sel
         ($out_macro:path)
@@ -487,21 +487,33 @@ macro_rules! __attribute_helper {
 
     {
         @extract_sel_duplicate
-        #[sel($($_sel_args:tt)*)]
-        $($rest:tt)*
+        (
+            #[sel($($_sel_args:tt)*)]
+            $($rest:tt)*
+        )
+        $($output:tt)*
     } => {{
         compile_error!("Cannot not specify a selector twice!");
     }};
     {
         @extract_sel_duplicate
-        #[$($m_checked:tt)*]
-        $($rest:tt)*
-    } => {{
+        (
+            #[$($m_checked:tt)*]
+            $($rest:tt)*
+        )
+        $($output:tt)*
+    } => {
         $crate::__attribute_helper! {
             @extract_sel_duplicate
-            $($rest)*
+            ($($rest:tt)*)
+            $($output)*
         }
+    };
+    {
+        @extract_sel_duplicate
+        ()
+        $($output:tt)*
+    } => {{
+        $($output)*
     }};
-    {@extract_sel_duplicate} => {};
-
 }

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -319,12 +319,12 @@ macro_rules! __inner_extern_methods {
         @($($args_rest:tt)*)
         @($($sel:tt)*)
     } => {
-        $crate::__collect_msg_send!(
+        $crate::__collect_msg_send! {
             $crate::msg_send;
             $self;
             ($($sel)*);
             ($($args_rest)*);
-        )
+        }
     };
     {
         @unsafe_method_body
@@ -336,12 +336,12 @@ macro_rules! __inner_extern_methods {
         @($($args_rest:tt)*)
         @($($sel:tt)*)
     } => {
-        $crate::__collect_msg_send!(
+        $crate::__collect_msg_send! {
             $crate::msg_send;
             Self::class();
             ($($sel)*);
             ($($args_rest)*);
-        )
+        }
     };
 }
 
@@ -377,16 +377,15 @@ macro_rules! __collect_msg_send {
         ($sel:ident : $($sel_rest:tt)*);
         ($arg:ident: $arg_ty:ty $(, $($args_rest:tt)*)?);
         $($output:tt)*
-    ) => {{
-        $crate::__collect_msg_send!(
+    ) => {
+        $crate::__collect_msg_send! {
             $macro;
             $obj;
             ($($sel_rest)*);
             ($($($args_rest)*)?);
-            $($output)*
-            $sel: $arg,
-        )
-    }};
+            $($output)* $sel: $arg,
+        }
+    };
 
     // If couldn't zip selector and arguments, show useful error message
     ($($_any:tt)*) => {{

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -37,8 +37,9 @@
 /// [`NSCalendar`]: https://developer.apple.com/documentation/foundation/nscalendar?language=objc
 ///
 /// ```
-/// use objc2::foundation::{NSObject, NSRange, NSString, NSUInteger};
+/// use objc2::foundation::{NSError, NSObject, NSRange, NSString, NSUInteger};
 /// use objc2::rc::{Id, Shared};
+/// use objc2::runtime::Object;
 /// use objc2::{extern_class, extern_methods, msg_send_id, Encode, Encoding, ClassType};
 /// #
 /// # #[cfg(feature = "gnustep-1-7")]
@@ -103,6 +104,16 @@
 ///
 ///         #[sel(maximumRangeOfUnit:)]
 ///         pub fn max_range(&self, unit: NSCalendarUnit) -> NSRange;
+///
+///         // From `NSKeyValueCoding`
+///         #[sel(validateValue:forKey:error:)]
+///         pub unsafe fn validate_value_for_key(
+///             &self,
+///             value: &mut *mut Object,
+///             key: &NSString,
+///             // Since the selector specifies one more argument than we
+///             // have, the return type is assumed to be `Result`.
+///         ) -> Result<(), Id<NSError, Shared>>;
 ///     }
 /// );
 /// ```
@@ -110,8 +121,9 @@
 /// The `extern_methods!` declaration then becomes:
 ///
 /// ```
-/// # use objc2::foundation::{NSObject, NSRange, NSString, NSUInteger};
+/// # use objc2::foundation::{NSError, NSObject, NSRange, NSString, NSUInteger};
 /// # use objc2::rc::{Id, Shared};
+/// # use objc2::runtime::Object;
 /// # use objc2::{extern_class, extern_methods, msg_send_id, Encode, Encoding, ClassType};
 /// #
 /// # #[cfg(feature = "gnustep-1-7")]
@@ -174,6 +186,14 @@
 ///     pub fn max_range(&self, unit: NSCalendarUnit) -> NSRange {
 ///         unsafe { msg_send![self, maximumRangeOfUnit: unit] }
 ///     }
+///
+///     pub unsafe fn validate_value_for_key(
+///         &self,
+///         value: &mut *mut Object,
+///         key: &NSString,
+///     ) -> Result<(), Id<NSError, Shared>> {
+///        unsafe { msg_send![self, validateValue: value, forKey: key, error: _] }
+///    }
 /// }
 /// ```
 #[macro_export]
@@ -369,6 +389,23 @@ macro_rules! __collect_msg_send {
     ) => {{
         $macro![$obj, $($output)+]
     }};
+
+    // Allow trailing `sel:` without a corresponding argument (for errors)
+    (
+        $macro:path;
+        $obj:expr;
+        ($sel:ident:);
+        ($(,)?);
+        $($output:tt)*
+    ) => {
+        $crate::__collect_msg_send! {
+            $macro;
+            $obj;
+            ();
+            ();
+            $($output)* $sel: _,
+        }
+    };
 
     // tt-munch each argument
     (

--- a/objc2/src/rc/id.rs
+++ b/objc2/src/rc/id.rs
@@ -438,7 +438,7 @@ impl<T: Message, O: Ownership> Id<T, O> {
     }
 
     #[inline]
-    fn autorelease_inner(self) -> *mut T {
+    pub(super) fn autorelease_inner(self) -> *mut T {
         // Note that this (and the actual `autorelease`) is not an associated
         // function. This breaks the guideline that smart pointers shouldn't
         // add inherent methods, but since autoreleasing only works on already

--- a/objc2/tests/use_macros.rs
+++ b/objc2/tests/use_macros.rs
@@ -32,7 +32,6 @@ fn test_msg_send_comma_handling(obj: &NSString, superclass: &Class) {
         let _: () = msg_send![obj, a: 32i32];
         let _: () = msg_send![obj, a: 32i32,];
         let _: () = msg_send![obj, a: 32i32 b: 32i32];
-        let _: () = msg_send![obj, a: 32i32 b: 32i32,];
         let _: () = msg_send![obj, a: 32i32, b: 32i32];
         let _: () = msg_send![obj, a: 32i32, b: 32i32,];
     }
@@ -43,7 +42,6 @@ fn test_msg_send_comma_handling(obj: &NSString, superclass: &Class) {
         let _: () = msg_send![super(obj, superclass), a: 32i32];
         let _: () = msg_send![super(obj, superclass), a: 32i32,];
         let _: () = msg_send![super(obj, superclass), a: 32i32 b: 32i32];
-        let _: () = msg_send![super(obj, superclass), a: 32i32 b: 32i32,];
         let _: () = msg_send![super(obj, superclass), a: 32i32, b: 32i32];
         let _: () = msg_send![super(obj, superclass), a: 32i32, b: 32i32,];
     }

--- a/test-assembly/crates/test_msg_send_id/expected/apple-aarch64.s
+++ b/test-assembly/crates/test_msg_send_id/expected/apple-aarch64.s
@@ -24,7 +24,7 @@ Lloh1:
 	add	x2, x2, l_anon.[ID].1@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh0, Lloh1
 
 	.globl	_handle_alloc
@@ -52,7 +52,7 @@ Lloh3:
 	add	x2, x2, l_anon.[ID].2@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh2, Lloh3
 
 	.globl	_handle_init
@@ -80,7 +80,7 @@ Lloh5:
 	add	x2, x2, l_anon.[ID].3@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh4, Lloh5
 
 	.globl	_handle_alloc_init
@@ -138,7 +138,7 @@ Lloh6:
 	adrp	x0, l_anon.[ID].4@PAGE
 Lloh7:
 	add	x0, x0, l_anon.[ID].4@PAGEOFF
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh6, Lloh7
 
 	.globl	_handle_autoreleased
@@ -177,7 +177,7 @@ Lloh9:
 	add	x2, x2, l_anon.[ID].5@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh8, Lloh9
 
 	.section	__TEXT,__const
@@ -203,11 +203,11 @@ l_anon.[ID].3:
 	.p2align	3
 l_anon.[ID].4:
 	.quad	l_anon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000>\000\000\000\005\000\000"
 
 	.p2align	3
 l_anon.[ID].5:
 	.quad	l_anon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000H\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_id/expected/apple-armv7.s
+++ b/test-assembly/crates/test_msg_send_id/expected/apple-armv7.s
@@ -25,7 +25,7 @@ LBB1_1:
 LPC1_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc
 	.p2align	2
@@ -52,7 +52,7 @@ LBB3_1:
 LPC3_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_init
 	.p2align	2
@@ -79,7 +79,7 @@ LBB5_1:
 LPC5_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc_init
 	.p2align	2
@@ -137,7 +137,7 @@ LBB10_1:
 LPC10_0:
 	add	r0, pc, r0
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_autoreleased
 	.p2align	2
@@ -175,7 +175,7 @@ LBB12_1:
 LPC12_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.section	__TEXT,__const
 l_anon.[ID].0:
@@ -200,11 +200,11 @@ l_anon.[ID].3:
 	.p2align	2
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000>\000\000\000\005\000\000"
 
 	.p2align	2
 l_anon.[ID].5:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000H\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_id/expected/apple-armv7s.s
+++ b/test-assembly/crates/test_msg_send_id/expected/apple-armv7s.s
@@ -28,7 +28,7 @@ LBB1_1:
 LPC1_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc
 	.p2align	2
@@ -58,7 +58,7 @@ LBB3_1:
 LPC3_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_init
 	.p2align	2
@@ -88,7 +88,7 @@ LBB5_1:
 LPC5_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc_init
 	.p2align	2
@@ -149,7 +149,7 @@ LBB10_1:
 LPC10_0:
 	add	r0, pc, r0
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_autoreleased
 	.p2align	2
@@ -187,7 +187,7 @@ LBB12_1:
 LPC12_0:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.section	__TEXT,__const
 l_anon.[ID].0:
@@ -212,11 +212,11 @@ l_anon.[ID].3:
 	.p2align	2
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000>\000\000\000\005\000\000"
 
 	.p2align	2
 l_anon.[ID].5:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000H\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_id/expected/apple-x86.s
+++ b/test-assembly/crates/test_msg_send_id/expected/apple-x86.s
@@ -41,7 +41,7 @@ LBB1_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc
 	.p2align	4, 0x90
@@ -84,7 +84,7 @@ LBB3_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_init
 	.p2align	4, 0x90
@@ -127,7 +127,7 @@ LBB5_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc_init
 	.p2align	4, 0x90
@@ -222,7 +222,7 @@ L10$pb:
 LBB10_2:
 	lea	eax, [esi + l_anon.[ID].4-L10$pb]
 	mov	dword ptr [esp], eax
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_autoreleased
 	.p2align	4, 0x90
@@ -288,7 +288,7 @@ LBB12_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.section	__TEXT,__const
 l_anon.[ID].0:
@@ -313,11 +313,11 @@ l_anon.[ID].3:
 	.p2align	2
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000>\000\000\000\005\000\000"
 
 	.p2align	2
 l_anon.[ID].5:
 	.long	l_anon.[ID].0
-	.asciz	",\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000H\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_id/expected/apple-x86_64.s
+++ b/test-assembly/crates/test_msg_send_id/expected/apple-x86_64.s
@@ -28,7 +28,7 @@ LBB1_2:
 	lea	rdx, [rip + l_anon.[ID].1]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc
 	.p2align	4, 0x90
@@ -58,7 +58,7 @@ LBB3_2:
 	lea	rdx, [rip + l_anon.[ID].2]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_init
 	.p2align	4, 0x90
@@ -88,7 +88,7 @@ LBB5_2:
 	lea	rdx, [rip + l_anon.[ID].3]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_alloc_init
 	.p2align	4, 0x90
@@ -154,7 +154,7 @@ _handle_copy_fallible:
 	ret
 LBB10_2:
 	lea	rdi, [rip + l_anon.[ID].4]
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_autoreleased
 	.p2align	4, 0x90
@@ -199,7 +199,7 @@ LBB12_2:
 	lea	rdx, [rip + l_anon.[ID].5]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.section	__TEXT,__const
 l_anon.[ID].0:
@@ -224,11 +224,11 @@ l_anon.[ID].3:
 	.p2align	3
 l_anon.[ID].4:
 	.quad	l_anon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000>\000\000\000\005\000\000"
 
 	.p2align	3
 l_anon.[ID].5:
 	.quad	l_anon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000H\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
+++ b/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
@@ -67,7 +67,7 @@ handle_new_fallible:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
 .Lfunc_end1:
@@ -140,7 +140,7 @@ handle_alloc_fallible:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)@PLT
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
 .Lfunc_end3:
@@ -223,7 +223,7 @@ handle_init_fallible:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)@PLT
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
 .Lfunc_end5:
@@ -420,7 +420,7 @@ handle_copy_fallible:
 .LBB10_1:
 	lea	eax, [ebx + .Lanon.[ID].4@GOTOFF]
 	mov	dword ptr [esp], eax
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)@PLT
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	ud2
 .Lfunc_end10:
 	.size	handle_copy_fallible, .Lfunc_end10-handle_copy_fallible
@@ -496,7 +496,7 @@ handle_autoreleased_fallible:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)@PLT
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
 .Lfunc_end12:
@@ -537,7 +537,7 @@ handle_autoreleased_fallible:
 	.p2align	2
 .Lanon.[ID].4:
 	.long	.Lanon.[ID].0
-	.asciz	",\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000>\000\000\000\005\000\000"
 	.size	.Lanon.[ID].4, 16
 
 	.type	.Lanon.[ID].5,@object
@@ -545,7 +545,7 @@ handle_autoreleased_fallible:
 	.p2align	2
 .Lanon.[ID].5:
 	.long	.Lanon.[ID].0
-	.asciz	",\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000H\000\000\000\005\000\000"
 	.size	.Lanon.[ID].5, 16
 
 	.section	".note.GNU-stack","",@progbits

--- a/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
+++ b/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
@@ -44,7 +44,7 @@ handle_new_fallible:
 	lea	rdx, [rip + .Lanon.[ID].1]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
+	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<1_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end1:
 	.size	handle_new_fallible, .Lfunc_end1-handle_new_fallible
@@ -93,7 +93,7 @@ handle_alloc_fallible:
 	lea	rdx, [rip + .Lanon.[ID].2]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 1)@GOTPCREL]
+	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<2_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end3:
 	.size	handle_alloc_fallible, .Lfunc_end3-handle_alloc_fallible
@@ -151,7 +151,7 @@ handle_init_fallible:
 	lea	rdx, [rip + .Lanon.[ID].3]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 2)@GOTPCREL]
+	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end5:
 	.size	handle_init_fallible, .Lfunc_end5-handle_init_fallible
@@ -294,7 +294,7 @@ handle_copy_fallible:
 	ret
 .LBB10_1:
 	lea	rdi, [rip + .Lanon.[ID].4]
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 3)@GOTPCREL]
+	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<4_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end10:
 	.size	handle_copy_fallible, .Lfunc_end10-handle_copy_fallible
@@ -347,7 +347,7 @@ handle_autoreleased_fallible:
 	lea	rdx, [rip + .Lanon.[ID].5]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 4)@GOTPCREL]
+	call	qword ptr [rip + SYM(<objc2::__macro_helpers::RetainSemantics<5_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end12:
 	.size	handle_autoreleased_fallible, .Lfunc_end12-handle_autoreleased_fallible
@@ -387,7 +387,7 @@ handle_autoreleased_fallible:
 	.p2align	3
 .Lanon.[ID].4:
 	.quad	.Lanon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000@\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000>\000\000\000\005\000\000"
 	.size	.Lanon.[ID].4, 24
 
 	.type	.Lanon.[ID].5,@object
@@ -395,7 +395,7 @@ handle_autoreleased_fallible:
 	.p2align	3
 .Lanon.[ID].5:
 	.quad	.Lanon.[ID].0
-	.asciz	",\000\000\000\000\000\000\000J\000\000\000\005\000\000"
+	.asciz	",\000\000\000\000\000\000\000H\000\000\000\005\000\000"
 	.size	.Lanon.[ID].5, 24
 
 	.section	".note.GNU-stack","",@progbits

--- a/test-assembly/crates/test_msg_send_id/lib.rs
+++ b/test-assembly/crates/test_msg_send_id/lib.rs
@@ -1,75 +1,73 @@
 //! Test assembly output of `msg_send_id!` internals.
-use objc2::__macro_helpers::{MsgSendId, RetainSemantics};
+use objc2::__macro_helpers::{Alloc, CopyOrMutCopy, Init, MsgSendId, New, Other};
 use objc2::rc::{Allocated, Id, Shared};
 use objc2::runtime::{Class, Object, Sel};
 
 #[no_mangle]
 unsafe fn handle_new(cls: &Class, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<true, false, false, false>>::send_message_id(cls, sel, ())
+    New::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_new_fallible(cls: &Class, sel: Sel) -> Id<Object, Shared> {
-    <RetainSemantics<true, false, false, false>>::send_message_id(cls, sel, ())
+    New::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc(cls: &Class, sel: Sel) -> Option<Allocated<Object>> {
-    <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ())
+    Alloc::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_fallible(cls: &Class, sel: Sel) -> Allocated<Object> {
-    <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ())
+    Alloc::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_init(obj: Option<Allocated<Object>>, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ())
+    Init::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_init_fallible(obj: Option<Allocated<Object>>, sel: Sel) -> Id<Object, Shared> {
-    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel, ())
+    Init::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init(cls: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object, Shared>> {
-    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel1, ());
-    <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ())
+    let obj = Alloc::send_message_id(cls, sel1, ());
+    Init::send_message_id(obj, sel2, ())
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
-    let obj: Option<Allocated<Object>> =
-        <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel, ());
+    let obj: Option<Allocated<Object>> = Alloc::send_message_id(cls, sel, ());
     let _obj = obj.unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
-    let obj = <RetainSemantics<false, true, false, false>>::send_message_id(cls, sel1, ());
-    let obj: Option<Id<Object, Shared>> =
-        <RetainSemantics<false, false, true, false>>::send_message_id(obj, sel2, ());
+    let obj = Alloc::send_message_id(cls, sel1, ());
+    let obj: Option<Id<Object, Shared>> = Init::send_message_id(obj, sel2, ());
     let _obj = obj.unwrap_unchecked();
 }
 
 #[no_mangle]
 unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, false, true>>::send_message_id(obj, sel, ())
+    CopyOrMutCopy::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_copy_fallible(obj: &Object, sel: Sel) -> Id<Object, Shared> {
-    <RetainSemantics<false, false, false, true>>::send_message_id(obj, sel, ())
+    CopyOrMutCopy::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object, Shared>> {
-    <RetainSemantics<false, false, false, false>>::send_message_id(obj, sel, ())
+    Other::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
 unsafe fn handle_autoreleased_fallible(obj: &Object, sel: Sel) -> Id<Object, Shared> {
-    <RetainSemantics<false, false, false, false>>::send_message_id(obj, sel, ())
+    Other::send_message_id(obj, sel, ())
 }

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
@@ -42,7 +42,7 @@ Lloh9:
 	add	x2, x2, l_anon.[ID].1@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	bl	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 	.loh AdrpLdrGotLdr	Lloh5, Lloh6, Lloh7
 	.loh AdrpLdrGotLdr	Lloh2, Lloh3, Lloh4
 	.loh AdrpAdd	Lloh8, Lloh9

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
@@ -40,7 +40,7 @@ LBB1_1:
 LPC1_2:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_use_generic
 	.p2align	2

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -43,7 +43,7 @@ LBB1_1:
 LPC1_2:
 	add	r2, pc, r2
 	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	b	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_use_generic
 	.p2align	2

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
@@ -57,7 +57,7 @@ LBB1_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_use_generic
 	.p2align	4, 0x90

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
@@ -57,7 +57,7 @@ LBB1_2:
 	push	eax
 	push	edi
 	push	esi
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_use_generic
 	.p2align	4, 0x90

--- a/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
+++ b/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
@@ -35,7 +35,7 @@ LBB1_2:
 	lea	rdx, [rip + l_anon.[ID].1]
 	mov	rdi, rbx
 	mov	rsi, r14
-	call	SYM(<objc2::__macro_helpers::RetainSemantics<_,_,_,_> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
+	call	SYM(<objc2::__macro_helpers::RetainSemantics<3_u8> as objc2::__macro_helpers::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_use_generic
 	.p2align	4, 0x90

--- a/test-ui/ui/extern_methods_wrong_arguments.rs
+++ b/test-ui/ui/extern_methods_wrong_arguments.rs
@@ -32,6 +32,13 @@ extern_methods!(
 
 extern_methods!(
     unsafe impl MyObject {
+        #[sel(f:g:)]
+        fn f();
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
         #[sel(x:)]
         fn x(&self);
     }

--- a/test-ui/ui/extern_methods_wrong_arguments.stderr
+++ b/test-ui/ui/extern_methods_wrong_arguments.stderr
@@ -3,19 +3,6 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(a:)]
-  | |         fn a();
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: Number of arguments in function and selector did not match!
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
   | |         #[sel(b)]
   | |         fn b(arg: i32);
   | |     }
@@ -29,21 +16,8 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(c:d:e:)]
-  | |         fn c(arg1: i32, arg2: u32);
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: Number of arguments in function and selector did not match!
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
-  | |         #[sel(x:)]
-  | |         fn x(&self);
+  | |         #[sel(f:g:)]
+  | |         fn f();
   | |     }
   | | );
   | |_^
@@ -62,3 +36,57 @@ error: Number of arguments in function and selector did not match!
   | |_^
   |
   = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[sel(a:)]
+  | |         fn a();
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `()`, found enum `Result`
+  |   expected `()` because of default return type
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[sel(c:d:e:)]
+  | |         fn c(arg1: i32, arg2: u32);
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `()`, found enum `Result`
+  |   expected `()` because of default return type
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[sel(x:)]
+  | |         fn x(&self);
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `()`, found enum `Result`
+  |   expected `()` because of default return type
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/invalid_msg_send.rs
+++ b/test-ui/ui/invalid_msg_send.rs
@@ -1,5 +1,6 @@
 //! Test invalid msg_send syntax
 use objc2::msg_send;
+use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
 
 fn main() {
@@ -13,4 +14,7 @@ fn main() {
     let _: () = unsafe { msg_send![obj, a: b: c] };
     let _: () = unsafe { msg_send![obj, a: b, c d] };
     let _: () = unsafe { msg_send![obj, a: b: c] };
+    let _: () = unsafe { msg_send![obj, a: b c: d,] };
+
+    let _: Result<(), Id<Object, Shared>> = unsafe { msg_send![obj, a: _, b: _] };
 }

--- a/test-ui/ui/invalid_msg_send.stderr
+++ b/test-ui/ui/invalid_msg_send.stderr
@@ -10,23 +10,41 @@ error: unexpected end of macro invocation
   |     let _: () = unsafe { msg_send![obj,] };
   |                                        ^ missing tokens in macro arguments
 
-error: unexpected end of macro invocation
+error: no rules expected the token `)`
  --> ui/invalid_msg_send.rs
   |
   |     let _: () = unsafe { msg_send![obj, a:] };
-  |                                           ^ missing tokens in macro arguments
+  |                          ^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call
+  |
+  = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected end of macro invocation
+error: no rules expected the token `)`
  --> ui/invalid_msg_send.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: b c] };
-  |                                               ^ missing tokens in macro arguments
+  |                          ^^^^^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call
+  |
+  = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `d`
+error: no rules expected the token `a`
  --> ui/invalid_msg_send.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: b, c d] };
-  |                                                 ^ no rules expected this token in macro call
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call
+  |
+  = note: this error originates in the macro `$crate::__msg_send_parse` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: no rules expected the token `,`
+ --> ui/invalid_msg_send.rs
+  |
+  |     let _: () = unsafe { msg_send![obj, a: b c: d,] };
+  |                                                  ^ no rules expected this token in macro call
+
+error: no rules expected the token `b`
+ --> ui/invalid_msg_send.rs
+  |
+  |     let _: Result<(), Id<Object, Shared>> = unsafe { msg_send![obj, a: _, b: _] };
+  |                                                                           ^ no rules expected this token in macro call
 
 error[E0412]: cannot find type `c` in this scope
  --> ui/invalid_msg_send.rs
@@ -41,4 +59,7 @@ error[E0412]: cannot find type `c` in this scope
  --> ui/invalid_msg_send.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: b: c] };
-  |                                               ^ expecting a type here because of type ascription
+  |                                               ^
+  |                                               |
+  |                                               not found in this scope
+  |                                               help: maybe you meant to write an assignment here: `let c`

--- a/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -95,7 +95,7 @@ error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiv
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T, O>
             &'a mut Id<T, objc2::rc::Owned>
-  = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>`
 
 error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiver` is not satisfied
  --> ui/msg_send_id_invalid_receiver.rs
@@ -109,4 +109,4 @@ error[E0277]: the trait bound `Id<objc2::runtime::Object, Shared>: MessageReceiv
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T, O>
             &'a mut Id<T, objc2::rc::Owned>
-  = note: required for `RetainSemantics<false, false, false, true>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>`
+  = note: required for `RetainSemantics<4>` to implement `MsgSendId<Id<objc2::runtime::Object, Shared>, Id<_, _>>`

--- a/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
             NSError
             NSException
           and $N others
-  = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
 
 error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -56,7 +56,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
             NSError
             NSException
           and $N others
-  = note: required for `RetainSemantics<true, false, false, false>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
 
 error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -95,7 +95,7 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
             NSError
             NSException
           and $N others
-  = note: required for `RetainSemantics<false, true, false, false>` to implement `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>>`
+  = note: required for `RetainSemantics<2>` to implement `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>>`
 
 error[E0271]: type mismatch resolving `<Id<objc2::runtime::Object, Shared> as MaybeUnwrap>::Input == Allocated<_>`
  --> ui/msg_send_id_invalid_return.rs

--- a/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -191,7 +191,7 @@ note: required by a bound in `send_message_id`
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `send_message_id`
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -209,7 +209,7 @@ note: required by a bound in `send_message_id`
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `send_message_id`
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Option<&objc2::runtime::Object>: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -225,4 +225,4 @@ note: required by a bound in `send_message_id`
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `send_message_id`
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_id_underspecified.stderr
+++ b/test-ui/ui/msg_send_id_underspecified.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
   |     let _: &Object = &*unsafe { msg_send_id![obj, description] };
   |                       ----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- type must be known at this point
   |
-  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider giving `result` an explicit type
  --> $WORKSPACE/objc2/src/macros.rs
   |

--- a/test-ui/ui/msg_send_invalid_error.rs
+++ b/test-ui/ui/msg_send_invalid_error.rs
@@ -1,0 +1,21 @@
+//! Test that msg_send! error handling works correctly.
+use objc2::{msg_send, msg_send_id};
+use objc2::ClassType;
+use objc2::rc::{Id, Shared};
+use objc2::foundation::NSString;
+
+fn main() {
+    let obj: &NSString;
+
+    // Wrong type
+    let _: () = unsafe { msg_send![obj, a: _] };
+    let _: Result<i32, _> = unsafe { msg_send![obj, b: _] };
+    let _: Result<(), i32> = unsafe { msg_send![obj, c: _] };
+    let _: Result<(), Id<i32, Shared>> = unsafe { msg_send![obj, d: _] };
+
+    // Different calls
+    let _: () = unsafe { msg_send![obj, e: obj, f: _] };
+    let _: () = unsafe { msg_send![super(obj), g: _] };
+    let _: () = unsafe { msg_send![super(obj, NSString::class()), h: _] };
+    let _: () = unsafe { msg_send_id![obj, i: _] };
+}

--- a/test-ui/ui/msg_send_invalid_error.stderr
+++ b/test-ui/ui/msg_send_invalid_error.stderr
@@ -1,0 +1,97 @@
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send![obj, a: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `Result`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: Result<i32, _> = unsafe { msg_send![obj, b: _] };
+  |                                      ^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `()`
+  |
+  = note: expected enum `Result<i32, _>`
+             found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try wrapping the expression in `Err`
+  --> $WORKSPACE/objc2/src/macros.rs
+   |
+   |         Err(result)
+   |         ++++      +
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: Result<(), i32> = unsafe { msg_send![obj, c: _] };
+  |                                       ^^^^^^^^^^^^^^^^^^^^ expected `i32`, found struct `Id`
+  |
+  = note: expected enum `Result<_, i32>`
+             found enum `Result<_, Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `i32: Message` is not satisfied
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: Result<(), Id<i32, Shared>> = unsafe { msg_send![obj, d: _] };
+  |                                                   ^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            NSArray<T, O>
+            NSAttributedString
+            NSBundle
+            NSData
+            NSDictionary<K, V>
+            NSError
+            NSException
+          and $N others
+note: required by a bound in `__send_message_error`
+ --> $WORKSPACE/objc2/src/message/mod.rs
+  |
+  |         E: Message,
+  |            ^^^^^^^ required by this bound in `__send_message_error`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send![obj, e: obj, f: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `Result`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send![super(obj), g: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `Result`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send![super(obj, NSString::class()), h: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `Result`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send_id![obj, i: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found enum `Result`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<Id<_, _>, Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_mutable.stderr
+++ b/test-ui/ui/msg_send_mutable.stderr
@@ -5,13 +5,7 @@ error[E0382]: use of moved value: `obj`
   |         --- move occurs because `obj` has type `&mut objc2::runtime::Object`, which does not implement the `Copy` trait
   |
   |     let _: () = unsafe { msg_send![obj, selector] };
-  |                          ------------------------ `obj` moved due to this method call
+  |                                    --- value moved here
   |     // Could be solved with a reborrow
   |     let _: () = unsafe { msg_send![obj, selector] };
   |                                    ^^^ value used here after move
-  |
-note: this function takes ownership of the receiver `self`, which moves `obj`
- --> $WORKSPACE/objc2/src/message/mod.rs
-  |
-  |     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> R
-  |                                  ^^^^

--- a/test-ui/ui/msg_send_no_return_type.stderr
+++ b/test-ui/ui/msg_send_no_return_type.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
   |         msg_send![cls, new];
   |         ^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider giving `result` an explicit type
  --> $WORKSPACE/objc2/src/macros.rs
   |

--- a/test-ui/ui/msg_send_not_encode.stderr
+++ b/test-ui/ui/msg_send_not_encode.stderr
@@ -20,7 +20,7 @@ note: required by a bound in `send_message`
   |
   |         R: EncodeConvert,
   |            ^^^^^^^^^^^^^ required by this bound in `send_message`
-  = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
  --> ui/msg_send_not_encode.rs
@@ -48,4 +48,4 @@ note: required by a bound in `send_message`
   |
   |         A: MessageArguments,
   |            ^^^^^^^^^^^^^^^^ required by this bound in `send_message`
-  = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_underspecified_error.rs
+++ b/test-ui/ui/msg_send_underspecified_error.rs
@@ -1,0 +1,13 @@
+//! Test underspecified msg_send! errors.
+use objc2::{msg_send, msg_send_id};
+use objc2::rc::{Id, Shared};
+use objc2::foundation::NSString;
+
+fn main() {
+    let obj: &NSString;
+    let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
+
+    let _: Result<_, _> = unsafe { msg_send_id![obj, b: _] };
+    let _: Result<Id<NSString, Shared>, _> = unsafe { msg_send_id![obj, c: _] };
+    let _: Result<Id<NSString, Shared>, Id<_, Shared>> = unsafe { msg_send_id![obj, d: _] };
+}

--- a/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/test-ui/ui/msg_send_underspecified_error.stderr
@@ -1,0 +1,84 @@
+error[E0282]: type annotations needed
+ --> ui/msg_send_underspecified_error.rs
+  |
+  |     let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
+  |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the associated function `__send_message_error`
+  |
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider specifying the generic arguments
+ --> $WORKSPACE/objc2/src/macros.rs
+  |
+  |             @(__send_message_error::<(), E>)
+  |                                   +++++++++
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_underspecified_error.rs
+  |
+  |     let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
+  |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `__send_message_error`
+ --> $WORKSPACE/objc2/src/message/mod.rs
+  |
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `__send_message_error`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_underspecified_error.rs
+  |
+  |     let _: Result<_, _> = unsafe { msg_send_id![obj, b: _] };
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/objc2/src/__macro_helpers.rs
+  |
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_underspecified_error.rs
+  |
+  |     let _: Result<Id<NSString, Shared>, _> = unsafe { msg_send_id![obj, c: _] };
+  |                                                       ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/objc2/src/__macro_helpers.rs
+  |
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_underspecified_error.rs
+  |
+  |     let _: Result<Id<NSString, Shared>, Id<_, Shared>> = unsafe { msg_send_id![obj, d: _] };
+  |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/objc2/src/__macro_helpers.rs
+  |
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/test-ui/ui/msg_send_underspecified_error.stderr
@@ -5,11 +5,6 @@ error[E0282]: type annotations needed
   |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the associated function `__send_message_error`
   |
   = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider specifying the generic arguments
- --> $WORKSPACE/objc2/src/macros.rs
-  |
-  |             @(__send_message_error::<(), E>)
-  |                                   +++++++++
 
 error[E0283]: type annotations needed
  --> ui/msg_send_underspecified_error.rs

--- a/test-ui/ui/msg_send_underspecified_error2.rs
+++ b/test-ui/ui/msg_send_underspecified_error2.rs
@@ -1,0 +1,9 @@
+//! Test underspecified msg_send! errors.
+use objc2::msg_send_id;
+use objc2::rc::{Id, Shared};
+use objc2::foundation::{NSError, NSString};
+
+fn main() {
+    let obj: &NSString;
+    let _: Result<Id<_, Shared>, Id<NSError, Shared>> = unsafe { msg_send_id![obj, a: _] };
+}

--- a/test-ui/ui/msg_send_underspecified_error2.stderr
+++ b/test-ui/ui/msg_send_underspecified_error2.stderr
@@ -1,0 +1,7 @@
+error[E0282]: type annotations needed
+ --> ui/msg_send_underspecified_error2.rs
+  |
+  |     let _: Result<Id<_, Shared>, Id<NSError, Shared>> = unsafe { msg_send_id![obj, a: _] };
+  |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the trait `MsgSendId`
+  |
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Background

Many methods take an `NSError**` as their last parameter, which is used to communicate errors to the caller, see [Error Handling Programming Guide For Cocoa](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorHandling/ErrorHandling.html).

Swift [has a convention](https://developer.apple.com/documentation/swift/about-imported-cocoa-error-parameters) for when they convert such methods, we should have something similar.

Note that only methods that return `BOOL` or an instance are supported, because, as per the documentation:
> Success or failure is indicated by the return value of the method. Although Cocoa methods that indirectly return error objects in the Cocoa error domain are guaranteed to return such objects if the method indicates failure by directly returning `nil` or `NO`, you should always check that the return value is `nil` or `NO` before attempting to do anything with the `NSError` object.

Examples of a few different methods in Foundation that return errors:
- [`-[NSDictionary writeToURL:error:]`](https://developer.apple.com/documentation/foundation/nsdictionary/2879139-writetourl?language=objc)
- [`-[NSExtensionContext cancelRequestWithError:]`](https://developer.apple.com/documentation/foundation/nsextensioncontext/1412773-cancelrequestwitherror?language=objc)
- [`-[NSObject validateValue:forKey:error:]`](https://developer.apple.com/documentation/objectivec/nsobject/1416754-validatevalue?language=objc)
- [`-[NSAppleScript compileAndReturnError:]`](https://developer.apple.com/documentation/foundation/nsapplescript/1407582-compileandreturnerror?language=objc)
- [`-[NSNumberFormatter getObjectValue:forString:range:error:]`](https://developer.apple.com/documentation/foundation/nsnumberformatter/1412588-getobjectvalue?language=objc)
- [`+[NSData dataWithContentsOfFile:options:error:]`](https://developer.apple.com/documentation/foundation/nsdata/1547244-datawithcontentsoffile?language=objc)


## Implementation

The idea is that we change `msg_send!` and `msg_send_id!` to support specifying `error: _` as the last part of the selector (`_` is not a valid expresion, so this is easy to distinguish), and if so, performs either a `BOOL != NO` check, or a NULL check, and returns a `Result` with the desired value or the error. Example:

```rust
fn myMethodThatReturnsError(&self, that_returns: i32) -> Result<(), Id<NSError, Shared>> {
    unsafe { msg_send![self, myMethod: that_returns, error: _] }
}
```

This way, it is very easy to specify, while also only happening if the user explicitly requests it!
