### PR TITLE
Fix CI and missing NULL check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
         ls -al $HOME/extern/*
 
     - name: Install GNUStep GUI
-      if: matrix.target == 'x86_64-unknown-linux-gnu' && steps.extern-cache.outputs.cache-hit != 'true'
+      if: contains(matrix.runtime, 'gnustep') && matrix.target == 'x86_64-unknown-linux-gnu' && steps.extern-cache.outputs.cache-hit != 'true'
       run: |
         wget https://github.com/gnustep/libs-gui/archive/refs/tags/gui-0_29_0.tar.gz
         tar -xzf gui-0_29_0.tar.gz

--- a/crates/objc2/src/runtime.rs
+++ b/crates/objc2/src/runtime.rs
@@ -706,6 +706,9 @@ impl Protocol {
                 &mut count,
             )
         };
+        if descriptions.is_null() {
+            return Vec::new();
+        }
         let descriptions = unsafe { Malloc::from_array(descriptions, count as usize) };
         descriptions
             .iter()


### PR DESCRIPTION
The CI was a mistake in https://github.com/madsmtm/objc2/pull/308.

The missing NULL check was found by running with `-Zbuild-std` (which enables debug assertions for `std`)