### PR TITLE
Update our nightly version manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,7 @@ env:
     --package=objc2
     --package=icrate
   # The current nightly Rust version that our CI uses
-  #
-  # To help find regressions, we explicitly _don't_ pin the version here!
-  CURRENT_NIGHTLY: nightly
+  CURRENT_NIGHTLY: nightly-2023-01-15
   # Various features that we'd usually want to test with
   #
   # Note: The `exception` feature is not enabled here, since it requires

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "apple-sdk"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41965f6961b03445e0f009ba9c8ae32eeca2a8c4be92553060a5d2fb8910d70"
+checksum = "a04f192a700686ee70008ff4e4eb76fe7d11814ab93b7ee9d48c36b9a9f0bd2a"
 
 [[package]]
 name = "atty"
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 dependencies = [
  "serde",
 ]
@@ -63,15 +63,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -109,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "header-translator"
@@ -290,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -385,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -475,6 +476,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed01de3de062db82c0920b5cabe804f88d599a3f217932292597c678c903754d"
+checksum = "f1212c215a87a183687a7cc7065901b1a98da6b37277d51a1b5faedbb4efd4f3"
 dependencies = [
  "glob",
  "once_cell",

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -27,7 +27,7 @@ run-icrate-check = [
 clang = { version = "2.0", features = ["runtime", "clang_10_0"], optional = true }
 toml = { version = "0.5.9", optional = true }
 serde = { version = "1.0.144", features = ["derive"], optional = true }
-apple-sdk = { version = "0.2.0", default-features = false, optional = true }
+apple-sdk = { version = "0.4.0", default-features = false, optional = true }
 tracing = { version = "0.1.37", default-features = false, features = ["std"], optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["fmt"], optional = true }
 tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git", optional = true }

--- a/crates/test-assembly/Cargo.toml
+++ b/crates/test-assembly/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 run = ["cargo_metadata", "rustc-demangle", "regex", "lazy_static"]
 
 [dependencies]
-cargo_metadata = { version = "0.14", optional = true }
+cargo_metadata = { version = "0.15.2", optional = true }
 rustc-demangle = { version = "0.1", optional = true }
 regex = { version = "1.6", optional = true }
 lazy_static = { version = "1.4.0", optional = true }

--- a/crates/test-ui/ui/extern_protocol_class_method.stderr
+++ b/crates/test-ui/ui/extern_protocol_class_method.stderr
@@ -39,17 +39,3 @@ error: class methods are not supported in `extern_protocol!`
   | |_^
   |
   = note: this error originates in the macro `$crate::__extern_protocol_method_out` which comes from the expansion of the macro `extern_protocol` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: class methods are not supported in `extern_protocol!`
- --> ui/extern_protocol_class_method.rs
-  |
-  | / extern_protocol!(
-  | |     pub struct MyProtocol;
-  | |
-  | |     unsafe impl ProtocolType for MyProtocol {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__extern_protocol_method_out` which comes from the expansion of the macro `extern_protocol` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error.stderr
@@ -1,10 +1,10 @@
 error[E0282]: type annotations needed
  --> ui/msg_send_underspecified_error.rs
   |
-  |     let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
-  |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the associated function `__send_message_error`
+  |     let _: Result<Id<NSString, Shared>, Id<_, Shared>> = unsafe { msg_send_id![obj, d: _] };
+  |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `E` declared on the associated function `send_message_id_error`
   |
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0283]: type annotations needed
  --> ui/msg_send_underspecified_error.rs


### PR DESCRIPTION
Previously, I've had it updated automatically, so that I could help find regressions in the compiler output faster.

But that's not really tenable now that there's starting to be other contributors to the project - so let's revert to manually updating said version (just like we do with out dependencies, which this PR also updates).