### PR TITLE
Add `EncodingBox`, and methods to parse it from a string

### DIFF
--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `EncodingBox` for dynamically creating encodings on the heap.
+
+
 ## 2.0.0-pre.2 - 2022-08-28
 
 ### Added

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Verify that the name in `Encoding::Struct` and
   `Encoding::Union` is a valid C identifier.
 
+### Removed
+* **BREAKING**: `Encoding` no longer implements `Copy`, though it is still
+  `Clone`.
+
 
 ## 2.0.0-pre.2 - 2022-08-28
 

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 * **BREAKING**: `Encoding` no longer implements `Copy`, though it is still
   `Clone`.
+* **BREAKING**: Removed `Encoding::equivalent_to_start_of_str`, since it
+  wasn't really useful.
 
 
 ## 2.0.0-pre.2 - 2022-08-28

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -7,7 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 ### Added
-* Added `EncodingBox` for dynamically creating encodings on the heap.
+* Added `EncodingBox` for dynamically parsing encodings and creating them on
+  the heap.
+* Added `ParseError`, a custom type that represents errors during encoding
+  parsing.
+* Added `Encoding::equivalent_to_box` for comparing `Encoding` and
+  `EncodingBox`.
 
 ### Changed
 * **BREAKING**: Verify that the name in `Encoding::Struct` and

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 * Added `EncodingBox` for dynamically creating encodings on the heap.
 
+### Changed
+* **BREAKING**: Verify that the name in `Encoding::Struct` and
+  `Encoding::Union` is a valid C identifier.
+
 
 ## 2.0.0-pre.2 - 2022-08-28
 

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -252,38 +252,6 @@ fn equivalent_to(enc1: &Encoding, enc2: &Encoding, level: NestingLevel) -> bool 
     }
 }
 
-fn display_fmt(this: &Encoding, f: &mut fmt::Formatter<'_>, level: NestingLevel) -> fmt::Result {
-    use Helper::*;
-    match Helper::new(this) {
-        Primitive(primitive) => f.write_str(primitive.to_str()),
-        BitField(b, _type) => {
-            // TODO: Use the type on GNUStep (nesting level?)
-            write!(f, "b{b}")
-        }
-        Indirection(kind, t) => {
-            write!(f, "{}", kind.prefix())?;
-            display_fmt(t, f, level.indirection(kind))
-        }
-        Array(len, item) => {
-            write!(f, "[")?;
-            write!(f, "{len}")?;
-            display_fmt(item, f, level.array())?;
-            write!(f, "]")
-        }
-        Container(kind, name, fields) => {
-            write!(f, "{}", kind.start())?;
-            write!(f, "{name}")?;
-            if let Some(level) = level.container() {
-                write!(f, "=")?;
-                for field in fields {
-                    display_fmt(field, f, level)?;
-                }
-            }
-            write!(f, "{}", kind.end())
-        }
-    }
-}
-
 /// Formats this [`Encoding`] in a similar way that the `@encode` directive
 /// would ordinarily do.
 ///
@@ -292,7 +260,7 @@ fn display_fmt(this: &Encoding, f: &mut fmt::Formatter<'_>, level: NestingLevel)
 /// Objective-C compilers.
 impl fmt::Display for Encoding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        display_fmt(self, f, NestingLevel::new())
+        Helper::new(self).display_fmt(f, NestingLevel::new())
     }
 }
 

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -418,11 +418,6 @@ mod tests {
             !"{SomeStruct=}";
         }
 
-        fn struct_unicode() {
-            Encoding::Struct("☃", &[Encoding::Char]);
-            "{☃=c}";
-        }
-
         fn pointer_struct() {
             Encoding::Pointer(&Encoding::Struct("SomeStruct", &[Encoding::Char, Encoding::Int]));
             !Encoding::Pointer(&Encoding::Struct("SomeStruct", &[Encoding::Int, Encoding::Char]));
@@ -519,5 +514,28 @@ mod tests {
             );
             "{abc=^[8B](def=@?)^^b255?}";
         }
+
+        fn identifier() {
+            Encoding::Struct("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", &[]);
+            "{_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789=}";
+        }
+    }
+
+    #[test]
+    #[should_panic = "Struct name was not a valid identifier"]
+    fn struct_empty() {
+        let _ = Encoding::Struct("", &[]).to_string();
+    }
+
+    #[test]
+    #[should_panic = "Struct name was not a valid identifier"]
+    fn struct_unicode() {
+        let _ = Encoding::Struct("☃", &[Encoding::Char]).to_string();
+    }
+
+    #[test]
+    #[should_panic = "Union name was not a valid identifier"]
+    fn union_invalid_identifier() {
+        let _ = Encoding::Union("a-b", &[Encoding::Char]).equivalent_to_str("(☃=c)");
     }
 }

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -33,7 +33,8 @@ use crate::parse;
 /// use objc2_encode::Encoding;
 /// assert!(Encoding::Array(10, &Encoding::FloatComplex).equivalent_to_str("[10jf]"));
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+// Not `Copy`, since this may one day contain `Box`
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 // See <https://en.cppreference.com/w/c/language/type>
 #[non_exhaustive] // Maybe we're missing some encodings?
 pub enum Encoding {

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use crate::helper::{compare_encodings, Helper, NestingLevel};
-use crate::parse;
+use crate::parse::Parser;
 
 /// An Objective-C type-encoding.
 ///
@@ -187,15 +187,16 @@ impl Encoding {
     /// See [`Encoding::equivalent_to`] for details about the meaning of
     /// "equivalence".
     pub fn equivalent_to_str(&self, s: &str) -> bool {
-        // strip leading qualifiers
-        let s = s.trim_start_matches(parse::QUALIFIERS);
+        let mut parser = Parser::new(s);
+
+        parser.strip_leading_qualifiers();
 
         // TODO: Allow missing/"?" names in structs and unions?
 
-        if let Some(res) = parse::rm_enc_prefix(s, self, NestingLevel::new()) {
+        if let Some(()) = parser.expect_encoding(self, NestingLevel::new()) {
             // if the given encoding can be successfully removed from the
             // start and an empty string remains, they were fully equivalent!
-            res.is_empty()
+            parser.is_empty()
         } else {
             false
         }

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -187,30 +187,18 @@ impl Encoding {
     /// See [`Encoding::equivalent_to`] for details about the meaning of
     /// "equivalence".
     pub fn equivalent_to_str(&self, s: &str) -> bool {
-        // if the given encoding can be successfully removed from the start
-        // and an empty string remains, they were fully equivalent!
-        if let Some(res) = self.equivalent_to_start_of_str(s) {
-            res.is_empty()
-        } else {
-            false
-        }
-    }
-
-    /// Check if an encoding is equivalent to the start of the given string
-    /// representation.
-    ///
-    /// If it is equivalent, the remaining part of the string is returned.
-    /// Otherwise this returns [`None`].
-    ///
-    /// See [`Encoding::equivalent_to`] for details about the meaning of
-    /// "equivalence".
-    pub fn equivalent_to_start_of_str<'a>(&self, s: &'a str) -> Option<&'a str> {
         // strip leading qualifiers
         let s = s.trim_start_matches(parse::QUALIFIERS);
 
         // TODO: Allow missing/"?" names in structs and unions?
 
-        parse::rm_enc_prefix(s, self, NestingLevel::new())
+        if let Some(res) = parse::rm_enc_prefix(s, self, NestingLevel::new()) {
+            // if the given encoding can be successfully removed from the
+            // start and an empty string remains, they were fully equivalent!
+            res.is_empty()
+        } else {
+            false
+        }
     }
 }
 
@@ -285,7 +273,6 @@ mod tests {
                 // Check equivalence comparisons
                 assert!(E.equivalent_to(&E));
                 assert!(E.equivalent_to_str($string));
-                assert_eq!(E.equivalent_to_start_of_str(concat!($string, "xyz")), Some("xyz"));
                 $(
                     assert!(E.equivalent_to(&$equivalent_encoding));
                     assert!(E.equivalent_to_str(&$equivalent_encoding.to_string()));

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -179,7 +179,7 @@ impl Encoding {
     /// For example, you should not rely on two equivalent encodings to have
     /// the same size or ABI - that is provided on a best-effort basis.
     pub fn equivalent_to(&self, other: &Self) -> bool {
-        compare_encodings(self, other, NestingLevel::new(), false)
+        compare_encodings(self, NestingLevel::new(), other, NestingLevel::new(), false)
     }
 
     /// Check if an encoding is equivalent to the given string representation.
@@ -211,7 +211,7 @@ impl Encoding {
 /// Objective-C compilers.
 impl fmt::Display for Encoding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Helper::new(self).display_fmt(f, NestingLevel::new())
+        write!(f, "{}", Helper::new(self, NestingLevel::new()))
     }
 }
 

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -196,4 +196,21 @@ mod tests {
         assert!(ENC3C.equivalent_to_box(&enc1));
         assert!(ENC3C.equivalent_to_box(&enc2), "now they're equivalent");
     }
+
+    #[test]
+    fn parse_atomic_struct() {
+        let expected = EncodingBox::Atomic(Box::new(EncodingBox::Atomic(Box::new(
+            EncodingBox::Struct("a".into(), Some(Vec::new())),
+        ))));
+        let actual = EncodingBox::from_str("AA{a=}").unwrap();
+        assert_eq!(expected, actual);
+        assert_eq!(expected.to_string(), "AA{a}");
+
+        let expected = EncodingBox::Atomic(Box::new(EncodingBox::Atomic(Box::new(
+            EncodingBox::Struct("a".into(), None),
+        ))));
+        let actual = EncodingBox::from_str("AA{a}").unwrap();
+        assert_eq!(expected, actual);
+        assert_eq!(expected.to_string(), "AA{a}");
+    }
 }

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -1,0 +1,113 @@
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::helper::{Helper, NestingLevel};
+use crate::Encoding;
+
+/// The boxed version of [`Encoding`].
+///
+/// This has exactly the same items as `Encoding`, the only difference is in
+/// where the contents of the more complex encodings like [`Struct`] are
+/// stored.
+///
+/// In `Encoding`, the data is stored in static memory, while in `EncodingBox`
+/// it is stored on the heap. The former allows storing in constants (which is
+/// required by the [`Encode`] and [`RefEncode`] traits), while the latter
+/// allows dynamically, such as in the case of parsing encodings.
+///
+/// **This should be considered a _temporary_ restriction**. `Encoding` and
+/// `EncodingBox` will become equivalent once heap allocation in constants
+/// is possible.
+///
+/// [`Struct`]: Self::Struct
+/// [`Encode`]: crate::Encode
+/// [`RefEncode`]: crate::RefEncode
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive] // Maybe we're missing some encodings?
+pub enum EncodingBox {
+    /// Same as [`Encoding::Char`].
+    Char,
+    /// Same as [`Encoding::Short`].
+    Short,
+    /// Same as [`Encoding::Int`].
+    Int,
+    /// Same as [`Encoding::Long`].
+    Long,
+    /// Same as [`Encoding::LongLong`].
+    LongLong,
+    /// Same as [`Encoding::UChar`].
+    UChar,
+    /// Same as [`Encoding::UShort`].
+    UShort,
+    /// Same as [`Encoding::UInt`].
+    UInt,
+    /// Same as [`Encoding::ULong`].
+    ULong,
+    /// Same as [`Encoding::ULongLong`].
+    ULongLong,
+    /// Same as [`Encoding::Float`].
+    Float,
+    /// Same as [`Encoding::Double`].
+    Double,
+    /// Same as [`Encoding::LongDouble`].
+    LongDouble,
+    /// Same as [`Encoding::FloatComplex`].
+    FloatComplex,
+    /// Same as [`Encoding::DoubleComplex`].
+    DoubleComplex,
+    /// Same as [`Encoding::LongDoubleComplex`].
+    LongDoubleComplex,
+    /// Same as [`Encoding::Bool`].
+    Bool,
+    /// Same as [`Encoding::Void`].
+    Void,
+    /// Same as [`Encoding::String`].
+    String,
+    /// Same as [`Encoding::Object`].
+    Object,
+    /// Same as [`Encoding::Block`].
+    Block,
+    /// Same as [`Encoding::Class`].
+    Class,
+    /// Same as [`Encoding::Sel`].
+    Sel,
+    /// Same as [`Encoding::Unknown`].
+    Unknown,
+    /// Same as [`Encoding::BitField`].
+    BitField(u8, Box<Self>),
+    /// Same as [`Encoding::Pointer`].
+    Pointer(Box<Self>),
+    /// Same as [`Encoding::Atomic`].
+    Atomic(Box<Self>),
+    /// Same as [`Encoding::Array`].
+    Array(usize, Box<Self>),
+    /// Same as [`Encoding::Struct`].
+    Struct(String, Vec<Self>),
+    /// Same as [`Encoding::Union`].
+    Union(String, Vec<Self>),
+}
+
+impl EncodingBox {
+    /// Same as [`Encoding::C_LONG`].
+    pub const C_LONG: Self = match Encoding::C_LONG {
+        Encoding::Long => Self::Long,
+        Encoding::LongLong => Self::LongLong,
+        _ => unreachable!(),
+    };
+
+    /// Same as [`Encoding::C_ULONG`].
+    pub const C_ULONG: Self = match Encoding::C_ULONG {
+        Encoding::ULong => Self::ULong,
+        Encoding::ULongLong => Self::ULongLong,
+        _ => unreachable!(),
+    };
+}
+
+/// Same formatting as [`Encoding`]'s `Display` implementation.
+impl fmt::Display for EncodingBox {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Helper::from_box(self).display_fmt(f, NestingLevel::new())
+    }
+}

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -76,7 +76,7 @@ pub enum EncodingBox {
     /// Same as [`Encoding::Unknown`].
     Unknown,
     /// Same as [`Encoding::BitField`].
-    BitField(u8, Box<Self>),
+    BitField(u8, Option<Box<Self>>),
     /// Same as [`Encoding::Pointer`].
     Pointer(Box<Self>),
     /// Same as [`Encoding::Atomic`].
@@ -84,9 +84,9 @@ pub enum EncodingBox {
     /// Same as [`Encoding::Array`].
     Array(usize, Box<Self>),
     /// Same as [`Encoding::Struct`].
-    Struct(String, Vec<Self>),
+    Struct(String, Option<Vec<Self>>),
     /// Same as [`Encoding::Union`].
-    Union(String, Vec<Self>),
+    Union(String, Option<Vec<Self>>),
 }
 
 impl EncodingBox {
@@ -108,13 +108,13 @@ impl EncodingBox {
 /// Same formatting as [`Encoding`]'s `Display` implementation.
 impl fmt::Display for EncodingBox {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Helper::from_box(self).display_fmt(f, NestingLevel::new())
+        write!(f, "{}", Helper::from_box(self, NestingLevel::new()))
     }
 }
 
 impl PartialEq<Encoding> for EncodingBox {
     fn eq(&self, other: &Encoding) -> bool {
-        compare_encodings(self, other, NestingLevel::new(), true)
+        compare_encodings(self, NestingLevel::new(), other, NestingLevel::new(), true)
     }
 }
 
@@ -147,11 +147,11 @@ mod tests {
         ));
         let enc2 = EncodingBox::Atomic(Box::new(EncodingBox::Struct(
             "test".to_string(),
-            vec![EncodingBox::Array(2, Box::new(EncodingBox::Int))],
+            Some(vec![EncodingBox::Array(2, Box::new(EncodingBox::Int))]),
         )));
         let enc3 = EncodingBox::Atomic(Box::new(EncodingBox::Struct(
             "test".to_string(),
-            vec![EncodingBox::Array(2, Box::new(EncodingBox::Char))],
+            Some(vec![EncodingBox::Array(2, Box::new(EncodingBox::Char))]),
         )));
         assert_eq!(enc1, enc2);
         assert_ne!(enc1, enc3);

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -172,4 +172,28 @@ mod tests {
         assert_eq!(enc1, enc2);
         assert_ne!(enc1, enc3);
     }
+
+    #[test]
+    fn ne_struct_with_without_fields() {
+        let enc1 = EncodingBox::Struct("test".to_string(), Some(vec![EncodingBox::Char]));
+        let enc2 = EncodingBox::Struct("test".to_string(), None);
+        const ENC3A: Encoding = Encoding::Struct("test", &[Encoding::Char]);
+        assert_ne!(enc1, enc2);
+        assert!(ENC3A.equivalent_to_box(&enc1));
+        assert!(!ENC3A.equivalent_to_box(&enc2));
+
+        let enc1 = EncodingBox::Pointer(Box::new(enc1));
+        let enc2 = EncodingBox::Pointer(Box::new(enc2));
+        const ENC3B: Encoding = Encoding::Pointer(&ENC3A);
+        assert_ne!(enc1, enc2);
+        assert!(ENC3B.equivalent_to_box(&enc1));
+        assert!(!ENC3B.equivalent_to_box(&enc2));
+
+        let enc1 = EncodingBox::Pointer(Box::new(enc1));
+        let enc2 = EncodingBox::Pointer(Box::new(enc2));
+        const ENC3C: Encoding = Encoding::Pointer(&ENC3B);
+        assert_ne!(enc1, enc2);
+        assert!(ENC3C.equivalent_to_box(&enc1));
+        assert!(ENC3C.equivalent_to_box(&enc2), "now they're equivalent");
+    }
 }

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -2,8 +2,10 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
+use core::str::FromStr;
 
 use crate::helper::{compare_encodings, Helper, NestingLevel};
+use crate::parse::{ParseError, Parser};
 use crate::Encoding;
 
 /// The boxed version of [`Encoding`].
@@ -121,6 +123,20 @@ impl PartialEq<Encoding> for EncodingBox {
 impl PartialEq<EncodingBox> for Encoding {
     fn eq(&self, other: &EncodingBox) -> bool {
         other.eq(self)
+    }
+}
+
+impl FromStr for EncodingBox {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parser = Parser::new(s);
+        parser.strip_leading_qualifiers();
+
+        parser
+            .parse_encoding()
+            .and_then(|enc| parser.expect_empty().map(|()| enc))
+            .map_err(|err| ParseError::new(parser, err))
     }
 }
 

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -232,7 +232,16 @@ impl ContainerKind {
     }
 }
 
-pub(crate) trait EncodingType: Sized {
+impl fmt::Display for ContainerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Struct => write!(f, "struct"),
+            Self::Union => write!(f, "union"),
+        }
+    }
+}
+
+pub(crate) trait EncodingType: Sized + fmt::Debug {
     fn helper(&self, level: NestingLevel) -> Helper<'_, Self>;
 }
 

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -385,9 +385,9 @@ impl<'a> Helper<'a, EncodingBox> {
             Sel => Self::Primitive(Primitive::Sel),
             Unknown => Self::Primitive(Primitive::Unknown),
             BitField(b, t) => Self::BitField(*b, t.as_deref(), level.bitfield()),
-            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, &t, level.pointer()),
-            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, &t, level.atomic()),
-            Array(len, item) => Self::Array(*len, &item, level.array()),
+            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t, level.pointer()),
+            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t, level.atomic()),
+            Array(len, item) => Self::Array(*len, item, level.array()),
             Struct(name, fields) => {
                 if !verify_name(name) {
                     panic!("Struct name was not a valid identifier");

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use core::write;
 
+use crate::parse::verify_name;
 use crate::Encoding;
 use crate::EncodingBox;
 
@@ -252,8 +253,18 @@ impl Helper<'_> {
             Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t),
             Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t),
             Array(len, item) => Self::Array(*len, item),
-            Struct(name, fields) => Self::Container(ContainerKind::Struct, name, fields),
-            Union(name, members) => Self::Container(ContainerKind::Union, name, members),
+            Struct(name, fields) => {
+                if !verify_name(name) {
+                    panic!("Struct name was not a valid identifier");
+                }
+                Self::Container(ContainerKind::Struct, name, fields)
+            }
+            Union(name, members) => {
+                if !verify_name(name) {
+                    panic!("Union name was not a valid identifier");
+                }
+                Self::Container(ContainerKind::Union, name, members)
+            }
         }
     }
 }
@@ -290,8 +301,18 @@ impl<'a> Helper<'a, EncodingBox> {
             Pointer(t) => Self::Indirection(IndirectionKind::Pointer, &**t),
             Atomic(t) => Self::Indirection(IndirectionKind::Atomic, &**t),
             Array(len, item) => Self::Array(*len, &**item),
-            Struct(name, fields) => Self::Container(ContainerKind::Struct, name, fields),
-            Union(name, members) => Self::Container(ContainerKind::Union, name, members),
+            Struct(name, fields) => {
+                if !verify_name(name) {
+                    panic!("Struct name was not a valid identifier");
+                }
+                Self::Container(ContainerKind::Struct, name, fields)
+            }
+            Union(name, members) => {
+                if !verify_name(name) {
+                    panic!("Union name was not a valid identifier");
+                }
+                Self::Container(ContainerKind::Union, name, members)
+            }
         }
     }
 }

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -90,7 +90,14 @@ pub(crate) fn compare_encodings<E1: EncodingType, E2: EncodingType>(
                     (Some(type1), Some(type2)) => {
                         compare_encodings(type1, level1, type2, level2, include_all)
                     }
-                    _ => true, // TODO
+                    // The type-encoding of a bitfield is always either
+                    // available, or it is not (depends on platform); so if it
+                    // was available in one, but not the other, we should
+                    // compare the encodings unequal.
+                    //
+                    // However, since bitfield types are not really supported
+                    // ATM, we'll do the opposite, and compare them equal.
+                    _ => true,
                 }
         }
         (Indirection(kind1, t1, level1), Indirection(kind2, t2, level2)) => {
@@ -115,7 +122,14 @@ pub(crate) fn compare_encodings<E1: EncodingType, E2: EncodingType>(
                         }
                         true
                     }
-                    _ => false, // TODO
+                    // A bit unsure about this one, but the "safe" default
+                    // here is just to say that one container with items do
+                    // not compare equal to another container without items.
+                    //
+                    // Note that this may be confusing, since a `Pointer` to
+                    // the two containers might suddenly start comparing
+                    // equal, but
+                    _ => false,
                 }
         }
         (_, _) => false,

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -117,3 +117,4 @@ mod static_str;
 pub use self::encode::{Encode, EncodeArguments, EncodeConvert, RefEncode};
 pub use self::encoding::Encoding;
 pub use self::encoding_box::EncodingBox;
+pub use self::parse::ParseError;

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -106,6 +106,7 @@ extern crate alloc;
 pub mod __bool;
 mod encode;
 mod encoding;
+mod encoding_box;
 mod helper;
 mod parse;
 
@@ -115,3 +116,4 @@ mod static_str;
 
 pub use self::encode::{Encode, EncodeArguments, EncodeConvert, RefEncode};
 pub use self::encoding::Encoding;
+pub use self::encoding_box::EncodingBox;

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -42,10 +42,10 @@ pub(crate) fn rm_enc_prefix<'a>(
             let mut s = s;
             s = s.strip_prefix(kind.start())?;
             s = s.strip_prefix(name)?;
-            if let Some(level) = level.container() {
+            if level.include_container_fields() {
                 s = s.strip_prefix('=')?;
                 for field in fields {
-                    s = rm_enc_prefix(s, field, level)?;
+                    s = rm_enc_prefix(s, field, level.container())?;
                 }
             }
             s.strip_prefix(kind.end())

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -16,7 +16,7 @@ pub(crate) const fn verify_name(name: &str) -> bool {
         return true;
     }
 
-    if bytes.len() == 0 {
+    if bytes.is_empty() {
         return false;
     }
 
@@ -267,9 +267,7 @@ impl Parser<'_> {
 
         // Parse name until hits `=`
         let has_items = loop {
-            let b = self
-                .try_peek()
-                .ok_or_else(|| ErrorKind::WrongEndContainer(kind))?;
+            let b = self.try_peek().ok_or(ErrorKind::WrongEndContainer(kind))?;
             if b == b'=' {
                 break true;
             } else if b == kind.end_byte() {
@@ -290,9 +288,7 @@ impl Parser<'_> {
             let mut items = Vec::new();
             // Parse items until hits end
             loop {
-                let b = self
-                    .try_peek()
-                    .ok_or_else(|| ErrorKind::WrongEndContainer(kind))?;
+                let b = self.try_peek().ok_or(ErrorKind::WrongEndContainer(kind))?;
                 if b == kind.end_byte() {
                     self.advance();
                     break;

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -4,6 +4,29 @@
 use crate::helper::{Helper, NestingLevel};
 use crate::Encoding;
 
+/// Check whether a struct or union name is a valid identifier
+pub(crate) const fn verify_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+
+    if let b"?" = bytes {
+        return true;
+    }
+
+    if bytes.len() == 0 {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if !(byte.is_ascii_alphanumeric() || byte == b'_') {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 pub(crate) const QUALIFIERS: &[char] = &[
     'r', // const
     'n', // in

--- a/crates/objc2-encode/src/static_str.rs
+++ b/crates/objc2-encode/src/static_str.rs
@@ -41,23 +41,23 @@ pub(crate) const fn static_int_str_array<const RES: usize>(mut n: u128) -> [u8; 
 pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingLevel) -> usize {
     use Helper::*;
 
-    match Helper::new(encoding) {
+    match Helper::new(encoding, level) {
         Primitive(primitive) => primitive.to_str().len(),
-        BitField(b, _type) => {
+        BitField(b, _type, _level) => {
             // TODO: Use the type on GNUStep (nesting level?)
             1 + static_int_str_len(b as u128)
         }
-        Indirection(kind, t) => 1 + static_encoding_str_len(t, level.indirection(kind)),
-        Array(len, item) => {
-            1 + static_int_str_len(len as u128) + static_encoding_str_len(item, level.array()) + 1
+        Indirection(_kind, t, level) => 1 + static_encoding_str_len(t, level),
+        Array(len, item, level) => {
+            1 + static_int_str_len(len as u128) + static_encoding_str_len(item, level) + 1
         }
-        Container(_, name, items) => {
+        Container(_, name, items, level) => {
             let mut res = 1 + name.len();
-            if level.include_container_fields() {
+            if let Some(items) = items {
                 res += 1;
                 let mut i = 0;
                 while i < items.len() {
-                    res += static_encoding_str_len(&items[i], level.container());
+                    res += static_encoding_str_len(&items[i], level);
                     i += 1;
                 }
             }
@@ -75,7 +75,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
     let mut res: [u8; LEN] = [0; LEN];
     let mut res_i = 0;
 
-    match Helper::new(encoding) {
+    match Helper::new(encoding, level) {
         Primitive(primitive) => {
             let s = primitive.to_str().as_bytes();
             let mut i = 0;
@@ -84,7 +84,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        BitField(b, _type) => {
+        BitField(b, _type, _level) => {
             // TODO: Use the type on GNUStep (nesting level?)
             res[res_i] = b'b';
             res_i += 1;
@@ -98,20 +98,20 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        Indirection(kind, t) => {
+        Indirection(kind, t, level) => {
             res[res_i] = kind.prefix_byte();
             res_i += 1;
 
             let mut i = 0;
             // We use LEN even though it creates an oversized array
-            let arr = static_encoding_str_array::<LEN>(t, level.indirection(kind));
-            while i < static_encoding_str_len(t, level.indirection(kind)) {
+            let arr = static_encoding_str_array::<LEN>(t, level);
+            while i < static_encoding_str_len(t, level) {
                 res[res_i] = arr[i];
                 res_i += 1;
                 i += 1;
             }
         }
-        Array(len, item) => {
+        Array(len, item, level) => {
             let mut res_i = 0;
 
             res[res_i] = b'[';
@@ -128,8 +128,8 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
 
             let mut i = 0;
             // We use LEN even though it creates an oversized array
-            let arr = static_encoding_str_array::<LEN>(item, level.array());
-            while i < static_encoding_str_len(item, level.array()) {
+            let arr = static_encoding_str_array::<LEN>(item, level);
+            while i < static_encoding_str_len(item, level) {
                 res[res_i] = arr[i];
                 res_i += 1;
                 i += 1;
@@ -137,7 +137,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
 
             res[res_i] = b']';
         }
-        Container(kind, name, items) => {
+        Container(kind, name, items, level) => {
             let mut res_i = 0;
 
             res[res_i] = kind.start_byte();
@@ -151,18 +151,17 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 name_i += 1;
             }
 
-            if level.include_container_fields() {
+            if let Some(items) = items {
                 res[res_i] = b'=';
                 res_i += 1;
 
                 let mut items_i = 0;
                 while items_i < items.len() {
                     // We use LEN even though it creates an oversized array
-                    let field_res =
-                        static_encoding_str_array::<LEN>(&items[items_i], level.container());
+                    let field_res = static_encoding_str_array::<LEN>(&items[items_i], level);
 
                     let mut item_res_i = 0;
-                    while item_res_i < static_encoding_str_len(&items[items_i], level.container()) {
+                    while item_res_i < static_encoding_str_len(&items[items_i], level) {
                         res[res_i] = field_res[item_res_i];
                         res_i += 1;
                         item_res_i += 1;

--- a/crates/objc2-encode/src/static_str.rs
+++ b/crates/objc2-encode/src/static_str.rs
@@ -53,11 +53,11 @@ pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingL
         }
         Container(_, name, items) => {
             let mut res = 1 + name.len();
-            if let Some(level) = level.container() {
+            if level.include_container_fields() {
                 res += 1;
                 let mut i = 0;
                 while i < items.len() {
-                    res += static_encoding_str_len(&items[i], level);
+                    res += static_encoding_str_len(&items[i], level.container());
                     i += 1;
                 }
             }
@@ -151,17 +151,18 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 name_i += 1;
             }
 
-            if let Some(level) = level.container() {
+            if level.include_container_fields() {
                 res[res_i] = b'=';
                 res_i += 1;
 
                 let mut items_i = 0;
                 while items_i < items.len() {
                     // We use LEN even though it creates an oversized array
-                    let field_res = static_encoding_str_array::<LEN>(&items[items_i], level);
+                    let field_res =
+                        static_encoding_str_array::<LEN>(&items[items_i], level.container());
 
                     let mut item_res_i = 0;
-                    while item_res_i < static_encoding_str_len(&items[items_i], level) {
+                    while item_res_i < static_encoding_str_len(&items[items_i], level.container()) {
                         res[res_i] = field_res[item_res_i];
                         res_i += 1;
                         item_res_i += 1;

--- a/crates/objc2/src/verify.rs
+++ b/crates/objc2/src/verify.rs
@@ -120,10 +120,12 @@ where
         return Err(Inner::MismatchedArgumentsCount(expected, actual).into());
     }
 
-    for (i, actual) in self_and_cmd.iter().chain(args).copied().enumerate() {
+    for (i, actual) in self_and_cmd.iter().chain(args).enumerate() {
         let expected = method.argument_type(i).unwrap();
         if !actual.equivalent_to_str(&*expected) {
-            return Err(Inner::MismatchedArgument(i, MallocEncoding(expected), actual).into());
+            return Err(
+                Inner::MismatchedArgument(i, MallocEncoding(expected), actual.clone()).into(),
+            );
         }
     }
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,2 +1,4 @@
 target/
 artifacts/
+# This grows very quickly, and doesn't really need to be in-tree
+corpus/encoding_parse/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,6 +22,9 @@ gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9"]
 gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1"]
 
+[workspace]
+members = ["."]
+
 [[bin]]
 name = "class"
 path = "fuzz_targets/class.rs"
@@ -34,5 +37,8 @@ path = "fuzz_targets/sel.rs"
 test = false
 doc = false
 
-[workspace]
-members = ["."]
+[[bin]]
+name = "encoding_parse"
+path = "fuzz_targets/encoding_parse.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/encoding_parse.rs
+++ b/fuzz/fuzz_targets/encoding_parse.rs
@@ -1,0 +1,24 @@
+#![no_main]
+use std::str::FromStr;
+
+use libfuzzer_sys::fuzz_target;
+use objc2::encode::{Encoding, EncodingBox};
+
+fuzz_target!(|s: &str| {
+    // Check that parsing encodings doesn't panic
+    if let Ok(enc) = EncodingBox::from_str(s) {
+        // Check a "negative" case of `equivalent_to_box`
+        if enc != EncodingBox::Char {
+            assert_ne!(EncodingBox::Char, enc, "not equal to char");
+            assert!(!Encoding::Char.equivalent_to_box(&enc), "not equivalent to char");
+        }
+
+        let s2 = enc.to_string();
+        // Note: s and s2 may not be equal!
+
+        // Test roundtrip
+        let enc2 = EncodingBox::from_str(&s2).expect("parsing valid encoding string");
+        let s3 = enc2.to_string();
+        assert_eq!(s2, s3);
+    }
+});


### PR DESCRIPTION
Required for https://github.com/madsmtm/objc2/pull/198.

This requires us to reimplement a few things from the Objective-C runtime, but that functionality is broken for complex types anyhow, and doing this ourselves will hopefully allow us to make _much_ better error messages in the future.