### PR TITLE
Allow types that are not `Encode` to be used as ivars

### DIFF
--- a/crates/objc2/src/declare.rs
+++ b/crates/objc2/src/declare.rs
@@ -116,6 +116,7 @@ mod declare_class_tests;
 mod ivar;
 mod ivar_drop;
 mod ivar_forwarding_impls;
+mod private_ivar;
 
 use alloc::format;
 use alloc::string::ToString;
@@ -133,8 +134,9 @@ use crate::sel;
 use crate::verify::verify_method_signature;
 use crate::Message;
 
-pub use ivar::{InnerIvarType, Ivar, IvarType};
-pub use ivar_drop::IvarDrop;
+pub use self::ivar::{InnerIvarType, Ivar, IvarType};
+pub use self::ivar_drop::IvarDrop;
+pub use self::private_ivar::PrivateIvar;
 
 pub(crate) mod private {
     pub trait Sealed {}

--- a/crates/objc2/src/declare/private_ivar.rs
+++ b/crates/objc2/src/declare/private_ivar.rs
@@ -1,0 +1,66 @@
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr::NonNull;
+
+use crate::encode::{Encode, Encoding};
+
+use super::InnerIvarType;
+
+/// TODO
+pub struct PrivateIvar<T> {
+    /// For proper variance and auto traits.
+    p: PhantomData<T>,
+}
+
+impl<T: Sized> super::ivar::private::Sealed for PrivateIvar<T> {}
+
+// SAFETY: TODO
+unsafe impl<T: Sized> InnerIvarType for PrivateIvar<T> {
+    const __ENCODING: Encoding = Encoding::Struct(
+        "__objc2_private",
+        &[Encoding::Array(
+            {
+                let size = mem::size_of::<T>();
+                let align = mem::align_of::<T>();
+                if size % align != 0 {
+                    panic!("size was not a multiple of alignment in `PrivateIvar`")
+                }
+                // When calculating size from an encoding, the size will be
+                // multiplied with the alignment of the type below.
+                size / align
+            },
+            // Output an encoding with the given alignment so that code that
+            // uses the encoding to determine alignment can still do so.
+            {
+                const INNER: Encoding = match mem::align_of::<T>() {
+                    1 => i8::ENCODING,
+                    2 => i16::ENCODING,
+                    4 => i32::ENCODING,
+                    8 => i64::ENCODING,
+                    _ => panic!("expected alignment to be one of 1, 2, 4 and 8 in `PrivateIvar`"),
+                };
+                &INNER
+            },
+        )],
+    );
+
+    type __Inner = T;
+    type Output = T;
+
+    const __MAY_DROP: bool = true;
+
+    #[inline]
+    unsafe fn __to_ref(this: &Self::__Inner) -> &Self::Output {
+        this
+    }
+
+    #[inline]
+    unsafe fn __to_mut(this: &mut Self::__Inner) -> &mut Self::Output {
+        this
+    }
+
+    #[inline]
+    fn __to_ptr(inner: NonNull<Self::__Inner>) -> NonNull<Self::Output> {
+        inner.cast()
+    }
+}


### PR DESCRIPTION
WIP.

For this to work properly we'd need some parameter that states whether the instance has been initialized or not yet (since it must be safe to `dealloc` an instance that has not had `init` called on it yet).