### PR TITLE
Remove the optional `uuid` integration from `icrate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ env:
   #
   # Note: The `exception` feature is not enabled here, since it requires
   # compiling C code, even if just running a `check`/`clippy` build.
-  INTERESTING_FEATURES: malloc,block,verify,uuid,unstable-private
+  INTERESTING_FEATURES: malloc,block,verify,unstable-private
   UNSTABLE_FEATURES: unstable-autoreleasesafe,unstable-c-unwind
   # Required when we want to use a different runtime than the default `apple`
   OTHER_RUNTIME: --no-default-features --features=std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ version = "0.0.1"
 dependencies = [
  "block2",
  "objc2",
- "uuid",
 ]
 
 [[package]]
@@ -591,12 +590,6 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "uuid"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "valuable"

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Updated the SDK version from XCode `14.0.1` to `14.2`.
   - See differences [here](https://sdk.news/macOS-13.0/).
 
+### Removed
+* **BREAKING**: The optional `uuid` integration, since one might want to use
+  `icrate` internally in that crate in the future, and that would break.
+
 
 ## icrate 0.0.1 - 2022-12-24
 

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -23,12 +23,9 @@ license = "MIT"
 objc2 = { path = "../objc2", version = "=0.3.0-beta.4", default-features = false, optional = true }
 block2 = { path = "../block2", version = "=0.2.0-alpha.7", default-features = false, optional = true }
 
-# Provide methods to convert between `uuid::Uuid` and `icrate::Foundation::NSUUID`
-uuid = { version = "1.1.2", optional = true, default-features = false }
-
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
-features = ["block", "objective-c", "uuid", "unstable-frameworks-all", "unstable-private", "unstable-docsrs"]
+features = ["block", "objective-c", "unstable-frameworks-all", "unstable-private", "unstable-docsrs"]
 
 targets = [
     # MacOS

--- a/crates/icrate/src/Foundation/additions/uuid.rs
+++ b/crates/icrate/src/Foundation/additions/uuid.rs
@@ -20,6 +20,22 @@ impl NSUUID {
         Self::from_bytes([0; 16])
     }
 
+    /// Create a new `NSUUID` from the given bytes.
+    ///
+    ///
+    /// # Example
+    ///
+    /// Create a new `NSUUID` from the `uuid` crate.
+    ///
+    /// ```ignore
+    /// use uuid::Uuid;
+    /// use icrate::Foundation::NSUUID;
+    ///
+    /// let uuid: Uuid;
+    /// # uuid = todo!();
+    /// let obj = NSUUID::from_bytes(uuid.into_bytes());
+    /// assert_eq!(obj.as_bytes(), uuid.into_bytes());
+    /// ```
     pub fn from_bytes(bytes: [u8; 16]) -> Id<Self, Shared> {
         let bytes = UuidBytes(bytes);
         Self::initWithUUIDBytes(Self::alloc(), &bytes)
@@ -67,18 +83,6 @@ impl fmt::Debug for NSUUID {
 //         res.into()
 //     }
 // }
-
-/// Conversion methods to/from `uuid` crate.
-#[cfg(feature = "uuid")]
-impl NSUUID {
-    pub fn from_uuid(uuid: uuid::Uuid) -> Id<Self, Shared> {
-        Self::from_bytes(uuid.into_bytes())
-    }
-
-    pub fn as_uuid(&self) -> uuid::Uuid {
-        uuid::Uuid::from_bytes(self.as_bytes())
-    }
-}
 
 impl DefaultId for NSUUID {
     type Ownership = Shared;

--- a/crates/icrate/src/Foundation/mod.rs
+++ b/crates/icrate/src/Foundation/mod.rs
@@ -98,11 +98,6 @@
 //! | `NSEnumerator<T, Shared>` | `impl Iterator<Arc<T>>` |
 //! | `NSEnumerator<T, Owned>` | `impl Iterator<T>` |
 //! | `@protocol NSCopying` | `trait Clone` |
-//!
-//!
-//! # Feature flags
-//!
-//! `"uuid"` -> Enables conversion methods between `NSUUID` and `uuid::Uuid`.
 #![allow(unused_imports)]
 
 #[doc(hidden)]

--- a/crates/icrate/tests/uuid.rs
+++ b/crates/icrate/tests/uuid.rs
@@ -29,12 +29,3 @@ fn display_debug() {
 //     let uuid2 = NSUUID::from_bytes([9; 16]);
 //     assert!(uuid1 > uuid2);
 // }
-
-#[cfg(feature = "uuid")]
-#[test]
-fn test_convert_roundtrip() {
-    let nsuuid1 = NSUUID::UUID();
-    let uuid = nsuuid1.as_uuid();
-    let nsuuid2 = NSUUID::from_uuid(uuid);
-    assert_eq!(nsuuid1, nsuuid2);
-}


### PR DESCRIPTION
It is very simple to do manually, and having the cargo feature may break if `uuid` crate's internals start using `icrate`.