### PR TITLE
Refactor `objc2_encode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "basic-toml"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e819b667739967cd44d308b8c7b71305d8bb0729ac44a248aa08f33d01950b4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "block-sys"
 version = "0.1.0-beta.2"
 dependencies = [
@@ -40,7 +49,7 @@ name = "block2"
 version = "0.2.0-alpha.7"
 dependencies = [
  "block-sys",
- "objc2-encode",
+ "objc2",
 ]
 
 [[package]]
@@ -77,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -241,7 +250,6 @@ dependencies = [
 name = "objc2"
 version = "0.3.0-beta.4"
 dependencies = [
- "block2",
  "iai",
  "malloc_buf",
  "objc-sys",
@@ -252,9 +260,6 @@ dependencies = [
 [[package]]
 name = "objc2-encode"
 version = "2.0.0-pre.3"
-dependencies = [
- "objc-sys",
-]
 
 [[package]]
 name = "objc2-proc-macros"
@@ -593,17 +598,17 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed2c57956f91546d4d33614265a85d55c8e1ab91484853a10335894786d7db6"
+checksum = "a44da5a6f2164c8e14d3bbc0657d69c5966af9f5f6930d4f600b1f5c4a673413"
 dependencies = [
+ "basic-toml",
  "glob",
  "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
 ]
 
 [[package]]

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -27,7 +27,7 @@ alloc = ["objc2/alloc", "block-sys/alloc"]
 
 # Runtime selection. Default is `apple`. See `block-sys` for details.
 apple = ["block-sys/apple", "objc2/apple"]
-compiler-rt = ["block-sys/compiler-rt", "objc2/apple"] # Use Apple's encoding
+compiler-rt = ["block-sys/compiler-rt", "objc2/unstable-compiler-rt"] # TODO: fix this
 gnustep-1-7 = ["block-sys/gnustep-1-7", "objc2/gnustep-1-7"]
 gnustep-1-8 = ["gnustep-1-7", "block-sys/gnustep-1-8", "objc2/gnustep-1-8"]
 gnustep-1-9 = ["gnustep-1-8", "block-sys/gnustep-1-9", "objc2/gnustep-1-9"]

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -22,20 +22,20 @@ license = "MIT"
 default = ["std", "apple"]
 
 # Currently not possible to turn off, put here for forwards compatibility.
-std = ["alloc", "objc2-encode/std", "block-sys/std"]
-alloc = ["objc2-encode/alloc", "block-sys/alloc"]
+std = ["alloc", "objc2/std", "block-sys/std"]
+alloc = ["objc2/alloc", "block-sys/alloc"]
 
 # Runtime selection. Default is `apple`. See `block-sys` for details.
-apple = ["block-sys/apple", "objc2-encode/apple"]
-compiler-rt = ["block-sys/compiler-rt", "objc2-encode/apple"] # Use Apple's encoding
-gnustep-1-7 = ["block-sys/gnustep-1-7", "objc2-encode/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "block-sys/gnustep-1-8", "objc2-encode/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "block-sys/gnustep-1-9", "objc2-encode/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0", "objc2-encode/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2-encode/gnustep-2-1"]
+apple = ["block-sys/apple", "objc2/apple"]
+compiler-rt = ["block-sys/compiler-rt", "objc2/apple"] # Use Apple's encoding
+gnustep-1-7 = ["block-sys/gnustep-1-7", "objc2/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "block-sys/gnustep-1-8", "objc2/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "block-sys/gnustep-1-9", "objc2/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0", "objc2/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2/gnustep-2-1"]
 
 [dependencies]
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.3", default-features = false }
+objc2 = { path = "../objc2", version = "=0.3.0-beta.4", default-features = false }
 block-sys = { path = "../block-sys", version = "=0.1.0-beta.2", default-features = false }
 
 [package.metadata.docs.rs]

--- a/crates/block2/src/block.rs
+++ b/crates/block2/src/block.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::mem;
 
-use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
+use objc2::encode::{Encode, EncodeArguments, Encoding, RefEncode};
 
 use crate::ffi;
 

--- a/crates/block2/src/concrete_block.rs
+++ b/crates/block2/src/concrete_block.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 use core::ptr;
 use std::os::raw::c_ulong;
 
-use objc2_encode::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 use crate::{ffi, Block, BlockArguments, RcBlock};
 

--- a/crates/block2/src/global.rs
+++ b/crates/block2/src/global.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 use core::ptr;
 use std::os::raw::c_ulong;
 
-use objc2_encode::Encode;
+use objc2::encode::Encode;
 
 use super::{ffi, Block};
 use crate::BlockArguments;

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -100,7 +100,7 @@ gnustep-2-1 = ["gnustep-2-0", "objc2?/gnustep-2-1", "block2?/gnustep-2-1"]
 objective-c = ["objc2"]
 
 # Expose features that requires creating blocks.
-block = ["objc2?/block", "block2"]
+block = ["block2"]
 
 # For better documentation on docs.rs
 unstable-docsrs = []

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -8,10 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Made the crate `no_std` compatible.
+* Made the crate platform-agnostic.
 
 ### Changed
 * **BREAKING**: Moved the `Encode`, `RefEncode`, `EncodeArguments`,
   `EncodeConvert`, `OptionEncode` to `objc2`.
+* **BREAKING**: `Encoding::BitField` now allows omitting the type using an
+  `Option`.
+* **BREAKING**: Changed length field in `Encoding::Array` from `usize` to
+  `u64` (to be platform-agnostic).
+
+### Fixed
+* Fixed `Encoding::BitField` encoding parsing.
 
 
 ## 2.0.0-pre.3 - 2022-12-24

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Made the crate `no_std` compatible.
+
+### Changed
+* **BREAKING**: Moved the `Encode`, `RefEncode`, `EncodeArguments`,
+  `EncodeConvert`, `OptionEncode` to `objc2`.
+
 
 ## 2.0.0-pre.3 - 2022-12-24
 

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"
 
-description = "Objective-C type-encodings"
+description = "Objective-C type-encoding representation and parsing"
 keywords = ["objective-c", "macos", "ios", "encode"]
 categories = [
     "development-tools::ffi",
@@ -20,27 +20,11 @@ documentation = "https://docs.rs/objc2-encode/"
 license = "MIT"
 
 [features]
-default = ["std", "apple"]
+default = ["std"]
 
-# Currently not possible to turn off, put here for forwards compatibility.
-std = ["alloc", "objc-sys/std"]
-alloc = ["objc-sys/alloc"]
-
-# Enables support for the nightly c_unwind feature
-unstable-c-unwind = []
-
-# Runtime selection. See `objc-sys` for details.
-apple = ["objc-sys/apple"]
-gnustep-1-7 = ["objc-sys/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
-
-[dependencies]
-# TODO: Remove this dependency when we can select `macabi` targets separately
-# from other targets without using a build script
-objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.3", default-features = false }
+std = ["alloc"]
+# Currently not possible to turn off, put here for forwards compatibility
+alloc = []
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/crates/objc2-encode/README.md
+++ b/crates/objc2-encode/README.md
@@ -7,8 +7,8 @@
 
 Objective-C type-encoding in Rust.
 
-This crates provides the equivalent of the Objective-C `@encode` directive,
-and functions for comparing these encodings.
+This crates provides types to parse and compare Objective-C type-encodings
+created with the `@encode` directive.
 
 See [the docs](https://docs.rs/objc2-encode/) for a more thorough overview.
 

--- a/crates/objc2-encode/README.md
+++ b/crates/objc2-encode/README.md
@@ -10,9 +10,6 @@ Objective-C type-encoding in Rust.
 This crates provides the equivalent of the Objective-C `@encode` directive,
 and functions for comparing these encodings.
 
-Additionally, it provides traits for annotating types that has an Objective-C
-encoding.
-
 See [the docs](https://docs.rs/objc2-encode/) for a more thorough overview.
 
 This crate is part of the [`objc2` project](https://github.com/madsmtm/objc2),

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -47,8 +47,8 @@ pub enum Encoding {
     Int,
     /// A C `long`. Corresponds to the `"l"` code.
     ///
-    /// This is treated as a 32-bit quantity in 64-bit programs.
-    // TODO: What does that mean??
+    /// This is treated as a 32-bit quantity in 64-bit programs, see
+    /// [`Encoding::C_LONG`].
     Long,
     /// A C `long long`. Corresponds to the `"q"` code.
     LongLong,
@@ -59,6 +59,8 @@ pub enum Encoding {
     /// A C `unsigned int`. Corresponds to the `"I"` code.
     UInt,
     /// A C `unsigned long`. Corresponds to the `"L"` code.
+    ///
+    /// See [`Encoding::C_ULONG`].
     ULong,
     /// A C `unsigned long long`. Corresponds to the `"Q"` code.
     ULongLong,
@@ -133,7 +135,8 @@ pub enum Encoding {
     ///
     /// Corresponds to the `"(" name "=" fields... ")"` code.
     Union(&'static str, &'static [Encoding]),
-    // "Vector" types have the '!' encoding, but are not implemented in clang
+    // TODO: "Vector" types have the '!' encoding, but are not implemented in
+    // clang
 
     // TODO: `t` and `T` codes for i128 and u128?
 }
@@ -149,7 +152,9 @@ impl Encoding {
     /// Unfortunately, `long` have a different encoding than `int` when it is
     /// 32 bits wide; the [`l`][`Encoding::Long`] encoding.
     pub const C_LONG: Self = {
-        // Alternative: `mem::size_of::<c_long>() == 4`
+        // TODO once `core::ffi::c_long` is in MSRV
+        // `mem::size_of::<c_long>() == 4`
+        //
         // That would exactly match what `clang` does:
         // https://github.com/llvm/llvm-project/blob/release/13.x/clang/lib/AST/ASTContext.cpp#L7245
         if cfg!(any(target_pointer_width = "32", windows)) {
@@ -202,8 +207,6 @@ impl Encoding {
         let mut parser = Parser::new(s);
 
         parser.strip_leading_qualifiers();
-
-        // TODO: Allow missing/"?" names in structs and unions?
 
         if let Some(()) = parser.expect_encoding(self, NestingLevel::new()) {
             // if the given encoding can be successfully removed from the
@@ -489,7 +492,6 @@ mod tests {
         fn empty_struct() {
             Encoding::Struct("SomeStruct", &[]);
             "{SomeStruct=}";
-            // TODO: Unsure about this
             !"{SomeStruct}";
         }
 

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -39,95 +39,99 @@ use crate::EncodingBox;
 // See <https://en.cppreference.com/w/c/language/type>
 #[non_exhaustive] // Maybe we're missing some encodings?
 pub enum Encoding {
-    /// A C `char`. Corresponds to the `c` code.
+    /// A C `char`. Corresponds to the `"c"` code.
     Char,
-    /// A C `short`. Corresponds to the `s` code.
+    /// A C `short`. Corresponds to the `"s"` code.
     Short,
-    /// A C `int`. Corresponds to the `i` code.
+    /// A C `int`. Corresponds to the `"i"` code.
     Int,
-    /// A C `long`. Corresponds to the `l` code.
+    /// A C `long`. Corresponds to the `"l"` code.
     ///
     /// This is treated as a 32-bit quantity in 64-bit programs.
     // TODO: What does that mean??
     Long,
-    /// A C `long long`. Corresponds to the `q` code.
+    /// A C `long long`. Corresponds to the `"q"` code.
     LongLong,
-    /// A C `unsigned char`. Corresponds to the `C` code.
+    /// A C `unsigned char`. Corresponds to the `"C"` code.
     UChar,
-    /// A C `unsigned short`. Corresponds to the `S` code.
+    /// A C `unsigned short`. Corresponds to the `"S"` code.
     UShort,
-    /// A C `unsigned int`. Corresponds to the `I` code.
+    /// A C `unsigned int`. Corresponds to the `"I"` code.
     UInt,
-    /// A C `unsigned long`. Corresponds to the `L` code.
+    /// A C `unsigned long`. Corresponds to the `"L"` code.
     ULong,
-    /// A C `unsigned long long`. Corresponds to the `Q` code.
+    /// A C `unsigned long long`. Corresponds to the `"Q"` code.
     ULongLong,
-    /// A C `float`. Corresponds to the `f` code.
+    /// A C `float`. Corresponds to the `"f"` code.
     Float,
-    /// A C `double`. Corresponds to the `d` code.
+    /// A C `double`. Corresponds to the `"d"` code.
     Double,
-    /// A C `long double`. Corresponds to the `D` code.
+    /// A C `long double`. Corresponds to the `"D"` code.
     LongDouble,
-    /// A C `float _Complex`. Corresponds to the `jf` code.
+    /// A C `float _Complex`. Corresponds to the `"j" "f"` code.
     FloatComplex,
-    /// A C `_Complex` or `double _Complex`. Corresponds to the `jd` code.
+    /// A C `_Complex` or `double _Complex`. Corresponds to the `"j" "d"` code.
     DoubleComplex,
-    /// A C `long double _Complex`. Corresponds to the `jD` code.
+    /// A C `long double _Complex`. Corresponds to the `"j" "D"` code.
     LongDoubleComplex,
-    // TODO: Complex(&Encoding) ???
-    /// A C++ `bool` / C99 `_Bool`. Corresponds to the `B` code.
+    /// A C++ `bool` / C99 `_Bool`. Corresponds to the `"B"` code.
     Bool,
-    /// A C `void`. Corresponds to the `v` code.
+    /// A C `void`. Corresponds to the `"v"` code.
     Void,
-    /// A C `char *`. Corresponds to the `*` code.
+    /// A C `char *`. Corresponds to the `"*"` code.
     String,
-    /// An Objective-C object (`id`). Corresponds to the `@` code.
+    /// An Objective-C object (`id`). Corresponds to the `"@"` code.
     Object,
-    /// An Objective-C block. Corresponds to the `@?` code.
+    /// An Objective-C block. Corresponds to the `"@" "?"` code.
     Block,
-    /// An Objective-C class (`Class`). Corresponds to the `#` code.
+    /// An Objective-C class (`Class`). Corresponds to the `"#"` code.
     Class,
-    /// An Objective-C selector (`SEL`). Corresponds to the `:` code.
+    /// An Objective-C selector (`SEL`). Corresponds to the `":"` code.
     Sel,
-    /// An unknown type. Corresponds to the `?` code.
+    /// An unknown type. Corresponds to the `"?"` code.
     ///
     /// This is usually used to encode functions.
     Unknown,
     /// A bitfield with the given number of bits, and the given type.
     ///
-    /// The type is not currently used, but may be in the future for better
-    /// compatibility with Objective-C runtimes.
+    /// Corresponds to the `"b" size` code.
     ///
-    /// Corresponds to the `b num` code.
-    BitField(u8, &'static Encoding),
+    /// On GNUStep, this uses the `"b" offset type size` code, so this
+    /// contains an `Option` that should be set for that. Only integral types
+    /// are possible for the type.
+    ///
+    /// A `BitField(_, Some(_))` and a `BitField(_, None)` do _not_ compare
+    /// equal; instead, you should set the bitfield depending on the target
+    /// platform.
+    BitField(u8, Option<&'static (u64, Encoding)>),
     /// A pointer to the given type.
     ///
-    /// Corresponds to the `^ type` code.
+    /// Corresponds to the `"^" type` code.
     Pointer(&'static Encoding),
     /// A C11 [`_Atomic`] type.
     ///
-    /// Corresponds to the `A type` code. Not all encodings are possible in
+    /// Corresponds to the `"A" type` code. Not all encodings are possible in
     /// this.
     ///
     /// [`_Atomic`]: https://en.cppreference.com/w/c/language/atomic
     Atomic(&'static Encoding),
     /// An array with the given length and type.
     ///
-    /// Corresponds to the `[len type]` code.
-    Array(usize, &'static Encoding),
+    /// Corresponds to the `"[" length type "]"` code.
+    Array(u64, &'static Encoding),
     /// A struct with the given name and fields.
     ///
     /// The order of the fields must match the order of the order in this.
     ///
     /// It is not uncommon for the name to be `"?"`.
     ///
-    /// Corresponds to the `{name=fields...}` code.
+    /// Corresponds to the `"{" name "=" fields... "}"` code.
     Struct(&'static str, &'static [Encoding]),
     /// A union with the given name and fields.
     ///
     /// The order of the fields must match the order of the order in this.
     ///
-    /// Corresponds to the `(name=fields...)` code.
+    /// Corresponds to the `"(" name "=" fields... ")"` code.
     Union(&'static str, &'static [Encoding]),
     // "Vector" types have the '!' encoding, but are not implemented in clang
 
@@ -135,7 +139,8 @@ pub enum Encoding {
 }
 
 impl Encoding {
-    /// The encoding of [`c_long`](`std::os::raw::c_long`).
+    /// The encoding of [`c_long`](`std::os::raw::c_long`) on the current
+    /// target.
     ///
     /// Ideally the encoding of `long` would just be the same as `int` when
     /// it's 32 bits wide and the same as `long long` when it is 64 bits wide;
@@ -156,7 +161,8 @@ impl Encoding {
         }
     };
 
-    /// The encoding of [`c_ulong`](`std::os::raw::c_ulong`).
+    /// The encoding of [`c_ulong`](`std::os::raw::c_ulong`) on the current
+    /// target.
     ///
     /// See [`Encoding::C_LONG`] for explanation.
     pub const C_ULONG: Self = {
@@ -374,13 +380,35 @@ mod tests {
         }
 
         fn bitfield() {
-            Encoding::BitField(32, &Encoding::Int);
+            Encoding::BitField(4, None);
             !Encoding::Int;
-            !Encoding::BitField(33, &Encoding::Int);
-            "b32";
-            !"b32a";
+            !Encoding::BitField(5, None);
+            !Encoding::BitField(4, Some(&(0, Encoding::Bool)));
+            "b4";
+            !"b4a";
+            !"b4c";
+            !"b4B";
             !"b";
-            !"b-32";
+            !"b-4";
+            !"b0B4";
+        }
+
+        fn bitfield_gnustep() {
+            Encoding::BitField(4, Some(&(16, Encoding::Bool)));
+            !Encoding::Int;
+            !Encoding::BitField(4, None);
+            !Encoding::BitField(5, Some(&(16, Encoding::Bool)));
+            !Encoding::BitField(4, Some(&(20, Encoding::Bool)));
+            !Encoding::BitField(4, Some(&(16, Encoding::Char)));
+            "b16B4";
+            !"b4";
+            !"b16B";
+            !"b20B4";
+            !"b16B5";
+            !"b16c4";
+            !"b4a";
+            !"b";
+            !"b-4";
         }
 
         fn atomic() {
@@ -517,11 +545,12 @@ mod tests {
                 &[
                     Encoding::Pointer(&Encoding::Array(8, &Encoding::Bool)),
                     Encoding::Union("def", &[Encoding::Block]),
-                    Encoding::Pointer(&Encoding::Pointer(&Encoding::BitField(255, &Encoding::Int))),
+                    Encoding::Pointer(&Encoding::Pointer(&Encoding::BitField(255, None))),
+                    Encoding::Char,
                     Encoding::Unknown,
                 ]
             );
-            "{abc=^[8B](def=@?)^^b255?}";
+            "{abc=^[8B](def=@?)^^b255c?}";
         }
 
         fn identifier() {

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -77,13 +77,13 @@ pub enum EncodingBox {
     /// Same as [`Encoding::Unknown`].
     Unknown,
     /// Same as [`Encoding::BitField`].
-    BitField(u8, Option<Box<Self>>),
+    BitField(u8, Option<Box<(u64, Self)>>),
     /// Same as [`Encoding::Pointer`].
     Pointer(Box<Self>),
     /// Same as [`Encoding::Atomic`].
     Atomic(Box<Self>),
     /// Same as [`Encoding::Array`].
-    Array(usize, Box<Self>),
+    Array(u64, Box<Self>),
     /// Same as [`Encoding::Struct`].
     Struct(String, Option<Vec<Self>>),
     /// Same as [`Encoding::Union`].
@@ -236,13 +236,17 @@ mod tests {
 
     #[test]
     fn parse_part_of_string() {
-        let mut s = "{a}c";
+        let mut s = "{a}cb0i16";
 
         let expected = EncodingBox::Struct("a".into(), None);
         let actual = EncodingBox::from_start_of_str(&mut s).unwrap();
         assert_eq!(expected, actual);
 
         let expected = EncodingBox::Char;
+        let actual = EncodingBox::from_start_of_str(&mut s).unwrap();
+        assert_eq!(expected, actual);
+
+        let expected = EncodingBox::BitField(16, Some(Box::new((0, EncodingBox::Int))));
         let actual = EncodingBox::from_start_of_str(&mut s).unwrap();
         assert_eq!(expected, actual);
 

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -16,16 +16,15 @@ use crate::Encoding;
 ///
 /// In `Encoding`, the data is stored in static memory, while in `EncodingBox`
 /// it is stored on the heap. The former allows storing in constants (which is
-/// required by the [`Encode`] and [`RefEncode`] traits), while the latter
-/// allows dynamically, such as in the case of parsing encodings.
+/// required by the `objc2::encode::Encode` and `objc2::encode::RefEncode`
+/// traits), while the latter allows dynamically, such as in the case of
+/// parsing encodings.
 ///
 /// **This should be considered a _temporary_ restriction**. `Encoding` and
 /// `EncodingBox` will become equivalent once heap allocation in constants
 /// is possible.
 ///
 /// [`Struct`]: Self::Struct
-/// [`Encode`]: crate::Encode
-/// [`RefEncode`]: crate::RefEncode
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive] // Maybe we're missing some encodings?
 pub enum EncodingBox {

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides the [`Encoding`] type to describe and compare these
 //! type-encodings, and the [`EncodingBox`] type which does the same, except
-//! is can be parsed from an encoding at runtime.
+//! it can be parsed from an encoding at runtime.
 //!
 //! The types from this crate is exported under the [`objc2`] crate as
 //! `objc2::encode`, so usually you would just use it from there.
@@ -15,7 +15,7 @@
 //!
 //! ## Example
 //!
-//! Parse an encoding from a string and compare it to
+//! Parse an encoding from a string and compare it to a known encoding.
 //!
 //! ```rust
 //! use objc2_encode::{Encoding, EncodingBox};

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -1,76 +1,31 @@
 //! # Objective-C type-encoding
 //!
-//! This is re-exported into the top level of `objc2`.
-//!
 //! The Objective-C directive `@encode` encodes types as strings, and this is
 //! used in various places in the runtime.
 //!
-//! This crate provides the [`Encoding`] type to efficiently describe and
-//! compare these type-encodings.
+//! This crate provides the [`Encoding`] type to describe and compare these
+//! type-encodings, and the [`EncodingBox`] type which does the same, except
+//! is can be parsed from an encoding at runtime.
 //!
-//! Additionally it provides traits for annotating types that has an
-//! Objective-C encoding: Specifically [`Encode`] for structs, [`RefEncode`]
-//! for references and [`EncodeArguments`] for function arguments.
-//!
-//! This crate is exported under the [`objc2`] crate as `objc2::encode`, so
-//! usually you would just use it from there.
+//! The types from this crate is exported under the [`objc2`] crate as
+//! `objc2::encode`, so usually you would just use it from there.
 //!
 //! [`objc2`]: https://crates.io/crates/objc2
 //!
 //!
 //! ## Example
 //!
-//! Implementing [`Encode`] and [`RefEncode`] for a custom type:
+//! Parse an encoding from a string and compare it to
 //!
+//! ```rust
+//! use objc2_encode::{Encoding, EncodingBox};
+//! let s = "{s=i}";
+//! let enc = Encoding::Struct("s", &[Encoding::Int]);
+//! let parsed: EncodingBox = s.parse()?;
+//! assert!(enc.equivalent_to_box(&parsed));
+//! assert_eq!(enc.to_string(), s);
+//! # Ok::<(), objc2_encode::ParseError>(())
 //! ```
-//! use objc2_encode::{Encode, Encoding, RefEncode};
-//! // or from objc2:
-//! // use objc2::{Encode, Encoding, RefEncode};
-//!
-//! #[repr(C)]
-//! struct MyStruct {
-//!     a: f32, // float
-//!     b: i16, // int16_t
-//! }
-//!
-//! unsafe impl Encode for MyStruct {
-//!     const ENCODING: Encoding = Encoding::Struct(
-//!         "MyStruct", // Must use the same name as defined in C header files
-//!         &[
-//!             f32::ENCODING, // Same as Encoding::Float
-//!             i16::ENCODING, // Same as Encoding::Short
-//!         ],
-//!     );
-//! }
-//!
-//! // @encode(MyStruct) -> "{MyStruct=fs}"
-//! assert!(MyStruct::ENCODING.equivalent_to_str("{MyStruct=fs}"));
-//!
-//! unsafe impl RefEncode for MyStruct {
-//!     // Note that if `MyStruct` is an Objective-C instance, this should
-//!     // be `Encoding::Object`.
-//!     const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-//! }
-//!
-//! // @encode(MyStruct*) -> "^{MyStruct=fs}"
-//! assert!(MyStruct::ENCODING_REF.equivalent_to_str("^{MyStruct=fs}"));
-//! ```
-//!
-//! See the [`examples`] folder for more complex usage.
-//!
-//! [`examples`]: https://github.com/madsmtm/objc2/tree/master/crates/objc2-encode/examples
-//!
-//!
-//! ## Caveats
-//!
-//! We've taken the pragmatic approach with [`Encode`] and [`RefEncode`], and
-//! have implemented it for as many types as possible (instead of defining a
-//! bunch of subtraits for very specific purposes). However, that might
-//! sometimes be slightly surprising.
-//!
-//! The primary example is [`()`][`unit`], which doesn't make sense as a
-//! method argument, but is a very common return type, and hence implements
-//! [`Encode`].
 //!
 //!
 //! ## Further resources
@@ -96,15 +51,15 @@
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
+#[cfg(not(feature = "alloc"))]
+compile_error!("the `alloc` feature currently must be enabled");
+
 #[cfg(any(feature = "std", doc))]
 extern crate std;
 
-#[cfg(any(feature = "alloc", test, doc))]
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
 
-#[doc(hidden)]
-pub mod __bool;
-mod encode;
 mod encoding;
 mod encoding_box;
 mod helper;
@@ -114,7 +69,6 @@ mod parse;
 #[allow(dead_code)]
 mod static_str;
 
-pub use self::encode::{Encode, EncodeArguments, EncodeConvert, OptionEncode, RefEncode};
 pub use self::encoding::Encoding;
 pub use self::encoding_box::EncodingBox;
 pub use self::parse::ParseError;

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -168,6 +168,7 @@ impl<'a> Parser<'a> {
 impl Parser<'_> {
     /// Strip leading qualifiers, if any.
     pub(crate) fn strip_leading_qualifiers(&mut self) {
+        // TODO: Add API for accessing and outputting qualifiers.
         const QUALIFIERS: &[u8] = &[
             b'r', // const
             b'n', // in
@@ -176,8 +177,8 @@ impl Parser<'_> {
             b'O', // bycopy
             b'R', // byref
             b'V', // oneway
-                  // b'!', // GCINVISIBLE
         ];
+        // TODO: b'|', // GCINVISIBLE
 
         self.consume_while(|b| QUALIFIERS.contains(&b));
     }

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -31,7 +31,7 @@ pub(crate) const fn verify_name(name: &str) -> bool {
     true
 }
 
-/// The error that was encountered while parsing the encoding.
+/// The error that was encountered while parsing an encoding string.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ParseError {
     kind: ErrorKind,
@@ -59,6 +59,7 @@ impl fmt::Display for ParseError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ParseError {}
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `Debug`, `Hash`, `PartialEq` and `Eq`.
 * Support running `Drop` impls on `dealloc` in `declare_class!`.
 * Added `declare::IvarEncode` and `declare::IvarBool` types.
+* Moved the `objc2_encode` traits to `objc2::encode` (API surface is
+  unchanged, since they were already exposed from that).
 
 ### Changed
 * **BREAKING**: Using the automatic `NSError**`-to-`Result` functionality in

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -23,8 +23,8 @@ license = "MIT"
 default = ["std", "apple"]
 
 # Currently not possible to turn off, put here for forwards compatibility.
-std = ["alloc", "objc2-encode/std", "objc-sys/std", "block2?/std"]
-alloc = ["objc2-encode/alloc", "objc-sys/alloc", "block2?/alloc"]
+std = ["alloc", "objc2-encode/std", "objc-sys/std"]
+alloc = ["objc2-encode/alloc", "objc-sys/alloc"]
 
 # Enables `objc2::exception::throw` and `objc2::exception::catch`
 exception = ["objc-sys/unstable-exception"]
@@ -40,9 +40,6 @@ verify = ["malloc"]
 # This is not enabled by default because most users won't need it, and it
 # increases compilation time.
 malloc = ["malloc_buf"]
-
-# Expose features that requires creating blocks.
-block = ["block2"]
 
 # Make the `sel!` macro look up the selector statically.
 #
@@ -62,27 +59,25 @@ unstable-autoreleasesafe = []
 
 # Uses the nightly c_unwind feature to make throwing safe
 #
-# You must manually enable `objc-sys/unstable-c-unwind` and
-# `objc2-encode/unstable-c-unwind` to use this.
+# You must manually enable `objc-sys/unstable-c-unwind` to use this.
 unstable-c-unwind = []
 
 # For better documentation on docs.rs
 unstable-docsrs = []
 
 # Runtime selection. See `objc-sys` for details.
-apple = ["objc-sys/apple", "objc2-encode/apple", "block2?/apple"]
-gnustep-1-7 = ["objc-sys/gnustep-1-7", "objc2-encode/gnustep-1-7", "block2?/gnustep-1-7"]
-gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8", "objc2-encode/gnustep-1-8", "block2?/gnustep-1-8"]
-gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9", "objc2-encode/gnustep-1-9", "block2?/gnustep-1-9"]
-gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0", "objc2-encode/gnustep-2-0", "block2?/gnustep-2-0"]
-gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1", "objc2-encode/gnustep-2-1", "block2?/gnustep-2-1"]
+apple = ["objc-sys/apple"]
+gnustep-1-7 = ["objc-sys/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.3", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.3", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.0", optional = true }
-block2 = { path = "../block2", version = "=0.2.0-alpha.7", default-features = false, optional = true }
 
 [dev-dependencies]
 iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callgrind" }

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -72,6 +72,8 @@ gnustep-1-8 = ["gnustep-1-7", "objc-sys/gnustep-1-8"]
 gnustep-1-9 = ["gnustep-1-8", "objc-sys/gnustep-1-9"]
 gnustep-2-0 = ["gnustep-1-9", "objc-sys/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "objc-sys/gnustep-2-1"]
+# Used by `block2`
+unstable-compiler-rt = ["apple"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }

--- a/crates/objc2/examples/encode_core_graphics.rs
+++ b/crates/objc2/examples/encode_core_graphics.rs
@@ -1,4 +1,4 @@
-use objc2_encode::{Encode, Encoding};
+use objc2::encode::{Encode, Encoding};
 
 #[cfg(target_pointer_width = "32")]
 type CGFloat = f32;

--- a/crates/objc2/examples/encode_ns_string.rs
+++ b/crates/objc2/examples/encode_ns_string.rs
@@ -1,4 +1,4 @@
-use objc2_encode::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 /// We don't know the size of NSString, so we can only hold pointers to it.
 ///

--- a/crates/objc2/examples/encode_ns_uinteger.rs
+++ b/crates/objc2/examples/encode_ns_uinteger.rs
@@ -2,7 +2,7 @@
 //!
 //! Note that in this case `NSUInteger` could actually just be a type alias
 //! for `usize`, and that's already available under `objc2::ffi::NSUInteger`.
-use objc2_encode::{Encode, Encoding, RefEncode};
+use objc2::encode::{Encode, Encoding, RefEncode};
 
 #[repr(transparent)]
 struct NSUInteger {

--- a/crates/objc2/examples/encode_opaque_type.rs
+++ b/crates/objc2/examples/encode_opaque_type.rs
@@ -1,5 +1,5 @@
 //! Implementing `RefEncode` for `NSDecimal`.
-use objc2_encode::{Encoding, RefEncode};
+use objc2::encode::{Encoding, RefEncode};
 
 /// We choose in this case to represent `NSDecimal` as an opaque struct
 /// (and in the future as an `extern type`) because we don't know much

--- a/crates/objc2/src/encode.rs
+++ b/crates/objc2/src/encode.rs
@@ -489,7 +489,7 @@ unsafe impl RefEncode for NonNull<c_void> {
 unsafe impl OptionEncode for NonNull<c_void> {}
 
 unsafe impl<T: Encode, const LENGTH: usize> Encode for [T; LENGTH] {
-    const ENCODING: Encoding = Encoding::Array(LENGTH, &T::ENCODING);
+    const ENCODING: Encoding = Encoding::Array(LENGTH as u64, &T::ENCODING);
 }
 
 unsafe impl<T: Encode, const LENGTH: usize> RefEncode for [T; LENGTH] {

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -225,6 +225,9 @@ mod test_utils;
 mod verify;
 
 // Link to Foundation to make NSObject work
-#[cfg_attr(feature = "apple", link(name = "Foundation", kind = "framework"))]
+#[cfg_attr(
+    all(feature = "apple", not(feature = "unstable-compiler-rt")),
+    link(name = "Foundation", kind = "framework")
+)]
 #[cfg_attr(feature = "gnustep-1-7", link(name = "gnustep-base", kind = "dylib"))]
 extern "C" {}

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -87,14 +87,13 @@
 //! ## Encodings and message type verification
 //!
 //! The Objective-C runtime includes encodings for each method that describe
-//! the argument and return types. See the [`objc2-encode`] crate for the
-//! full overview of what this is (it is re-exported in this crate under the
-//! [`encode`] module).
+//! the argument and return types. See the [`encode`] module for a full
+//! overview of what this is.
 //!
 //! The important part is: To make message sending safer, all arguments and
-//! return values for messages must implement [`Encode`]. This allows the Rust
-//! compiler to prevent you from passing e.g. a [`Vec`] into Objective-C,
-//! which would both be UB and leak the vector.
+//! return values for messages must implement [`encode::Encode`]. This allows
+//! the Rust compiler to prevent you from passing e.g. a [`Vec`] into
+//! Objective-C, which would both be UB and leak the vector.
 //!
 //! Furthermore, we can take advantage of the encodings provided by the
 //! runtime to verify that the types used in Rust actually match the types
@@ -126,7 +125,6 @@
 //! This library contains further such debug checks, most of which are enabled
 //! by default. To enable all of them, use the `"verify"` cargo feature.
 //!
-//! [`objc2-encode`]: objc2_encode
 //! [`Vec`]: std::vec::Vec
 //!
 //!
@@ -186,16 +184,15 @@ extern crate std;
 #[doc = include_str!("../README.md")]
 extern "C" {}
 
-pub use objc2_encode as encode;
+#[doc(no_inline)]
 pub use objc_sys as ffi;
 
+pub use self::class_type::ClassType;
 #[doc(no_inline)]
-pub use objc2_encode::{Encode, EncodeArguments, Encoding, RefEncode};
-
-pub use crate::class_type::ClassType;
-pub use crate::message::{Message, MessageArguments, MessageReceiver};
-pub use crate::protocol::{ImplementedBy, ProtocolObject, ProtocolType};
-pub use crate::verify::VerificationError;
+pub use self::encode::{Encode, EncodeArguments, Encoding, RefEncode};
+pub use self::message::{Message, MessageArguments, MessageReceiver};
+pub use self::protocol::{ImplementedBy, ProtocolObject, ProtocolType};
+pub use self::verify::VerificationError;
 
 #[cfg(feature = "objc2-proc-macros")]
 #[doc(hidden)]
@@ -216,6 +213,7 @@ pub mod __macro_helpers;
 mod cache;
 mod class_type;
 pub mod declare;
+pub mod encode;
 pub mod exception;
 mod macros;
 mod message;

--- a/crates/objc2/src/runtime.rs
+++ b/crates/objc2/src/runtime.rs
@@ -21,6 +21,7 @@ use std::os::raw::c_uint;
 
 #[doc(hidden)]
 pub mod __nsstring;
+mod bool;
 mod method_encoding_iter;
 mod nsobject;
 mod nszone;
@@ -30,10 +31,9 @@ use crate::encode::{Encode, EncodeArguments, EncodeConvert, Encoding, OptionEnco
 use crate::ffi;
 use crate::verify::{verify_method_signature, Inner, VerificationError};
 
+pub use self::bool::Bool;
 pub use self::nsobject::{NSObject, NSObjectProtocol};
 pub use self::nszone::NSZone;
-#[doc(inline)]
-pub use crate::encode::__bool::Bool;
 
 /// Use [`Bool`] or [`ffi::BOOL`] instead.
 #[deprecated = "Use `Bool` or `ffi::BOOL` instead"]

--- a/crates/objc2/src/runtime/bool.rs
+++ b/crates/objc2/src/runtime/bool.rs
@@ -1,8 +1,7 @@
-//! This belongs in `objc2`, but it is put here to make `EncodeConvert` work
-//! properly!
 use core::fmt;
 
-use crate::{Encode, EncodeConvert, Encoding, RefEncode};
+use crate::encode::{Encode, EncodeConvert, Encoding, RefEncode};
+use crate::ffi;
 
 /// The Objective-C `BOOL` type.
 ///
@@ -23,35 +22,35 @@ use crate::{Encode, EncodeConvert, Encoding, RefEncode};
 // And it is not immediately clear for users which one was chosen.
 #[derive(Copy, Clone, Default)]
 pub struct Bool {
-    value: objc_sys::BOOL,
+    value: ffi::BOOL,
 }
 
 impl Bool {
     /// The equivalent of [`true`] for Objective-C's `BOOL` type.
-    pub const YES: Self = Self::from_raw(objc_sys::YES);
+    pub const YES: Self = Self::from_raw(ffi::YES);
 
     /// The equivalent of [`false`] for Objective-C's `BOOL` type.
-    pub const NO: Self = Self::from_raw(objc_sys::NO);
+    pub const NO: Self = Self::from_raw(ffi::NO);
 
     /// Creates an Objective-C boolean from a Rust boolean.
     #[inline]
     pub const fn new(value: bool) -> Self {
         // true as BOOL => 1 (YES)
         // false as BOOL => 0 (NO)
-        let value = value as objc_sys::BOOL;
+        let value = value as ffi::BOOL;
         Self { value }
     }
 
     /// Creates this from a boolean value received from a raw Objective-C API.
     #[inline]
-    pub const fn from_raw(value: objc_sys::BOOL) -> Self {
+    pub const fn from_raw(value: ffi::BOOL) -> Self {
         Self { value }
     }
 
-    /// Retrieves the inner [`objc_sys::BOOL`] boolean type, to be used in raw
+    /// Retrieves the inner [`ffi::BOOL`] boolean type, to be used in raw
     /// Objective-C APIs.
     #[inline]
-    pub const fn as_raw(self) -> objc_sys::BOOL {
+    pub const fn as_raw(self) -> ffi::BOOL {
         self.value
     }
 
@@ -76,7 +75,7 @@ impl Bool {
     pub const fn as_bool(self) -> bool {
         // Always compare with 0 (NO)
         // This is what happens with the `!` operator / when using `if` in C.
-        self.value != objc_sys::NO
+        self.value != ffi::NO
     }
 }
 
@@ -106,7 +105,7 @@ unsafe impl Encode for Bool {
     // u8::__ENCODING == Encoding::UChar
     // bool::__ENCODING == Encoding::Bool
     // i32::__ENCODING == Encoding::Int
-    const ENCODING: Encoding = objc_sys::BOOL::__ENCODING;
+    const ENCODING: Encoding = ffi::BOOL::__ENCODING;
 }
 
 // Note that we shouldn't delegate to `BOOL`'s  `ENCODING_REF` since `BOOL` is

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -20,9 +20,9 @@ error[E0277]: the trait bound `Id<CustomObject, Shared>: Encode` is not satisfie
             *mut c_void
             AtomicI16
           and $N others
-  = note: required for `Id<CustomObject, Shared>` to implement `encode::encode::convert_private::Sealed`
+  = note: required for `Id<CustomObject, Shared>` to implement `encode::convert_private::Sealed`
 note: required by a bound in `EncodeConvert`
- --> $WORKSPACE/crates/objc2-encode/src/encode.rs
+ --> $WORKSPACE/crates/objc2/src/encode.rs
   |
   | pub trait EncodeConvert: convert_private::Sealed {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvert`
@@ -50,9 +50,9 @@ error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
             *mut c_void
             AtomicI16
           and $N others
-  = note: required for `Vec<()>` to implement `encode::encode::convert_private::Sealed`
+  = note: required for `Vec<()>` to implement `encode::convert_private::Sealed`
 note: required by a bound in `EncodeConvert`
- --> $WORKSPACE/crates/objc2-encode/src/encode.rs
+ --> $WORKSPACE/crates/objc2/src/encode.rs
   |
   | pub trait EncodeConvert: convert_private::Sealed {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvert`
@@ -80,9 +80,9 @@ error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
             *mut c_void
             AtomicI16
           and $N others
-  = note: required for `Box<u32>` to implement `encode::encode::convert_private::Sealed`
+  = note: required for `Box<u32>` to implement `encode::convert_private::Sealed`
 note: required by a bound in `EncodeConvert`
- --> $WORKSPACE/crates/objc2-encode/src/encode.rs
+ --> $WORKSPACE/crates/objc2/src/encode.rs
   |
   | pub trait EncodeConvert: convert_private::Sealed {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvert`
@@ -110,9 +110,9 @@ error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
             *mut c_void
             AtomicI16
           and $N others
-  = note: required for `CustomObject` to implement `encode::encode::convert_private::Sealed`
+  = note: required for `CustomObject` to implement `encode::convert_private::Sealed`
 note: required by a bound in `EncodeConvert`
- --> $WORKSPACE/crates/objc2-encode/src/encode.rs
+ --> $WORKSPACE/crates/objc2/src/encode.rs
   |
   | pub trait EncodeConvert: convert_private::Sealed {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvert`

--- a/crates/test-ui/ui/global_block_not_encode.stderr
+++ b/crates/test-ui/ui/global_block_not_encode.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `Box<i32>: objc2_encode::encode::Encode` is not satisfied
+error[E0277]: the trait bound `Box<i32>: objc2::encode::Encode` is not satisfied
  --> ui/global_block_not_encode.rs
   |
   | / global_block! {
   | |     pub static BLOCK = |_b: Box<i32>| {};
   | | }
-  | |_^ the trait `objc2_encode::encode::Encode` is not implemented for `Box<i32>`
+  | |_^ the trait `objc2::encode::Encode` is not implemented for `Box<i32>`
   |
-  = help: the following other types implement trait `objc2_encode::encode::Encode`:
+  = help: the following other types implement trait `objc2::encode::Encode`:
             &'a T
             &'a mut T
             ()

--- a/crates/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error.stderr
@@ -12,7 +12,7 @@ error[E0283]: type annotations needed
   |     let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
   |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
   |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
           - impl RefEncode for *mut c_void;
           - impl<T> RefEncode for *mut T
             where T: RefEncode, T: ?Sized;
@@ -30,7 +30,7 @@ error[E0283]: type annotations needed
   |     let _: Result<_, _> = unsafe { msg_send_id![obj, b: _] };
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
   |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
           - impl RefEncode for *mut c_void;
           - impl<T> RefEncode for *mut T
             where T: RefEncode, T: ?Sized;
@@ -48,7 +48,7 @@ error[E0283]: type annotations needed
   |     let _: Result<Id<NSString, Shared>, _> = unsafe { msg_send_id![obj, c: _] };
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
   |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
           - impl RefEncode for *mut c_void;
           - impl<T> RefEncode for *mut T
             where T: RefEncode, T: ?Sized;
@@ -66,7 +66,7 @@ error[E0283]: type annotations needed
   |     let _: Result<Id<NSString, Shared>, Id<_, Shared>> = unsafe { msg_send_id![obj, d: _] };
   |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
   |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2_encode` crate:
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
           - impl RefEncode for *mut c_void;
           - impl<T> RefEncode for *mut T
             where T: RefEncode, T: ?Sized;

--- a/crates/tests/extern/encode_utils.m
+++ b/crates/tests/extern/encode_utils.m
@@ -102,10 +102,45 @@ ENCODING(STRUCT_WITH_ATOMIC, struct with_atomic);
 // Bit field
 
 struct bitfield {
-    unsigned int a: 1;
-    unsigned int b: 30;
+    int8_t b1 : 5;
+    int16_t : 0;
+    int8_t b2 : 2;
 };
 ENCODING(BITFIELD, struct bitfield);
+
+struct bitfield_all_types {
+    struct bitfield nested;
+
+    char      b_char      : 1;
+    short     b_short     : 1;
+    int       b_int       : 1;
+    long      b_long      : 1;
+    long long b_long_long : 1;
+
+    signed char      b_signed_char      : 1;
+    signed short     b_signed_short     : 1;
+    signed int       b_signed_int       : 1;
+    signed long      b_signed_long      : 1;
+    signed long long b_signed_long_long : 1;
+
+    unsigned char      b_unsigned_char      : 1;
+    unsigned short     b_unsigned_short     : 1;
+    unsigned int       b_unsigned_int       : 1;
+    unsigned long      b_unsigned_long      : 1;
+    unsigned long long b_unsigned_long_long : 1;
+
+    bool      b_bool      : 1;
+};
+ENCODING(BITFIELD_ALL_TYPES, struct bitfield_all_types);
+
+// Ill-supported in compilers
+// #if __has_builtin(__int128_t)
+// struct bitfield_128 {
+//     __int128_t b_signed : 1;
+//     __uint128_t b_unsigned : 1;
+// };
+// ENCODING(BITFIELD_128, struct bitfield_128);
+// #endif
 
 // Union
 

--- a/crates/tests/src/test_encode_utils.rs
+++ b/crates/tests/src/test_encode_utils.rs
@@ -100,6 +100,71 @@ const WITH_ATOMIC_INNER: Encoding = Encoding::Struct(
     ],
 );
 
+#[cfg(feature = "apple")]
+const BITFIELD: Encoding = Encoding::Struct(
+    "bitfield",
+    &[
+        Encoding::BitField(5, None),
+        Encoding::BitField(0, None),
+        Encoding::BitField(2, None),
+    ],
+);
+#[cfg(feature = "apple")]
+const BITFIELD_ALL_TYPES: Encoding = Encoding::Struct(
+    "bitfield_all_types",
+    &[
+        BITFIELD,
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+        Encoding::BitField(1, None),
+    ],
+);
+#[cfg(feature = "gnustep-1-7")]
+const BITFIELD: Encoding = Encoding::Struct(
+    "bitfield",
+    &[
+        Encoding::BitField(5, Some(&(0, i8::ENCODING))),
+        Encoding::BitField(0, Some(&(16, i16::ENCODING))),
+        Encoding::BitField(2, Some(&(16, i8::ENCODING))),
+    ],
+);
+#[cfg(feature = "gnustep-1-7")]
+const BITFIELD_ALL_TYPES: Encoding = Encoding::Struct(
+    "bitfield_all_types",
+    &[
+        BITFIELD,
+        Encoding::BitField(1, Some(&(24, Encoding::Char))),
+        Encoding::BitField(1, Some(&(25, Encoding::Short))),
+        Encoding::BitField(1, Some(&(26, Encoding::Int))),
+        Encoding::BitField(1, Some(&(27, Encoding::C_LONG))),
+        Encoding::BitField(1, Some(&(28, Encoding::LongLong))),
+        Encoding::BitField(1, Some(&(29, Encoding::Char))),
+        Encoding::BitField(1, Some(&(30, Encoding::Short))),
+        Encoding::BitField(1, Some(&(31, Encoding::Int))),
+        Encoding::BitField(1, Some(&(32, Encoding::C_LONG))),
+        Encoding::BitField(1, Some(&(33, Encoding::LongLong))),
+        Encoding::BitField(1, Some(&(34, Encoding::UChar))),
+        Encoding::BitField(1, Some(&(35, Encoding::UShort))),
+        Encoding::BitField(1, Some(&(36, Encoding::UInt))),
+        Encoding::BitField(1, Some(&(37, Encoding::C_ULONG))),
+        Encoding::BitField(1, Some(&(38, Encoding::ULongLong))),
+        Encoding::BitField(1, Some(&(39, Encoding::Bool))),
+    ],
+);
+
 assert_types! {
     // C types
 
@@ -174,14 +239,8 @@ assert_types! {
 
     // Bitfields
 
-    #[cfg(feature = "apple")]
-    BITFIELD => enc Encoding::Struct(
-        "bitfield",
-        &[
-            Encoding::BitField(1, &Encoding::UInt),
-            Encoding::BitField(30, &Encoding::UInt),
-        ],
-    ),
+    BITFIELD => enc BITFIELD,
+    BITFIELD_ALL_TYPES => enc BITFIELD_ALL_TYPES,
 
     // Unions
 
@@ -242,15 +301,4 @@ assert_types! {
 
     // SIGNED_INT_128 => i128,
     // UNSIGNED_INT_128 => u128,
-}
-
-// Bitfields
-
-#[cfg(feature = "gnustep-1-7")]
-mod bitfields {
-    use super::*;
-
-    assert_inner!(str ENCODING_BITFIELD => "{bitfield=b0I1b1I30}");
-    assert_inner!(str ENCODING_BITFIELD_POINTER => "^{bitfield=b0I1b1I30}");
-    assert_inner!(str ENCODING_BITFIELD_ATOMIC => "A{bitfield}");
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,30 +4,15 @@ version = 3
 
 [[package]]
 name = "arbitrary"
-version = "1.2.0"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d47fbf90d5149a107494b15a7dc8d69b351be2db3bb9691740e88ec17fd880"
-
-[[package]]
-name = "block-sys"
-version = "0.1.0-beta.2"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.2.0-alpha.7"
-dependencies = [
- "block-sys",
- "objc2-encode",
-]
+checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -51,15 +36,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fff891139ee62800da71b7fd5b508d570b9ad95e614a53c6f453ca08366038"
+checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
 dependencies = [
  "arbitrary",
  "cc",
@@ -74,7 +59,6 @@ version = "0.2.0-beta.3"
 name = "objc2"
 version = "0.3.0-beta.4"
 dependencies = [
- "block2",
  "objc-sys",
  "objc2-encode",
 ]
@@ -82,12 +66,9 @@ dependencies = [
 [[package]]
 name = "objc2-encode"
 version = "2.0.0-pre.3"
-dependencies = [
- "objc-sys",
-]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"


### PR DESCRIPTION
Move the traits in it to `objc2::encode`, and make it `no_std` and target/platform-agnostic. I also fixed bitfields along the way.

Now, `objc2_encode` just contains the parsing/representation of encodings (which may be usable elsewhere, e.g. in an Objective-C compiler or something).

This is done because I've found that keeping the `Encode`/`RefEncode`/`EncodeConvert` traits in a separate crate than the rest of `objc2` is just too much of a hassle, and a blocker for https://github.com/madsmtm/objc2/pull/277.

Downside is that `block2` now depends on `objc2` instead of just `objc2-encode`, which makes the compilation graph slightly worse, but eh, on the other hand `objc2-encode` now has no dependencies.