### PR TITLE
Add support for `this` marking an instance method in `extern_methods!`

### DIFF
--- a/objc2/CHANGELOG.md
+++ b/objc2/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Verify in `declare_class!` that protocols are implemented correctly.
 * **BREAKING**: Changed the name of the attribute macro in `extern_methods`
   from `#[sel(...)]` to `#[method(...)]`.
+* **BREAKING**: Changed `extern_methods!` and `declare_class!` such that
+  associated functions whoose first parameter is called `this`, is treated as
+  instance methods instead of class methods.
 
 
 ## 0.3.0-beta.3 - 2022-09-01

--- a/objc2/src/macros/__rewrite_self_arg.rs
+++ b/objc2/src/macros/__rewrite_self_arg.rs
@@ -82,6 +82,74 @@ macro_rules! __rewrite_self_arg {
         }
     };
 
+    // `this: Type` or `_this: Type` instance method
+    // Workaround for arbitary self types being unstable
+    // https://doc.rust-lang.org/nightly/unstable-book/language-features/arbitrary-self-types.html
+    {
+        ($out_macro:path)
+        @(mut this: $__self_ty:ty $(, $($__rest_args:tt)*)?)
+        @(mut $this:ident: $this_ty:ty $(, $($rest:tt)*)?)
+        $($macro_args:tt)*
+    } => {
+        $out_macro! {
+            $($macro_args)*
+            @(instance_method)
+            @(
+                mut $this: $this_ty,
+                _: $crate::runtime::Sel,
+            )
+            @($($($rest)*)?)
+        }
+    };
+    {
+        ($out_macro:path)
+        @(this: $__self_ty:ty $(, $($__rest_args:tt)*)?)
+        @($this:ident: $this_ty:ty $(, $($rest:tt)*)?)
+        $($macro_args:tt)*
+    } => {
+        $out_macro! {
+            $($macro_args)*
+            @(instance_method)
+            @(
+                $this: $this_ty,
+                _: $crate::runtime::Sel,
+            )
+            @($($($rest)*)?)
+        }
+    };
+    {
+        ($out_macro:path)
+        @(mut _this: $__self_ty:ty $(, $($__rest_args:tt)*)?)
+        @(mut $this:ident: $this_ty:ty $(, $($rest:tt)*)?)
+        $($macro_args:tt)*
+    } => {
+        $out_macro! {
+            $($macro_args)*
+            @(instance_method)
+            @(
+                mut $this: $this_ty,
+                _: $crate::runtime::Sel,
+            )
+            @($($($rest)*)?)
+        }
+    };
+    {
+        ($out_macro:path)
+        @(_this: $__self_ty:ty $(, $($__rest_args:tt)*)?)
+        @($this:ident: $this_ty:ty $(, $($rest:tt)*)?)
+        $($macro_args:tt)*
+    } => {
+        $out_macro! {
+            $($macro_args)*
+            @(instance_method)
+            @(
+                $this: $this_ty,
+                _: $crate::runtime::Sel,
+            )
+            @($($($rest)*)?)
+        }
+    };
+
     // Class method
     {
         ($out_macro:path)

--- a/objc2/src/macros/declare_class.rs
+++ b/objc2/src/macros/declare_class.rs
@@ -44,8 +44,9 @@
 /// Within the `impl` block you can define two types of functions;
 /// ["associated functions"] and ["methods"]. These are then mapped to the
 /// Objective-C equivalents "class methods" and "instance methods". In
-/// particular, if you use `self` your method will be registered as an
-/// instance method, and if you don't it will be registered as a class method.
+/// particular, if you use `self` or the special name `this` (or `_this`),
+/// your method will be registered as an instance method, and if you don't it
+/// will be registered as a class method.
 ///
 /// The desired selector can be specified using the `#[method(my:selector:)]`
 /// attribute, similar to the [`extern_methods!`] macro.
@@ -140,9 +141,9 @@
 ///
 ///     unsafe impl MyCustomObject {
 ///         #[method(initWithFoo:)]
-///         fn init_with(&mut self, foo: u8) -> Option<&mut Self> {
+///         fn init_with(this: &mut Self, foo: u8) -> Option<&mut Self> {
 ///             let this: Option<&mut Self> = unsafe {
-///                 msg_send![super(self), init]
+///                 msg_send![super(this), init]
 ///             };
 ///
 ///             // TODO: `ns_string` can't be used inside closures.

--- a/objc2/src/rc/test_object.rs
+++ b/objc2/src/rc/test_object.rs
@@ -94,9 +94,9 @@ declare_class!(
         }
 
         #[method(init)]
-        fn init(&mut self) -> *mut Self {
+        fn init(this: &mut Self) -> *mut Self {
             TEST_DATA.with(|data| data.borrow_mut().init += 1);
-            unsafe { msg_send![super(self), init] }
+            unsafe { msg_send![super(this), init] }
         }
 
         #[method(initReturningNull)]
@@ -153,12 +153,12 @@ declare_class!(
         }
 
         #[method(copyReturningNull)]
-        fn copy_returning_null(&self) -> *const Self {
+        fn copy_returning_null(_this: &Self) -> *const Self {
             ptr::null()
         }
 
         #[method(methodReturningNull)]
-        fn method_returning_null(&self) -> *const Self {
+        fn method_returning_null(self: &Self) -> *const Self {
             ptr::null()
         }
 
@@ -207,7 +207,7 @@ declare_class!(
 
         #[method(idAndShouldError:error:)]
         fn instance_error_id(
-            &self,
+            self: &Self,
             should_error: bool,
             err: Option<&mut *mut RcTestObject>,
         ) -> *mut RcTestObject {
@@ -247,7 +247,7 @@ declare_class!(
 
         #[method(initAndShouldError:error:)]
         fn init_error(
-            &mut self,
+            this: &mut Self,
             should_error: bool,
             err: Option<&mut *mut RcTestObject>,
         ) -> *mut Self {
@@ -255,10 +255,10 @@ declare_class!(
                 if let Some(err) = err {
                     *err = RcTestObject::new().autorelease_inner();
                 }
-                let _: () = unsafe { msg_send![self, release] };
+                let _: () = unsafe { msg_send![this, release] };
                 ptr::null_mut()
             } else {
-                unsafe { msg_send![self, init] }
+                unsafe { msg_send![this, init] }
             }
         }
     }

--- a/test-ui/ui/extern_methods_wrong_arguments.rs
+++ b/test-ui/ui/extern_methods_wrong_arguments.rs
@@ -51,4 +51,18 @@ extern_methods!(
     }
 );
 
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(z:)]
+        fn z(this: &Self);
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(w)]
+        fn w(this: &Self, arg: i32);
+    }
+);
+
 fn main() {}

--- a/test-ui/ui/extern_methods_wrong_arguments.stderr
+++ b/test-ui/ui/extern_methods_wrong_arguments.stderr
@@ -37,6 +37,19 @@ error: Number of arguments in function and selector did not match!
   |
   = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(w)]
+  | |         fn w(this: &Self, arg: i32);
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0308]: mismatched types
  --> ui/extern_methods_wrong_arguments.rs
   |
@@ -80,6 +93,24 @@ error[E0308]: mismatched types
   | |     unsafe impl MyObject {
   | |         #[method(x:)]
   | |         fn x(&self);
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `()`, found enum `Result`
+  |   expected `()` because of default return type
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), Id<_, Shared>>`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(z:)]
+  | |         fn z(this: &Self);
   | |     }
   | | );
   | | ^


### PR DESCRIPTION
Required for #244 as a workaround for [arbitrary self types](https://github.com/rust-lang/rust/issues/44874) or similar not being available.