### PR TITLE
Allow ivar names to be elided

### DIFF
--- a/crates/icrate/examples/delegate.rs
+++ b/crates/icrate/examples/delegate.rs
@@ -14,12 +14,12 @@ extern "C" {}
 declare_class!(
     #[derive(Debug)]
     struct CustomAppDelegate {
-        pub ivar: IvarEncode<u8, "_ivar">,
-        another_ivar: IvarBool<"_another_ivar">,
-        box_ivar: IvarDrop<Box<i32>, "_box_ivar">,
-        maybe_box_ivar: IvarDrop<Option<Box<i32>>, "_maybe_box_ivar">,
-        id_ivar: IvarDrop<Id<NSString, Shared>, "_id_ivar">,
-        maybe_id_ivar: IvarDrop<Option<Id<NSString, Shared>>, "_maybe_id_ivar">,
+        pub ivar: IvarEncode<u8>,
+        another_ivar: IvarBool,
+        box_ivar: IvarDrop<Box<i32>>,
+        maybe_box_ivar: IvarDrop<Option<Box<i32>>>,
+        id_ivar: IvarDrop<Id<NSString, Shared>>,
+        maybe_id_ivar: IvarDrop<Option<Id<NSString, Shared>>>,
     }
 
     mod ivars;

--- a/crates/objc2/src/macros/__field_helpers.rs
+++ b/crates/objc2/src/macros/__field_helpers.rs
@@ -180,7 +180,7 @@ macro_rules! __parse_fields {
     (
         (
             $(#[$m:meta])*
-            $vis:vis $field_name:ident: IvarDrop<$ty:ty, $ivar_name:literal>
+            $vis:vis $field_name:ident: IvarDrop<$ty:ty $(, $ivar_name:literal)?>
             $(, $($rest_fields:tt)*)?
         )
         ($($ivar_helper_module_v:vis mod $ivar_helper_module:ident)?)
@@ -208,7 +208,7 @@ macro_rules! __parse_fields {
                 // - Caller upholds that the ivars are properly initialized.
                 unsafe impl $crate::declare::IvarType for $field_name {
                     type Type = IvarDrop<$ty>;
-                    const NAME: &'static $crate::__macro_helpers::str = $ivar_name;
+                    const NAME: &'static $crate::__macro_helpers::str = $crate::__select_ivar_name!($field_name; $($ivar_name)?);
                 }
             ) ($($ivar_type_name)* $field_name)
             (
@@ -227,7 +227,7 @@ macro_rules! __parse_fields {
     (
         (
             $(#[$m:meta])*
-            $vis:vis $field_name:ident: IvarEncode<$ty:ty, $ivar_name:literal>
+            $vis:vis $field_name:ident: IvarEncode<$ty:ty $(, $ivar_name:literal)?>
             $(, $($rest_fields:tt)*)?
         )
         ($($ivar_helper_module_v:vis mod $ivar_helper_module:ident)?)
@@ -252,7 +252,7 @@ macro_rules! __parse_fields {
                 // SAFETY: See above
                 unsafe impl $crate::declare::IvarType for $field_name {
                     type Type = IvarEncode<$ty>;
-                    const NAME: &'static $crate::__macro_helpers::str = $ivar_name;
+                    const NAME: &'static $crate::__macro_helpers::str = $crate::__select_ivar_name!($field_name; $($ivar_name)?);
                 }
             ) ($($ivar_type_name)* $field_name)
             (
@@ -271,7 +271,7 @@ macro_rules! __parse_fields {
     (
         (
             $(#[$m:meta])*
-            $vis:vis $field_name:ident: IvarBool<$ivar_name:literal>
+            $vis:vis $field_name:ident: IvarBool$(<$ivar_name:literal>)?
             $(, $($rest_fields:tt)*)?
         )
         ($($ivar_helper_module_v:vis mod $ivar_helper_module:ident)?)
@@ -296,7 +296,7 @@ macro_rules! __parse_fields {
                 // SAFETY: See above
                 unsafe impl $crate::declare::IvarType for $field_name {
                     type Type = IvarBool;
-                    const NAME: &'static $crate::__macro_helpers::str = $ivar_name;
+                    const NAME: &'static $crate::__macro_helpers::str = $crate::__select_ivar_name!($field_name; $($ivar_name)?);
                 }
             ) ($($ivar_type_name)* $field_name)
             (
@@ -348,4 +348,15 @@ macro_rules! __parse_fields {
             $($macro_args)*
         }
     }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __select_ivar_name {
+    ($field_name:ident; $ivar_name:literal) => {
+        $ivar_name
+    };
+    ($field_name:ident;) => {
+        concat!('_', stringify!($field_name))
+    };
 }


### PR DESCRIPTION
This PR makes the ivar names optional (re: my earlier comment).

I attempted to do the same for the ivar helper module but it seemed problematic without more serious refactoring of the macros. The reason being that you wouldn't want to create the helper module if there were no ivars specified, but this is hard to detect without more intermediate macros.

One thought I had though is that it feels like many of the macros are rather complicated. I wonder if it might not be worth considering rewriting many of them as proc-macros.

There are the usual downsides to that approach, but on the other hand, it would make some things much easier to implement (like allowing the ivar helper module to be optional) and it would allow us much more control over what kind of error messages we could produce.

I also wonder, especially given the size of `icrate`, whether it might make an impact in terms of performance. As I note in #393, there's at least one framework (`Matter`) that I couldn't get to finish compiling even after raising the recursion limit significantly (up to 2048). In that case I think the issue was partly due to a giant enum, which with a proc macro, we could handle with iteration rather than recursion.

I realize it would be quite a lot of work to rewrite those but that's something I would be willing to help with if you think it's a good idea.