### PR TITLE
Separate Rust struct type names and Objc internal struct names during header translations

### DIFF
--- a/crates/header-translator/src/data/Foundation.rs
+++ b/crates/header-translator/src/data/Foundation.rs
@@ -127,6 +127,7 @@ data! {
     class NSProcessInfo {
         unsafe +processInfo;
         unsafe -processName;
+        unsafe -operatingSystemVersion;
     }
 
     class NSSet {

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -266,6 +266,9 @@ pub enum Stmt {
     /// } name;
     StructDecl {
         id: ItemIdentifier,
+        // internal objc struct name (before typedef). shows up in encoding
+        // and is used in message verification.
+        struct_name: String,
         availability: Availability,
         boxable: bool,
         fields: Vec<(String, Ty)>,
@@ -576,6 +579,7 @@ impl Stmt {
                 let id = ItemIdentifier::new(entity, context);
                 let availability = Availability::parse(entity, context);
                 let mut struct_ = None;
+                let mut struct_name = "?".to_string();
                 let mut skip_struct = false;
                 let mut kind = None;
 
@@ -599,11 +603,13 @@ impl Stmt {
                             return;
                         }
 
-                        let struct_name = entity.get_name();
-                        if struct_name
-                            .map(|name| name.starts_with('_'))
-                            .unwrap_or(true)
-                        {
+                        if let Some(name) = entity.get_name() {
+                            // if the struct has a name use it
+                            // otherwise it will be the default "?"
+                            struct_name = name;
+                        }
+
+                        if struct_name == "?" || struct_name.starts_with('_') {
                             // If this struct doesn't have a name, or the
                             // name is private, let's parse it with the
                             // typedef name.
@@ -623,6 +629,7 @@ impl Stmt {
                     assert_eq!(kind, None, "should not have parsed a kind");
                     return vec![Self::StructDecl {
                         id,
+                        struct_name,
                         availability,
                         boxable,
                         fields,
@@ -677,8 +684,10 @@ impl Stmt {
 
                     if !id.name.starts_with('_') {
                         let (boxable, fields) = parse_struct(entity, context);
+                        let struct_name = id.name.clone();
                         return vec![Self::StructDecl {
                             id,
+                            struct_name,
                             availability,
                             boxable,
                             fields,
@@ -1278,12 +1287,14 @@ impl fmt::Display for Stmt {
             }
             Self::StructDecl {
                 id,
+                struct_name,
                 availability,
                 boxable: _,
                 fields,
             } => {
                 writeln!(f, "extern_struct!(")?;
                 write!(f, "{availability}")?;
+                writeln!(f, "    #[struct_name(\"{struct_name}\")]")?;
                 writeln!(f, "    pub struct {} {{", id.name)?;
                 for (name, ty) in fields {
                     write!(f, "        ")?;

--- a/crates/icrate/src/macros.rs
+++ b/crates/icrate/src/macros.rs
@@ -17,7 +17,7 @@ macro_rules! impl_encode {
 
 macro_rules! extern_struct {
     (
-        #[struct_name($struct_name:literal)]
+        #[encoding_name($encoding_name:literal)]
         $(#[$m:meta])*
         $v:vis struct $name:ident {
             $($field_v:vis $field:ident: $ty:ty),* $(,)?
@@ -32,7 +32,27 @@ macro_rules! extern_struct {
 
         impl_encode! {
             $name = objc2::Encoding::Struct(
-                $struct_name,
+                $encoding_name,
+                &[$(<$ty as objc2::Encode>::ENCODING),*],
+            );
+        }
+    };
+    (
+        $(#[$m:meta])*
+        $v:vis struct $name:ident {
+            $($field_v:vis $field:ident: $ty:ty),* $(,)?
+        }
+    ) => {
+        #[repr(C)]
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        $(#[$m])*
+        $v struct $name {
+            $($field_v $field: $ty,)*
+        }
+
+        impl_encode! {
+            $name = objc2::Encoding::Struct(
+                stringify!($name),
                 &[$(<$ty as objc2::Encode>::ENCODING),*],
             );
         }

--- a/crates/icrate/src/macros.rs
+++ b/crates/icrate/src/macros.rs
@@ -17,6 +17,7 @@ macro_rules! impl_encode {
 
 macro_rules! extern_struct {
     (
+        #[struct_name($struct_name:literal)]
         $(#[$m:meta])*
         $v:vis struct $name:ident {
             $($field_v:vis $field:ident: $ty:ty),* $(,)?
@@ -31,7 +32,7 @@ macro_rules! extern_struct {
 
         impl_encode! {
             $name = objc2::Encoding::Struct(
-                stringify!($name),
+                $struct_name,
                 &[$(<$ty as objc2::Encode>::ENCODING),*],
             );
         }

--- a/crates/icrate/tests/struct_encoding.rs
+++ b/crates/icrate/tests/struct_encoding.rs
@@ -1,0 +1,16 @@
+#[test]
+#[cfg(feature = "Foundation_NSProcessInfo")]
+fn test_operating_system_version() {
+    let info = icrate::Foundation::NSProcessInfo::processInfo();
+    let _version = info.operatingSystemVersion();
+}
+
+#[test]
+#[cfg(feature = "Metal")]
+fn test_packed_float() {
+    use objc2::encode::Encode;
+    assert_eq!(
+        icrate::Metal::MTLPackedFloat4x3::ENCODING.to_string(),
+        "{_MTLPackedFloat4x3=[4{_MTLPackedFloat3=(?={?=fff}[3f])}]}",
+    );
+}


### PR DESCRIPTION
Fixes: #387 

Currently `header-translator` uses the struct typedef name as the struct name which is incorrect.
When Objc encodes structs it uses the struct name without any typedefs. E.g. the following struct has the internal struct name of `foo` and `@encode(bar) = {foo=q}`:
```
typedef struct foo {
    NSInteger x;
} bar;
```

This pull request fixes the header translator to store the internal struct name separately from the potentially typedef'd identifier. Additionally the `extern_struct!` macro is modified to require a `#[struct_name("name")]` attribute to generate the proper `Encoding`.

# Next step
Rerun `header-translator` and update [`icrate-generated`](https://github.com/madsmtm/icrate-generated/).