### PR TITLE
Move `objc2::foundation` to `icrate::Foundation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
       ARGS: --no-default-features --features=std,${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
-      SOME_FEATURES: ${{ matrix.features || 'malloc,block,exception,foundation' }}
-      FEATURES: ${{ matrix.features || 'malloc,block,exception,foundation,catch-all,verify,uuid' }}
+      SOME_FEATURES: ${{ matrix.features || 'malloc,block,exception,Foundation' }}
+      FEATURES: ${{ matrix.features || 'malloc,block,exception,Foundation,catch-all,verify,uuid' }}
       UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind' }}
       CMD: cargo
 
@@ -428,7 +428,7 @@ jobs:
 
     - name: Test static class and selectors
       if: ${{ !matrix.dinghy && (matrix.runtime || 'apple') == 'apple' }}
-      run: cargo test ${{ env.ARGS }} ${{ env.TESTARGS }} --features=foundation,unstable-static-sel,unstable-static-class
+      run: cargo test ${{ env.ARGS }} ${{ env.TESTARGS }} --features=Foundation,unstable-static-sel,unstable-static-class
 
     - name: Run assembly tests
       if: ${{ !contains(matrix.runtime, 'compiler-rt') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
       SOME_FEATURES: ${{ matrix.features || 'malloc,block,exception,Foundation' }}
-      FEATURES: ${{ matrix.features || 'malloc,block,exception,Foundation,catch-all,verify,uuid' }}
+      FEATURES: ${{ matrix.features || 'malloc,block,exception,unstable-all-frameworks,catch-all,verify,uuid' }}
       UNSTABLE_FEATURES: ${{ matrix.unstable-features || 'unstable-autoreleasesafe,unstable-c-unwind' }}
       CMD: cargo
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ appreciated!
 ## Crate overview
 
 The core crate is [`objc2`], which contains everything you need to interface
-with Objective-C. It also provides safe abstraction over (parts of) the
-Foundation Framework, since that is used in almost all Objective-C code.
+with Objective-C. [`icrate`] then use that to provide a safe abstraction over
+(parts of) the Foundation Framework, since that is used in almost all
+Objective-C code.
 
 [`block2`] has a bit of a weird position in all of this: Apple's C language
 extension of blocks is _technically_ not limited to being used in Objective-C,
@@ -21,11 +22,12 @@ though in practice that's the only place it's used, so it makes sense to
 develop these together.
 
 [`objc2-encode`] is really just a part of `objc2`, it mostly exists as a
-separate crate to help people cutting down on unneeded dependencies.
+separate crate to help users of it cutting down on unneeded dependencies.
 [`objc-sys`] and [`block-sys`] contain raw bindings to the underlying C
 runtime libraries.
 
 [`objc2`]: ./crates/objc2
+[`icrate`]: ./crates/icrate
 [`block2`]: ./crates/block2
 [`objc2-encode`]: ./crates/objc2-encode
 [`objc-sys`]: ./crates/objc-sys
@@ -49,8 +51,8 @@ objc = { package = "objc2", version = "0.2.7" }
 
 Afterwards, you can upgrade to the next release, in this case
 `v0.3.0-alpha.0`, and make the required changes to your code (the
-[changelog](crates/objc2/CHANGELOG.md) contains recommendations for this). And so on,
-with every following release.
+[changelog](crates/objc2/CHANGELOG.md) contains recommendations for this). And
+so on, with every following release.
 
 
 ## Goals

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ fork [here][origin-issue-101]:
 - [`objc_id`](https://github.com/SSheldon/rust-objc-id)
   - Moved to `objc2::rc`.
 - [`objc-foundation`](https://github.com/SSheldon/rust-objc-foundation)
-  - Moved to `objc2::foundation`.
+  - Moved to `icrate::Foundation`.
 - [`block`](https://github.com/SSheldon/rust-block)
   - Renamed to `block2`.
 

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -1,22 +1,27 @@
 # Changelog
 
-Changes to the `objc2::foundation` module will be documented in this file.
-This previously existed as a separate crate `objc2_foundation`, hence the
-separation.
+Changes to `icrate` will be documented in this file.
+
+This previously existed as a separate crate `objc2_foundation`, later it was
+integrated into `objc2::foundation`, and later again split out - hence the
+confusing versioning.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased - YYYY-MM-DD
+## icrate Unreleased - YYYY-MM-DD
 
 ### Added
 * Added `NSString::write_to_file`.
 * Added `NSLock` class and `NSLocking` protocol.
 
+### Changed
+* **BREAKING**: Moved from `objc2::foundation` into `icrate::Foundation`.
+
 ### Fixed
 * Fixed `NSZone` not being `#[repr(C)]`.
 
 
-## objc2 0.3.0-beta.3 - 2022-09-01
+## objc2::foundation 0.3.0-beta.3 - 2022-09-01
 
 ### Added
 * Added `NSSet`.
@@ -36,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   binding to requires a non-negative size.
 
 
-## objc2 0.3.0-beta.2 - 2022-08-28
+## objc2::foundation 0.3.0-beta.2 - 2022-08-28
 
 ### Added
 * Added `NSNumber`.

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -27,7 +27,7 @@ uuid = { version = "1.1.2", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
-all-features = true
+features = ["block", "objective-c", "uuid", "unstable-all-frameworks", "unstable-docsrs"]
 
 targets = [
     # MacOS
@@ -81,7 +81,7 @@ gnustep-2-1 = ["gnustep-2-0", "objc2?/gnustep-2-1", "block2?/gnustep-2-1"]
 objective-c = ["objc2"]
 
 # Expose features that requires creating blocks.
-blocks = ["objc2?/block", "block2"]
+block = ["objc2?/block", "block2"]
 
 # For better documentation on docs.rs
 unstable-docsrs = []
@@ -91,4 +91,5 @@ unstable-docsrs = []
 AppKit = ["Foundation", "CoreData"]
 AuthenticationServices = ["Foundation"]
 CoreData = ["Foundation"]
-Foundation = ["objective-c", "blocks"]
+Foundation = ["objective-c", "block"]
+unstable-all-frameworks = ["AppKit", "AuthenticationServices", "CoreData", "Foundation"]

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -43,6 +43,22 @@ targets = [
     "x86_64-pc-windows-msvc",
 ]
 
+[[example]]
+name = "basic_usage"
+required-features = ["Foundation"]
+
+[[example]]
+name = "delegate"
+required-features = ["apple", "Foundation"]
+
+[[example]]
+name = "speech_synthesis"
+required-features = ["apple", "Foundation"]
+
+[[example]]
+name = "nspasteboard"
+required-features = ["apple", "Foundation"]
+
 [features]
 default = ["std", "apple"]
 

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -22,6 +22,9 @@ license = "MIT"
 objc2 = { path = "../objc2", version = "=0.3.0-beta.3", default-features = false, optional = true }
 block2 = { path = "../block2", version = "=0.2.0-alpha.6", default-features = false, optional = true }
 
+# Provide methods to convert between `uuid::Uuid` and `icrate::Foundation::NSUUID`
+uuid = { version = "1.1.2", optional = true, default-features = false }
+
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 all-features = true
@@ -88,4 +91,4 @@ unstable-docsrs = []
 AppKit = ["Foundation", "CoreData"]
 AuthenticationServices = ["Foundation"]
 CoreData = ["Foundation"]
-Foundation = ["objective-c", "blocks", "objc2/foundation"]
+Foundation = ["objective-c", "blocks"]

--- a/crates/icrate/examples/basic_usage.rs
+++ b/crates/icrate/examples/basic_usage.rs
@@ -1,5 +1,6 @@
+use icrate::ns_string;
 use icrate::objc2::rc::autoreleasepool;
-use icrate::Foundation::{ns_string, NSArray, NSDictionary, NSObject};
+use icrate::Foundation::{NSArray, NSDictionary, NSObject};
 
 fn main() {
     // Create and compare NSObjects

--- a/crates/icrate/examples/basic_usage.rs
+++ b/crates/icrate/examples/basic_usage.rs
@@ -1,6 +1,5 @@
-use objc2::foundation::{NSArray, NSDictionary, NSObject};
-use objc2::ns_string;
-use objc2::rc::autoreleasepool;
+use icrate::objc2::rc::autoreleasepool;
+use icrate::Foundation::{ns_string, NSArray, NSDictionary, NSObject};
 
 fn main() {
     // Create and compare NSObjects

--- a/crates/icrate/examples/delegate.rs
+++ b/crates/icrate/examples/delegate.rs
@@ -1,9 +1,10 @@
 #![cfg_attr(not(target_os = "macos"), allow(unused))]
+use icrate::ns_string;
 use icrate::objc2::declare::{Ivar, IvarDrop};
 use icrate::objc2::rc::{Id, Shared};
 use icrate::objc2::runtime::Object;
 use icrate::objc2::{declare_class, extern_class, msg_send, msg_send_id, ClassType};
-use icrate::Foundation::{ns_string, NSCopying, NSObject, NSString};
+use icrate::Foundation::{NSCopying, NSObject, NSString};
 
 #[cfg(target_os = "macos")]
 #[link(name = "AppKit", kind = "framework")]

--- a/crates/icrate/examples/delegate.rs
+++ b/crates/icrate/examples/delegate.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(not(target_os = "macos"), allow(unused))]
-use objc2::declare::{Ivar, IvarDrop};
-use objc2::foundation::{NSCopying, NSObject, NSString};
-use objc2::rc::{Id, Shared};
-use objc2::runtime::Object;
-use objc2::{declare_class, extern_class, msg_send, msg_send_id, ns_string, ClassType};
+use icrate::objc2::declare::{Ivar, IvarDrop};
+use icrate::objc2::rc::{Id, Shared};
+use icrate::objc2::runtime::Object;
+use icrate::objc2::{declare_class, extern_class, msg_send, msg_send_id, ClassType};
+use icrate::Foundation::{ns_string, NSCopying, NSObject, NSString};
 
 #[cfg(target_os = "macos")]
 #[link(name = "AppKit", kind = "framework")]

--- a/crates/icrate/examples/nspasteboard.rs
+++ b/crates/icrate/examples/nspasteboard.rs
@@ -6,10 +6,10 @@
 
 use std::mem::ManuallyDrop;
 
-use objc2::foundation::{NSArray, NSDictionary, NSInteger, NSObject, NSString};
-use objc2::rc::{Id, Shared};
-use objc2::runtime::{Class, Object};
-use objc2::{extern_class, msg_send, msg_send_id, ClassType};
+use icrate::objc2::rc::{Id, Shared};
+use icrate::objc2::runtime::{Class, Object};
+use icrate::objc2::{extern_class, msg_send, msg_send_id, ClassType};
+use icrate::Foundation::{NSArray, NSDictionary, NSInteger, NSObject, NSString};
 
 type NSPasteboardType = NSString;
 type NSPasteboardReadingOptionKey = NSString;

--- a/crates/icrate/examples/nspasteboard.rs
+++ b/crates/icrate/examples/nspasteboard.rs
@@ -63,7 +63,7 @@ impl NSPasteboard {
     /// <https://developer.apple.com/documentation/appkit/nspasteboard/1524454-readobjectsforclasses?language=objc>
     pub fn text_impl_2(&self) -> Id<NSString, Shared> {
         // The NSPasteboard API is a bit weird, it requires you to pass
-        // classes as objects, which `objc2::foundation::NSArray` was not
+        // classes as objects, which `icrate::Foundation::NSArray` was not
         // really made for - so we convert the class to an `Object` type
         // instead. Also, we wrap it in `ManuallyDrop` because I'm not sure
         // how classes handle `release` calls?

--- a/crates/icrate/examples/speech_synthesis.rs
+++ b/crates/icrate/examples/speech_synthesis.rs
@@ -12,13 +12,14 @@
 use std::thread;
 use std::time::Duration;
 
-use objc2::foundation::{NSObject, NSString};
-use objc2::rc::{Id, Owned};
-use objc2::{extern_class, msg_send, msg_send_id, ns_string, ClassType};
+use icrate::objc2::rc::{Id, Owned};
+use icrate::objc2::{extern_class, msg_send, msg_send_id, ClassType};
+use icrate::Foundation::{ns_string, NSObject, NSString};
 
 #[cfg(target_os = "macos")]
 mod appkit {
-    use objc2::{foundation::NSCopying, rc::Shared};
+    use icrate::objc2::rc::Shared;
+    use icrate::Foundation::NSCopying;
 
     use super::*;
 

--- a/crates/icrate/examples/speech_synthesis.rs
+++ b/crates/icrate/examples/speech_synthesis.rs
@@ -12,9 +12,10 @@
 use std::thread;
 use std::time::Duration;
 
+use icrate::ns_string;
 use icrate::objc2::rc::{Id, Owned};
 use icrate::objc2::{extern_class, msg_send, msg_send_id, ClassType};
-use icrate::Foundation::{ns_string, NSObject, NSString};
+use icrate::Foundation::{NSObject, NSString};
 
 #[cfg(target_os = "macos")]
 mod appkit {

--- a/crates/icrate/src/Foundation/additions/__ns_string.rs
+++ b/crates/icrate/src/Foundation/additions/__ns_string.rs
@@ -256,8 +256,7 @@ impl CachedNSString {
 /// ```
 /// use icrate::ns_string;
 /// use icrate::Foundation::NSString;
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
+///
 /// let hello: &'static NSString = ns_string!("hello");
 /// assert_eq!(hello.to_string(), "hello");
 ///
@@ -275,8 +274,6 @@ impl CachedNSString {
 ///
 /// ```
 /// # use icrate::ns_string;
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// let hello_ru = ns_string!("Привет");
 /// assert_eq!(hello_ru.to_string(), "Привет");
 /// ```
@@ -293,8 +290,6 @@ impl CachedNSString {
 ///
 /// ```
 /// # use icrate::ns_string;
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// let example = ns_string!("example\0");
 /// assert_eq!(example.to_string(), "example\0");
 ///

--- a/crates/icrate/src/Foundation/additions/__ns_string.rs
+++ b/crates/icrate/src/Foundation/additions/__ns_string.rs
@@ -17,9 +17,9 @@ use core::mem::ManuallyDrop;
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-use crate::foundation::NSString;
-use crate::rc::Id;
-use crate::runtime::Class;
+use crate::Foundation::NSString;
+use objc2::rc::Id;
+use objc2::runtime::Class;
 
 // This is defined in CoreFoundation, but we don't emit a link attribute
 // here because it is already linked via Foundation.
@@ -239,7 +239,7 @@ impl CachedNSString {
     }
 }
 
-/// Creates an [`NSString`][`crate::foundation::NSString`] from a static string.
+/// Creates an [`NSString`][`crate::Foundation::NSString`] from a static string.
 ///
 /// Note: This works by placing statics in special sections, which may not
 /// work completely reliably yet, see [#258]; until then, you should be
@@ -254,8 +254,8 @@ impl CachedNSString {
 /// the argument, and produces a `&'static NSString`:
 ///
 /// ```
-/// use objc2::ns_string;
-/// use objc2::foundation::NSString;
+/// use icrate::ns_string;
+/// use icrate::Foundation::NSString;
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// let hello: &'static NSString = ns_string!("hello");
@@ -274,7 +274,7 @@ impl CachedNSString {
 /// string to the most efficient encoding, you don't have to do anything!
 ///
 /// ```
-/// # use objc2::ns_string;
+/// # use icrate::ns_string;
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// let hello_ru = ns_string!("Привет");
@@ -292,7 +292,7 @@ impl CachedNSString {
 /// expect:
 ///
 /// ```
-/// # use objc2::ns_string;
+/// # use icrate::ns_string;
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// let example = ns_string!("example\0");
@@ -312,8 +312,8 @@ impl CachedNSString {
 /// Because of that, this should be preferred over [`NSString::from_str`]
 /// where possible.
 ///
-/// [`NSString::from_str`]: crate::foundation::NSString::from_str
-#[cfg(feature = "foundation")] // For auto_doc_cfg
+/// [`NSString::from_str`]: crate::Foundation::NSString::from_str
+#[cfg(feature = "Foundation")] // For auto_doc_cfg
 #[macro_export]
 macro_rules! ns_string {
     ($s:expr) => {{
@@ -362,7 +362,7 @@ macro_rules! __ns_string_inner {
         // The full UTF-16 contents along with the written length.
         const UTF16_FULL: (&[u16; $inp.len()], usize) = {
             let mut out = [0u16; $inp.len()];
-            let mut iter = $crate::foundation::__ns_string::EncodeUtf16Iter::new($inp);
+            let mut iter = $crate::Foundation::__ns_string::EncodeUtf16Iter::new($inp);
             let mut written = 0;
 
             while let Some((state, chars)) = iter.next() {
@@ -403,17 +403,17 @@ macro_rules! __ns_string_inner {
         // The section is the same as what clang sets, see:
         // https://github.com/llvm/llvm-project/blob/release/13.x/clang/lib/CodeGen/CodeGenModule.cpp#L5243
         #[link_section = "__DATA,__cfstring"]
-        static CFSTRING: $crate::foundation::__ns_string::CFConstString = unsafe {
-            if $crate::foundation::__ns_string::is_ascii_no_nul($inp) {
+        static CFSTRING: $crate::Foundation::__ns_string::CFConstString = unsafe {
+            if $crate::Foundation::__ns_string::is_ascii_no_nul($inp) {
                 // This is technically an optimization (UTF-16 strings are
                 // always valid), but it's a fairly important one!
-                $crate::foundation::__ns_string::CFConstString::new_ascii(
-                    &$crate::foundation::__ns_string::__CFConstantStringClassReference,
+                $crate::Foundation::__ns_string::CFConstString::new_ascii(
+                    &$crate::Foundation::__ns_string::__CFConstantStringClassReference,
                     &ASCII,
                 )
             } else {
-                $crate::foundation::__ns_string::CFConstString::new_utf16(
-                    &$crate::foundation::__ns_string::__CFConstantStringClassReference,
+                $crate::Foundation::__ns_string::CFConstString::new_utf16(
+                    &$crate::Foundation::__ns_string::__CFConstantStringClassReference,
                     &UTF16,
                 )
             }
@@ -426,7 +426,7 @@ macro_rules! __ns_string_inner {
 #[macro_export]
 macro_rules! __ns_string_inner {
     ($inp:ident) => {{
-        use $crate::foundation::__ns_string::CachedNSString;
+        use $crate::Foundation::__ns_string::CachedNSString;
         static CACHED_NSSTRING: CachedNSString = CachedNSString::new();
         CACHED_NSSTRING.get($inp)
     }};

--- a/crates/icrate/src/Foundation/additions/array.rs
+++ b/crates/icrate/src/Foundation/additions/array.rs
@@ -8,9 +8,9 @@ use super::{
     NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableArray, NSMutableCopying,
     NSObject, NSRange,
 };
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::runtime::Object;
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
+use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use objc2::runtime::Object;
+use objc2::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
 
 __inner_extern_class!(
     /// An immutable ordered collection of objects.
@@ -306,8 +306,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::*;
-    use crate::foundation::{NSNumber, NSString};
-    use crate::rc::{RcTestObject, ThreadTestData};
+    use crate::Foundation::{NSNumber, NSString};
+    use objc2::rc::{__RcTestObject, __ThreadTestData};
 
     fn sample_array(len: usize) -> Id<NSArray<NSObject, Owned>, Owned> {
         let mut vec = Vec::with_capacity(len);
@@ -377,8 +377,8 @@ mod tests {
 
     #[test]
     fn test_retains_stored() {
-        let obj = Id::into_shared(RcTestObject::new());
-        let mut expected = ThreadTestData::current();
+        let obj = Id::into_shared(__RcTestObject::new());
+        let mut expected = __ThreadTestData::current();
 
         let input = [obj.clone(), obj.clone()];
         expected.retain += 2;
@@ -417,9 +417,9 @@ mod tests {
 
     #[test]
     fn test_nscopying_uses_retain() {
-        let obj = Id::into_shared(RcTestObject::new());
+        let obj = Id::into_shared(__RcTestObject::new());
         let array = NSArray::from_slice(&[obj]);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let _copy = array.copy();
         expected.assert_current();
@@ -435,9 +435,9 @@ mod tests {
         ignore = "this works differently on different framework versions"
     )]
     fn test_iter_no_retain() {
-        let obj = Id::into_shared(RcTestObject::new());
+        let obj = Id::into_shared(__RcTestObject::new());
         let array = NSArray::from_slice(&[obj]);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let iter = array.iter();
         expected.retain += 0;

--- a/crates/icrate/src/Foundation/additions/attributed_string.rs
+++ b/crates/icrate/src/Foundation/additions/attributed_string.rs
@@ -4,9 +4,9 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use super::{
     NSCopying, NSDictionary, NSMutableAttributedString, NSMutableCopying, NSObject, NSString,
 };
-use crate::rc::{Allocated, DefaultId, Id, Shared};
-use crate::runtime::Object;
-use crate::{extern_class, extern_methods, ClassType};
+use objc2::rc::{Allocated, DefaultId, Id, Shared};
+use objc2::runtime::Object;
+use objc2::{extern_class, extern_methods, ClassType};
 
 extern_class!(
     /// A string that has associated attributes for portions of its text.
@@ -150,7 +150,7 @@ mod tests {
     use alloc::{format, vec};
 
     use super::*;
-    use crate::rc::{autoreleasepool, Owned};
+    use objc2::rc::{autoreleasepool, Owned};
 
     #[test]
     fn test_new() {

--- a/crates/icrate/src/Foundation/additions/bundle.rs
+++ b/crates/icrate/src/Foundation/additions/bundle.rs
@@ -2,8 +2,8 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSDictionary, NSObject, NSString};
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, ClassType};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, ClassType};
 
 extern_class!(
     /// A representation of the code and resources stored in a bundle

--- a/crates/icrate/src/Foundation/additions/comparison_result.rs
+++ b/crates/icrate/src/Foundation/additions/comparison_result.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use crate::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 /// Constants that indicate sort order.
 ///

--- a/crates/icrate/src/Foundation/additions/copying.rs
+++ b/crates/icrate/src/Foundation/additions/copying.rs
@@ -1,5 +1,5 @@
-use crate::rc::{Id, Owned, Ownership};
-use crate::{msg_send_id, Message};
+use objc2::rc::{Id, Owned, Ownership};
+use objc2::{msg_send_id, Message};
 
 pub unsafe trait NSCopying: Message {
     /// Indicates whether the type is mutable or immutable.
@@ -21,7 +21,7 @@ pub unsafe trait NSCopying: Message {
     /// `copy` message (and others) does not create a new instance, but
     /// instead just retains the instance).
     ///
-    /// [`NSString`]: crate::foundation::NSString
+    /// [`NSString`]: crate::Foundation::NSString
     type Ownership: Ownership;
 
     /// The output type.

--- a/crates/icrate/src/Foundation/additions/data.rs
+++ b/crates/icrate/src/Foundation/additions/data.rs
@@ -7,9 +7,9 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::slice::{self, SliceIndex};
 
 use super::{NSCopying, NSMutableCopying, NSMutableData, NSObject};
-use crate::rc::{DefaultId, Id, Shared};
-use crate::runtime::{Class, Object};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::rc::{DefaultId, Id, Shared};
+use objc2::runtime::{Class, Object};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// A static byte buffer in memory.
@@ -53,7 +53,7 @@ extern_methods!(
             //
             // NSMutableData does not have this problem.
             #[cfg(feature = "gnustep-1-7")]
-            let cls = crate::class!(NSDataWithDeallocatorBlock);
+            let cls = objc2::class!(NSDataWithDeallocatorBlock);
             #[cfg(not(feature = "gnustep-1-7"))]
             let cls = Self::class();
 

--- a/crates/icrate/src/Foundation/additions/dictionary.rs
+++ b/crates/icrate/src/Foundation/additions/dictionary.rs
@@ -7,8 +7,8 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
 
 use super::{NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSObject};
-use crate::rc::{DefaultId, Id, Owned, Shared, SliceId};
-use crate::{ClassType, __inner_extern_class, extern_methods, msg_send, msg_send_id, Message};
+use objc2::rc::{DefaultId, Id, Owned, Shared, SliceId};
+use objc2::{ClassType, __inner_extern_class, extern_methods, msg_send, msg_send_id, Message};
 
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
@@ -162,8 +162,8 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::foundation::NSString;
-    use crate::rc::autoreleasepool;
+    use crate::Foundation::NSString;
+    use objc2::rc::autoreleasepool;
 
     fn sample_dict(key: &str) -> Id<NSDictionary<NSString, NSObject>, Shared> {
         let string = NSString::from_str(key);

--- a/crates/icrate/src/Foundation/additions/enumerator.rs
+++ b/crates/icrate/src/Foundation/additions/enumerator.rs
@@ -4,9 +4,9 @@ use core::ptr;
 use core::slice;
 use std::os::raw::c_ulong;
 
-use crate::rc::{Id, Owned};
-use crate::runtime::Object;
-use crate::{msg_send, Encode, Encoding, Message, RefEncode};
+use objc2::rc::{Id, Owned};
+use objc2::runtime::Object;
+use objc2::{msg_send, Encode, Encoding, Message, RefEncode};
 
 // TODO: https://doc.rust-lang.org/stable/reference/trait-bounds.html#lifetime-bounds
 pub struct NSEnumerator<'a, T: Message> {
@@ -168,7 +168,7 @@ impl<'a, C: NSFastEnumeration + ?Sized> Iterator for NSFastEnumerator<'a, C> {
 #[cfg(test)]
 mod tests {
     use super::NSFastEnumeration;
-    use crate::foundation::{NSArray, NSNumber};
+    use crate::Foundation::{NSArray, NSNumber};
 
     #[test]
     fn test_enumerator() {

--- a/crates/icrate/src/Foundation/additions/error.rs
+++ b/crates/icrate/src/Foundation/additions/error.rs
@@ -2,9 +2,9 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSDictionary, NSObject, NSString};
-use crate::ffi::NSInteger;
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::ffi::NSInteger;
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// Information about an error condition including a domain, a

--- a/crates/icrate/src/Foundation/additions/exception.rs
+++ b/crates/icrate/src/Foundation/additions/exception.rs
@@ -3,10 +3,10 @@ use core::hint::unreachable_unchecked;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSDictionary, NSObject, NSString};
-use crate::exception::Exception;
-use crate::rc::{Id, Shared};
-use crate::runtime::Object;
-use crate::{extern_class, extern_methods, msg_send_id, sel, ClassType};
+use objc2::exception::Exception;
+use objc2::rc::{Id, Shared};
+use objc2::runtime::Object;
+use objc2::{extern_class, extern_methods, msg_send_id, sel, ClassType};
 
 extern_class!(
     /// A special condition that interrupts the normal flow of program

--- a/crates/icrate/src/Foundation/additions/geometry.rs
+++ b/crates/icrate/src/Foundation/additions/geometry.rs
@@ -1,4 +1,4 @@
-use crate::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 #[cfg(target_pointer_width = "64")]
 type InnerFloat = f64;
@@ -73,7 +73,7 @@ impl CGPoint {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::CGPoint;
+    /// use icrate::Foundation::CGPoint;
     /// assert_eq!(CGPoint::new(10.0, -2.3), CGPoint { x: 10.0, y: -2.3 });
     /// ```
     #[inline]
@@ -89,7 +89,7 @@ impl CGPoint {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::CGPoint;
+    /// use icrate::Foundation::CGPoint;
     /// assert_eq!(CGPoint::ZERO, CGPoint { x: 0.0, y: 0.0 });
     /// ```
     #[doc(alias = "NSZeroPoint")]
@@ -134,7 +134,7 @@ impl CGSize {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::CGSize;
+    /// use icrate::Foundation::CGSize;
     /// let size = CGSize::new(10.0, 2.3);
     /// assert_eq!(size.width, 10.0);
     /// assert_eq!(size.height, 2.3);
@@ -143,7 +143,7 @@ impl CGSize {
     /// Negative values are allowed (though often undesired).
     ///
     /// ```
-    /// use objc2::foundation::CGSize;
+    /// use icrate::Foundation::CGSize;
     /// let size = CGSize::new(-1.0, 0.0);
     /// assert_eq!(size.width, -1.0);
     /// ```
@@ -168,7 +168,7 @@ impl CGSize {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::CGSize;
+    /// use icrate::Foundation::CGSize;
     /// assert_eq!(CGSize::new(-1.0, 1.0).abs(), CGSize::new(1.0, 1.0));
     /// ```
     #[inline]
@@ -182,7 +182,7 @@ impl CGSize {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::CGSize;
+    /// use icrate::Foundation::CGSize;
     /// assert_eq!(CGSize::ZERO, CGSize { width: 0.0, height: 0.0 });
     /// ```
     #[doc(alias = "NSZeroSize")]
@@ -229,7 +229,7 @@ impl CGRect {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::{CGPoint, CGRect, CGSize};
+    /// use icrate::Foundation::{CGPoint, CGRect, CGSize};
     /// let origin = CGPoint::new(10.0, -2.3);
     /// let size = CGSize::new(5.0, 0.0);
     /// let rect = CGRect::new(origin, size);
@@ -254,7 +254,7 @@ impl CGRect {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::{CGPoint, CGRect, CGSize};
+    /// use icrate::Foundation::{CGPoint, CGRect, CGSize};
     /// let origin = CGPoint::new(1.0, 1.0);
     /// let size = CGSize::new(-5.0, -2.0);
     /// let rect = CGRect::new(origin, size);
@@ -308,7 +308,7 @@ impl CGRect {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::{CGPoint, CGRect, CGSize};
+    /// use icrate::Foundation::{CGPoint, CGRect, CGSize};
     /// assert!(CGRect::ZERO.is_empty());
     /// let point = CGPoint::new(1.0, 2.0);
     /// assert!(CGRect::new(point, CGSize::ZERO).is_empty());
@@ -391,7 +391,7 @@ mod tests {
     #[test]
     #[cfg(any(all(feature = "apple", target_os = "macos"), feature = "gnustep-1-7"))] // or macabi
     fn test_partial_eq() {
-        use crate::runtime::Bool;
+        use objc2::runtime::Bool;
 
         // Note: No need to use "C-unwind"
         extern "C" {

--- a/crates/icrate/src/Foundation/additions/lock.rs
+++ b/crates/icrate/src/Foundation/additions/lock.rs
@@ -1,6 +1,6 @@
 use super::{NSObject, NSString};
-use crate::rc::{Id, Owned, Shared};
-use crate::{extern_class, extern_methods, extern_protocol, ClassType, ConformsTo, ProtocolType};
+use objc2::rc::{Id, Owned, Shared};
+use objc2::{extern_class, extern_methods, extern_protocol, ClassType, ConformsTo, ProtocolType};
 
 // TODO: Proper Send/Sync impls here
 

--- a/crates/icrate/src/Foundation/additions/mod.rs
+++ b/crates/icrate/src/Foundation/additions/mod.rs
@@ -19,8 +19,8 @@
 //! call a method on them using the [`msg_send!`] family of macros.
 //!
 //! [pull requests]: https://github.com/madsmtm/objc2/pulls
-//! [`Message`]: crate::Message
-//! [`msg_send!`]: crate::msg_send
+//! [`Message`]: crate::objc2::Message
+//! [`msg_send!`]: crate::objc2::msg_send
 //!
 //!
 //! # Use of `Deref`
@@ -43,9 +43,9 @@
 //! conversion, that is a possibility too.
 //!
 //! [`Deref`]: std::ops::Deref
-//! [`ClassType`]: crate::ClassType
+//! [`ClassType`]: crate::objc2::ClassType
 //! [anti-pattern-deref]: https://rust-unofficial.github.io/patterns/anti_patterns/deref.html
-//! [`Id::into_super`]: crate::rc::Id::into_super
+//! [`Id::into_super`]: objc2::rc::Id::into_super
 
 // TODO: Remove these
 #![allow(missing_docs)]
@@ -80,18 +80,18 @@ pub use self::thread::{is_main_thread, is_multi_threaded, MainThreadMarker, NSTh
 #[cfg(not(macos_10_7))] // Temporary
 pub use self::uuid::NSUUID;
 pub use self::value::NSValue;
-pub use crate::runtime::{NSObject, NSZone};
+pub use objc2::runtime::{NSObject, NSZone};
 
 // Available under Foundation, so makes sense here as well:
 // https://developer.apple.com/documentation/foundation/numbers_data_and_basic_values?language=objc
 #[doc(no_inline)]
-pub use crate::ffi::{NSInteger, NSUInteger};
+pub use objc2::ffi::{NSInteger, NSUInteger};
 
 /// A value indicating that a requested item couldn’t be found or doesn’t exist.
 ///
 /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nsnotfound?language=objc).
 #[allow(non_upper_case_globals)]
-pub const NSNotFound: NSInteger = crate::ffi::NSIntegerMax;
+pub const NSNotFound: NSInteger = objc2::ffi::NSIntegerMax;
 
 /// A number of seconds.
 ///
@@ -142,7 +142,7 @@ mod tests {
     use core::panic::{RefUnwindSafe, UnwindSafe};
 
     use super::*;
-    use crate::rc::{Id, Owned, Shared};
+    use objc2::rc::{Id, Owned, Shared};
 
     // We expect most Foundation types to be UnwindSafe and RefUnwindSafe,
     // since they follow Rust's usual mutability rules (&T = immutable).

--- a/crates/icrate/src/Foundation/additions/mod.rs
+++ b/crates/icrate/src/Foundation/additions/mod.rs
@@ -25,9 +25,9 @@
 //!
 //! # Use of `Deref`
 //!
-//! `objc2::foundation` uses the [`Deref`] trait in a bit special way: All
-//! objects deref to their superclasses. For example, `NSMutableArray` derefs
-//! to `NSArray`, which in turn derefs to `NSObject`.
+//! `icrate` uses the [`Deref`] trait in a bit special way: All objects deref
+//! to their superclasses. For example, `NSMutableArray` derefs to `NSArray`,
+//! which in turn derefs to `NSObject`.
 //!
 //! Note that this is explicitly recommended against in [the
 //! documentation][`Deref`] and [the Rust Design patterns

--- a/crates/icrate/src/Foundation/additions/mod.rs
+++ b/crates/icrate/src/Foundation/additions/mod.rs
@@ -98,14 +98,6 @@ pub const NSNotFound: NSInteger = objc2::ffi::NSIntegerMax;
 /// See [Apple's documentation](https://developer.apple.com/documentation/foundation/nstimeinterval?language=objc).
 pub type NSTimeInterval = c_double;
 
-#[cfg(feature = "apple")]
-#[link(name = "Foundation", kind = "framework")]
-extern "C" {}
-
-#[cfg(feature = "gnustep-1-7")]
-#[link(name = "gnustep-base", kind = "dylib")]
-extern "C" {}
-
 #[doc(hidden)]
 pub mod __ns_string;
 mod array;

--- a/crates/icrate/src/Foundation/additions/mutable_array.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_array.rs
@@ -10,8 +10,8 @@ use super::{
     NSArray, NSComparisonResult, NSCopying, NSFastEnumeration, NSFastEnumerator, NSMutableCopying,
     NSObject,
 };
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send};
+use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use objc2::{ClassType, Message, __inner_extern_class, extern_methods, msg_send};
 
 __inner_extern_class!(
     /// A growable ordered collection of objects.
@@ -245,15 +245,15 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::foundation::NSString;
-    use crate::rc::{autoreleasepool, RcTestObject, ThreadTestData};
+    use crate::Foundation::NSString;
+    use objc2::rc::{__RcTestObject, __ThreadTestData, autoreleasepool};
 
     #[test]
     fn test_adding() {
         let mut array = NSMutableArray::new();
-        let obj1 = RcTestObject::new();
-        let obj2 = RcTestObject::new();
-        let mut expected = ThreadTestData::current();
+        let obj1 = __RcTestObject::new();
+        let obj2 = __RcTestObject::new();
+        let mut expected = __ThreadTestData::current();
 
         array.push(obj1);
         expected.retain += 1;
@@ -272,10 +272,10 @@ mod tests {
     #[test]
     fn test_replace() {
         let mut array = NSMutableArray::new();
-        let obj1 = RcTestObject::new();
-        let obj2 = RcTestObject::new();
+        let obj1 = __RcTestObject::new();
+        let obj2 = __RcTestObject::new();
         array.push(obj1);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let old_obj = array.replace(0, obj2);
         expected.retain += 2;
@@ -288,9 +288,9 @@ mod tests {
     fn test_remove() {
         let mut array = NSMutableArray::new();
         for _ in 0..4 {
-            array.push(RcTestObject::new());
+            array.push(__RcTestObject::new());
         }
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let _obj = array.remove(1);
         expected.retain += 1;

--- a/crates/icrate/src/Foundation/additions/mutable_attributed_string.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_attributed_string.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
 use super::{NSAttributedString, NSCopying, NSMutableCopying, NSObject, NSString};
-use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// A mutable string that has associated attributes.

--- a/crates/icrate/src/Foundation/additions/mutable_data.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_data.rs
@@ -8,8 +8,8 @@ use std::io;
 
 use super::data::with_slice;
 use super::{NSCopying, NSData, NSMutableCopying, NSObject, NSRange};
-use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// A dynamic byte buffer in memory.
@@ -239,7 +239,7 @@ impl<'a> IntoIterator for &'a mut NSMutableData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::Object;
+    use objc2::runtime::Object;
 
     #[test]
     fn test_bytes_mut() {

--- a/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
@@ -6,8 +6,8 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
 
 use super::{NSArray, NSCopying, NSDictionary, NSFastEnumeration, NSObject};
-use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{ClassType, __inner_extern_class, extern_methods, msg_send_id, Message};
+use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{ClassType, __inner_extern_class, extern_methods, msg_send_id, Message};
 
 __inner_extern_class!(
     /// A mutable collection of objects associated with unique keys.
@@ -46,7 +46,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -67,7 +67,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSNumber, NSObject};
+        /// use icrate::Foundation::{NSMutableDictionary, NSNumber, NSObject};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// let dict = NSMutableDictionary::from_keys_and_objects(
@@ -93,8 +93,8 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
-        /// use objc2::ns_string;
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::ns_string;
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -114,7 +114,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -148,7 +148,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -176,8 +176,8 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
-        /// use objc2::ns_string;
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::ns_string;
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -203,7 +203,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -222,7 +222,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableDictionary, NSObject, NSString};
+        /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -276,10 +276,8 @@ mod tests {
     use super::*;
     use alloc::vec;
 
-    use crate::{
-        foundation::{NSNumber, NSString},
-        rc::{RcTestObject, ThreadTestData},
-    };
+    use crate::Foundation::{NSNumber, NSString};
+    use objc2::rc::{__RcTestObject, __ThreadTestData};
 
     fn sample_dict() -> Id<NSMutableDictionary<NSNumber, NSObject>, Owned> {
         NSMutableDictionary::from_keys_and_objects(
@@ -326,10 +324,10 @@ mod tests {
     #[test]
     fn test_insert_retain_release() {
         let mut dict = NSMutableDictionary::new();
-        dict.insert(NSNumber::new_i32(1), RcTestObject::new());
-        let mut expected = ThreadTestData::current();
+        dict.insert(NSNumber::new_i32(1), __RcTestObject::new());
+        let mut expected = __ThreadTestData::current();
 
-        let old = dict.insert(NSNumber::new_i32(1), RcTestObject::new());
+        let old = dict.insert(NSNumber::new_i32(1), __RcTestObject::new());
         expected.alloc += 1;
         expected.init += 1;
         expected.retain += 2;
@@ -366,9 +364,9 @@ mod tests {
     fn test_remove_clear_release_dealloc() {
         let mut dict = NSMutableDictionary::new();
         for i in 0..4 {
-            dict.insert(NSNumber::new_i32(i), RcTestObject::new());
+            dict.insert(NSNumber::new_i32(i), __RcTestObject::new());
         }
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let _obj = dict.remove(&NSNumber::new_i32(1));
         expected.retain += 1;

--- a/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
@@ -47,8 +47,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let dict = NSMutableDictionary::<NSString, NSObject>::new();
         /// ```
@@ -68,8 +66,7 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSNumber, NSObject};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
+        ///
         /// let dict = NSMutableDictionary::from_keys_and_objects(
         ///    &[
         ///        &*NSNumber::new_i32(1),
@@ -95,8 +92,6 @@ extern_methods!(
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// use icrate::ns_string;
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());
@@ -115,8 +110,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());
@@ -149,8 +142,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());
@@ -178,8 +169,6 @@ extern_methods!(
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
         /// use icrate::ns_string;
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());
@@ -204,8 +193,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());
@@ -223,8 +210,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableDictionary, NSObject, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut dict = NSMutableDictionary::new();
         /// dict.insert(NSString::from_str("one"), NSObject::new());

--- a/crates/icrate/src/Foundation/additions/mutable_set.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_set.rs
@@ -39,8 +39,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set = NSMutableSet::<NSString>::new();
         /// ```
@@ -55,8 +53,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str).to_vec();
         /// let set = NSMutableSet::from_vec(strs);
@@ -74,8 +70,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut set = NSMutableSet::new();
         /// set.insert(NSString::from_str("one"));
@@ -92,8 +86,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSMutableString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = vec![
         ///     NSMutableString::from_str("one"),
@@ -118,8 +110,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSMutableSet::from_slice(&strs);
@@ -149,8 +139,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut set = NSMutableSet::new();
         ///
@@ -182,8 +170,6 @@ extern_methods!(
         /// ```
         /// use icrate::Foundation::{NSMutableSet, NSString};
         /// use icrate::ns_string;
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let mut set = NSMutableSet::new();
         ///

--- a/crates/icrate/src/Foundation/additions/mutable_set.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_set.rs
@@ -4,8 +4,8 @@ use core::marker::PhantomData;
 
 use super::set::with_objects;
 use super::{NSCopying, NSFastEnumeration, NSFastEnumerator, NSMutableCopying, NSObject, NSSet};
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods};
+use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use objc2::{ClassType, Message, __inner_extern_class, extern_methods};
 
 __inner_extern_class!(
     /// A growable unordered collection of unique objects.
@@ -38,7 +38,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
+        /// use icrate::Foundation::{NSMutableSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -54,7 +54,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
+        /// use icrate::Foundation::{NSMutableSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -73,7 +73,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
+        /// use icrate::Foundation::{NSMutableSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -91,7 +91,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSMutableString};
+        /// use icrate::Foundation::{NSMutableSet, NSMutableString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -117,7 +117,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
+        /// use icrate::Foundation::{NSMutableSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -148,7 +148,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
+        /// use icrate::Foundation::{NSMutableSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -180,8 +180,8 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableSet, NSString};
-        /// use objc2::ns_string;
+        /// use icrate::Foundation::{NSMutableSet, NSString};
+        /// use icrate::ns_string;
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -258,9 +258,9 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::foundation::{NSMutableString, NSString};
     use crate::ns_string;
-    use crate::rc::{RcTestObject, ThreadTestData};
+    use crate::Foundation::{NSMutableString, NSString};
+    use objc2::rc::{__RcTestObject, __ThreadTestData};
 
     #[test]
     fn test_insert() {
@@ -332,9 +332,9 @@ mod tests {
     #[test]
     fn test_insert_retain_release() {
         let mut set = NSMutableSet::new();
-        let obj1 = RcTestObject::new();
-        let obj2 = RcTestObject::new();
-        let mut expected = ThreadTestData::current();
+        let obj1 = __RcTestObject::new();
+        let obj2 = __RcTestObject::new();
+        let mut expected = __ThreadTestData::current();
 
         set.insert(obj1);
         expected.retain += 1;
@@ -354,9 +354,9 @@ mod tests {
     fn test_clear_release_dealloc() {
         let mut set = NSMutableSet::new();
         for _ in 0..4 {
-            set.insert(RcTestObject::new());
+            set.insert(__RcTestObject::new());
         }
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         set.clear();
         expected.release += 4;

--- a/crates/icrate/src/Foundation/additions/mutable_string.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_string.rs
@@ -4,8 +4,8 @@ use core::ops::AddAssign;
 use core::str;
 
 use super::{NSCopying, NSMutableCopying, NSObject, NSString};
-use crate::rc::{DefaultId, Id, Owned, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::rc::{DefaultId, Id, Owned, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// A dynamic plain-text Unicode string object.

--- a/crates/icrate/src/Foundation/additions/number.rs
+++ b/crates/icrate/src/Foundation/additions/number.rs
@@ -9,8 +9,8 @@ use std::os::raw::{
 use super::{
     CGFloat, NSComparisonResult, NSCopying, NSInteger, NSObject, NSString, NSUInteger, NSValue,
 };
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send, msg_send_id, ClassType, Encoding};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send, msg_send_id, ClassType, Encoding};
 
 extern_class!(
     /// An object wrapper for primitive scalars.
@@ -167,9 +167,9 @@ impl NSNumber {
     /// number properties.
     ///
     /// ```
-    /// use objc2::Encoding;
-    /// use objc2::foundation::NSNumber;
-    /// use objc2::rc::{Id, Shared};
+    /// use icrate::Foundation::NSNumber;
+    /// use icrate::objc2::Encoding;
+    /// use icrate::objc2::rc::{Id, Shared};
     ///
     /// // Note: `bool` would convert to either `Signed` or `Unsigned`,
     /// // depending on platform

--- a/crates/icrate/src/Foundation/additions/process_info.rs
+++ b/crates/icrate/src/Foundation/additions/process_info.rs
@@ -2,8 +2,8 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSObject, NSString};
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, ClassType};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, ClassType};
 
 extern_class!(
     /// A collection of information about the current process.

--- a/crates/icrate/src/Foundation/additions/range.rs
+++ b/crates/icrate/src/Foundation/additions/range.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
 use super::NSUInteger;
-use crate::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 /// TODO.
 ///
@@ -22,7 +22,7 @@ impl NSRange {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::NSRange;
+    /// use icrate::Foundation::NSRange;
     /// assert_eq!(NSRange::new(3, 2), NSRange::from(3..5));
     /// ```
     #[inline]
@@ -37,7 +37,7 @@ impl NSRange {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::NSRange;
+    /// use icrate::Foundation::NSRange;
     ///
     /// assert!(!NSRange::from(3..5).is_empty());
     /// assert!( NSRange::from(3..3).is_empty());
@@ -52,7 +52,7 @@ impl NSRange {
     /// # Examples
     ///
     /// ```
-    /// use objc2::foundation::NSRange;
+    /// use icrate::Foundation::NSRange;
     ///
     /// assert!(!NSRange::from(3..5).contains(2));
     /// assert!( NSRange::from(3..5).contains(3));

--- a/crates/icrate/src/Foundation/additions/set.rs
+++ b/crates/icrate/src/Foundation/additions/set.rs
@@ -59,8 +59,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set = NSSet::<NSString>::new();
         /// ```
@@ -79,8 +77,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str).to_vec();
         /// let set = NSSet::from_vec(strs);
@@ -100,8 +96,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -117,8 +111,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set = NSSet::<NSString>::new();
         /// assert!(set.is_empty());
@@ -134,8 +126,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -152,8 +142,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -175,8 +163,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSMutableString, NSSet};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = vec![
         ///     NSMutableString::from_str("one"),
@@ -201,8 +187,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -224,8 +208,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSNumber, NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let nums = [1, 2, 3];
         /// let set = NSSet::from_slice(&nums.map(NSNumber::new_i32));
@@ -252,8 +234,6 @@ extern_methods!(
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
         /// use icrate::ns_string;
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -271,8 +251,6 @@ extern_methods!(
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
         /// use icrate::ns_string;
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let strs = ["one", "two", "three"].map(NSString::from_str);
         /// let set = NSSet::from_slice(&strs);
@@ -290,8 +268,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set1 = NSSet::from_slice(&["one", "two"].map(NSString::from_str));
         /// let set2 = NSSet::from_slice(&["one", "two", "three"].map(NSString::from_str));
@@ -310,8 +286,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set1 = NSSet::from_slice(&["one", "two"].map(NSString::from_str));
         /// let set2 = NSSet::from_slice(&["one", "two", "three"].map(NSString::from_str));
@@ -332,8 +306,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSSet, NSString};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
         /// let set1 = NSSet::from_slice(&["one", "two"].map(NSString::from_str));
         /// let set2 = NSSet::from_slice(&["one", "two", "three"].map(NSString::from_str));

--- a/crates/icrate/src/Foundation/additions/set.rs
+++ b/crates/icrate/src/Foundation/additions/set.rs
@@ -7,8 +7,8 @@ use super::{
     NSArray, NSCopying, NSEnumerator, NSFastEnumeration, NSFastEnumerator, NSMutableCopying,
     NSMutableSet, NSObject,
 };
-use crate::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use crate::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
+use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
+use objc2::{ClassType, Message, __inner_extern_class, extern_methods, msg_send, msg_send_id};
 
 __inner_extern_class!(
     /// An immutable unordered collection of unique objects.
@@ -58,7 +58,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -78,7 +78,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -99,7 +99,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -116,7 +116,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -133,7 +133,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -151,7 +151,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -174,7 +174,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSMutableString, NSSet};
+        /// use icrate::Foundation::{NSMutableString, NSSet};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -200,7 +200,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -223,7 +223,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSNumber, NSSet, NSString};
+        /// use icrate::Foundation::{NSNumber, NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -250,8 +250,8 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
-        /// use objc2::ns_string;
+        /// use icrate::Foundation::{NSSet, NSString};
+        /// use icrate::ns_string;
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -269,8 +269,8 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
-        /// use objc2::ns_string;
+        /// use icrate::Foundation::{NSSet, NSString};
+        /// use icrate::ns_string;
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -289,7 +289,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -309,7 +309,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -331,7 +331,7 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2::foundation::{NSSet, NSString};
+        /// use icrate::Foundation::{NSSet, NSString};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         ///
@@ -400,9 +400,9 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::foundation::{NSMutableString, NSNumber, NSString};
     use crate::ns_string;
-    use crate::rc::{RcTestObject, ThreadTestData};
+    use crate::Foundation::{NSMutableString, NSNumber, NSString};
+    use objc2::rc::{__RcTestObject, __ThreadTestData};
 
     #[test]
     fn test_new() {
@@ -604,8 +604,8 @@ mod tests {
 
     #[test]
     fn test_retains_stored() {
-        let obj = Id::into_shared(RcTestObject::new());
-        let mut expected = ThreadTestData::current();
+        let obj = Id::into_shared(__RcTestObject::new());
+        let mut expected = __ThreadTestData::current();
 
         let input = [obj.clone(), obj.clone()];
         expected.retain += 2;
@@ -639,9 +639,9 @@ mod tests {
 
     #[test]
     fn test_nscopying_uses_retain() {
-        let obj = Id::into_shared(RcTestObject::new());
+        let obj = Id::into_shared(__RcTestObject::new());
         let set = NSSet::from_slice(&[obj]);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let _copy = set.copy();
         expected.assert_current();
@@ -657,9 +657,9 @@ mod tests {
         ignore = "this works differently on different framework versions"
     )]
     fn test_iter_no_retain() {
-        let obj = Id::into_shared(RcTestObject::new());
+        let obj = Id::into_shared(__RcTestObject::new());
         let set = NSSet::from_slice(&[obj]);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let iter = set.iter();
         expected.retain += 0;

--- a/crates/icrate/src/Foundation/additions/string.rs
+++ b/crates/icrate/src/Foundation/additions/string.rs
@@ -13,10 +13,10 @@ use core::str;
 use std::os::raw::c_char;
 
 use super::{NSComparisonResult, NSCopying, NSError, NSMutableCopying, NSMutableString, NSObject};
-use crate::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
-use crate::runtime::__nsstring::{nsstring_len, nsstring_to_str, UTF8_ENCODING};
-use crate::runtime::{Class, Object};
-use crate::{extern_class, extern_methods, msg_send, ClassType};
+use objc2::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
+use objc2::runtime::__nsstring::{nsstring_len, nsstring_to_str, UTF8_ENCODING};
+use objc2::runtime::{Class, Object};
+use objc2::{extern_class, extern_methods, msg_send, ClassType};
 
 extern_class!(
     /// An immutable, plain-text Unicode string object.
@@ -62,7 +62,7 @@ extern_methods!(
         /// ```
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-        /// use objc2::ns_string;
+        /// use icrate::ns_string;
         /// let error_tag = ns_string!("Error: ");
         /// let error_string = ns_string!("premature end of file.");
         /// let error_message = error_tag.concat(error_string);
@@ -89,7 +89,7 @@ extern_methods!(
         /// ```
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-        /// use objc2::ns_string;
+        /// use icrate::ns_string;
         ///
         /// let extension = ns_string!("scratch.tiff");
         /// assert_eq!(&*ns_string!("/tmp").join_path(extension), ns_string!("/tmp/scratch.tiff"));

--- a/crates/icrate/src/Foundation/additions/string.rs
+++ b/crates/icrate/src/Foundation/additions/string.rs
@@ -60,8 +60,6 @@ extern_methods!(
         /// # Example
         ///
         /// ```
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// use icrate::ns_string;
         /// let error_tag = ns_string!("Error: ");
         /// let error_string = ns_string!("premature end of file.");
@@ -87,8 +85,6 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// use icrate::ns_string;
         ///
         /// let extension = ns_string!("scratch.tiff");

--- a/crates/icrate/src/Foundation/additions/thread.rs
+++ b/crates/icrate/src/Foundation/additions/thread.rs
@@ -3,8 +3,8 @@ use core::marker::PhantomData;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSObject, NSString};
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
 extern_class!(
     /// A thread of execution.
@@ -106,9 +106,9 @@ fn make_multithreaded() {
 /// Use when designing APIs that are only safe to use on the main thread:
 ///
 /// ```no_run
-/// use objc2::foundation::MainThreadMarker;
-/// use objc2::runtime::Object;
-/// use objc2::msg_send;
+/// use icrate::Foundation::MainThreadMarker;
+/// use icrate::objc2::runtime::Object;
+/// use icrate::objc2::msg_send;
 /// # let obj = 0 as *const Object;
 ///
 /// // This action requires the main thread, so we take a marker as parameter.

--- a/crates/icrate/src/Foundation/additions/uuid.rs
+++ b/crates/icrate/src/Foundation/additions/uuid.rs
@@ -2,8 +2,8 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use super::{NSCopying, NSObject, NSString};
-use crate::rc::{DefaultId, Id, Shared};
-use crate::{extern_class, extern_methods, msg_send_id, ClassType, Encode, Encoding, RefEncode};
+use objc2::rc::{DefaultId, Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send_id, ClassType, Encode, Encoding, RefEncode};
 
 extern_class!(
     /// A universally unique value.

--- a/crates/icrate/src/Foundation/additions/value.rs
+++ b/crates/icrate/src/Foundation/additions/value.rs
@@ -59,8 +59,6 @@ extern_methods!(
         ///
         /// ```
         /// use icrate::Foundation::{NSPoint, NSValue};
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// let val = NSValue::new::<NSPoint>(NSPoint::new(1.0, 1.0));
         /// ```
         pub fn new<T: 'static + Copy + Encode>(value: T) -> Id<Self, Shared> {
@@ -110,8 +108,6 @@ extern_methods!(
         /// use std::ptr;
         /// use icrate::Foundation::NSValue;
         ///
-        /// # #[cfg(feature = "gnustep-1-7")]
-        /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// let val = NSValue::new::<*const c_void>(ptr::null());
         /// // SAFETY: The value was just created with a pointer
         /// let res = unsafe { val.get::<*const c_void>() };

--- a/crates/icrate/src/Foundation/additions/value.rs
+++ b/crates/icrate/src/Foundation/additions/value.rs
@@ -9,8 +9,8 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
 use super::{NSCopying, NSObject, NSPoint, NSRange, NSRect, NSSize};
-use crate::rc::{Id, Shared};
-use crate::{extern_class, extern_methods, msg_send, msg_send_id, ClassType, Encode};
+use objc2::rc::{Id, Shared};
+use objc2::{extern_class, extern_methods, msg_send, msg_send_id, ClassType, Encode};
 
 extern_class!(
     /// A container wrapping any encodable type as an Obective-C object.
@@ -58,7 +58,7 @@ extern_methods!(
         /// Create an `NSValue` containing an [`NSPoint`][super::NSPoint].
         ///
         /// ```
-        /// use objc2::foundation::{NSPoint, NSValue};
+        /// use icrate::Foundation::{NSPoint, NSValue};
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
         /// let val = NSValue::new::<NSPoint>(NSPoint::new(1.0, 1.0));
@@ -108,7 +108,7 @@ extern_methods!(
         /// ```
         /// use std::ffi::c_void;
         /// use std::ptr;
-        /// use objc2::foundation::NSValue;
+        /// use icrate::Foundation::NSValue;
         ///
         /// # #[cfg(feature = "gnustep-1-7")]
         /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
@@ -237,7 +237,7 @@ mod tests {
     use core::{ptr, slice};
 
     use super::*;
-    use crate::rc::{RcTestObject, ThreadTestData};
+    use objc2::rc::{__RcTestObject, __ThreadTestData};
 
     #[test]
     fn basic() {
@@ -247,13 +247,16 @@ mod tests {
 
     #[test]
     fn does_not_retain() {
-        let obj = RcTestObject::new();
-        let expected = ThreadTestData::current();
+        let obj = __RcTestObject::new();
+        let expected = __ThreadTestData::current();
 
-        let val = NSValue::new::<*const RcTestObject>(&*obj);
+        let val = NSValue::new::<*const __RcTestObject>(&*obj);
         expected.assert_current();
 
-        assert!(ptr::eq(unsafe { val.get::<*const RcTestObject>() }, &*obj));
+        assert!(ptr::eq(
+            unsafe { val.get::<*const __RcTestObject>() },
+            &*obj
+        ));
         expected.assert_current();
 
         let _clone = val.clone();

--- a/crates/icrate/src/Foundation/mod.rs
+++ b/crates/icrate/src/Foundation/mod.rs
@@ -6,3 +6,4 @@ pub use self::fixes::*;
 pub use self::generated::*;
 
 pub use objc2::foundation::*;
+pub use objc2::ns_string;

--- a/crates/icrate/src/Foundation/mod.rs
+++ b/crates/icrate/src/Foundation/mod.rs
@@ -1,11 +1,10 @@
+mod additions;
 mod fixes;
 #[path = "../generated/Foundation/mod.rs"]
 mod generated;
 
+pub use self::additions::*;
 #[allow(unreachable_pub)]
 pub use self::fixes::*;
 #[allow(unreachable_pub)]
 pub use self::generated::*;
-
-pub use objc2::foundation::*;
-pub use objc2::ns_string;

--- a/crates/icrate/src/Foundation/mod.rs
+++ b/crates/icrate/src/Foundation/mod.rs
@@ -2,7 +2,9 @@ mod fixes;
 #[path = "../generated/Foundation/mod.rs"]
 mod generated;
 
+#[allow(unreachable_pub)]
 pub use self::fixes::*;
+#[allow(unreachable_pub)]
 pub use self::generated::*;
 
 pub use objc2::foundation::*;

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -19,7 +19,7 @@ pub(crate) use objc2::runtime::{Bool, Class, Object, Sel};
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::{__inner_extern_class, extern_class, extern_methods, ClassType, Message};
 
-#[cfg(feature = "blocks")]
+#[cfg(feature = "block")]
 pub(crate) use block2::Block;
 
 // TODO

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -12,6 +12,9 @@
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/icrate/0.0.1")]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -15,6 +15,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "objective-c")]
+pub extern crate objc2;
+
 mod common;
 #[macro_use]
 mod macros;

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg))]
 #![warn(elided_lifetimes_in_paths)]
 #![deny(non_ascii_idents)]
-#![warn(unreachable_pub)]
+// #![warn(unreachable_pub)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg))]
 #![warn(elided_lifetimes_in_paths)]
 #![deny(non_ascii_idents)]
 #![warn(unreachable_pub)]

--- a/crates/objc-sys/src/types.rs
+++ b/crates/objc-sys/src/types.rs
@@ -155,7 +155,7 @@ pub type NSInteger = isize;
 /// use objc_sys::NSUInteger;
 /// // Or:
 /// // use objc2::ffi::NSUInteger;
-/// // use objc2::foundation::NSUInteger;
+/// // use icrate::Foundation::NSUInteger;
 /// extern "C" {
 ///     fn some_external_function() -> NSUInteger;
 /// }

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-Notable changes to this crate will be documented in this file. See the
-`CHANGELOG_FOUNDATION.md` file for changes to the `objc2::foundation` module!
+Notable changes to this crate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
@@ -61,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: `declare_class!` uses `ConformsTo<...>` instead of the
   temporary `Protocol<...>` syntax.
 * Require implementors of `Message` to support weak references.
+* **BREAKING**: Moved `objc2::foundation` into `icrate::Foundation`.
+* **BREAKING**: Moved `objc2::ns_string` into `icrate::ns_string`.
 
 ### Fixed
 * Fixed duplicate selector extraction in `extern_methods!`.

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -19,14 +19,11 @@ license = "MIT"
 # NOTE: 'unstable' features are _not_ considered part of the SemVer contract,
 # and may be removed in a minor release.
 [features]
-default = ["std", "apple", "foundation"]
+default = ["std", "apple"]
 
 # Currently not possible to turn off, put here for forwards compatibility.
 std = ["alloc", "objc2-encode/std", "objc-sys/std", "block2?/std"]
 alloc = ["objc2-encode/alloc", "objc-sys/alloc", "block2?/alloc"]
-
-# Enable the `objc2::foundation` submodule. It is enabled by default.
-foundation = []
 
 # Enables `objc2::exception::throw` and `objc2::exception::catch`
 exception = ["objc-sys/unstable-exception"]
@@ -85,9 +82,6 @@ objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.2", default-features =
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.2", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.0", optional = true }
 block2 = { path = "../block2", version = "=0.2.0-alpha.6", default-features = false, optional = true }
-
-# Provide methods to convert between `uuid::Uuid` and `objc2::foundation::NSUUID`
-uuid = { version = "1.1.2", optional = true, default-features = false }
 
 [dev-dependencies]
 iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callgrind" }

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -96,30 +96,6 @@ iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callg
 name = "autorelease"
 harness = false
 
-[[example]]
-name = "basic_usage"
-required-features = ["foundation"]
-
-[[example]]
-name = "class_with_lifetime"
-required-features = ["foundation"]
-
-[[example]]
-name = "delegate"
-required-features = ["apple", "foundation"]
-
-[[example]]
-name = "introspection"
-required-features = ["foundation"]
-
-[[example]]
-name = "speech_synthesis"
-required-features = ["apple", "foundation"]
-
-[[example]]
-name = "nspasteboard"
-required-features = ["apple", "foundation"]
-
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
 features = ["exception", "malloc", "block", "uuid", "unstable-docsrs"]

--- a/crates/objc2/benches/autorelease.rs
+++ b/crates/objc2/benches/autorelease.rs
@@ -7,12 +7,7 @@ use objc2::{class, msg_send, sel};
 
 const BYTES: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-fn empty() {
-    #[cfg(feature = "gnustep-1-7")]
-    unsafe {
-        objc2::__gnustep_hack::get_class_to_force_linkage()
-    };
-}
+fn empty() {}
 
 fn pool_cleanup() {
     autoreleasepool(|_| {})

--- a/crates/objc2/src/__macro_helpers.rs
+++ b/crates/objc2/src/__macro_helpers.rs
@@ -637,15 +637,13 @@ mod tests {
     use super::*;
 
     use alloc::string::ToString;
-    use alloc::vec;
     use core::ptr;
 
     #[cfg(feature = "objc2-proc-macros")]
     use crate::__hash_idents;
-    use crate::foundation::{NSDictionary, NSString, NSValue};
     use crate::rc::{Owned, RcTestObject, Shared, ThreadTestData};
     use crate::runtime::{NSObject, NSZone, Object};
-    use crate::{class, msg_send_id, ns_string, ClassType};
+    use crate::{class, msg_send_id, ClassType};
 
     #[test]
     fn test_new() {
@@ -672,16 +670,15 @@ mod tests {
         let mut expected = ThreadTestData::current();
 
         let object_class = RcTestObject::class();
-        let key = ns_string!("");
+        let key: Id<Object, Shared> = unsafe { msg_send_id![class!(NSString), new] };
         let contents_value: *const Object = ptr::null();
-        let properties: Id<NSDictionary<NSString, Object>, _> =
-            NSDictionary::from_keys_and_objects::<NSString>(&[], vec![]);
+        let properties: Id<Object, Shared> = unsafe { msg_send_id![class!(NSDictionary), new] };
 
         let _obj: Option<Id<Object, Shared>> = unsafe {
             msg_send_id![
                 NSObject::class(),
                 newScriptingObjectOfClass: object_class,
-                forValueForKey: key,
+                forValueForKey: &*key,
                 withContentsValue: contents_value,
                 properties: &*properties,
             ]
@@ -787,7 +784,7 @@ mod tests {
     // GNUStep instead returns an invalid instance that panics on accesses
     #[cfg_attr(feature = "gnustep-1-7", ignore)]
     fn new_nsvalue_fails() {
-        let _val: Id<NSValue, Shared> = unsafe { msg_send_id![NSValue::class(), new] };
+        let _val: Id<Object, Shared> = unsafe { msg_send_id![class!(NSValue), new] };
     }
 
     #[test]
@@ -854,7 +851,7 @@ mod tests {
     #[cfg(not(debug_assertions))] // Does NULL receiver checks
     fn test_normal_with_null_receiver() {
         let obj: *const NSObject = ptr::null();
-        let _obj: Id<NSString, Shared> = unsafe { msg_send_id![obj, description] };
+        let _obj: Id<Object, Shared> = unsafe { msg_send_id![obj, description] };
     }
 
     #[test]

--- a/crates/objc2/src/class_type.rs
+++ b/crates/objc2/src/class_type.rs
@@ -34,8 +34,6 @@ use crate::Message;
 /// Use the trait to access the [`Class`] of different objects.
 ///
 /// ```
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// use objc2::ClassType;
 /// use objc2::runtime::NSObject;
 /// // Get a class object representing `NSObject`

--- a/crates/objc2/src/declare.rs
+++ b/crates/objc2/src/declare.rs
@@ -19,8 +19,6 @@
 //! use objc2::rc::{Id, Owned};
 //! use objc2::runtime::{Class, Object, NSObject, Sel};
 //! use objc2::{sel, msg_send, msg_send_id, ClassType};
-//! # #[cfg(feature = "gnustep-1-7")]
-//! # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 //!
 //! fn register_class() -> &'static Class {
 //!     // Inherit from NSObject

--- a/crates/objc2/src/declare/ivar.rs
+++ b/crates/objc2/src/declare/ivar.rs
@@ -397,7 +397,7 @@ mod tests {
         static HAS_RUN_DEALLOC: AtomicBool = AtomicBool::new(false);
 
         declare_class!(
-            #[derive(Debug, PartialEq)]
+            #[derive(Debug, PartialEq, Eq)]
             struct CustomDrop {
                 ivar: u8,
             }

--- a/crates/objc2/src/declare/ivar.rs
+++ b/crates/objc2/src/declare/ivar.rs
@@ -168,9 +168,6 @@ pub unsafe trait IvarType {
 /// ```
 /// use objc2::declare::{Ivar, IvarType};
 /// use objc2::runtime::Object;
-/// #
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 ///
 /// // Declare ivar with given type and name
 /// struct MyCustomIvar;

--- a/crates/objc2/src/declare/ivar_drop.rs
+++ b/crates/objc2/src/declare/ivar_drop.rs
@@ -209,7 +209,7 @@ unsafe fn box_unreachable() -> ! {
 mod tests {
     use super::*;
     use crate::declare::{Ivar, IvarType};
-    use crate::rc::{Allocated, Owned, RcTestObject, Shared, ThreadTestData};
+    use crate::rc::{Allocated, Owned, Shared, __RcTestObject, __ThreadTestData};
     use crate::runtime::NSObject;
     use crate::runtime::Object;
     use crate::{declare_class, msg_send, msg_send_id, ClassType};
@@ -239,12 +239,12 @@ mod tests {
     }
 
     declare_class!(
-        #[derive(Debug, PartialEq)]
+        #[derive(Debug, PartialEq, Eq)]
         struct IvarTester {
-            ivar1: IvarDrop<Id<RcTestObject, Shared>>,
-            ivar2: IvarDrop<Option<Id<RcTestObject, Owned>>>,
-            ivar3: IvarDrop<Box<Id<RcTestObject, Owned>>>,
-            ivar4: IvarDrop<Option<Box<Id<RcTestObject, Owned>>>>,
+            ivar1: IvarDrop<Id<__RcTestObject, Shared>>,
+            ivar2: IvarDrop<Option<Id<__RcTestObject, Owned>>>,
+            ivar3: IvarDrop<Box<Id<__RcTestObject, Owned>>>,
+            ivar4: IvarDrop<Option<Box<Id<__RcTestObject, Owned>>>>,
         }
 
         unsafe impl ClassType for IvarTester {
@@ -256,10 +256,10 @@ mod tests {
             fn init(&mut self) -> Option<&mut Self> {
                 let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
                 this.map(|this| {
-                    Ivar::write(&mut this.ivar1, Id::into_shared(RcTestObject::new()));
-                    *this.ivar2 = Some(RcTestObject::new());
-                    Ivar::write(&mut this.ivar3, Box::new(RcTestObject::new()));
-                    *this.ivar4 = Some(Box::new(RcTestObject::new()));
+                    Ivar::write(&mut this.ivar1, Id::into_shared(__RcTestObject::new()));
+                    *this.ivar2 = Some(__RcTestObject::new());
+                    Ivar::write(&mut this.ivar3, Box::new(__RcTestObject::new()));
+                    *this.ivar4 = Some(Box::new(__RcTestObject::new()));
                     this
                 })
             }
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_alloc_dealloc() {
-        let expected = ThreadTestData::current();
+        let expected = __ThreadTestData::current();
 
         let obj: Allocated<IvarTester> = unsafe { msg_send_id![IvarTester::class(), alloc] };
         expected.assert_current();
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_init_drop() {
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let mut obj: Id<IvarTester, Owned> = unsafe { msg_send_id![IvarTester::class(), new] };
         expected.alloc += 4;
@@ -326,6 +326,6 @@ mod tests {
         let mut obj: Id<IvarTester, Owned> =
             unsafe { msg_send_id![IvarTester::alloc(), initInvalid] };
 
-        *obj.ivar1 = RcTestObject::new().into();
+        *obj.ivar1 = __RcTestObject::new().into();
     }
 }

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -217,8 +217,6 @@ mod cache;
 mod class_type;
 pub mod declare;
 pub mod exception;
-#[cfg(feature = "foundation")]
-pub mod foundation;
 mod macros;
 mod message;
 mod protocol;
@@ -227,6 +225,11 @@ pub mod runtime;
 #[cfg(test)]
 mod test_utils;
 mod verify;
+
+#[cfg(test)]
+#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
+extern "C" {}
 
 /// Hacky way to make GNUStep link properly to Foundation while testing.
 ///

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -73,8 +73,8 @@
 //! other type, and this would trigger undefined behaviour!
 //!
 //! Making the ergonomics better is something that is currently being worked
-//! on, the [`foundation`] module contains more ergonomic usage of at
-//! least parts of the `Foundation` framework.
+//! on, see the `icrate` crate for much more ergonomic usage of the built-in
+//! frameworks like `Foundation`, `AppKit`, `UIKit` and so on.
 //!
 //! Anyhow, all of this `unsafe` nicely leads us to another feature that this
 //! crate has:
@@ -83,7 +83,6 @@
 //! [`runtime::Object`]: crate::runtime::Object
 //! [`rc::Owned`]: crate::rc::Owned
 //! [`rc::Id`]: crate::rc::Id
-//! [`foundation`]: crate::foundation
 //!
 //!
 //! ## Encodings and message type verification

--- a/crates/objc2/src/macros.rs
+++ b/crates/objc2/src/macros.rs
@@ -693,7 +693,7 @@ macro_rules! __class_inner {
 ///
 /// In particular, you can make the last argument the special marker `_`, and
 /// then the macro will return a `Result<(), Id<E, Shared>>` (where you must
-/// specify `E` yourself, usually you'd use [`foundation::NSError`]).
+/// specify `E` yourself, usually you'd use `icrate::Foundation::NSError`).
 ///
 /// At runtime, a temporary error variable is created on the stack and sent as
 /// the last parameter. If the message send then returns `NO`/`false` (or in
@@ -705,7 +705,6 @@ macro_rules! __class_inner {
 ///
 /// [cocoa-error]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorHandling/ErrorHandling.html
 /// [swift-error]: https://developer.apple.com/documentation/swift/about-imported-cocoa-error-parameters
-/// [`foundation::NSError`]: crate::foundation::NSError
 ///
 ///
 /// # Panics
@@ -782,11 +781,19 @@ macro_rules! __class_inner {
 ///
 /// ```no_run
 /// use objc2::msg_send;
-/// # use objc2::ns_string;
-/// # use objc2::foundation::{NSString as MyObject};
+/// # use objc2::runtime::NSObject;
+/// # use objc2::{declare_class, ClassType};
+/// #
+/// # declare_class!(
+/// #     struct MyObject {}
+/// #
+/// #     unsafe impl ClassType for MyObject {
+/// #         type Super = NSObject;
+/// #     }
+/// # );
 ///
 /// let obj: &MyObject; // Some object that implements ClassType
-/// # obj = ns_string!("");
+/// # obj = todo!();
 /// let _: () = unsafe { msg_send![super(obj), someMethod] };
 /// ```
 ///
@@ -1006,9 +1013,8 @@ macro_rules! msg_send_bool {
 ///
 /// In particular, you can make the last argument the special marker `_`, and
 /// then the macro will return a `Result<Id<T, O>, Id<E, Shared>>` (where you
-/// must specify `E` yourself, usually you'd use [`foundation::NSError`]).
-///
-/// [`foundation::NSError`]: crate::foundation::NSError
+/// must specify `E` yourself, usually you'd use
+/// `icrate::Foundation::NSError`).
 ///
 ///
 /// # Panics

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -137,9 +137,6 @@
 ///     declare_class, extern_protocol, msg_send, msg_send_id, ClassType,
 ///     ConformsTo, ProtocolType,
 /// };
-/// #
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 ///
 /// // Declare the NSCopying protocol so that we can implement it (since
 /// // NSCopying is a trait currently).

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -66,6 +66,11 @@
 /// # #[cfg(feature = "gnustep-1-7")]
 /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 ///
+/// // Link to the Foundation framework
+/// #[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+/// #[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
+/// extern "C" {}
+///
 /// extern_class!(
 ///     /// An example description.
 ///     #[derive(PartialEq, Eq, Hash)] // Uses the superclass' implementation

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -62,14 +62,6 @@
 /// use objc2::runtime::NSObject;
 /// use objc2::rc::{Id, Shared};
 /// use objc2::{ClassType, extern_class, msg_send_id};
-/// #
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-///
-/// // Link to the Foundation framework
-/// #[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
-/// #[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
-/// extern "C" {}
 ///
 /// extern_class!(
 ///     /// An example description.

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -116,7 +116,7 @@
 /// );
 /// ```
 ///
-/// See the source code of `objc2::foundation` in general for more examples.
+/// See the source code of `icrate` for many more examples.
 #[doc(alias = "@interface")]
 #[macro_export]
 macro_rules! extern_class {

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -130,7 +130,7 @@
 /// /// Creation methods.
 /// impl MyObject {
 ///     pub fn new() -> Id<Self, Shared> {
-///          unsafe { msg_send_id![Self::class(), new] }
+///         unsafe { msg_send_id![Self::class(), new] }
 ///     }
 ///
 ///     pub fn init(this: Option<Allocated<Self>>, val: usize) -> Id<Self, Shared> {

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -57,9 +57,6 @@
 /// use objc2::rc::{Allocated, Id, Shared};
 /// use objc2::runtime::NSObject;
 /// use objc2::{declare_class, extern_methods, ClassType};
-/// #
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 ///
 /// // Shim
 /// type NSError = NSObject;
@@ -112,9 +109,6 @@
 /// # use objc2::rc::{Allocated, Id, Shared};
 /// # use objc2::runtime::NSObject;
 /// # use objc2::{declare_class, extern_methods, ClassType};
-/// #
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// #
 /// # // Shim
 /// # type NSError = NSObject;

--- a/crates/objc2/src/protocol.rs
+++ b/crates/objc2/src/protocol.rs
@@ -24,8 +24,6 @@ use crate::Message;
 /// Use the trait to access the [`Protocol`] of different objects.
 ///
 /// ```
-/// # #[cfg(feature = "gnustep-1-7")]
-/// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 /// use objc2::ProtocolType;
 /// use objc2::runtime::NSObject;
 /// // Get a protocol object representing `NSObject`

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -488,9 +488,6 @@ impl<T: Message, O: Ownership> Id<T, O> {
     /// use objc2::declare::ClassBuilder;
     /// use objc2::rc::{Id, Owned};
     /// use objc2::runtime::{Class, Object, Sel};
-    /// #
-    /// # #[cfg(feature = "gnustep-1-7")]
-    /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
     ///
     /// let mut builder = ClassBuilder::new("ExampleObject", class!(NSObject)).unwrap();
     ///

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -762,7 +762,7 @@ impl<T: UnwindSafe + ?Sized> UnwindSafe for Id<T, Owned> {}
 mod tests {
     use super::*;
     use crate::msg_send;
-    use crate::rc::{autoreleasepool, RcTestObject, ThreadTestData};
+    use crate::rc::{__RcTestObject, __ThreadTestData, autoreleasepool};
     use crate::runtime::Object;
 
     #[track_caller]
@@ -773,9 +773,9 @@ mod tests {
 
     #[test]
     fn test_drop() {
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
-        let obj = RcTestObject::new();
+        let obj = __RcTestObject::new();
         expected.alloc += 1;
         expected.init += 1;
         expected.assert_current();
@@ -788,9 +788,9 @@ mod tests {
 
     #[test]
     fn test_autorelease() {
-        let obj: Id<_, Shared> = RcTestObject::new().into();
+        let obj: Id<_, Shared> = __RcTestObject::new().into();
         let cloned = obj.clone();
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         autoreleasepool(|pool| {
             let _ref = obj.autorelease(pool);
@@ -814,9 +814,9 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let obj: Id<_, Owned> = RcTestObject::new();
+        let obj: Id<_, Owned> = __RcTestObject::new();
         assert_retain_count(&obj, 1);
-        let mut expected = ThreadTestData::current();
+        let mut expected = __ThreadTestData::current();
 
         let obj: Id<_, Shared> = obj.into();
         expected.assert_current();
@@ -841,10 +841,10 @@ mod tests {
 
     #[test]
     fn test_retain_autoreleased_works_as_retain() {
-        let obj: Id<_, Shared> = RcTestObject::new().into();
-        let mut expected = ThreadTestData::current();
+        let obj: Id<_, Shared> = __RcTestObject::new().into();
+        let mut expected = __ThreadTestData::current();
 
-        let ptr = Id::as_ptr(&obj) as *mut RcTestObject;
+        let ptr = Id::as_ptr(&obj) as *mut __RcTestObject;
         let _obj2: Id<_, Shared> = unsafe { Id::retain_autoreleased(ptr) }.unwrap();
         expected.retain += 1;
         expected.assert_current();
@@ -852,15 +852,15 @@ mod tests {
 
     #[test]
     fn test_cast() {
-        let obj: Id<RcTestObject, _> = RcTestObject::new();
-        let expected = ThreadTestData::current();
+        let obj: Id<__RcTestObject, _> = __RcTestObject::new();
+        let expected = __ThreadTestData::current();
 
         // SAFETY: Any object can be cast to `Object`
         let obj: Id<Object, _> = unsafe { Id::cast(obj) };
         expected.assert_current();
 
-        // SAFETY: The object was originally `RcTestObject`
-        let _obj: Id<RcTestObject, _> = unsafe { Id::cast(obj) };
+        // SAFETY: The object was originally `__RcTestObject`
+        let _obj: Id<__RcTestObject, _> = unsafe { Id::cast(obj) };
         expected.assert_current();
     }
 }

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -61,20 +61,16 @@ mod id;
 mod id_forwarding_impls;
 mod id_traits;
 mod ownership;
-mod weak_id;
-
-#[cfg(test)]
 mod test_object;
+mod weak_id;
 
 pub use self::allocated::Allocated;
 pub use self::autorelease::{autoreleasepool, AutoreleasePool, AutoreleaseSafe};
 pub use self::id::Id;
 pub use self::id_traits::{DefaultId, SliceId, SliceIdMut};
 pub use self::ownership::{Owned, Ownership, Shared};
+pub use self::test_object::{__RcTestObject, __ThreadTestData};
 pub use self::weak_id::WeakId;
-
-#[cfg(test)]
-pub(crate) use self::test_object::{RcTestObject, ThreadTestData};
 
 #[cfg(test)]
 mod tests {

--- a/crates/objc2/src/rc/weak_id.rs
+++ b/crates/objc2/src/rc/weak_id.rs
@@ -150,13 +150,13 @@ impl<T: Message> TryFrom<WeakId<T>> for Id<T, Shared> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rc::{RcTestObject, ThreadTestData};
+    use crate::rc::{__RcTestObject, __ThreadTestData};
     use crate::runtime::Object;
 
     #[test]
     fn test_weak() {
-        let obj: Id<_, Shared> = RcTestObject::new().into();
-        let mut expected = ThreadTestData::current();
+        let obj: Id<_, Shared> = __RcTestObject::new().into();
+        let mut expected = __ThreadTestData::current();
 
         let weak = WeakId::new(&obj);
         expected.assert_current();
@@ -184,8 +184,8 @@ mod tests {
 
     #[test]
     fn test_weak_clone() {
-        let obj: Id<_, Shared> = RcTestObject::new().into();
-        let mut expected = ThreadTestData::current();
+        let obj: Id<_, Shared> = __RcTestObject::new().into();
+        let mut expected = __ThreadTestData::current();
 
         let weak = WeakId::new(&obj);
         expected.assert_current();

--- a/crates/objc2/src/runtime.rs
+++ b/crates/objc2/src/runtime.rs
@@ -602,8 +602,6 @@ impl Class {
     /// # Example
     ///
     /// ```
-    /// # #[cfg(feature = "gnustep-1-7")]
-    /// # unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
     /// # use objc2::{class, sel};
     /// # use objc2::runtime::Class;
     /// let cls = class!(NSObject);

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -178,7 +178,7 @@ mod tests {
     use super::*;
     use alloc::format;
 
-    use crate::rc::RcTestObject;
+    use crate::rc::__RcTestObject;
 
     #[test]
     fn test_deref() {
@@ -247,10 +247,10 @@ mod tests {
     fn test_is_kind_of() {
         let obj = NSObject::new();
         assert!(obj.is_kind_of::<NSObject>());
-        assert!(!obj.is_kind_of::<RcTestObject>());
+        assert!(!obj.is_kind_of::<__RcTestObject>());
 
-        let obj = RcTestObject::new();
+        let obj = __RcTestObject::new();
         assert!(obj.is_kind_of::<NSObject>());
-        assert!(obj.is_kind_of::<RcTestObject>());
+        assert!(obj.is_kind_of::<__RcTestObject>());
     }
 }

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -15,11 +15,11 @@ __inner_extern_class! {
     /// This represents both the [`NSObject` class][cls] and the [`NSObject`
     /// protocol][proto].
     ///
-    /// To properly use this, you must either enable the `"foundation"`
-    /// feature, or link a framework/library where the `NSObject` symbol is
-    /// available.
+    /// To properly use this, you must either use the `icrate` crate with the
+    /// `"Foundation"` feature, or manually link a framework/library where the
+    /// `NSObject` class symbol is available.
     ///
-    /// This is exported under `objc2::foundation::NSObject`, you probably
+    /// This is exported under `icrate::Foundation::NSObject`, you probably
     /// want to use that path instead.
     ///
     /// [cls]: https://developer.apple.com/documentation/objectivec/nsobject?language=objc

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -15,9 +15,8 @@ __inner_extern_class! {
     /// This represents both the [`NSObject` class][cls] and the [`NSObject`
     /// protocol][proto].
     ///
-    /// To properly use this, you must either use the `icrate` crate with the
-    /// `"Foundation"` feature, or manually link a framework/library where the
-    /// `NSObject` class symbol is available.
+    /// Since this class is only available with the `Foundation` framework,
+    /// this crate links to it for you.
     ///
     /// This is exported under `icrate::Foundation::NSObject`, you probably
     /// want to use that path instead.
@@ -37,14 +36,23 @@ unsafe impl ClassType for NSObject {
 
     #[inline]
     fn class() -> &'static Class {
-        #[cfg(not(all(feature = "unstable-static-class", not(feature = "apple"))))]
+        #[cfg(feature = "apple")]
         {
             crate::class!(NSObject)
         }
-        // Fix for `unstable-static-class` not working on GNUStep
-        #[cfg(all(feature = "unstable-static-class", not(feature = "apple")))]
+        #[cfg(feature = "gnustep-1-7")]
         {
-            Class::get("NSObject").unwrap()
+            extern "C" {
+                // The linking changed in libobjc2 v2.0
+                #[cfg_attr(feature = "gnustep-2-0", link_name = "._OBJC_CLASS_NSObject")]
+                #[cfg_attr(not(feature = "gnustep-2-0"), link_name = "_OBJC_CLASS_NSObject")]
+                static OBJC_CLASS_NSObject: Class;
+                // Others:
+                // __objc_class_name_NSObject
+                // _OBJC_CLASS_REF_NSObject
+            }
+
+            unsafe { &OBJC_CLASS_NSObject }
         }
     }
 

--- a/crates/objc2/tests/id_retain_autoreleased.rs
+++ b/crates/objc2/tests/id_retain_autoreleased.rs
@@ -1,8 +1,12 @@
-use std::ffi::c_void;
+use core::mem::ManuallyDrop;
 
+use objc2::msg_send;
 use objc2::rc::{autoreleasepool, Id, Shared};
-use objc2::runtime::Object;
-use objc2::{class, msg_send};
+use objc2::runtime::NSObject;
+
+#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
+extern "C" {}
 
 #[cfg(feature = "gnustep-1-7")]
 #[test]
@@ -10,31 +14,14 @@ fn ensure_linkage() {
     unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
 }
 
-fn retain_count(obj: &Object) -> usize {
+fn retain_count(obj: &NSObject) -> usize {
     unsafe { msg_send![obj, retainCount] }
 }
 
-fn create_data(bytes: &[u8]) -> Id<Object, Shared> {
-    let bytes_ptr: *const c_void = bytes.as_ptr().cast();
+fn create_obj() -> Id<NSObject, Shared> {
+    let obj = ManuallyDrop::new(NSObject::new());
     unsafe {
-        // let obj: *mut Object = msg_send![
-        //     class!(NSMutableData),
-        //     dataWithBytes: bytes_ptr,
-        //     length: bytes.len(),
-        // ];
-        //
-        // On x86 (and perhaps others), dataWithBytes does not tail call
-        // `autorelease` and hence the return address points into that instead
-        // of our code, making the fast autorelease scheme fail.
-        //
-        // So instead, we call `autorelease` manually here.
-        let obj: *mut Object = msg_send![class!(NSMutableData), alloc];
-        let obj: *mut Object = msg_send![
-            obj,
-            initWithBytes: bytes_ptr,
-            length: bytes.len(),
-        ];
-        let obj: *mut Object = msg_send![obj, autorelease];
+        let obj: *mut NSObject = msg_send![&*obj, autorelease];
         // All code between the `msg_send!` and the `retain_autoreleased` must
         // be able to be optimized away for this to work.
         Id::retain_autoreleased(obj).unwrap()
@@ -46,7 +33,7 @@ fn test_retain_autoreleased() {
     autoreleasepool(|_| {
         // Run once to allow DYLD to resolve the symbol stubs.
         // Required for making `retain_autoreleased` work on x86_64.
-        let _data = create_data(b"12");
+        let _data = create_obj();
 
         // When compiled in release mode / with optimizations enabled,
         // subsequent usage of `retain_autoreleased` will succeed in retaining
@@ -59,14 +46,14 @@ fn test_retain_autoreleased() {
             1
         };
 
-        let data = create_data(b"34");
+        let data = create_obj();
         assert_eq!(retain_count(&data), expected);
 
-        let data = create_data(b"56");
+        let data = create_obj();
         assert_eq!(retain_count(&data), expected);
 
         // Here we manually clean up the autorelease, so it will always be 1.
-        let data = autoreleasepool(|_| create_data(b"78"));
+        let data = autoreleasepool(|_| create_obj());
         assert_eq!(retain_count(&data), 1);
     });
 }

--- a/crates/objc2/tests/id_retain_autoreleased.rs
+++ b/crates/objc2/tests/id_retain_autoreleased.rs
@@ -4,16 +4,6 @@ use objc2::msg_send;
 use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::NSObject;
 
-#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
-#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
-extern "C" {}
-
-#[cfg(feature = "gnustep-1-7")]
-#[test]
-fn ensure_linkage() {
-    unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-}
-
 fn retain_count(obj: &NSObject) -> usize {
     unsafe { msg_send![obj, retainCount] }
 }

--- a/crates/objc2/tests/no_prelude.rs
+++ b/crates/objc2/tests/no_prelude.rs
@@ -11,6 +11,10 @@ extern crate objc2 as new_objc2;
 
 use new_objc2::{ClassType, ProtocolType};
 
+#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
+extern "C" {}
+
 #[cfg(feature = "gnustep-1-7")]
 #[test]
 fn ensure_linkage() {

--- a/crates/objc2/tests/no_prelude.rs
+++ b/crates/objc2/tests/no_prelude.rs
@@ -11,16 +11,6 @@ extern crate objc2 as new_objc2;
 
 use new_objc2::{ClassType, ProtocolType};
 
-#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
-#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
-extern "C" {}
-
-#[cfg(feature = "gnustep-1-7")]
-#[test]
-fn ensure_linkage() {
-    unsafe { new_objc2::__gnustep_hack::get_class_to_force_linkage() };
-}
-
 mod core {}
 mod std {}
 mod libc {}

--- a/crates/objc2/tests/use_macros.rs
+++ b/crates/objc2/tests/use_macros.rs
@@ -1,5 +1,13 @@
-use objc2::runtime::Object;
-use objc2::{class, msg_send, sel};
+use objc2::runtime::{Class, NSObject, Object};
+use objc2::{class, declare_class, msg_send, sel, ClassType};
+
+declare_class!(
+    struct MyObject {}
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+    }
+);
 
 #[cfg(feature = "gnustep-1-7")]
 #[test]
@@ -24,11 +32,7 @@ fn use_sel() {
 }
 
 #[allow(unused)]
-#[cfg(feature = "foundation")]
-fn test_msg_send_comma_handling(
-    obj: &objc2::foundation::NSString,
-    superclass: &objc2::runtime::Class,
-) {
+fn test_msg_send_comma_handling(obj: &MyObject, superclass: &Class) {
     unsafe {
         let _: () = msg_send![obj, a];
         let _: () = msg_send![obj, a,];

--- a/crates/objc2/tests/use_macros.rs
+++ b/crates/objc2/tests/use_macros.rs
@@ -1,16 +1,6 @@
 use objc2::runtime::{Class, NSObject, Object};
 use objc2::{class, declare_class, msg_send, sel, ClassType};
 
-#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
-#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
-extern "C" {}
-
-#[cfg(feature = "gnustep-1-7")]
-#[test]
-fn ensure_linkage() {
-    unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-}
-
 declare_class!(
     struct MyObject {}
 

--- a/crates/objc2/tests/use_macros.rs
+++ b/crates/objc2/tests/use_macros.rs
@@ -1,6 +1,16 @@
 use objc2::runtime::{Class, NSObject, Object};
 use objc2::{class, declare_class, msg_send, sel, ClassType};
 
+#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
+extern "C" {}
+
+#[cfg(feature = "gnustep-1-7")]
+#[test]
+fn ensure_linkage() {
+    unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
+}
+
 declare_class!(
     struct MyObject {}
 
@@ -8,12 +18,6 @@ declare_class!(
         type Super = NSObject;
     }
 );
-
-#[cfg(feature = "gnustep-1-7")]
-#[test]
-fn ensure_linkage() {
-    unsafe { objc2::__gnustep_hack::get_class_to_force_linkage() };
-}
 
 #[test]
 fn use_class_and_msg_send() {

--- a/crates/test-assembly/crates/test_ns_string/Cargo.toml
+++ b/crates/test-assembly/crates/test_ns_string/Cargo.toml
@@ -8,20 +8,21 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-objc2 = { path = "../../../objc2", default-features = false }
+icrate = { path = "../../../icrate", default-features = false }
 
 [features]
-default = ["apple", "std", "foundation"]
-std = ["objc2/std"]
-# Runtime
-apple = ["objc2/apple"]
-gnustep-1-7 = ["objc2/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "objc2/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "objc2/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "objc2/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "objc2/gnustep-2-1"]
+default = ["apple", "std", "Foundation"]
+std = ["icrate/std"]
 
-foundation = ["objc2/foundation"]
+# Runtime
+apple = ["icrate/apple"]
+gnustep-1-7 = ["icrate/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "icrate/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "icrate/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "icrate/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "icrate/gnustep-2-1"]
+
+Foundation = ["icrate/Foundation"]
 
 # Hack
-assembly-features = ["foundation"]
+assembly-features = ["Foundation"]

--- a/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86.s
@@ -23,7 +23,7 @@ get_ascii:
 	lea	eax, [ebx + .Lanon.[ID].0@GOTOFF]
 	push	3
 	push	eax
-	call	SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@PLT
+	call	SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	mov	ecx, eax
 	xchg	dword ptr [ebx + SYM(test_ns_string[CRATE_ID]::get_ascii::CACHED_NSSTRING, 0).0@GOTOFF], ecx
@@ -56,7 +56,7 @@ get_utf16:
 	lea	eax, [ebx + .Lanon.[ID].1@GOTOFF]
 	push	5
 	push	eax
-	call	SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@PLT
+	call	SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	mov	ecx, eax
 	xchg	dword ptr [ebx + SYM(test_ns_string[CRATE_ID]::get_utf16::CACHED_NSSTRING, 0).0@GOTOFF], ecx
@@ -89,7 +89,7 @@ get_with_nul:
 	lea	eax, [ebx + .Lanon.[ID].2@GOTOFF]
 	push	6
 	push	eax
-	call	SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@PLT
+	call	SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	mov	ecx, eax
 	xchg	dword ptr [ebx + SYM(test_ns_string[CRATE_ID]::get_with_nul::CACHED_NSSTRING, 0).0@GOTOFF], ecx

--- a/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86_64.s
@@ -14,7 +14,7 @@ get_ascii:
 .LBB0_1:
 	lea	rdi, [rip + .Lanon.[ID].0]
 	mov	esi, 3
-	call	qword ptr [rip + SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
+	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_ascii::CACHED_NSSTRING, 0).0], rcx
 	pop	rcx
@@ -36,7 +36,7 @@ get_utf16:
 .LBB1_1:
 	lea	rdi, [rip + .Lanon.[ID].1]
 	mov	esi, 5
-	call	qword ptr [rip + SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
+	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_utf16::CACHED_NSSTRING, 0).0], rcx
 	pop	rcx
@@ -58,7 +58,7 @@ get_with_nul:
 .LBB2_1:
 	lea	rdi, [rip + .Lanon.[ID].2]
 	mov	esi, 6
-	call	qword ptr [rip + SYM(objc2::foundation::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
+	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::NSString::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_with_nul::CACHED_NSSTRING, 0).0], rcx
 	pop	rcx

--- a/crates/test-assembly/crates/test_ns_string/lib.rs
+++ b/crates/test-assembly/crates/test_ns_string/lib.rs
@@ -1,8 +1,8 @@
 //! Test the output of the `ns_string!` macro.
-#![cfg(feature = "foundation")]
+#![cfg(feature = "Foundation")]
 
-use objc2::foundation::NSString;
-use objc2::ns_string;
+use icrate::Foundation::ns_string;
+use icrate::Foundation::NSString;
 
 // Temporary to allow testing putting string references in statics.
 // This doesn't yet compile on other platforms, but could in the future!
@@ -10,14 +10,14 @@ use objc2::ns_string;
 #[no_mangle]
 static EMPTY: &NSString = {
     const INPUT: &[u8] = b"";
-    objc2::__ns_string_inner!(@inner INPUT);
+    icrate::objc2::__ns_string_inner!(@inner INPUT);
     CFSTRING.as_nsstring_const()
 };
 #[cfg(feature = "apple")]
 #[no_mangle]
 static XYZ: &NSString = {
     const INPUT: &[u8] = b"xyz";
-    objc2::__ns_string_inner!(@inner INPUT);
+    icrate::objc2::__ns_string_inner!(@inner INPUT);
     CFSTRING.as_nsstring_const()
 };
 

--- a/crates/test-assembly/crates/test_ns_string/lib.rs
+++ b/crates/test-assembly/crates/test_ns_string/lib.rs
@@ -1,7 +1,7 @@
 //! Test the output of the `ns_string!` macro.
 #![cfg(feature = "Foundation")]
 
-use icrate::Foundation::ns_string;
+use icrate::ns_string;
 use icrate::Foundation::NSString;
 
 // Temporary to allow testing putting string references in statics.
@@ -10,14 +10,14 @@ use icrate::Foundation::NSString;
 #[no_mangle]
 static EMPTY: &NSString = {
     const INPUT: &[u8] = b"";
-    icrate::objc2::__ns_string_inner!(@inner INPUT);
+    icrate::__ns_string_inner!(@inner INPUT);
     CFSTRING.as_nsstring_const()
 };
 #[cfg(feature = "apple")]
 #[no_mangle]
 static XYZ: &NSString = {
     const INPUT: &[u8] = b"xyz";
-    icrate::objc2::__ns_string_inner!(@inner INPUT);
+    icrate::__ns_string_inner!(@inner INPUT);
     CFSTRING.as_nsstring_const()
 };
 

--- a/crates/test-ui/Cargo.toml
+++ b/crates/test-ui/Cargo.toml
@@ -8,17 +8,17 @@ repository = "https://github.com/madsmtm/objc2"
 license = "MIT"
 
 [features]
-# UI tests don't work without `foundation` feature, but we have no way of
+# UI tests don't work without `Foundation` feature, but we have no way of
 # specifying that, as trybuild doesn't take any arguments
-default = ["apple", "std", "objc2/foundation"]
-std = ["block2/std", "objc2/std"]
+default = ["apple", "std", "icrate/Foundation"]
+std = ["block2/std", "objc2/std", "icrate/std"]
 
-apple = ["block2/apple", "objc2/apple"]
-gnustep-1-7 = ["block2/gnustep-1-7", "objc2/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "block2/gnustep-1-8", "objc2/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2/gnustep-2-1"]
+apple = ["block2/apple", "objc2/apple", "icrate/apple"]
+gnustep-1-7 = ["block2/gnustep-1-7", "objc2/gnustep-1-7", "icrate/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "block2/gnustep-1-8", "objc2/gnustep-1-8", "icrate/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2/gnustep-1-9", "icrate/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2/gnustep-2-0", "icrate/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2/gnustep-2-1", "icrate/gnustep-2-1"]
 
 run = ["trybuild"]
 
@@ -26,6 +26,7 @@ run = ["trybuild"]
 trybuild = { version = "1.0.72", optional = true }
 block2 = { path = "../block2", default-features = false }
 objc2 = { path = "../objc2", default-features = false }
+icrate = { path = "../icrate", default-features = false }
 
 [[bin]]
 name = "test-ui"

--- a/crates/test-ui/ui/invalid_ns_string_input.rs
+++ b/crates/test-ui/ui/invalid_ns_string_input.rs
@@ -1,4 +1,4 @@
-use objc2::ns_string;
+use icrate::ns_string;
 
 fn main() {
     let _ = ns_string!(1u8);

--- a/crates/test-ui/ui/invalid_ns_string_output.rs
+++ b/crates/test-ui/ui/invalid_ns_string_output.rs
@@ -1,4 +1,4 @@
-use objc2::ns_string;
+use icrate::ns_string;
 
 fn main() {
     let _: u8 = ns_string!("abc");

--- a/crates/test-ui/ui/mainthreadmarker_not_send_sync.rs
+++ b/crates/test-ui/ui/mainthreadmarker_not_send_sync.rs
@@ -1,5 +1,5 @@
 //! Test that MainThreadMarker is neither Send nor Sync.
-use objc2::foundation::MainThreadMarker;
+use icrate::Foundation::MainThreadMarker;
 
 fn needs_sync<T: Sync>() {}
 fn needs_send<T: Send>() {}

--- a/crates/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -27,14 +27,9 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
   |
   = help: the following other types implement trait `Message`:
             Exception
-            NSArray<T, O>
-            NSAttributedString
-            NSBundle
-            NSData
-            NSDictionary<K, V>
-            NSError
-            NSException
-          and $N others
+            NSObject
+            __RcTestObject
+            objc2::runtime::Object
   = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
 
 error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
@@ -48,14 +43,9 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
   |
   = help: the following other types implement trait `Message`:
             Exception
-            NSArray<T, O>
-            NSAttributedString
-            NSBundle
-            NSData
-            NSDictionary<K, V>
-            NSError
-            NSException
-          and $N others
+            NSObject
+            __RcTestObject
+            objc2::runtime::Object
   = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class, Shared>>`
 
 error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
@@ -87,14 +77,9 @@ error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
   |
   = help: the following other types implement trait `Message`:
             Exception
-            NSArray<T, O>
-            NSAttributedString
-            NSBundle
-            NSData
-            NSDictionary<K, V>
-            NSError
-            NSException
-          and $N others
+            NSObject
+            __RcTestObject
+            objc2::runtime::Object
   = note: required for `RetainSemantics<2>` to implement `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>>`
 
 error[E0271]: type mismatch resolving `<Id<objc2::runtime::Object, Shared> as MaybeUnwrap>::Input == Allocated<_>`

--- a/crates/test-ui/ui/msg_send_invalid_error.rs
+++ b/crates/test-ui/ui/msg_send_invalid_error.rs
@@ -2,7 +2,7 @@
 use objc2::{msg_send, msg_send_id};
 use objc2::ClassType;
 use objc2::rc::{Id, Shared};
-use objc2::foundation::NSString;
+use icrate::Foundation::NSString;
 
 fn main() {
     let obj: &NSString;

--- a/crates/test-ui/ui/msg_send_super_not_classtype.stderr
+++ b/crates/test-ui/ui/msg_send_super_not_classtype.stderr
@@ -8,15 +8,8 @@ error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfi
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
-            NSArray<T, O>
-            NSAttributedString
-            NSBundle
-            NSData
-            NSDictionary<K, V>
-            NSError
-            NSException
-            NSLock
-          and $N others
+            NSObject
+            __RcTestObject
 note: required by a bound in `__send_super_message_static`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs
   |
@@ -33,15 +26,8 @@ error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfi
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
-            NSArray<T, O>
-            NSAttributedString
-            NSBundle
-            NSData
-            NSDictionary<K, V>
-            NSError
-            NSException
-            NSLock
-          and $N others
+            NSObject
+            __RcTestObject
 note: required by a bound in `__send_super_message_static`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs
   |

--- a/crates/test-ui/ui/msg_send_underspecified_error.rs
+++ b/crates/test-ui/ui/msg_send_underspecified_error.rs
@@ -1,7 +1,7 @@
 //! Test underspecified msg_send! errors.
 use objc2::{msg_send, msg_send_id};
 use objc2::rc::{Id, Shared};
-use objc2::foundation::NSString;
+use icrate::Foundation::NSString;
 
 fn main() {
     let obj: &NSString;

--- a/crates/test-ui/ui/msg_send_underspecified_error2.rs
+++ b/crates/test-ui/ui/msg_send_underspecified_error2.rs
@@ -1,7 +1,7 @@
 //! Test underspecified msg_send! errors.
 use objc2::msg_send_id;
 use objc2::rc::{Id, Shared};
-use objc2::foundation::{NSError, NSString};
+use icrate::Foundation::{NSError, NSString};
 
 fn main() {
     let obj: &NSString;

--- a/crates/test-ui/ui/ns_string_not_const.rs
+++ b/crates/test-ui/ui/ns_string_not_const.rs
@@ -1,4 +1,4 @@
-use objc2::ns_string;
+use icrate::ns_string;
 
 fn main() {
     let s: &str = "abc";

--- a/crates/test-ui/ui/ns_string_output_not_const.rs
+++ b/crates/test-ui/ui/ns_string_output_not_const.rs
@@ -1,4 +1,4 @@
-use objc2::foundation::NSString;
+use icrate::Foundation::NSString;
 use objc2::ns_string;
 
 fn main() {

--- a/crates/test-ui/ui/ns_string_output_not_const.rs
+++ b/crates/test-ui/ui/ns_string_output_not_const.rs
@@ -1,5 +1,5 @@
 use icrate::Foundation::NSString;
-use objc2::ns_string;
+use icrate::ns_string;
 
 fn main() {
     static STRING: &NSString = ns_string!("abc");

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.rs
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.rs
@@ -1,4 +1,4 @@
-use objc2::foundation::NSArray;
+use icrate::Foundation::NSArray;
 use objc2::rc::Shared;
 use objc2::runtime::Object;
 

--- a/crates/test-ui/ui/nsstring_as_str_use_after_release.rs
+++ b/crates/test-ui/ui/nsstring_as_str_use_after_release.rs
@@ -1,6 +1,6 @@
 //! Test that the lifetime of `NSString::as_str` is bound to the string.
 
-use objc2::foundation::NSString;
+use icrate::Foundation::NSString;
 use objc2::rc::autoreleasepool;
 
 fn main() {

--- a/crates/test-ui/ui/nsstring_as_str_use_outside_pool.rs
+++ b/crates/test-ui/ui/nsstring_as_str_use_outside_pool.rs
@@ -1,6 +1,6 @@
 //! Test that the lifetime of `NSString::as_str` is bound to the pool.
 
-use objc2::foundation::NSString;
+use icrate::Foundation::NSString;
 use objc2::rc::autoreleasepool;
 
 fn main() {

--- a/crates/test-ui/ui/object_not_send_sync.rs
+++ b/crates/test-ui/ui/object_not_send_sync.rs
@@ -4,7 +4,7 @@
 //! Also test that `NSValue` is not Send nor Sync, because its contained value
 //! might not be.
 
-use objc2::foundation::NSValue;
+use icrate::Foundation::NSValue;
 use objc2::runtime::{Object, NSObject};
 
 fn needs_sync<T: ?Sized + Sync>() {}

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -11,16 +11,16 @@ build = "build.rs"
 
 [features]
 default = ["apple", "std"]
-std = ["block2/std", "objc2/std"]
+std = ["block2/std", "objc2/std", "icrate/std"]
 exception = ["objc2/exception"]
 catch-all = ["objc2/catch-all", "exception"]
 
-apple = ["block2/apple", "objc2/apple"]
-gnustep-1-7 = ["block2/gnustep-1-7", "objc2/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "block2/gnustep-1-8", "objc2/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2/gnustep-2-1"]
+apple = ["block2/apple", "objc2/apple", "icrate/apple"]
+gnustep-1-7 = ["block2/gnustep-1-7", "objc2/gnustep-1-7", "icrate/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "block2/gnustep-1-8", "objc2/gnustep-1-8", "icrate/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2/gnustep-1-9", "icrate/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2/gnustep-2-0", "icrate/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2/gnustep-2-1", "icrate/gnustep-2-1"]
 
 malloc = ["objc2/malloc"]
 
@@ -28,7 +28,8 @@ malloc = ["objc2/malloc"]
 block2 = { path = "../block2", default-features = false }
 block-sys = { path = "../block-sys", default-features = false }
 objc-sys = { path = "../objc-sys", default-features = false }
-objc2 = { path = "../objc2", default-features = false, features = ["foundation"] }
+objc2 = { path = "../objc2", default-features = false }
+icrate = { path = "../icrate", default-features = false, features = ["Foundation"] }
 
 [build-dependencies]
 cc = "1.0"

--- a/crates/tests/src/exception.rs
+++ b/crates/tests/src/exception.rs
@@ -1,7 +1,7 @@
 use alloc::format;
 
+use icrate::Foundation::{NSArray, NSException, NSString};
 use objc2::exception::{catch, throw};
-use objc2::foundation::{NSArray, NSException, NSString};
 use objc2::msg_send;
 use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::Object;

--- a/crates/tests/src/test_object.rs
+++ b/crates/tests/src/test_object.rs
@@ -1,7 +1,7 @@
 use core::mem::{size_of, ManuallyDrop};
 use std::os::raw::c_int;
 
-use objc2::foundation::NSNumber;
+use icrate::Foundation::NSNumber;
 use objc2::rc::{autoreleasepool, AutoreleasePool, Id, Owned, Shared};
 use objc2::runtime::{Bool, Class, NSObject, Object, Protocol};
 #[cfg(feature = "malloc")]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-objc2 = { path = "../crates/objc2", features = ["foundation"], default-features = false }
+objc2 = { path = "../crates/objc2", default-features = false }
 
 [features]
 default = ["apple", "std"]

--- a/fuzz/fuzz_targets/class.rs
+++ b/fuzz/fuzz_targets/class.rs
@@ -1,13 +1,12 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use objc2::runtime::Class;
+use objc2::runtime::{NSObject, Class};
+use objc2::ClassType;
 use std::ffi::CString;
 
 fuzz_target!(|s: &str| {
     #[cfg(feature = "gnustep-1-7")]
-    unsafe {
-        objc2::__gnustep_hack::get_class_to_force_linkage()
-    };
+    let _cls = NSObject::class();
 
     if CString::new(s).is_ok() {
         #[allow(clippy::eq_op)]

--- a/fuzz/fuzz_targets/sel.rs
+++ b/fuzz/fuzz_targets/sel.rs
@@ -1,13 +1,12 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use objc2::runtime::Sel;
+use objc2::runtime::{NSObject, Sel};
+use objc2::ClassType;
 use std::ffi::CString;
 
 fuzz_target!(|s: &str| {
     #[cfg(feature = "gnustep-1-7")]
-    unsafe {
-        objc2::__gnustep_hack::get_class_to_force_linkage()
-    };
+    let _cls = NSObject::class();
 
     #[allow(clippy::eq_op)]
     if CString::new(s).is_ok() {


### PR DESCRIPTION
First `objc2_foundation`, then `objc2::foundation`, now `icrate::Foundation` - back and forth we go...

Anyway, this should help moving #264 forwards.

Slight regressions to some examples, since we can no longer use Foundation types in those, but not really a big deal compared to the gain we'll receive with #264.