### PR TITLE
Emit arguments in snake_case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ version = "0.1.0"
 dependencies = [
  "apple-sdk",
  "clang",
+ "heck",
  "proc-macro2",
  "serde",
  "toml",
@@ -126,6 +127,12 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -8,15 +8,7 @@ repository = "https://github.com/madsmtm/objc2"
 license = "Zlib OR Apache-2.0 OR MIT"
 
 [features]
-run = [
-    "clang",
-    "toml",
-    "serde",
-    "apple-sdk",
-    "tracing",
-    "tracing-subscriber",
-    "tracing-tree",
-]
+run = ["clang", "toml", "serde", "apple-sdk", "tracing", "tracing-subscriber", "tracing-tree"]
 
 [dependencies]
 clang = { version = "2.0", features = ["runtime", "clang_10_0"], optional = true }
@@ -27,6 +19,7 @@ tracing = { version = "0.1.37", default-features = false, features = ["std"], op
 tracing-subscriber = { version = "0.3.16", features = ["fmt"], optional = true }
 tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git", optional = true }
 proc-macro2 = "1.0.49"
+heck = "0.4.0"
 
 [[bin]]
 name = "header-translator"

--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -465,7 +465,8 @@ impl fmt::Display for Method {
             }
         }
         for (param, _qualifier, arg_ty) in &self.arguments {
-            write!(f, "{}: {arg_ty},", handle_reserved(param))?;
+            let param = heck::ToSnakeCase::to_snake_case(param.as_str());
+            write!(f, "{}: {arg_ty},", handle_reserved(param.as_str()))?;
         }
         write!(f, ")")?;
 

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1062,7 +1062,8 @@ impl fmt::Display for Stmt {
                 writeln!(f, "extern_fn!(")?;
                 write!(f, "    pub{unsafe_} fn {name}(")?;
                 for (param, arg_ty) in arguments {
-                    write!(f, "{}: {arg_ty},", handle_reserved(param))?;
+                    let param = heck::ToSnakeCase::to_snake_case(param.as_str());
+                    write!(f, "{}: {arg_ty},", handle_reserved(param.as_str()))?;
                 }
                 writeln!(f, "){result_type};")?;
                 writeln!(f, ");")?;


### PR DESCRIPTION
This PR makes the header translator output method and function arguments in snake_case.

The rationale for this change is that having the arguments in snake case works a little better overall with several rust analyzer features and idiomatic rust code.

For example, there is one rust analyzer feature that shows inlay hints for the names of function and method arguments, but it elides those hints in the case where the hint name and the actual argument name are the same. I show an example of this below. (See the method call `data_store.removeDataOfTypes_modifiedSince_completionHandler` at the bottom).

(snake_case arguments, where the hints are shown, redundantly)
<img width="552" alt="snake_case" src="https://user-images.githubusercontent.com/11022302/211964320-2128bb7c-731d-4897-a461-7ceb089cbfbd.png">

(camelCase arguments, where the hints are elided, but then we have warnings (yellow underlines) about non-snake_case identifiers)
<img width="545" alt="camelCase" src="https://user-images.githubusercontent.com/11022302/211964345-295124b6-9043-495b-b9a8-452b5ff5f9be.png">

Similarly, there is another feature of rust-analyzer that can autocomplete method calls, filling in arguments from those already in scope, if the names and types match what the function or method expects:

```
rust-analyzer.completion.callable.snippets (default: "fill_arguments")
    Whether to add parenthesis and argument snippets when completing function.
```