### PR TITLE
Make running `header-translator` and `test-assembly` easier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,16 @@ env:
   CXX: clang++
 
   # Crates that we want to run `rustdoc` and `clippy` on
+  #
+  # This excludes `header-translator`, `test-assembly`, `tests` and `test-ui`.
   PUBLIC_CRATES: >-
-    --package=objc2-proc-macros
-    --package=objc-sys
-    --package=objc2-encode
     --package=block-sys
     --package=block2
-    --package=objc2
     --package=icrate
+    --package=objc-sys
+    --package=objc2
+    --package=objc2-encode
+    --package=objc2-proc-macros
   # The current nightly Rust version that our CI uses
   CURRENT_NIGHTLY: nightly-2023-01-15
   # Various features that we'd usually want to test with
@@ -113,14 +115,10 @@ jobs:
             --features=unstable-frameworks-gnustep
         - name: header-translator
           target: x86_64-unknown-linux-gnu
-          args: >-
-            -pheader-translator
-            --features=run
+          args: -pheader-translator
         - name: test-assembly
           target: x86_64-unknown-linux-gnu
-          args: >-
-            -ptest-assembly
-            --features=run
+          args: -ptest-assembly
 
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
@@ -247,7 +245,7 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Run macOS x86_64 assembly tests
-      run: cargo run --features=run --bin=test-assembly -- --target=x86_64-apple-darwin
+      run: cargo run --bin=test-assembly -- --target=x86_64-apple-darwin
 
     - name: Run all assembly tests
       if: ${{ env.FULL }}
@@ -278,7 +276,7 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Run header translator
-      run: cargo run --features=run --bin=header-translator
+      run: cargo run --bin=header-translator
 
     - name: Verify that no files changed
       run: git diff --exit-code --submodule=diff
@@ -308,7 +306,7 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check `icrate` with each feature enabled separately
-      run: cargo run --bin=check_icrate_features --features=run-icrate-check
+      run: cargo run --bin=check_icrate_features
 
   test-macos:
     name: Test macOS 12
@@ -340,10 +338,10 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Test without features
-      run: cargo test $ARGS
+      run: cargo test $ARGS $PUBLIC_CRATES -ptests
 
     - name: Test all frameworks
-      run: cargo test $ARGS --features=$INTERESTING_FEATURES,unstable-frameworks-macos-12
+      run: cargo test $ARGS $PUBLIC_CRATES -ptests --features=$INTERESTING_FEATURES,unstable-frameworks-macos-12
 
   test-apple:
     # if: ${{ env.FULL }}
@@ -460,25 +458,35 @@ jobs:
       run: echo "SDKROOT=$HOME/sdk" >> $GITHUB_ENV
 
     - name: Test without features
-      run: cargo test $ARGS
+      run: cargo test $ARGS $PUBLIC_CRATES -ptests
 
     - name: Test Foundation
-      run: cargo test $ARGS --features=$INTERESTING_FEATURES,Foundation_all
+      run: >-
+        cargo test $ARGS $PUBLIC_CRATES -ptests
+        --features=$INTERESTING_FEATURES,Foundation_all
 
     - name: Test all frameworks
-      run: cargo test $ARGS --features=$INTERESTING_FEATURES,catch-all,unstable-frameworks-${{ matrix.frameworks }}
+      run: >-
+        cargo test $ARGS $PUBLIC_CRATES -ptests
+        --features=$INTERESTING_FEATURES,catch-all,unstable-frameworks-${{ matrix.frameworks }}
 
     - name: Test in release mode
-      run: cargo test $ARGS --features=$INTERESTING_FEATURES,catch-all,Foundation_all --release
+      run: >-
+        cargo test $ARGS $PUBLIC_CRATES -ptests
+        --features=$INTERESTING_FEATURES,catch-all,Foundation_all --release
 
     - name: Test with unstable features
       if: ${{ matrix.nightly }}
-      run: cargo test $ARGS --features=$INTERESTING_FEATURES,catch-all,Foundation_all,$UNSTABLE_FEATURES
+      run: >-
+        cargo test $ARGS $PUBLIC_CRATES -ptests
+        --features=$INTERESTING_FEATURES,catch-all,Foundation_all,$UNSTABLE_FEATURES
 
     # TODO: Re-enable this on Foundation once we do some form of
     # availability checking.
     - name: Test static class and selectors
-      run: cargo test $ARGS --features=unstable-static-sel,unstable-static-class
+      run: >-
+        cargo test $ARGS $PUBLIC_CRATES -ptests
+        --features=unstable-static-sel,unstable-static-class
 
   test-ios:
     # if: ${{ env.FULL }}
@@ -538,6 +546,7 @@ jobs:
     - name: Test
       run: >-
         cargo-dinghy --device=$SIM_ID test
+        $PUBLIC_CRATES -ptests
         --features=$INTERESTING_FEATURES,catch-all
         --features=unstable-frameworks-ios
 

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -7,37 +7,13 @@ publish = false
 repository = "https://github.com/madsmtm/objc2"
 license = "Zlib OR Apache-2.0 OR MIT"
 
-[features]
-run = [
-    "clang",
-    "toml",
-    "serde",
-    "apple-sdk",
-    "tracing",
-    "tracing-subscriber",
-    "tracing-tree",
-    "syn",
-]
-run-icrate-check = [
-    "toml",
-    "serde",
-]
-
 [dependencies]
-clang = { version = "2.0", features = ["runtime", "clang_10_0"], optional = true }
-toml = { version = "0.5.9", optional = true }
-serde = { version = "1.0.144", features = ["derive"], optional = true }
-apple-sdk = { version = "0.4.0", default-features = false, optional = true }
-tracing = { version = "0.1.37", default-features = false, features = ["std"], optional = true }
-tracing-subscriber = { version = "0.3.16", features = ["fmt"], optional = true }
-tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git", optional = true }
+clang = { version = "2.0", features = ["runtime", "clang_10_0"] }
+toml = "0.5.9"
+serde = { version = "1.0.144", features = ["derive"] }
+apple-sdk = { version = "0.4.0", default-features = false }
+tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
+tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git" }
 proc-macro2 = "1.0.49"
-syn = { version = "1.0", features = ["parsing"], optional = true }
-
-[[bin]]
-name = "header-translator"
-required-features = ["run"]
-
-[[bin]]
-name = "check_icrate_features"
-required-features = ["run-icrate-check"]
+syn = { version = "1.0", features = ["parsing"] }

--- a/crates/header-translator/README.md
+++ b/crates/header-translator/README.md
@@ -1,11 +1,31 @@
 # Objective-C header translator
 
-For use in making `icrate`.
+For use in making `icrate`. Run using:
 
 ```console
-cargo run --features=run --bin header-translator -- /Applications/Xcode.app/Contents/Developer
+cargo run --bin header-translator
 ```
+
 
 ## SDKs
 
-We do not redistribute the relevant SDKs, to hopefully avoid a license violation. You can download the SDKs yourself (they're bundled in XCode) from [Apple's website](https://developer.apple.com/download/all/?q=xcode) (requires an Apple ID).
+Make sure you have the same XCode version installed as the one documented in [`crates/icrate/README.md`](../icrate/README.md).
+
+If you have the SDK stored in a different directory, you can specify that as the first argument:
+
+```console
+cargo run --bin header-translator -- /Applications/Xcode_new.app/Contents/Developer
+```
+
+We do not redistribute SDKs, to hopefully avoid a license violation. You should download XCode (which contain the SDKs) yourself from [Apple's website](https://developer.apple.com/download/all/?q=xcode) (requires an Apple ID).
+
+
+## Test `icrate`'s feature setup
+
+`header-translator` emits a bunch of features to conditionally enable classes.
+
+If you're working on improving this, you should run the `check_icrate_features` tool to (somewhat) ensure that your changes still compile.
+
+```console
+cargo run --bin=check_icrate_features
+```

--- a/crates/header-translator/src/bin/check_icrate_features.rs
+++ b/crates/header-translator/src/bin/check_icrate_features.rs
@@ -31,10 +31,9 @@ const POPULAR_FEATURES: &[&str] = &[
 
 fn get_pairs<'a>(items: &'a [&'a str]) -> impl Iterator<Item = (&'a str, &'a str)> + 'a {
     items
-        .into_iter()
+        .iter()
         .enumerate()
-        .map(|(i, &item1)| items[i..].into_iter().map(move |&item2| (item1, item2)))
-        .flatten()
+        .flat_map(|(i, &item1)| items[i..].iter().map(move |&item2| (item1, item2)))
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -49,6 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let feature_sets = get_pairs(POPULAR_FEATURES)
         .map(|(feature1, feature2)| vec![feature1, feature2])
         .chain(features.keys().filter_map(|feature| {
+            #[allow(clippy::if_same_then_else)]
             if feature.contains("gnustep") {
                 // Skip GNUStep-related features
                 None

--- a/crates/header-translator/src/bin/check_icrate_features.rs
+++ b/crates/header-translator/src/bin/check_icrate_features.rs
@@ -1,9 +1,4 @@
-//! # Utility for testing `icrate`'s feature set
-//!
-//! Run using:
-//! ```sh
-//! cargo run --bin=check_icrate_features --features=run
-//! ```
+//! Utility for testing `icrate`'s feature set
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;

--- a/crates/header-translator/src/lib.rs
+++ b/crates/header-translator/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "run")]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/crates/test-assembly/Cargo.toml
+++ b/crates/test-assembly/Cargo.toml
@@ -9,15 +9,8 @@ license = "MIT"
 
 build = "build.rs"
 
-[features]
-run = ["cargo_metadata", "rustc-demangle", "regex", "lazy_static"]
-
 [dependencies]
-cargo_metadata = { version = "0.15.2", optional = true }
-rustc-demangle = { version = "0.1", optional = true }
-regex = { version = "1.6", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
-
-[[bin]]
-name = "test-assembly"
-required-features = ["run"]
+cargo_metadata = "0.15.2"
+rustc-demangle = "0.1"
+regex = "1.6"
+lazy_static = "1.4.0"

--- a/crates/test-assembly/src/lib.rs
+++ b/crates/test-assembly/src/lib.rs
@@ -4,7 +4,6 @@ use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 
-#[cfg(feature = "run")]
 pub fn get_runtime() -> String {
     use regex::Regex;
     let re = Regex::new(r"--features[= ]+(([a-z0-9_-]+,?)+)").unwrap();
@@ -24,11 +23,6 @@ pub fn get_runtime() -> String {
         .unwrap_or("apple")
         .to_string();
     result
-}
-
-#[cfg(not(feature = "run"))]
-pub fn get_runtime() -> String {
-    panic!("`run` feature must be enabled")
 }
 
 fn strip_lines(data: &str, starts_with: &str) -> String {
@@ -104,7 +98,6 @@ pub fn read_assembly<P: AsRef<Path>>(path: P, package_path: &Path) -> io::Result
     Ok(s)
 }
 
-#[cfg(feature = "run")]
 pub fn get_artifact(result_stream: &[u8], package: &str) -> PathBuf {
     use cargo_metadata::Message;
     Message::parse_stream(result_stream)
@@ -128,13 +121,7 @@ pub fn get_artifact(result_stream: &[u8], package: &str) -> PathBuf {
         .into_std_path_buf()
 }
 
-#[cfg(not(feature = "run"))]
-pub fn get_artifact(_result_stream: &[u8], _package: &str) -> PathBuf {
-    panic!("`run` feature must be enabled")
-}
-
 /// VERY BRITTLE!
-#[cfg(feature = "run")]
 fn demangle_assembly(assembly: &str) -> String {
     use std::collections::HashMap;
 
@@ -196,14 +183,8 @@ fn demangle_assembly(assembly: &str) -> String {
     RE_ANON.replace_all(&assembly, "anon.[ID].").to_string()
 }
 
-#[cfg(not(feature = "run"))]
-fn demangle_assembly(_s: &str) -> String {
-    panic!("`run` feature must be enabled")
-}
-
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "run")]
     #[test]
     fn test_demangle() {
         use super::*;

--- a/crates/test-assembly/src/main.rs
+++ b/crates/test-assembly/src/main.rs
@@ -4,7 +4,7 @@
 //!
 //! Use as:
 //! ```
-//! TEST_OVERWRITE=1 cargo run --features=run --bin test-assembly -- --target=x86_64-apple-darwin
+//! TEST_OVERWRITE=1 cargo run --bin test-assembly -- --target=x86_64-apple-darwin
 //! ```
 //!
 //! Very limited currently, for example we can't stably test things that emits


### PR DESCRIPTION
Previously, I was guarding these with a `run` cargo feature so that a simple `cargo test` wouldn't need to download all the dependencies. But nowadays, I only run `cargo test` on the specific crate I want to test, so the point is moot.

Also fixes the complaint that @silvanshade had in https://github.com/madsmtm/objc2/pull/333