### PR TITLE
icrate method skips for ASAuthorization*

### DIFF
--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -743,3 +743,12 @@ skipped = true
 [class.CAMediaTimingFunction.methods]
 functionWithControlPoints = { skipped = true }
 initWithControlPoints = { skipped = true }
+
+[class.ASAuthorizationProviderExtensionLoginConfiguration.methods]
+setCustomAssertionRequestBodyClaims_returningError = { skipped = true }
+setCustomAssertionRequestHeaderClaims_returningError = { skipped = true }
+setCustomLoginRequestBodyClaims_returningError = { skipped = true }
+setCustomLoginRequestHeaderClaims_returningError = { skipped = true }
+
+[class.ASAuthorizationProviderExtensionLoginManager.methods]
+saveLoginConfiguration_error = { skipped = true }


### PR DESCRIPTION
I was trying to use the header translator on my system and needed to add these entries to the `translation-config.toml`.

I am running on macOS 13.0.1 with Xcode 14.2. When I run the header translator there are several changes to the generated output, which I'm guessing may be due to running the translator with more recent SDKs.