### PR TITLE
Various header translator refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ version = "0.1.0"
 dependencies = [
  "apple-sdk",
  "clang",
+ "proc-macro2",
  "serde",
  "toml",
  "tracing",

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -26,6 +26,7 @@ apple-sdk = { version = "0.2.0", default-features = false, optional = true }
 tracing = { version = "0.1.37", default-features = false, features = ["std"], optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["fmt"], optional = true }
 tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git", optional = true }
+proc-macro2 = "1.0.49"
 
 [[bin]]
 name = "header-translator"

--- a/crates/header-translator/src/cache.rs
+++ b/crates/header-translator/src/cache.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 use std::mem;
 
-use tracing::{debug_span, warn};
-
 use crate::availability::Availability;
 use crate::config::{ClassData, Config};
 use crate::file::File;

--- a/crates/header-translator/src/data/README.md
+++ b/crates/header-translator/src/data/README.md
@@ -9,7 +9,7 @@ You can also view it as that, over time, we need to _decrease_ the amount of stu
 
 ## Example
 
-```rust
+```rust , ignore
 data! {
     // Everywhere that the class is returned, it is as
     // `Id<MyMutableClass, Owned>`.

--- a/crates/header-translator/src/file.rs
+++ b/crates/header-translator/src/file.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use tracing::debug_span;
-
 use crate::context::Context;
 use crate::stmt::Stmt;
 

--- a/crates/header-translator/src/lib.rs
+++ b/crates/header-translator/src/lib.rs
@@ -1,12 +1,15 @@
 #![cfg(feature = "run")]
 #![recursion_limit = "256"]
+
+#[macro_use]
+extern crate tracing;
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 use clang::{Entity, EntityVisitResult};
-use tracing::debug_span;
 use tracing::span::EnteredSpan;
 
 mod availability;

--- a/crates/header-translator/src/library.rs
+++ b/crates/header-translator/src/library.rs
@@ -4,8 +4,6 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use tracing::debug_span;
-
 use crate::file::{File, FILE_PRELUDE};
 
 #[derive(Debug, PartialEq, Default)]

--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -369,6 +369,9 @@ impl<'tu> PartialMethod<'tu> {
                 // TODO: Can we use this for something?
                 // <https://clang.llvm.org/docs/AttributeReference.html#objc-requires-super>
             }
+            EntityKind::WarnUnusedResultAttr => {
+                // TODO: Emit `#[must_use]` on this
+            }
             EntityKind::UnexposedAttr => {
                 if let Some(macro_) = UnexposedMacro::parse(&entity) {
                     warn!(?macro_, "unknown macro");

--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use clang::{Entity, EntityKind, ObjCQualifiers};
 use tracing::span::EnteredSpan;
-use tracing::{debug_span, error, warn};
 
 use crate::availability::Availability;
 use crate::config::MethodData;
@@ -245,7 +244,7 @@ impl<'tu> PartialMethod<'tu> {
         }
 
         if entity.is_variadic() {
-            warn!("Can't handle variadic method");
+            warn!("can't handle variadic method");
             return None;
         }
 
@@ -285,7 +284,7 @@ impl<'tu> PartialMethod<'tu> {
                     }
                     // For some reason we recurse into array types
                     EntityKind::IntegerLiteral => {}
-                    _ => warn!("unknown"),
+                    _ => error!("unknown"),
                 });
 
                 let ty = entity.get_type().expect("argument type");
@@ -375,7 +374,7 @@ impl<'tu> PartialMethod<'tu> {
                     warn!(?macro_, "unknown macro");
                 }
             }
-            _ => warn!("unknown"),
+            _ => error!("unknown"),
         });
 
         if consumes_self {

--- a/crates/header-translator/src/output.rs
+++ b/crates/header-translator/src/output.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
 
-use tracing::debug_span;
-
 use crate::library::Library;
 
 #[derive(Debug, PartialEq)]

--- a/crates/header-translator/src/property.rs
+++ b/crates/header-translator/src/property.rs
@@ -1,6 +1,5 @@
 use clang::{Entity, EntityKind, ObjCAttributes};
 use tracing::span::EnteredSpan;
-use tracing::{error, warn};
 
 use crate::availability::Availability;
 use crate::config::MethodData;
@@ -79,7 +78,7 @@ impl PartialProperty<'_> {
                     warn!(?macro_, "unknown macro");
                 }
             }
-            _ => warn!("unknown"),
+            _ => error!("unknown"),
         });
 
         let qualifier = entity.get_objc_qualifiers().map(Qualifier::parse);

--- a/crates/header-translator/src/property.rs
+++ b/crates/header-translator/src/property.rs
@@ -38,6 +38,13 @@ impl PartialProperty<'_> {
             _span,
         } = self;
 
+        // Early return if both getter and setter are skipped
+        //
+        // To reduce warnings.
+        if getter_data.skipped && setter_data.map(|data| data.skipped).unwrap_or(true) {
+            return (None, None);
+        }
+
         let availability = Availability::parse(
             entity
                 .get_platform_availability()

--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use clang::{CallingConvention, EntityKind, Nullability, Type, TypeKind};
 use serde::Deserialize;
-use tracing::{debug_span, error, warn};
 
 use crate::context::Context;
 use crate::method::MemoryManagement;

--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -254,18 +254,26 @@ impl IdType {
         }
     }
 
-    fn ownership(&self) -> Ownership {
-        match self {
-            Self::Class {
-                ownership: Some(ownership),
-                ..
+    fn ownership(&self) -> impl fmt::Display + '_ {
+        struct IdTypeOwnership<'a>(&'a IdType);
+
+        impl fmt::Display for IdTypeOwnership<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    IdType::Class {
+                        ownership: Some(ownership),
+                        ..
+                    }
+                    | IdType::Self_ {
+                        ownership: Some(ownership),
+                    } => write!(f, "{ownership}"),
+                    IdType::GenericParam { name } => write!(f, "{name}Ownership"),
+                    _ => write!(f, "{}", Ownership::Shared),
+                }
             }
-            | Self::Self_ {
-                ownership: Some(ownership),
-                ..
-            } => ownership.clone(),
-            _ => Ownership::Shared,
         }
+
+        IdTypeOwnership(self)
     }
 
     fn parse_objc_pointer(

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -93,7 +93,7 @@ fn parse_objc_decl(
         EntityKind::ObjCExplicitProtocolImpl if generics.is_none() && !superclass => {
             // TODO NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION
         }
-        EntityKind::ObjCIvarDecl if superclass => {
+        EntityKind::ObjCIvarDecl | EntityKind::StructDecl | EntityKind::UnionDecl if superclass => {
             // Explicitly ignored
         }
         EntityKind::ObjCSuperClassRef | EntityKind::TypeRef if superclass => {

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -5,7 +5,6 @@ use std::iter;
 use std::mem;
 
 use clang::{Entity, EntityKind, EntityVisitResult};
-use tracing::{debug, debug_span, error, warn};
 
 use crate::availability::Availability;
 use crate::config::ClassData;
@@ -168,7 +167,7 @@ fn parse_objc_decl(
                 warn!(?macro_, "unknown macro");
             }
         }
-        _ => warn!("unknown"),
+        _ => error!("unknown"),
     });
 
     if !properties.is_empty() {
@@ -315,7 +314,7 @@ fn parse_struct(entity: &Entity<'_>, context: &Context<'_>) -> (bool, Vec<(Strin
             boxable = true;
         }
         EntityKind::UnionDecl => error!("can't handle unions in structs yet"),
-        _ => warn!("unknown"),
+        _ => error!("unknown"),
     });
 
     (boxable, fields)
@@ -531,7 +530,7 @@ impl Stmt {
                     | EntityKind::ObjCProtocolRef
                     | EntityKind::TypeRef
                     | EntityKind::ParmDecl => {}
-                    _ => warn!("unknown"),
+                    _ => error!("unknown"),
                 });
 
                 if let Some((boxable, fields)) = struct_ {
@@ -666,7 +665,7 @@ impl Stmt {
                     EntityKind::VisibilityAttr => {
                         // Already exposed as entity.get_visibility()
                     }
-                    _ => warn!("unknown"),
+                    _ => error!("unknown"),
                 });
 
                 if name.is_none() && variants.is_empty() {
@@ -754,7 +753,9 @@ impl Stmt {
                             warn!(?macro_, "unknown macro");
                         }
                     }
-                    EntityKind::ObjCClassRef | EntityKind::TypeRef => {}
+                    EntityKind::ObjCClassRef
+                    | EntityKind::TypeRef
+                    | EntityKind::ObjCProtocolRef => {}
                     EntityKind::ParmDecl => {
                         // Could also be retrieved via. `get_arguments`
                         let name = entity.get_name().unwrap_or_else(|| "_".into());
@@ -765,7 +766,7 @@ impl Stmt {
                     EntityKind::VisibilityAttr => {
                         // CG_EXTERN or UIKIT_EXTERN
                     }
-                    _ => warn!("unknown"),
+                    _ => error!("unknown"),
                 });
 
                 let body = if entity.is_inline_function() {

--- a/crates/header-translator/src/unexposed_macro.rs
+++ b/crates/header-translator/src/unexposed_macro.rs
@@ -1,6 +1,5 @@
 use clang::source::SourceLocation;
 use clang::{Entity, EntityKind};
-use tracing::warn;
 
 use crate::context::Context;
 

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -783,9 +783,3 @@ newRenderPipelineStateWithTileDescriptor_options_reflection_error = { skipped = 
 skipped = true
 [fn.MTLPackedFloat3Make]
 skipped = true
-
-# Uses __unsafe_unretained on a generic which is weirdly printed by clang.
-#
-# Also, supporting "NSGenericFastEnumeraiton" manually is desired anyhow.
-[class.NSDictionary.methods.countByEnumeratingWithState_objects_count]
-skipped = true

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -783,3 +783,9 @@ newRenderPipelineStateWithTileDescriptor_options_reflection_error = { skipped = 
 skipped = true
 [fn.MTLPackedFloat3Make]
 skipped = true
+
+# Uses __unsafe_unretained on a generic which is weirdly printed by clang.
+#
+# Also, supporting "NSGenericFastEnumeraiton" manually is desired anyhow.
+[class.NSDictionary.methods.countByEnumeratingWithState_objects_count]
+skipped = true

--- a/crates/icrate/src/Foundation/__ns_string.rs
+++ b/crates/icrate/src/Foundation/__ns_string.rs
@@ -447,6 +447,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow, enable this if working on ns_string!"]
     fn test_decode_utf8() {
         for c in '\u{0}'..=core::char::MAX {
             let mut buf;
@@ -469,6 +470,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow, enable this if working on ns_string!"]
     fn encode_utf16() {
         for c in '\u{0}'..=core::char::MAX {
             assert_eq!(

--- a/crates/objc2/src/__macro_helpers.rs
+++ b/crates/objc2/src/__macro_helpers.rs
@@ -311,6 +311,10 @@ impl<T: ?Sized> MaybeUnwrap for Allocated<T> {
 
 // Note: It would have been much easier to do this kind of thing using
 // closures, but then `track_caller` doesn't work properly!
+//
+// Also note: This behavior (that #[method_id(...)] always unwraps instead of
+// using `unwrap_unchecked`) is relied upon by `header-translator` for
+// soundness, see e.g. `parse_property_return`.
 pub trait MsgSendIdFailed<'a> {
     type Args;
 


### PR DESCRIPTION
I basically redid the whole "parse lifetime from a string"-part, and tweaked a lot of other small things (a lot of these were small irritating things that were preventing me from doing "real" work like https://github.com/madsmtm/objc2/pull/328)