### PR TITLE
Remove libstd from objc-sys and block-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
       CXXFLAGS: ${{ matrix.cflags }}
       ASMFLAGS: ${{ matrix.cflags }}
       LDFLAGS: ${{ matrix.cflags }}
+      NDF_ARGS: --no-default-features --features=${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       ARGS: --no-default-features --features=std,${{ matrix.runtime || 'apple' }} ${{ matrix.args }}
       # Use --no-fail-fast, except with dinghy
       TESTARGS: ${{ matrix.dinghy && ' ' || '--no-fail-fast' }} ${{ matrix.test-args }}
@@ -371,8 +372,8 @@ jobs:
 
     - name: Build objc-sys/block-sys with no_std
       run: |
-        $CMD build ${{ env.ARGS }} --no-default-features -p objc-sys
-        $CMD build ${{ env.ARGS }} --no-default-features -p block-sys
+        $CMD build ${{ env.NDF_ARGS }} -p objc-sys 
+        $CMD build ${{ env.NDF_ARGS }} -p block-sys
 
     - name: Check documentation
       run: $CMD doc ${{ env.ARGS }} --no-deps --document-private-items

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,11 @@ jobs:
     - name: Build
       run: $CMD build ${{ env.ARGS }}
 
+    - name: Build objc-sys/block-sys with no_std
+      run: |
+        $CMD build ${{ env.ARGS }} --no-default-features -p objc-sys
+        $CMD build ${{ env.ARGS }} --no-default-features -p block-sys
+
     - name: Check documentation
       run: $CMD doc ${{ env.ARGS }} --no-deps --document-private-items
 

--- a/crates/block-sys/src/lib.rs
+++ b/crates/block-sys/src/lib.rs
@@ -24,6 +24,9 @@
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 // Ensure linkage actually happens
 #[cfg(feature = "gnustep-1-7")]
 extern crate objc_sys as _;

--- a/crates/block-sys/src/lib.rs
+++ b/crates/block-sys/src/lib.rs
@@ -409,7 +409,7 @@ pub struct Block_byref_extended {
     pub layout: *const c_char,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use core::ptr;

--- a/crates/block-sys/src/lib.rs
+++ b/crates/block-sys/src/lib.rs
@@ -24,11 +24,6 @@
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 
-extern crate std;
-
-#[cfg(not(feature = "std"))]
-compile_error!("The `std` feature currently must be enabled.");
-
 // Ensure linkage actually happens
 #[cfg(feature = "gnustep-1-7")]
 extern crate objc_sys as _;
@@ -38,9 +33,8 @@ extern crate objc_sys as _;
 extern "C" {}
 
 use core::cell::UnsafeCell;
-use core::ffi::c_void;
+use core::ffi::{c_char, c_ulong, c_void};
 use core::marker::{PhantomData, PhantomPinned};
-use std::os::raw::{c_char, c_ulong};
 
 #[repr(C)]
 pub struct Class {

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -29,7 +29,6 @@ build = "build.rs"
 # correct feature flag is not specified.
 default = ["std", "apple"]
 
-# Currently not possible to turn off, put here for forwards compatibility.
 std = ["alloc"]
 alloc = []
 

--- a/crates/objc-sys/src/class.rs
+++ b/crates/objc-sys/src/class.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_char, c_int, c_uint};
+use core::ffi::{c_char, c_int, c_uint};
 
 #[cfg(any(doc, not(objfw)))]
 use crate::{objc_ivar, objc_method, objc_object, objc_property, objc_property_attribute_t};

--- a/crates/objc-sys/src/constants.rs
+++ b/crates/objc-sys/src/constants.rs
@@ -1,7 +1,7 @@
 //! Various common #defines and enum constants.
 
 #[cfg(any(doc, apple))]
-use std::os::raw::c_int;
+use core::ffi::c_int;
 
 use crate::{id, objc_class, BOOL};
 

--- a/crates/objc-sys/src/exception.rs
+++ b/crates/objc-sys/src/exception.rs
@@ -2,11 +2,11 @@
 //! Apple: `objc-exception.h`
 //! GNUStep: `eh_personality.c`, which is a bit brittle to rely on, but I
 //!   think it's fine...
-use core::ffi::c_void;
 #[cfg(any(doc, apple_new))]
-use std::os::raw::c_int;
+use core::ffi::c_int;
 #[cfg(feature = "unstable-exception")]
-use std::os::raw::c_uchar;
+use core::ffi::c_uchar;
+use core::ffi::c_void;
 
 #[cfg(any(doc, apple_new))]
 use crate::objc_class;

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -29,14 +29,6 @@
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 
-// TODO: Remove this and add "no-std" category to Cargo.toml
-// Requires a better solution for C-types in `no_std` crates.
-// See https://github.com/japaric/cty/issues/14.
-extern crate std;
-
-#[cfg(not(feature = "std"))]
-compile_error!("The `std` feature currently must be enabled.");
-
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
 extern "C" {}

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -29,6 +29,9 @@
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]
 extern "C" {}

--- a/crates/objc-sys/src/method.rs
+++ b/crates/objc-sys/src/method.rs
@@ -1,6 +1,6 @@
-use std::os::raw::c_char;
+use core::ffi::c_char;
 #[cfg(any(doc, not(objfw)))]
-use std::os::raw::c_uint;
+use core::ffi::c_uint;
 
 #[cfg(any(doc, not(objfw)))]
 use crate::IMP;

--- a/crates/objc-sys/src/object.rs
+++ b/crates/objc-sys/src/object.rs
@@ -1,6 +1,6 @@
+use core::ffi::c_char;
 #[cfg(any(doc, not(objfw)))]
 use core::ffi::c_void;
-use std::os::raw::c_char;
 
 #[cfg(any(doc, not(objfw)))]
 use crate::objc_ivar;

--- a/crates/objc-sys/src/property.rs
+++ b/crates/objc-sys/src/property.rs
@@ -1,6 +1,6 @@
-use std::os::raw::c_char;
+use core::ffi::c_char;
 #[cfg(any(doc, not(objfw)))]
-use std::os::raw::c_uint;
+use core::ffi::c_uint;
 
 use crate::OpaqueData;
 

--- a/crates/objc-sys/src/protocol.rs
+++ b/crates/objc-sys/src/protocol.rs
@@ -1,6 +1,6 @@
-use std::os::raw::c_char;
+use core::ffi::c_char;
 #[cfg(any(doc, not(objfw)))]
-use std::os::raw::c_uint;
+use core::ffi::c_uint;
 
 #[cfg(any(doc, not(objfw)))]
 use crate::{objc_method_description, objc_property, objc_property_attribute_t, objc_selector};

--- a/crates/objc-sys/src/selector.rs
+++ b/crates/objc-sys/src/selector.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_char;
+use core::ffi::c_char;
 
 use crate::{OpaqueData, BOOL};
 

--- a/crates/objc-sys/src/types.rs
+++ b/crates/objc-sys/src/types.rs
@@ -45,7 +45,7 @@ mod inner {
 mod inner {
     // windows && !32bit-MinGW
     #[cfg(all(windows, not(all(target_pointer_width = "64", target_env = "gnu"))))]
-    pub(crate) type BOOL = std::os::raw::c_int;
+    pub(crate) type BOOL = core::ffi::c_int;
 
     // The inverse
     #[cfg(not(all(windows, not(all(target_pointer_width = "64", target_env = "gnu")))))]

--- a/crates/objc-sys/src/various.rs
+++ b/crates/objc-sys/src/various.rs
@@ -1,9 +1,9 @@
-use core::ffi::c_void;
 #[cfg(any(doc, not(objfw)))]
-use std::os::raw::c_char;
-use std::os::raw::c_int;
+use core::ffi::c_char;
+use core::ffi::c_int;
 #[cfg(any(doc, apple))]
-use std::os::raw::c_uint;
+use core::ffi::c_uint;
+use core::ffi::c_void;
 
 #[cfg(any(doc, not(objfw)))]
 use crate::{objc_AssociationPolicy, BOOL};


### PR DESCRIPTION
This removes `libstd` as a dependency for `objc-sys` and `block-sys`, by replacing `std::os::raw` with `core::ffi`, which contains the necessary types.

This bumps to MSRV to at least 1.64, but it looks like this package doesn't have an MSRV policy yet (#203), so I hope that's not an issue.