### PR TITLE
Enable header-translator/run feature for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.cargo.features": [
+        "header-translator/run"
+    ]
+}


### PR DESCRIPTION
I don't know if you want to merge this but it makes developing the header-translator crate a little easier with vscode.