### PR TITLE
Rename `#[sel(...)]` to `#[method(...)]` in `extern_methods!`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Verify the message signature of overriden methods when declaring classes if
   the `verify_message` feature is enabled.
 * Verify in `declare_class!` that protocols are implemented correctly.
+* **BREAKING**: Changed the name of the attribute macro in `extern_methods`
+  from `#[sel(...)]` to `#[method(...)]`.
 
 
 ## 0.3.0-beta.3 - 2022-09-01

--- a/objc2/examples/delegate.rs
+++ b/objc2/examples/delegate.rs
@@ -38,7 +38,7 @@ declare_class!(
     }
 
     unsafe impl CustomAppDelegate {
-        #[sel(initWith:another:)]
+        #[method(initWith:another:)]
         fn init_with(self: &mut Self, ivar: u8, another_ivar: bool) -> Option<&mut Self> {
             let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
 
@@ -56,7 +56,7 @@ declare_class!(
             })
         }
 
-        #[sel(myClassMethod)]
+        #[method(myClassMethod)]
         fn my_class_method() {
             println!("A class method!");
         }
@@ -69,7 +69,7 @@ declare_class!(
     // TODO: Investigate this!
     unsafe impl CustomAppDelegate {
         /// This is `unsafe` because it expects `sender` to be valid
-        #[sel(applicationDidFinishLaunching:)]
+        #[method(applicationDidFinishLaunching:)]
         unsafe fn did_finish_launching(&self, sender: *mut Object) {
             println!("Did finish launching!");
             // Do something with `sender`
@@ -77,7 +77,7 @@ declare_class!(
         }
 
         /// Some comment before `sel`.
-        #[sel(applicationWillTerminate:)]
+        #[method(applicationWillTerminate:)]
         /// Some comment after `sel`.
         fn will_terminate(&self, _: *mut Object) {
             println!("Will terminate!");

--- a/objc2/src/declare.rs
+++ b/objc2/src/declare.rs
@@ -832,7 +832,7 @@ mod tests {
 
             // Implementing this should work
             unsafe impl Protocol<NSCopying> for Custom {
-                #[sel(copyWithZone:)]
+                #[method(copyWithZone:)]
                 #[allow(unreachable_code)]
                 fn copy_with_zone(&self, _zone: *const NSZone) -> *mut Self {
                     unimplemented!()
@@ -862,7 +862,7 @@ mod tests {
 
             unsafe impl Custom {
                 // Override `description` with a bad return type
-                #[sel(description)]
+                #[method(description)]
                 fn description(&self) {}
             }
         );
@@ -905,7 +905,7 @@ mod tests {
 
             unsafe impl Protocol<NSCopying> for Custom {
                 // Override with a bad return type
-                #[sel(copyWithZone:)]
+                #[method(copyWithZone:)]
                 fn copy_with_zone(&self, _zone: *const NSZone) -> u8 {
                     42
                 }
@@ -928,14 +928,14 @@ mod tests {
             }
 
             unsafe impl Protocol<NSCopying> for Custom {
-                #[sel(copyWithZone:)]
+                #[method(copyWithZone:)]
                 #[allow(unreachable_code)]
                 fn copy_with_zone(&self, _zone: *const NSZone) -> *mut Self {
                     unimplemented!()
                 }
 
                 // This doesn't exist on the protocol
-                #[sel(someOtherMethod)]
+                #[method(someOtherMethod)]
                 fn some_other_method(&self) {}
             }
         );

--- a/objc2/src/declare/ivar.rs
+++ b/objc2/src/declare/ivar.rs
@@ -407,7 +407,7 @@ mod tests {
             }
 
             unsafe impl CustomDrop {
-                #[sel(dealloc)]
+                #[method(dealloc)]
                 fn dealloc(&mut self) {
                     HAS_RUN_DEALLOC.store(true, Ordering::SeqCst);
                     unsafe { msg_send![super(self), dealloc] }

--- a/objc2/src/declare/ivar_drop.rs
+++ b/objc2/src/declare/ivar_drop.rs
@@ -252,7 +252,7 @@ mod tests {
         }
 
         unsafe impl IvarTester {
-            #[sel(init)]
+            #[method(init)]
             fn init(&mut self) -> Option<&mut Self> {
                 let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
                 this.map(|this| {
@@ -264,7 +264,7 @@ mod tests {
                 })
             }
 
-            #[sel(initInvalid)]
+            #[method(initInvalid)]
             fn init_invalid(&mut self) -> Option<&mut Self> {
                 // Don't actually initialize anything here; this creates an
                 // invalid instance, where accessing the two ivars `ivar1`

--- a/objc2/src/foundation/array.rs
+++ b/objc2/src/foundation/array.rs
@@ -134,14 +134,14 @@ extern_methods!(
     /// Generic accessor methods.
     unsafe impl<T: Message, O: Ownership> NSArray<T, O> {
         #[doc(alias = "count")]
-        #[sel(count)]
+        #[method(count)]
         pub fn len(&self) -> usize;
 
         pub fn is_empty(&self) -> bool {
             self.len() == 0
         }
 
-        #[sel(objectAtIndex:)]
+        #[method(objectAtIndex:)]
         unsafe fn get_unchecked(&self, index: usize) -> &T;
 
         #[doc(alias = "objectAtIndex:")]
@@ -156,11 +156,11 @@ extern_methods!(
         }
 
         #[doc(alias = "firstObject")]
-        #[sel(firstObject)]
+        #[method(firstObject)]
         pub fn first(&self) -> Option<&T>;
 
         #[doc(alias = "lastObject")]
-        #[sel(lastObject)]
+        #[method(lastObject)]
         pub fn last(&self) -> Option<&T>;
 
         #[doc(alias = "objectEnumerator")]
@@ -171,7 +171,7 @@ extern_methods!(
             }
         }
 
-        #[sel(getObjects:range:)]
+        #[method(getObjects:range:)]
         unsafe fn get_objects(&self, ptr: *mut &T, range: NSRange);
 
         pub fn objects_in_range(&self, range: Range<usize>) -> Vec<&T> {
@@ -229,11 +229,11 @@ extern_methods!(
         }
 
         #[doc(alias = "firstObject")]
-        #[sel(firstObject)]
+        #[method(firstObject)]
         pub fn first_mut(&mut self) -> Option<&mut T>;
 
         #[doc(alias = "lastObject")]
-        #[sel(lastObject)]
+        #[method(lastObject)]
         pub fn last_mut(&mut self) -> Option<&mut T>;
     }
 );

--- a/objc2/src/foundation/attributed_string.rs
+++ b/objc2/src/foundation/attributed_string.rs
@@ -84,7 +84,7 @@ extern_methods!(
 
         /// Alias for `self.string().len_utf16()`.
         #[doc(alias = "length")]
-        #[sel(length)]
+        #[method(length)]
         pub fn len_utf16(&self) -> usize;
 
         // /// TODO

--- a/objc2/src/foundation/data.rs
+++ b/objc2/src/foundation/data.rs
@@ -64,7 +64,7 @@ extern_methods!(
 
     /// Accessor methods.
     unsafe impl NSData {
-        #[sel(length)]
+        #[method(length)]
         #[doc(alias = "length")]
         pub fn len(&self) -> usize;
 
@@ -72,7 +72,7 @@ extern_methods!(
             self.len() == 0
         }
 
-        #[sel(bytes)]
+        #[method(bytes)]
         fn bytes_raw(&self) -> *const c_void;
 
         pub fn bytes(&self) -> &[u8] {

--- a/objc2/src/foundation/dictionary.rs
+++ b/objc2/src/foundation/dictionary.rs
@@ -37,7 +37,7 @@ extern_methods!(
         }
 
         #[doc(alias = "count")]
-        #[sel(count)]
+        #[method(count)]
         pub fn len(&self) -> usize;
 
         pub fn is_empty(&self) -> bool {
@@ -45,10 +45,10 @@ extern_methods!(
         }
 
         #[doc(alias = "objectForKey:")]
-        #[sel(objectForKey:)]
+        #[method(objectForKey:)]
         pub fn get(&self, key: &K) -> Option<&V>;
 
-        #[sel(getObjects:andKeys:)]
+        #[method(getObjects:andKeys:)]
         unsafe fn get_objects_and_keys(&self, objects: *mut &V, keys: *mut &K);
 
         #[doc(alias = "getObjects:andKeys:")]

--- a/objc2/src/foundation/error.rs
+++ b/objc2/src/foundation/error.rs
@@ -67,7 +67,7 @@ extern_methods!(
             unsafe { msg_send_id![self, domain] }
         }
 
-        #[sel(code)]
+        #[method(code)]
         pub fn code(&self) -> NSInteger;
 
         pub fn user_info(&self) -> Option<Id<NSDictionary<NSErrorUserInfoKey, NSObject>, Shared>> {

--- a/objc2/src/foundation/exception.rs
+++ b/objc2/src/foundation/exception.rs
@@ -56,7 +56,7 @@ extern_methods!(
             }
         }
 
-        #[sel(raise)]
+        #[method(raise)]
         unsafe fn raise_raw(&self);
 
         /// Raises the exception, causing program flow to jump to the local

--- a/objc2/src/foundation/mutable_array.rs
+++ b/objc2/src/foundation/mutable_array.rs
@@ -104,7 +104,7 @@ extern_methods!(
             old_obj
         }
 
-        #[sel(removeObjectAtIndex:)]
+        #[method(removeObjectAtIndex:)]
         unsafe fn remove_at(&mut self, index: usize);
 
         #[doc(alias = "removeObjectAtIndex:")]
@@ -118,7 +118,7 @@ extern_methods!(
             obj
         }
 
-        #[sel(removeLastObject)]
+        #[method(removeLastObject)]
         unsafe fn remove_last(&mut self);
 
         #[doc(alias = "removeLastObject")]
@@ -133,7 +133,7 @@ extern_methods!(
         }
 
         #[doc(alias = "removeAllObjects")]
-        #[sel(removeAllObjects)]
+        #[method(removeAllObjects)]
         pub fn clear(&mut self);
 
         #[doc(alias = "sortUsingFunction:context:")]

--- a/objc2/src/foundation/mutable_attributed_string.rs
+++ b/objc2/src/foundation/mutable_attributed_string.rs
@@ -47,7 +47,7 @@ extern_methods!(
 
         /// Replaces the entire attributed string.
         #[doc(alias = "setAttributedString:")]
-        #[sel(setAttributedString:)]
+        #[method(setAttributedString:)]
         pub fn replace(&mut self, attributed_string: &NSAttributedString);
     }
 );

--- a/objc2/src/foundation/mutable_data.rs
+++ b/objc2/src/foundation/mutable_data.rs
@@ -62,10 +62,10 @@ extern_methods!(
     unsafe impl NSMutableData {
         /// Expands with zeroes, or truncates the buffer.
         #[doc(alias = "setLength:")]
-        #[sel(setLength:)]
+        #[method(setLength:)]
         pub fn set_len(&mut self, len: usize);
 
-        #[sel(mutableBytes)]
+        #[method(mutableBytes)]
         fn bytes_mut_raw(&mut self) -> *mut c_void;
 
         #[doc(alias = "mutableBytes")]
@@ -80,7 +80,7 @@ extern_methods!(
             }
         }
 
-        #[sel(appendBytes:length:)]
+        #[method(appendBytes:length:)]
         unsafe fn append_raw(&mut self, ptr: *const c_void, len: usize);
 
         #[doc(alias = "appendBytes:length:")]
@@ -93,7 +93,7 @@ extern_methods!(
             self.extend_from_slice(&[byte])
         }
 
-        #[sel(replaceBytesInRange:withBytes:length:)]
+        #[method(replaceBytesInRange:withBytes:length:)]
         unsafe fn replace_raw(&mut self, range: NSRange, ptr: *const c_void, len: usize);
 
         #[doc(alias = "replaceBytesInRange:withBytes:length:")]

--- a/objc2/src/foundation/mutable_dictionary.rs
+++ b/objc2/src/foundation/mutable_dictionary.rs
@@ -59,7 +59,7 @@ extern_methods!(
             unsafe { msg_send_id![Self::class(), new] }
         }
 
-        #[sel(setDictionary:)]
+        #[method(setDictionary:)]
         fn set_dictionary(&mut self, dict: &NSDictionary<K, V>);
 
         /// Creates an [`NSMutableDictionary`] from a slice of keys and a
@@ -104,10 +104,10 @@ extern_methods!(
         /// println!("{:?}", dict.get_mut(ns_string!("one")));
         /// ```
         #[doc(alias = "objectForKey:")]
-        #[sel(objectForKey:)]
+        #[method(objectForKey:)]
         pub fn get_mut(&mut self, key: &K) -> Option<&mut V>;
 
-        #[sel(getObjects:andKeys:)]
+        #[method(getObjects:andKeys:)]
         unsafe fn get_objects_and_keys(&self, objects: *mut &mut V, keys: *mut &K);
 
         /// Returns a vector of mutable references to the values in the dictionary.
@@ -137,7 +137,7 @@ extern_methods!(
             vals
         }
 
-        #[sel(setObject:forKey:)]
+        #[method(setObject:forKey:)]
         fn set_object_for_key(&mut self, object: &V, key: &K);
 
         /// Inserts a key-value pair into the dictionary.
@@ -168,7 +168,7 @@ extern_methods!(
             obj
         }
 
-        #[sel(removeObjectForKey:)]
+        #[method(removeObjectForKey:)]
         fn remove_object_for_key(&mut self, key: &K);
 
         /// Removes a key from the dictionary, returning the value at the key
@@ -214,7 +214,7 @@ extern_methods!(
         /// assert!(dict.is_empty());
         /// ```
         #[doc(alias = "removeAllObjects")]
-        #[sel(removeAllObjects)]
+        #[method(removeAllObjects)]
         pub fn clear(&mut self);
 
         /// Returns an [`NSArray`] containing the dictionary's values,

--- a/objc2/src/foundation/mutable_set.rs
+++ b/objc2/src/foundation/mutable_set.rs
@@ -84,7 +84,7 @@ extern_methods!(
         /// assert!(set.is_empty());
         /// ```
         #[doc(alias = "removeAllObjects")]
-        #[sel(removeAllObjects)]
+        #[method(removeAllObjects)]
         pub fn clear(&mut self);
 
         /// Returns a [`Vec`] containing the set's elements, consuming the set.
@@ -140,7 +140,7 @@ extern_methods!(
     // set compares the input value with elements in the set
     // For comparison: Rust's HashSet requires similar methods to be `Hash` + `Eq`
     unsafe impl<T: Message + PartialEq, O: Ownership> NSMutableSet<T, O> {
-        #[sel(addObject:)]
+        #[method(addObject:)]
         fn add_object(&mut self, value: &T);
 
         /// Adds a value to the set. Returns whether the value was
@@ -172,7 +172,7 @@ extern_methods!(
             !contains_value
         }
 
-        #[sel(removeObject:)]
+        #[method(removeObject:)]
         fn remove_object(&mut self, value: &T);
 
         /// Removes a value from the set. Returns whether the value was present

--- a/objc2/src/foundation/mutable_string.rs
+++ b/objc2/src/foundation/mutable_string.rs
@@ -55,13 +55,13 @@ extern_methods!(
         /// Appends the given [`NSString`] onto the end of this.
         #[doc(alias = "appendString:")]
         // SAFETY: The string is not nil
-        #[sel(appendString:)]
+        #[method(appendString:)]
         pub fn push_nsstring(&mut self, nsstring: &NSString);
 
         /// Replaces the entire string.
         #[doc(alias = "setString:")]
         // SAFETY: The string is not nil
-        #[sel(setString:)]
+        #[method(setString:)]
         pub fn replace(&mut self, nsstring: &NSString);
 
         // TODO:

--- a/objc2/src/foundation/number.rs
+++ b/objc2/src/foundation/number.rs
@@ -238,10 +238,10 @@ impl NSNumber {
 
 extern_methods!(
     unsafe impl NSNumber {
-        #[sel(compare:)]
+        #[method(compare:)]
         fn compare(&self, other: &Self) -> NSComparisonResult;
 
-        #[sel(isEqualToNumber:)]
+        #[method(isEqualToNumber:)]
         fn is_equal_to_number(&self, other: &Self) -> bool;
 
         fn string(&self) -> Id<NSString, Shared> {

--- a/objc2/src/foundation/object.rs
+++ b/objc2/src/foundation/object.rs
@@ -39,13 +39,13 @@ extern_methods!(
             unsafe { msg_send_id![Self::class(), new] }
         }
 
-        #[sel(isKindOfClass:)]
+        #[method(isKindOfClass:)]
         fn is_kind_of_inner(&self, cls: &Class) -> bool;
 
-        #[sel(isEqual:)]
+        #[method(isEqual:)]
         fn is_equal(&self, other: &Self) -> bool;
 
-        #[sel(hash)]
+        #[method(hash)]
         fn hash_code(&self) -> usize;
 
         /// Check if the object is an instance of the class, or one of it's

--- a/objc2/src/foundation/set.rs
+++ b/objc2/src/foundation/set.rs
@@ -109,7 +109,7 @@ extern_methods!(
         /// assert_eq!(set.len(), 3);
         /// ```
         #[doc(alias = "count")]
-        #[sel(count)]
+        #[method(count)]
         pub fn len(&self) -> usize;
 
         /// Returns `true` if the set contains no elements.
@@ -144,7 +144,7 @@ extern_methods!(
         /// assert!(any == &*strs[0] || any == &*strs[1] || any == &*strs[2]);
         /// ```
         #[doc(alias = "anyObject")]
-        #[sel(anyObject)]
+        #[method(anyObject)]
         pub fn get_any(&self) -> Option<&T>;
 
         /// An iterator visiting all elements in arbitrary order.
@@ -262,7 +262,7 @@ extern_methods!(
         /// assert!(set.contains(ns_string!("one")));
         /// ```
         #[doc(alias = "containsObject:")]
-        #[sel(containsObject:)]
+        #[method(containsObject:)]
         pub fn contains(&self, value: &T) -> bool;
 
         /// Returns a reference to the value in the set, if any, that is equal
@@ -282,7 +282,7 @@ extern_methods!(
         /// assert_eq!(set.get(ns_string!("four")), None);
         /// ```
         #[doc(alias = "member:")]
-        #[sel(member:)]
+        #[method(member:)]
         pub fn get(&self, value: &T) -> Option<&T>;
 
         /// Returns `true` if the set is a subset of another, i.e., `other`
@@ -302,7 +302,7 @@ extern_methods!(
         /// assert!(!set2.is_subset(&set1));
         /// ```
         #[doc(alias = "isSubsetOfSet:")]
-        #[sel(isSubsetOfSet:)]
+        #[method(isSubsetOfSet:)]
         pub fn is_subset(&self, other: &NSSet<T, O>) -> bool;
 
         /// Returns `true` if the set is a superset of another, i.e., `self`
@@ -325,7 +325,7 @@ extern_methods!(
             other.is_subset(self)
         }
 
-        #[sel(intersectsSet:)]
+        #[method(intersectsSet:)]
         fn intersects_set(&self, other: &NSSet<T, O>) -> bool;
 
         /// Returns `true` if `self` has no elements in common with `other`.

--- a/objc2/src/foundation/string.rs
+++ b/objc2/src/foundation/string.rs
@@ -118,7 +118,7 @@ extern_methods!(
         ///
         /// See also [`NSString::len`].
         #[doc(alias = "length")]
-        #[sel(length)]
+        #[method(length)]
         pub fn len_utf16(&self) -> usize;
 
         pub fn is_empty(&self) -> bool {
@@ -248,7 +248,7 @@ extern_methods!(
         /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsstring/1410309-hasprefix?language=objc).
         #[doc(alias = "hasPrefix")]
         #[doc(alias = "hasPrefix:")]
-        #[sel(hasPrefix:)]
+        #[method(hasPrefix:)]
         pub fn has_prefix(&self, prefix: &NSString) -> bool;
 
         /// Whether the given string matches the ending characters of this string.
@@ -256,7 +256,7 @@ extern_methods!(
         /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsstring/1416529-hassuffix?language=objc).
         #[doc(alias = "hasSuffix")]
         #[doc(alias = "hasSuffix:")]
-        #[sel(hasSuffix:)]
+        #[method(hasSuffix:)]
         pub fn has_suffix(&self, suffix: &NSString) -> bool;
 
         // TODO: Other comparison methods:
@@ -267,14 +267,14 @@ extern_methods!(
         // - caseInsensitiveCompare:
         // - localizedCaseInsensitiveCompare:
         // - localizedStandardCompare:
-        #[sel(compare:)]
+        #[method(compare:)]
         fn compare(&self, other: &Self) -> NSComparisonResult;
 
         // pub fn from_nsrange(range: NSRange) -> Id<Self, Shared>
         // https://developer.apple.com/documentation/foundation/1415155-nsstringfromrange?language=objc
 
         // TODO: Safety
-        #[sel(writeToFile:atomically:encoding:error:)]
+        #[method(writeToFile:atomically:encoding:error:)]
         pub unsafe fn write_to_file(
             &self,
             path: &NSString,

--- a/objc2/src/foundation/thread.rs
+++ b/objc2/src/foundation/thread.rs
@@ -40,7 +40,7 @@ extern_methods!(
         }
 
         /// Returns `true` if the thread is the main thread.
-        #[sel(isMainThread)]
+        #[method(isMainThread)]
         pub fn is_main(&self) -> bool;
 
         /// The name of the thread.
@@ -52,13 +52,13 @@ extern_methods!(
             unsafe { msg_send_id![Self::class(), new] }
         }
 
-        #[sel(start)]
+        #[method(start)]
         unsafe fn start(&self);
 
-        #[sel(isMainThread)]
+        #[method(isMainThread)]
         fn is_current_main() -> bool;
 
-        #[sel(isMultiThreaded)]
+        #[method(isMultiThreaded)]
         fn is_global_multi() -> bool;
     }
 );

--- a/objc2/src/foundation/uuid.rs
+++ b/objc2/src/foundation/uuid.rs
@@ -63,7 +63,7 @@ extern_methods!(
             unsafe { msg_send_id![Self::alloc(), initWithUUIDString: string] }
         }
 
-        #[sel(getUUIDBytes:)]
+        #[method(getUUIDBytes:)]
         fn get_bytes_raw(&self, bytes: &mut UuidBytes);
 
         pub fn as_bytes(&self) -> [u8; 16] {

--- a/objc2/src/foundation/value.rs
+++ b/objc2/src/foundation/value.rs
@@ -188,7 +188,7 @@ extern_methods!(
             }
         }
 
-        #[sel(isEqualToValue:)]
+        #[method(isEqualToValue:)]
         fn is_equal_to_value(&self, other: &Self) -> bool;
     }
 );

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -47,7 +47,7 @@
 /// particular, if you use `self` your method will be registered as an
 /// instance method, and if you don't it will be registered as a class method.
 ///
-/// The desired selector can be specified using the `#[sel(my:selector:)]`
+/// The desired selector can be specified using the `#[method(my:selector:)]`
 /// attribute, similar to the [`extern_methods!`] macro.
 ///
 /// A transformation step is performed on the functions (to make them have the
@@ -139,7 +139,7 @@
 ///     }
 ///
 ///     unsafe impl MyCustomObject {
-///         #[sel(initWithFoo:)]
+///         #[method(initWithFoo:)]
 ///         fn init_with(&mut self, foo: u8) -> Option<&mut Self> {
 ///             let this: Option<&mut Self> = unsafe {
 ///                 msg_send![super(self), init]
@@ -167,24 +167,24 @@
 ///             })
 ///         }
 ///
-///         #[sel(foo)]
+///         #[method(foo)]
 ///         fn __get_foo(&self) -> u8 {
 ///             *self.foo
 ///         }
 ///
-///         #[sel(string)]
+///         #[method(string)]
 ///         fn __get_string(&self) -> *mut NSString {
 ///             Id::autorelease_return((*self.string).copy())
 ///         }
 ///
-///         #[sel(myClassMethod)]
+///         #[method(myClassMethod)]
 ///         fn __my_class_method() -> bool {
 ///             true
 ///         }
 ///     }
 ///
 ///     unsafe impl Protocol<NSCopying> for MyCustomObject {
-///         #[sel(copyWithZone:)]
+///         #[method(copyWithZone:)]
 ///         fn copy_with_zone(&self, _zone: *const NSZone) -> *mut Self {
 ///             let mut obj = Self::new(*self.foo);
 ///             *obj.bar = *self.bar;

--- a/objc2/src/macros/extern_class.rs
+++ b/objc2/src/macros/extern_class.rs
@@ -397,10 +397,10 @@ macro_rules! __inner_extern_class {
 #[macro_export]
 macro_rules! __attribute_helper {
     // Convert a set of attributes described with `@[...]` to `#[...]`, while
-    // parsing out the `sel(...)` attribute.
+    // parsing out the `method(...)` attribute.
     {
         @strip_sel
-        @[sel($($_sel_args:tt)*)]
+        @[method($($_sel_args:tt)*)]
         $(@[$($m_rest:tt)*])*
 
         $(#[$($m:tt)*])*
@@ -440,12 +440,12 @@ macro_rules! __attribute_helper {
         $($fn)*
     };
 
-    // Extract the `#[sel(...)]` attribute and send it to another macro
+    // Extract the `#[method(...)]` attribute and send it to another macro
     {
         @extract_sel
         ($out_macro:path)
         (
-            #[sel($($sel:tt)*)]
+            #[method($($sel:tt)*)]
             $($rest:tt)*
         )
         $($macro_args:tt)*
@@ -482,13 +482,13 @@ macro_rules! __attribute_helper {
         ()
         $($macro_args:tt)*
     } => {{
-        compile_error!("Must specify the desired selector using `#[sel(...)]`");
+        compile_error!("Must specify the desired selector using `#[method(...)]`");
     }};
 
     {
         @extract_sel_duplicate
         (
-            #[sel($($_sel_args:tt)*)]
+            #[method($($_sel_args:tt)*)]
             $($rest:tt)*
         )
         $($output:tt)*

--- a/objc2/src/macros/extern_methods.rs
+++ b/objc2/src/macros/extern_methods.rs
@@ -13,7 +13,7 @@
 /// method will assumbed to be an instance method, and if you don't it will be
 /// assumed to be a class method.
 ///
-/// The desired selector can be specified using the `#[sel(my:selector:)]`
+/// The desired selector can be specified using the `#[method(my:selector:)]`
 /// attribute. The name of the function doesn't matter.
 ///
 /// If you specify a function/method with a body, the macro will simply ignore
@@ -25,7 +25,7 @@
 ///
 /// # Safety
 ///
-/// You must ensure that any methods you declare with the `#[sel(...)]`
+/// You must ensure that any methods you declare with the `#[method(...)]`
 /// attribute upholds the safety guarantees decribed in the
 /// [`msg_send!`][crate::msg_send] macro, _or_ are marked `unsafe`.
 ///
@@ -89,24 +89,24 @@
 ///     /// Accessor methods.
 ///     // SAFETY: `first_weekday` is correctly defined
 ///     unsafe impl NSCalendar {
-///         #[sel(firstWeekday)]
+///         #[method(firstWeekday)]
 ///         pub fn first_weekday(&self) -> NSUInteger;
 ///
 ///         pub fn am_symbol(&self) -> Id<NSString, Shared> {
 ///             unsafe { msg_send_id![self, amSymbol] }
 ///         }
 ///
-///         #[sel(date:matchesComponents:)]
+///         #[method(date:matchesComponents:)]
 ///         // `unsafe` because we don't have definitions for `NSDate` and
 ///         // `NSDateComponents` yet, so the user must ensure that is what's
 ///         // passed.
 ///         pub unsafe fn date_matches(&self, date: &NSObject, components: &NSObject) -> bool;
 ///
-///         #[sel(maximumRangeOfUnit:)]
+///         #[method(maximumRangeOfUnit:)]
 ///         pub fn max_range(&self, unit: NSCalendarUnit) -> NSRange;
 ///
 ///         // From `NSKeyValueCoding`
-///         #[sel(validateValue:forKey:error:)]
+///         #[method(validateValue:forKey:error:)]
 ///         pub unsafe fn validate_value_for_key(
 ///             &self,
 ///             value: &mut *mut Object,

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -58,22 +58,22 @@ declare_class!(
     }
 
     unsafe impl RcTestObject {
-        #[sel(newReturningNull)]
+        #[method(newReturningNull)]
         fn new_returning_null() -> *mut Self {
             ptr::null_mut()
         }
 
-        #[sel(newMethodOnInstance)]
+        #[method(newMethodOnInstance)]
         fn new_method_on_instance(&self) -> *mut Self {
             Id::consume_as_ptr(ManuallyDrop::new(Self::new()))
         }
 
-        #[sel(newMethodOnInstanceNull)]
+        #[method(newMethodOnInstanceNull)]
         fn new_method_on_instance_null(&self) -> *mut Self {
             ptr::null_mut()
         }
 
-        #[sel(alloc)]
+        #[method(alloc)]
         fn alloc_() -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().alloc += 1);
             let superclass = NSObject::class().metaclass();
@@ -81,55 +81,55 @@ declare_class!(
             unsafe { msg_send![super(Self::class(), superclass), allocWithZone: zone] }
         }
 
-        #[sel(allocWithZone:)]
+        #[method(allocWithZone:)]
         fn alloc_with_zone(zone: *const NSZone) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().alloc += 1);
             let superclass = NSObject::class().metaclass();
             unsafe { msg_send![super(Self::class(), superclass), allocWithZone: zone] }
         }
 
-        #[sel(allocReturningNull)]
+        #[method(allocReturningNull)]
         fn alloc_returning_null() -> *mut Self {
             ptr::null_mut()
         }
 
-        #[sel(init)]
+        #[method(init)]
         fn init(&mut self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().init += 1);
             unsafe { msg_send![super(self), init] }
         }
 
-        #[sel(initReturningNull)]
+        #[method(initReturningNull)]
         fn init_returning_null(&mut self) -> *mut Self {
             let _: () = unsafe { msg_send![self, release] };
             ptr::null_mut()
         }
 
-        #[sel(retain)]
+        #[method(retain)]
         fn retain(&self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().retain += 1);
             unsafe { msg_send![super(self), retain] }
         }
 
-        #[sel(release)]
+        #[method(release)]
         fn release(&self) {
             TEST_DATA.with(|data| data.borrow_mut().release += 1);
             unsafe { msg_send![super(self), release] }
         }
 
-        #[sel(autorelease)]
+        #[method(autorelease)]
         fn autorelease(&self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().autorelease += 1);
             unsafe { msg_send![super(self), autorelease] }
         }
 
-        #[sel(dealloc)]
+        #[method(dealloc)]
         unsafe fn dealloc(&mut self) {
             TEST_DATA.with(|data| data.borrow_mut().dealloc += 1);
             unsafe { msg_send![super(self), dealloc] }
         }
 
-        #[sel(_tryRetain)]
+        #[method(_tryRetain)]
         unsafe fn try_retain(&self) -> bool {
             TEST_DATA.with(|data| data.borrow_mut().try_retain += 1);
             let res: bool = unsafe { msg_send![super(self), _tryRetain] };
@@ -140,29 +140,29 @@ declare_class!(
             res
         }
 
-        #[sel(copyWithZone:)]
+        #[method(copyWithZone:)]
         fn copy_with_zone(&self, _zone: *const NSZone) -> *const Self {
             TEST_DATA.with(|data| data.borrow_mut().copy += 1);
             Id::consume_as_ptr(ManuallyDrop::new(Self::new()))
         }
 
-        #[sel(mutableCopyWithZone:)]
+        #[method(mutableCopyWithZone:)]
         fn mutable_copy_with_zone(&self, _zone: *const NSZone) -> *const Self {
             TEST_DATA.with(|data| data.borrow_mut().mutable_copy += 1);
             Id::consume_as_ptr(ManuallyDrop::new(Self::new()))
         }
 
-        #[sel(copyReturningNull)]
+        #[method(copyReturningNull)]
         fn copy_returning_null(&self) -> *const Self {
             ptr::null()
         }
 
-        #[sel(methodReturningNull)]
+        #[method(methodReturningNull)]
         fn method_returning_null(&self) -> *const Self {
             ptr::null()
         }
 
-        #[sel(boolAndShouldError:error:)]
+        #[method(boolAndShouldError:error:)]
         fn class_error_bool(should_error: bool, err: Option<&mut *mut RcTestObject>) -> bool {
             if should_error {
                 if let Some(err) = err {
@@ -174,7 +174,7 @@ declare_class!(
             }
         }
 
-        #[sel(boolAndShouldError:error:)]
+        #[method(boolAndShouldError:error:)]
         fn instance_error_bool(
             &self,
             should_error: bool,
@@ -190,7 +190,7 @@ declare_class!(
             }
         }
 
-        #[sel(idAndShouldError:error:)]
+        #[method(idAndShouldError:error:)]
         fn class_error_id(
             should_error: bool,
             err: Option<&mut *mut RcTestObject>,
@@ -205,7 +205,7 @@ declare_class!(
             }
         }
 
-        #[sel(idAndShouldError:error:)]
+        #[method(idAndShouldError:error:)]
         fn instance_error_id(
             &self,
             should_error: bool,
@@ -221,7 +221,7 @@ declare_class!(
             }
         }
 
-        #[sel(newAndShouldError:error:)]
+        #[method(newAndShouldError:error:)]
         fn new_error(should_error: bool, err: Option<&mut *mut RcTestObject>) -> *mut Self {
             if should_error {
                 if let Some(err) = err {
@@ -233,7 +233,7 @@ declare_class!(
             }
         }
 
-        #[sel(allocAndShouldError:error:)]
+        #[method(allocAndShouldError:error:)]
         fn alloc_error(should_error: bool, err: Option<&mut *mut RcTestObject>) -> *mut Self {
             if should_error {
                 if let Some(err) = err {
@@ -245,7 +245,7 @@ declare_class!(
             }
         }
 
-        #[sel(initAndShouldError:error:)]
+        #[method(initAndShouldError:error:)]
         fn init_error(
             &mut self,
             should_error: bool,

--- a/test-ui/ui/extern_methods_missing_method.rs
+++ b/test-ui/ui/extern_methods_missing_method.rs
@@ -1,0 +1,18 @@
+use objc2::{extern_class, extern_methods, ClassType};
+use objc2::foundation::NSObject;
+
+extern_class!(
+    pub struct MyObject;
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        fn a();
+    }
+);
+
+fn main() {}

--- a/test-ui/ui/extern_methods_missing_method.stderr
+++ b/test-ui/ui/extern_methods_missing_method.stderr
@@ -1,0 +1,11 @@
+error: Must specify the desired selector using `#[method(...)]`
+ --> ui/extern_methods_missing_method.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         fn a();
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__attribute_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test-ui/ui/extern_methods_wrong_arguments.rs
+++ b/test-ui/ui/extern_methods_wrong_arguments.rs
@@ -11,42 +11,42 @@ extern_class!(
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(a:)]
+        #[method(a:)]
         fn a();
     }
 );
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(b)]
+        #[method(b)]
         fn b(arg: i32);
     }
 );
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(c:d:e:)]
+        #[method(c:d:e:)]
         fn c(arg1: i32, arg2: u32);
     }
 );
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(f:g:)]
+        #[method(f:g:)]
         fn f();
     }
 );
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(x:)]
+        #[method(x:)]
         fn x(&self);
     }
 );
 
 extern_methods!(
     unsafe impl MyObject {
-        #[sel(y)]
+        #[method(y)]
         fn y(&self, arg: i32);
     }
 );

--- a/test-ui/ui/extern_methods_wrong_arguments.stderr
+++ b/test-ui/ui/extern_methods_wrong_arguments.stderr
@@ -3,7 +3,7 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(b)]
+  | |         #[method(b)]
   | |         fn b(arg: i32);
   | |     }
   | | );
@@ -16,7 +16,7 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(f:g:)]
+  | |         #[method(f:g:)]
   | |         fn f();
   | |     }
   | | );
@@ -29,7 +29,7 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(y)]
+  | |         #[method(y)]
   | |         fn y(&self, arg: i32);
   | |     }
   | | );
@@ -42,7 +42,7 @@ error[E0308]: mismatched types
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(a:)]
+  | |         #[method(a:)]
   | |         fn a();
   | |     }
   | | );
@@ -60,7 +60,7 @@ error[E0308]: mismatched types
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(c:d:e:)]
+  | |         #[method(c:d:e:)]
   | |         fn c(arg1: i32, arg2: u32);
   | |     }
   | | );
@@ -78,7 +78,7 @@ error[E0308]: mismatched types
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[sel(x:)]
+  | |         #[method(x:)]
   | |         fn x(&self);
   | |     }
   | | );


### PR DESCRIPTION
The new name is more descriptive, and allows us to swap it out with an actual attribute macro in the future if desired.