### PR TITLE
Make our current MSRV match `winit`'s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,39 @@ jobs:
     - name: cargo clippy
       run: cargo clippy --all-targets ${{ matrix.args }}
 
+  msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+
+    env:
+      CARGO_BUILD_TARGET: x86_64-apple-darwin
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: '1.60'
+        profile: minimal
+        override: true
+        target: x86_64-apple-darwin
+
+    - name: Cache Cargo
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.CARGO_CACHE_PATH }}
+        key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: cargo check
+      run: >-
+        cargo check
+        $PUBLIC_CRATES
+        --features=$INTERESTING_FEATURES
+        --features=unstable-frameworks-macos-12
+
   ui:
     name: Compiler UI
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ so on, with every following release.
 [#32]: https://github.com/madsmtm/objc2/issues/32
 
 
+## Minimum Supported Rust Version (MSRV)
+
+The _currently_ minimum supported Rust version is `1.60`; this is _not_
+defined by policy, though, so it may change in at any time in a patch
+release.
+
+Help us define a policy over in [#203].
+
+[#203]: https://github.com/madsmtm/objc2/issues/203
+
+
 ## License
 
 This project is licensed under the MIT license, see [`LICENSE.txt`].

--- a/crates/block-sys/Cargo.toml
+++ b/crates/block-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "block-sys"
 version = "0.1.0-beta.2" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Raw bindings to Apple's C language extension of blocks"
 keywords = ["objective-c", "macos", "ios", "blocks", "sys"]

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -4,6 +4,7 @@ name = "block2"
 version = "0.2.0-alpha.7"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Apple's C language extension of blocks"
 keywords = ["objective-c", "macos", "ios", "blocks"]

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -3,6 +3,7 @@ name = "icrate"
 version = "0.0.1"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Bindings to Apple's frameworks"
 keywords = ["macos", "ios", "cocoa", "apple", "framework"]

--- a/crates/icrate/src/Foundation/additions/value.rs
+++ b/crates/icrate/src/Foundation/additions/value.rs
@@ -192,7 +192,7 @@ impl fmt::Debug for NSValue {
 mod tests {
     use alloc::format;
     use core::{ptr, slice};
-    use std::ffi::c_char;
+    use std::os::raw::c_char;
 
     use super::*;
     use objc2::rc::{__RcTestObject, __ThreadTestData};

--- a/crates/icrate/src/Foundation/fixes/NSDecimal.rs
+++ b/crates/icrate/src/Foundation/fixes/NSDecimal.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_ushort;
+use std::os::raw::c_ushort;
 
 extern_struct!(
     pub struct NSDecimal {

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -5,7 +5,7 @@ pub(crate) use core::ffi::c_void;
 pub(crate) use core::marker::PhantomData;
 pub(crate) use core::ptr::NonNull;
 #[cfg(feature = "std")]
-pub(crate) use std::ffi::{
+pub(crate) use std::os::raw::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
     c_ulong, c_ulonglong, c_ushort,
 };

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -5,6 +5,7 @@ name = "objc-sys"
 version = "0.2.0-beta.3"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Raw bindings to the Objective-C runtime and ABI"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "sys"]

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -4,6 +4,7 @@ name = "objc2-encode"
 version = "2.0.0-pre.3"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Objective-C type-encodings"
 keywords = ["objective-c", "macos", "ios", "encode"]

--- a/crates/objc2-proc-macros/Cargo.toml
+++ b/crates/objc2-proc-macros/Cargo.toml
@@ -4,6 +4,7 @@ name = "objc2-proc-macros"
 version = "0.1.0"
 authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Procedural macros for the objc2 project"
 keywords = ["objective-c", "macos", "ios", "proc-macro"]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -3,6 +3,7 @@ name = "objc2"
 version = "0.3.0-beta.4" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
+rust-version = "1.60"
 
 description = "Objective-C interface and bindings to the Cocoa Foundation framework"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "cocoa"]


### PR DESCRIPTION
This is _not_ a MSRV policy, e.g. bumping the MSRV is still NOT a breaking change, see #203 for that.