### PR TITLE
Improve `extern_methods!`

### DIFF
--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -434,15 +434,18 @@ impl fmt::Display for Method {
             writeln!(f, "        #[optional]")?;
         }
 
+        let error_trailing = if self.result_type.is_error() { "_" } else { "" };
+
         if self.result_type.is_id() {
             writeln!(
                 f,
-                "        #[method_id(@__retain_semantics {} {})]",
+                "        #[method_id(@__retain_semantics {} {}{})]",
                 MemoryManagement::get_memory_management_name(&self.selector),
-                self.selector
+                self.selector,
+                error_trailing,
             )?;
         } else {
-            writeln!(f, "        #[method({})]", self.selector)?;
+            writeln!(f, "        #[method({}{})]", self.selector, error_trailing)?;
         };
 
         write!(f, "        pub ")?;

--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -1259,6 +1259,14 @@ impl Ty {
         self.kind = TyKind::MethodReturnWithError;
     }
 
+    pub fn is_error(&self) -> bool {
+        match &self.kind {
+            TyKind::MethodReturn => false,
+            TyKind::MethodReturnWithError => true,
+            _ => panic!("invalid is_error usage"),
+        }
+    }
+
     pub fn is_instancetype(&self) -> bool {
         matches!(
             &self.ty,

--- a/crates/icrate/src/Foundation/additions/lock.rs
+++ b/crates/icrate/src/Foundation/additions/lock.rs
@@ -1,5 +1,4 @@
 use objc2::rc::{Id, Owned};
-use objc2::ClassType;
 use objc2::{extern_methods, ConformsTo};
 
 use crate::Foundation::{NSLock, NSLocking};

--- a/crates/icrate/src/Foundation/additions/mutable_array.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_array.rs
@@ -5,7 +5,7 @@ use core::ops::{Index, IndexMut};
 use core::ptr::NonNull;
 
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use objc2::{extern_methods, ClassType, Message};
+use objc2::{extern_methods, Message};
 
 use super::array::with_objects;
 use crate::Foundation::{

--- a/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_dictionary.rs
@@ -3,7 +3,7 @@ use core::ops::{Index, IndexMut};
 use core::ptr;
 
 use objc2::rc::{DefaultId, Id, Owned, Shared};
-use objc2::{extern_methods, msg_send_id, ClassType, Message};
+use objc2::{extern_methods, msg_send_id, Message};
 
 use crate::Foundation::{
     NSArray, NSCopying, NSDictionary, NSFastEnumeration2, NSMutableDictionary,

--- a/crates/icrate/src/Foundation/additions/mutable_set.rs
+++ b/crates/icrate/src/Foundation/additions/mutable_set.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use objc2::rc::{DefaultId, Id, Owned, Ownership, Shared, SliceId};
-use objc2::{extern_methods, ClassType, Message};
+use objc2::{extern_methods, Message};
 
 use super::set::with_objects;
 use crate::Foundation::{

--- a/crates/icrate/src/Foundation/additions/thread.rs
+++ b/crates/icrate/src/Foundation/additions/thread.rs
@@ -4,7 +4,6 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use objc2::extern_methods;
 use objc2::rc::{Id, Shared};
-use objc2::ClassType;
 
 use crate::Foundation::NSThread;
 

--- a/crates/icrate/src/Foundation/fixes/NSThread.rs
+++ b/crates/icrate/src/Foundation/fixes/NSThread.rs
@@ -1,4 +1,4 @@
-use objc2::{extern_methods, ClassType};
+use objc2::extern_methods;
 
 use crate::Foundation::NSThread;
 

--- a/crates/icrate/src/Foundation/fixes/generic_return.rs
+++ b/crates/icrate/src/Foundation/fixes/generic_return.rs
@@ -10,7 +10,7 @@ extern_methods!(
     unsafe impl<ObjectType: Message, ObjectTypeOwnership: Ownership>
         NSArray<ObjectType, ObjectTypeOwnership>
     {
-        #[method_id(initWithContentsOfURL:error:)]
+        #[method_id(initWithContentsOfURL:error:_)]
         pub unsafe fn initWithContentsOfURL_error(
             this: Option<Allocated<Self>>,
             url: &NSURL,

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Using the automatic `NSError**`-to-`Result` functionality in
+  `extern_methods!` now requires a trailing underscore (so now it's
+  `#[method(myMethod:error:_)]` instead of `#[method(myMethod:error:)]`).
+
 ### Fixed
 * Allow empty structs in `declare_class!` macro.
 * Allow using `extern_methods!` without the `ClassType` trait in scope.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Allow empty structs in `declare_class!` macro.
+* Allow using `extern_methods!` without the `ClassType` trait in scope.
 
 
 ## 0.3.0-beta.4 - 2022-12-24

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -20,6 +20,12 @@
 /// or `#[method_id(my:selector:)]` attribute. The `method` attribute maps to
 /// a call to [`msg_send!`], while the `method_id` maps to [`msg_send_id!`].
 ///
+/// If the attribute ends with "_", as in `#[method(my:error:_)]` or
+/// `#[method_id(my:error:_)]`, the method is assumed to take an
+/// implicit `NSError**` parameter, which is automatically converted to a
+/// [`Result`]. See the error section in [`msg_send!`] and [`msg_send_id!`]
+/// for details.
+///
 /// Putting other attributes on the method such as `cfg`, `allow`, `doc`,
 /// `deprecated` and so on is supported. However, note that `cfg_attr` may not
 /// work correctly, due to implementation difficulty - if you have a concrete
@@ -93,9 +99,9 @@
 ///         #[method_id(fooObject)]
 ///         pub fn foo_object(&self) -> Id<NSObject, Shared>;
 ///
-///         #[method(withError:)]
-///         // Since the selector specifies one more argument than we
-///         // have, the return type is assumed to be `Result`.
+///         #[method(withError:_)]
+///         // Since the selector specifies "_", the return type is assumed to
+///         // be `Result`.
 ///         pub fn with_error(&self) -> Result<(), Id<NSError, Shared>>;
 ///     }
 /// );
@@ -399,11 +405,11 @@ macro_rules! __collect_msg_send {
         $macro![$obj, $($output)+]
     }};
 
-    // Allow trailing `sel:` without a corresponding argument (for errors)
+    // Allow trailing `sel:_` without a corresponding argument (for errors)
     (
         $macro:path;
         $obj:expr;
-        ($(@__retain_semantics $retain_semantics:ident )? $sel:ident:);
+        ($(@__retain_semantics $retain_semantics:ident )? $sel:ident: _);
         ($(,)?);
         $($output:tt)*
     ) => {

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -370,7 +370,7 @@ macro_rules! __extern_methods_get_receiver {
             _: $sel_ty:ty,
         )
     } => {
-        Self::class()
+        <Self as $crate::ClassType>::class()
     };
 }
 

--- a/crates/objc2/tests/no_prelude.rs
+++ b/crates/objc2/tests/no_prelude.rs
@@ -97,12 +97,20 @@ new_objc2::declare_class!(
     }
 );
 
-new_objc2::extern_methods!(
-    unsafe impl CustomObject {
-        #[method(a)]
-        pub fn a();
-    }
-);
+// Ensure that extern_methods! works without the ClassType trait in scope
+mod test_extern_methods {
+    use super::{new_objc2, CustomObject};
+
+    new_objc2::extern_methods!(
+        unsafe impl CustomObject {
+            #[method(a)]
+            pub fn a();
+
+            #[method(b)]
+            pub fn b(&self);
+        }
+    );
+}
 
 new_objc2::extern_class!(
     struct NSObject2;
@@ -117,8 +125,8 @@ new_objc2::extern_protocol!(
     struct CustomProtocol;
 
     unsafe impl ProtocolType for CustomProtocol {
-        #[method(b)]
-        fn b(&self);
+        #[method(c)]
+        fn c(&self);
     }
 );
 

--- a/crates/test-ui/ui/extern_methods_invalid_type.rs
+++ b/crates/test-ui/ui/extern_methods_invalid_type.rs
@@ -1,6 +1,6 @@
 use objc2::{extern_class, extern_methods, ClassType};
 use objc2::runtime::NSObject;
-use objc2::rc::{Id, Owned};
+use objc2::rc::{Id, Owned, Shared};
 
 extern_class!(
     pub struct MyObject;
@@ -28,6 +28,20 @@ extern_methods!(
     unsafe impl MyObject {
         #[method_id(init)]
         fn init(&mut self) -> Option<Id<Self, Owned>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(error:)]
+        fn error(arg: i32) -> Result<(), Id<NSObject, Shared>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method_id(error:)]
+        fn error_id(arg: i32) -> Result<Id<Self, Owned>, Id<NSObject, Shared>>;
     }
 );
 

--- a/crates/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_type.stderr
@@ -71,4 +71,56 @@ note: associated function defined here
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |               ^^^^^^^^^^^^^^^
-  = note: this error originates in the macro `$crate::__inner_extern_methods` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_get_receiver` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Result<(), Id<NSObject, Shared>>: Encode` is not satisfied
+ --> ui/extern_methods_invalid_type.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(error:)]
+  | |         fn error(arg: i32) -> Result<(), Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Result<(), Id<NSObject, Shared>>`
+  |
+  = help: the following other types implement trait `Encode`:
+            &'a T
+            &'a mut T
+            ()
+            *const T
+            *const c_void
+            *mut T
+            *mut c_void
+            AtomicI16
+          and $N others
+  = note: required for `Result<(), Id<NSObject, Shared>>` to implement `EncodeConvert`
+note: required by a bound in `send_message`
+ --> $WORKSPACE/crates/objc2/src/message/mod.rs
+  |
+  |         R: EncodeConvert,
+  |            ^^^^^^^^^^^^^ required by this bound in `MessageReceiver::send_message`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Result<Id<MyObject, objc2::rc::Owned>, Id<NSObject, Shared>>: MaybeUnwrap` is not satisfied
+ --> ui/extern_methods_invalid_type.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method_id(error:)]
+  | |         fn error_id(arg: i32) -> Result<Id<Self, Owned>, Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^ the trait `MaybeUnwrap` is not implemented for `Result<Id<MyObject, objc2::rc::Owned>, Id<NSObject, Shared>>`
+  |
+  = help: the following other types implement trait `MaybeUnwrap`:
+            Allocated<T>
+            Id<T, O>
+            Option<Allocated<T>>
+            Option<Id<T, O>>
+note: required by a bound in `send_message_id`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers.rs
+  |
+  |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
+  |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_wrong_arguments.stderr
+++ b/crates/test-ui/ui/extern_methods_wrong_arguments.stderr
@@ -3,8 +3,34 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
+  | |         #[method(a:)]
+  | |         fn a();
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
   | |         #[method(b)]
   | |         fn b(arg: i32);
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(c:d:e:)]
+  | |         fn c(arg1: i32, arg2: u32);
   | |     }
   | | );
   | |_^
@@ -29,8 +55,34 @@ error: Number of arguments in function and selector did not match!
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
+  | |         #[method(x:)]
+  | |         fn x(&self);
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
   | |         #[method(y)]
   | |         fn y(&self, arg: i32);
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(z:)]
+  | |         fn z(this: &Self);
   | |     }
   | | );
   | |_^
@@ -49,75 +101,3 @@ error: Number of arguments in function and selector did not match!
   | |_^
   |
   = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
-  | |         #[method(a:)]
-  | |         fn a();
-  | |     }
-  | | );
-  | | ^
-  | | |
-  | |_expected `()`, found enum `Result`
-  |   expected `()` because of default return type
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), Id<_, Shared>>`
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
-  | |         #[method(c:d:e:)]
-  | |         fn c(arg1: i32, arg2: u32);
-  | |     }
-  | | );
-  | | ^
-  | | |
-  | |_expected `()`, found enum `Result`
-  |   expected `()` because of default return type
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), Id<_, Shared>>`
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
-  | |         #[method(x:)]
-  | |         fn x(&self);
-  | |     }
-  | | );
-  | | ^
-  | | |
-  | |_expected `()`, found enum `Result`
-  |   expected `()` because of default return type
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), Id<_, Shared>>`
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> ui/extern_methods_wrong_arguments.rs
-  |
-  | / extern_methods!(
-  | |     unsafe impl MyObject {
-  | |         #[method(z:)]
-  | |         fn z(this: &Self);
-  | |     }
-  | | );
-  | | ^
-  | | |
-  | |_expected `()`, found enum `Result`
-  |   expected `()` because of default return type
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), Id<_, Shared>>`
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_wrong_arguments_error.rs
+++ b/crates/test-ui/ui/extern_methods_wrong_arguments_error.rs
@@ -1,0 +1,41 @@
+use objc2::{extern_class, extern_methods, ClassType};
+use objc2::runtime::NSObject;
+use objc2::rc::{Id, Shared};
+
+extern_class!(
+    pub struct MyObject;
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(too:few:_)]
+        fn class_too_few() -> Result<(), Id<NSObject, Shared>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(tooMany:_)]
+        fn class_too_many(arg: i32) -> Result<(), Id<NSObject, Shared>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(too:few:_)]
+        fn too_few(&self) -> Result<(), Id<NSObject, Shared>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method(tooMany:_)]
+        fn too_many(&self, arg: i32) -> Result<(), Id<NSObject, Shared>>;
+    }
+);
+
+fn main() {}

--- a/crates/test-ui/ui/extern_methods_wrong_arguments_error.stderr
+++ b/crates/test-ui/ui/extern_methods_wrong_arguments_error.stderr
@@ -1,0 +1,51 @@
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments_error.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(too:few:_)]
+  | |         fn class_too_few() -> Result<(), Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments_error.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(tooMany:_)]
+  | |         fn class_too_many(arg: i32) -> Result<(), Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments_error.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(too:few:_)]
+  | |         fn too_few(&self) -> Result<(), Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Number of arguments in function and selector did not match!
+ --> ui/extern_methods_wrong_arguments_error.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method(tooMany:_)]
+  | |         fn too_many(&self, arg: i32) -> Result<(), Id<NSObject, Shared>>;
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__collect_msg_send` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_invalid_error.rs
+++ b/crates/test-ui/ui/msg_send_invalid_error.rs
@@ -1,6 +1,5 @@
 //! Test that msg_send! error handling works correctly.
-use objc2::{msg_send, msg_send_id};
-use objc2::ClassType;
+use objc2::{ClassType, msg_send, msg_send_id};
 use objc2::rc::{Id, Shared};
 use icrate::Foundation::NSString;
 

--- a/crates/test-ui/ui/wrong_optional.stderr
+++ b/crates/test-ui/ui/wrong_optional.stderr
@@ -10,7 +10,7 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__inner_extern_methods` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_unsafe_method_body` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[optional]` is only supported in `extern_protocol!`
  --> ui/wrong_optional.rs
@@ -24,7 +24,7 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__inner_extern_methods` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_unsafe_method_body` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[optional]` is only supported in `extern_protocol!`
  --> ui/wrong_optional.rs


### PR DESCRIPTION
See the changelog and commits for details.

Inspired in part by https://github.com/madsmtm/objc2/issues/291#issuecomment-1364748151, this will improve the error message when the user specifies an invalid selector.