### PR TITLE
New versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ env:
   #
   # This condition is duplicated a few places, since there's no good way to
   # deduplicate such information in GitHub Actions...
-  FULL: ${{ (github.ref_name == 'new-versions' || github.ref_name == 'ci-full') && true || '' }}
+  FULL: ${{ (github.head_ref == 'new-versions' || github.ref_name == 'ci-full') && true || '' }}
 
 jobs:
   fmt:
@@ -284,7 +284,7 @@ jobs:
   check-icrate-features:
     # if: ${{ env.FULL }}
     # This will take ~40 minutes
-    if: ${{ github.ref_name == 'new-versions' || github.ref_name == 'ci-full' }}
+    if: ${{ github.head_ref == 'new-versions' || github.ref_name == 'ci-full' }}
     name: Check icrate features
     runs-on: macos-12
     needs:
@@ -345,7 +345,7 @@ jobs:
 
   test-apple:
     # if: ${{ env.FULL }}
-    if: ${{ github.ref_name == 'new-versions' || github.ref_name == 'ci-full' }}
+    if: ${{ github.head_ref == 'new-versions' || github.ref_name == 'ci-full' }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os || 'macos-latest' }}
     needs:
@@ -491,7 +491,7 @@ jobs:
 
   test-ios:
     # if: ${{ env.FULL }}
-    if: ${{ github.ref_name == 'new-versions' || github.ref_name == 'ci-full' }}
+    if: ${{ github.head_ref == 'new-versions' || github.ref_name == 'ci-full' }}
     name: Test on iOS simulator w. dinghy
     runs-on: macos-11
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,7 @@ jobs:
     # TODO: Re-enable this on all of Foundation once we do some form of
     # availability checking.
     - name: Test static class and selectors
+      if: ${{ !contains(matrix.frameworks, 'ios') && !contains(matrix.frameworks, 'macos-10-7') }}
       run: >-
         cargo test $ARGS $PUBLIC_CRATES -ptests
         --features=unstable-static-sel,unstable-static-class,unstable-static-nsstring

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,7 +745,8 @@ jobs:
       run: cargo test $ARGS --features=$INTERESTING_FEATURES,catch-all,unstable-frameworks-${{ matrix.frameworks }}
 
     - name: Test in release mode
-      if: ${{ env.FULL }}
+      # Disabled on GNUStep 2.1 for now
+      if: ${{ env.FULL && matrix.runtime != 'gnustep-2-1' }}
       run: cargo test $ARGS --features=Foundation --release
 
     - name: Run fuzzing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ Copy and fill out the following checklist into the release PR:
     - `objc-sys`
     - `objc2-encode`
     - `block-sys`
-    - `block2`
     - `objc2`
+    - `block2`
     - `icrate`
 - Local tests have been run (see `helper-scripts/test-local.fish`):
     - [ ] macOS 10.14.6 32bit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "block-sys"
-version = "0.1.0-beta.2"
+version = "0.2.0"
 dependencies = [
  "objc-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ version = "2.0.0-pre.3"
 
 [[package]]
 name = "objc2-proc-macros"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0-pre.3"
+version = "2.0.0-pre.4"
 
 [[package]]
 name = "objc2-proc-macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "icrate"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "block2",
  "dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.3"
+version = "0.3.0"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.4"
+version = "0.3.0-beta.5"
 dependencies = [
  "iai",
  "malloc_buf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.2.0-alpha.7"
+version = "0.2.0-alpha.8"
 dependencies = [
  "block-sys",
  "objc2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "clang-sys",
  "heck",
  "proc-macro2",
+ "semver",
  "serde",
  "syn",
  "toml",

--- a/crates/block-sys/CHANGELOG.md
+++ b/crates/block-sys/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+## 0.2.0 - 2023-02-03
+
 ### Changed
 * Updated `objc-sys` to `v0.3.0`.
+* **BREAKING**: Changed `links` key from `block_0_1` to `block_0_2` (so
+  `DEP_BLOCK_0_1_CC_ARGS` in build scripts becomes `DEP_BLOCK_0_2_CC_ARGS`).
 
 
 ## 0.1.0-beta.2 - 2022-12-24

--- a/crates/block-sys/CHANGELOG.md
+++ b/crates/block-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* Updated `objc-sys` to `v0.3.0`.
+
 
 ## 0.1.0-beta.2 - 2022-12-24
 

--- a/crates/block-sys/CHANGELOG.md
+++ b/crates/block-sys/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
-## 0.2.0 - 2023-02-03
+
+## 0.2.0 - 2023-02-07
 
 ### Changed
 * Updated `objc-sys` to `v0.3.0`.

--- a/crates/block-sys/Cargo.toml
+++ b/crates/block-sys/Cargo.toml
@@ -56,7 +56,7 @@ unstable-objfw = []
 unstable-docsrs = ["objc-sys", "objc-sys/unstable-docsrs"]
 
 [dependencies]
-objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.3", default-features = false, optional = true }
+objc-sys = { path = "../objc-sys", version = "0.3.0", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/crates/block-sys/Cargo.toml
+++ b/crates/block-sys/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "block-sys"
-version = "0.1.0-beta.2" # Remember to update html_root_url in lib.rs
+# Remember to update `html_root_url` in lib.rs and the `links` key.
+#
+# Also, beware of using pre-release versions here, since because of the
+# `links` key, two pre-releases requested with `=...` are incompatible.
+version = "0.2.0"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"
@@ -20,7 +24,7 @@ readme = "README.md"
 
 # Downstream users can customize the linking!
 # See https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts
-links = "block_0_1"
+links = "block_0_2"
 build = "build.rs"
 
 [features]

--- a/crates/block-sys/README.md
+++ b/crates/block-sys/README.md
@@ -95,7 +95,7 @@ TODO.
 To our knowledge, currently only `clang` supports the [Language Specification
 for Blocks][block-lang]. To assist in compiling C (or Objective-C) sources
 using these features, this crate's build script expose the
-`DEP_BLOCK_0_1_CC_ARGS` environment variable to downstream build scripts.
+`DEP_BLOCK_0_2_CC_ARGS` environment variable to downstream build scripts.
 
 Example usage in your `build.rs` (using the `cc` crate) would be as follows:
 
@@ -105,7 +105,7 @@ fn main() {
     builder.compiler("clang");
     builder.file("my_script_using_blocks.c");
 
-    for flag in std::env::var("DEP_BLOCK_0_1_CC_ARGS").unwrap().split(' ') {
+    for flag in std::env::var("DEP_BLOCK_0_2_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 

--- a/crates/block-sys/src/lib.rs
+++ b/crates/block-sys/src/lib.rs
@@ -20,7 +20,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block-sys/0.1.0-beta.2")]
+#![doc(html_root_url = "https://docs.rs/block-sys/0.2.0")]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 ### Changed
-* **BREAKING**: Use traits from `objc2` `v0.3.0-beta.4` instead of
+* **BREAKING**: Use traits from `objc2` `v0.3.0-beta.5` instead of
   `objc2-encode`.
 * Updated `ffi` module to `block-sys v0.2.0`.
 

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
-## 0.2.0-alpha.8 - 2023-02-03
+## 0.2.0-alpha.8 - 2023-02-07
 
 ### Changed
 * **BREAKING**: Use traits from `objc2` `v0.3.0-beta.5` instead of

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * **BREAKING**: Use traits from `objc2` `v0.3.0-beta.4` instead of
   `objc2-encode`.
+* Updated `ffi` module to `block-sys v0.2.0`.
 
 
 ## 0.2.0-alpha.7 - 2022-12-24

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0-alpha.8 - 2023-02-03
+
 ### Changed
 * **BREAKING**: Use traits from `objc2` `v0.3.0-beta.5` instead of
   `objc2-encode`.

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Use traits from `objc2` `v0.3.0-beta.4` instead of
+  `objc2-encode`.
+
 
 ## 0.2.0-alpha.7 - 2022-12-24
 

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -36,7 +36,7 @@ gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2/gnustep-2-1"]
 
 [dependencies]
 objc2 = { path = "../objc2", version = "=0.3.0-beta.4", default-features = false }
-block-sys = { path = "../block-sys", version = "=0.1.0-beta.2", default-features = false }
+block-sys = { path = "../block-sys", version = "0.2.0", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -35,7 +35,7 @@ gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0", "objc2/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2/gnustep-2-1"]
 
 [dependencies]
-objc2 = { path = "../objc2", version = "=0.3.0-beta.4", default-features = false }
+objc2 = { path = "../objc2", version = "=0.3.0-beta.5", default-features = false }
 block-sys = { path = "../block-sys", version = "0.2.0", default-features = false }
 
 [package.metadata.docs.rs]

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs and README.md
-version = "0.2.0-alpha.7"
+version = "0.2.0-alpha.8"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/block2/src/lib.rs
+++ b/crates/block2/src/lib.rs
@@ -83,7 +83,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.7")]
+#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.8")]
 
 extern crate alloc;
 extern crate std;

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -19,3 +19,4 @@ tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git" }
 proc-macro2 = "1.0.49"
 syn = { version = "1.0", features = ["parsing"] }
 heck = "0.4"
+semver = { version = "1.0", features = ["serde"] }

--- a/crates/header-translator/src/config.rs
+++ b/crates/header-translator/src/config.rs
@@ -61,11 +61,25 @@ impl Config {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct LibraryData {
+    #[serde(default)]
     pub name: Option<String>,
     pub imports: Vec<String>,
+    #[serde(rename = "extra-features")]
+    #[serde(default)]
+    pub extra_features: Vec<String>,
+    #[serde(default)]
+    pub macos: Option<semver::VersionReq>,
+    #[serde(default)]
+    pub maccatalyst: Option<semver::VersionReq>,
+    #[serde(default)]
+    pub ios: Option<semver::VersionReq>,
+    #[serde(default)]
+    pub tvos: Option<semver::VersionReq>,
+    #[serde(default)]
+    pub watchos: Option<semver::VersionReq>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone, PartialEq, Eq)]

--- a/crates/header-translator/src/file.rs
+++ b/crates/header-translator/src/file.rs
@@ -8,6 +8,7 @@ pub(crate) const FILE_PRELUDE: &str = r#"//! This file has been automatically ge
 
 #[derive(Debug, PartialEq)]
 pub struct File {
+    library_name: String,
     imports: Vec<String>,
     pub(crate) stmts: Vec<Stmt>,
 }
@@ -15,6 +16,7 @@ pub struct File {
 impl File {
     pub fn new(library_name: &str, context: &Context<'_>) -> Self {
         Self {
+            library_name: context.get_library_alias(library_name.to_string()),
             imports: context
                 .libraries
                 .get(library_name)
@@ -42,6 +44,7 @@ impl fmt::Display for File {
         writeln!(f, "{FILE_PRELUDE}")?;
 
         writeln!(f, "use crate::common::*;")?;
+        writeln!(f, "use crate::{}::*;", self.library_name)?;
         for import in &self.imports {
             writeln!(f, "use crate::{import}::*;")?;
         }

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -5,140 +5,384 @@
 ###
 
 [library.Accessibility]
-imports = ["Accessibility", "Foundation"]
+imports = ["Foundation"]
+macos = "11.0"
+maccatalyst = "14.0"
+ios = "14.0"
+tvos = "14.0"
+watchos = "7.0"
 
 [library.AdServices]
-imports = ["AdServices", "Foundation"]
+imports = ["Foundation"]
+macos = "11.1"
+maccatalyst = "14.3"
+ios = "14.3"
 
 [library.AdSupport]
-imports = ["AdSupport", "Foundation"]
+imports = ["Foundation"]
+macos = "10.14"
+maccatalyst = "13.0"
+ios = "6.0"
+tvos = "9.0"
 
 [library.AppKit]
-imports = ["AppKit", "CoreData", "Foundation"]
+imports = ["CoreData", "Foundation"]
+extra-features = [
+    # Temporary, since some structs and statics use these
+    "AppKit_NSApplication",
+    "AppKit_NSCollectionLayoutSection",
+    "AppKit_NSCollectionLayoutGroupCustomItem",
+    "AppKit_NSCollectionView",
+    "AppKit_NSView",
+    "AppKit_NSTableView",
+    "AppKit_NSTableColumn",
+    "AppKit_NSTableRowView",
+    "Foundation_NSIndexPath",
+    "Foundation_NSArray",
+    "Foundation_NSCoder",
+]
+macos = "10.0"
+maccatalyst = "13.0"
 
 [library.AuthenticationServices]
-imports = ["AuthenticationServices", "Foundation"]
+imports = ["Foundation"]
+# Temporary, since some structs and statics use these
+extra-features = ["Foundation_NSURL"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "12.0"
+tvos = "13.0"
+watchos = "6.0"
 
 [library.AutomaticAssessmentConfiguration]
-imports = ["AutomaticAssessmentConfiguration", "Foundation"]
+imports = ["Foundation"]
+macos = "10.15.4"
+maccatalyst = "13.4"
+ios = "13.4"
 
 [library.Automator]
-imports = ["Automator", "AppKit", "Foundation", "OSAKit"]
+imports = ["AppKit", "Foundation", "OSAKit"]
+macos = "10.4"
+maccatalyst = "14.0"
 
 [library.BackgroundAssets]
-imports = ["BackgroundAssets", "Foundation"]
+imports = ["Foundation"]
+macos = "13.0"
+maccatalyst = "16.0"
+ios = "16.0"
 
 [library.BackgroundTasks]
-imports = ["BackgroundTasks", "Foundation"]
+imports = ["Foundation"]
+maccatalyst = "13.0"
+ios = "13.0"
+tvos = "13.0"
 
 [library.BusinessChat]
-imports = ["BusinessChat", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "10.14"
+maccatalyst = "13.0" # Unsure
+ios = "11.0" # Unsure
 
 [library.CallKit]
-imports = ["CallKit", "Foundation"]
+imports = ["Foundation"]
+macos = "13.0"
+maccatalyst = "13.0"
+ios = "10.0"
+watchos = "9.0"
 
 [library.ClassKit]
-imports = ["ClassKit", "Foundation"]
+imports = ["Foundation"]
+macos = "11.0"
+maccatalyst = "14.0"
+ios = "11.4"
 
 [library.CloudKit]
-imports = ["CloudKit", "CoreLocation", "Foundation"]
+imports = ["CoreLocation", "Foundation"]
+extra-features = [
+    "CloudKit_CKShare",
+]
+macos = "10.10"
+maccatalyst = "13.0"
+ios = "8.0"
+tvos = "9.0"
+watchos = "3.0"
 
 [library.Contacts]
-imports = ["Contacts", "Foundation"]
+imports = ["Foundation"]
+macos = "10.11"
+maccatalyst = "13.0"
+ios = "9.0"
+watchos = "2.0"
 
 [library.CoreData]
-imports = ["CoreData", "Foundation"]
+imports = ["Foundation"]
+# Temporary, since some structs and statics use these
+extra-features = ["CoreData_NSAsynchronousFetchResult"]
+macos = "10.4"
+maccatalyst = "13.0"
+ios = "3.0"
+tvos = "9.0"
+watchos = "2.0"
 
 [library.CoreLocation]
-imports = ["CoreLocation", "Contacts", "Foundation"]
+imports = ["Contacts", "Foundation"]
+extra-features = [
+    "CoreLocation_CLPlacemark",
+]
+# macos = "10.6"
+macos = "10.11" # Temporarily raised since `CoreLocation` imports `Contacts`
+maccatalyst = "13.0"
+ios = "2.0"
+tvos = "9.0"
+watchos = "2.0"
 
 [library.DataDetection]
-imports = ["DataDetection", "Foundation"]
+imports = ["Foundation"]
+macos = "12.0"
+maccatalyst = "15.0"
+ios = "15.0"
+tvos = "15.0"
+watchos = "8.0"
 
 [library.DeviceCheck]
-imports = ["DeviceCheck", "Foundation"]
+imports = ["Foundation"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "11.0"
+tvos = "11.0"
+watchos = "9.0"
 
 [library.EventKit]
-imports = ["EventKit", "AppKit", "CoreLocation", "Foundation", "MapKit"]
+imports = ["AppKit", "CoreLocation", "Foundation", "MapKit"]
+extra-features = [
+    "EventKit_EKEvent",
+]
+macos = "10.8"
+maccatalyst = "13.0"
+ios = "4.0"
+watchos = "2.0"
 
 [library.ExceptionHandling]
-imports = ["ExceptionHandling", "Foundation"]
+imports = ["Foundation"]
+macos = "10.0"
+maccatalyst = "13.0"
 
 [library.ExtensionKit]
-imports = ["ExtensionKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "13.0"
+maccatalyst = "13.0"
+ios = "16.1"
+tvos = "16.0"
+watchos = "9.0"
 
 [library.ExternalAccessory]
-imports = ["ExternalAccessory", "Foundation"]
+imports = ["Foundation"]
+macos = "10.13"
+maccatalyst = "16.0"
+ios = "3.0"
+tvos = "10.0"
 
 [library.FileProvider]
-imports = ["FileProvider", "AppKit", "Foundation", "UniformTypeIdentifiers"]
+imports = ["AppKit", "Foundation", "UniformTypeIdentifiers"]
+macos = "10.15"
+ios = "11.0"
 
 [library.FileProviderUI]
-imports = ["FileProviderUI", "AppKit", "FileProvider", "Foundation"]
+imports = ["AppKit", "FileProvider", "Foundation"]
+macos = "10.15"
+maccatalyst = "15.0"
+ios = "11.0"
 
 [library.Foundation]
-imports = ["Foundation"]
+imports = []
+extra-features = [
+    "objective-c",
+    "block",
+    "Foundation_NSProxy",
+    # Temporary, since some structs and statics use these
+    "Foundation_NSError",
+    "Foundation_NSAppleEventDescriptor",
+    "Foundation_NSHashTable",
+    "Foundation_NSMapTable",
+    "Foundation_NSProgress",
+    # Some fmt::Debug impls require these
+    "Foundation_NSString",
+    "Foundation_NSDictionary",
+    "Foundation_NSEnumerator",
+]
+macos = "10.0"
+maccatalyst = "13.0"
+ios = "2.0"
+tvos = "9.0"
+watchos = "2.0"
 
 [library.GameController]
-imports = ["GameController", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+extra-features = [
+    "GameController_GCControllerAxisInput",
+    "GameController_GCControllerButtonInput",
+    "GameController_GCControllerDirectionPad",
+    "GameController_GCControllerTouchpad",
+    "GameController_GCExtendedGamepad",
+    "GameController_GCControllerElement",
+    "GameController_GCGamepad",
+    "GameController_GCKeyboardInput",
+    "GameController_GCMicroGamepad",
+    "GameController_GCMotion",
+    "GameController_GCMouseInput",
+]
+macos = "10.9"
+maccatalyst = "13.0"
+ios = "7.0"
+tvos = "9.0"
 
 [library.GameKit]
-imports = ["GameKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+extra-features = [
+    "AppKit_NSViewController",
+]
+macos = "10.8"
+maccatalyst = "13.0"
+ios = "3.0"
+tvos = "9.0"
+watchos = "3.0"
 
 [library.IdentityLookup]
-imports = ["IdentityLookup", "Foundation"]
+imports = ["Foundation"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "11.0"
 
 [library.InputMethodKit]
-imports = ["InputMethodKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "10.5"
+maccatalyst = "13.0"
 
 [library.LocalAuthentication]
-imports = ["LocalAuthentication", "Foundation"]
+imports = ["Foundation"]
+macos = "10.10"
+maccatalyst = "13.0"
+ios = "8.0"
+watchos = "9.0"
 
 [library.LocalAuthenticationEmbeddedUI]
-imports = ["LocalAuthenticationEmbeddedUI", "AppKit", "Foundation", "LocalAuthentication"]
+imports = ["AppKit", "Foundation", "LocalAuthentication"]
+extra-features = [
+    "AppKit_NSWindow",
+]
+macos = "12.0"
+maccatalyst = "16.0"
+ios = "16.0"
 
 [library.LinkPresentation]
-imports = ["LinkPresentation", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "13.0"
+tvos = "14.0"
 
 [library.MailKit]
-imports = ["MailKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "12.0"
 
 [library.MapKit]
-imports = ["MapKit", "AppKit", "Contacts", "CoreLocation", "Foundation"]
+imports = ["AppKit", "Contacts", "CoreLocation", "Foundation"]
+extra-features = [
+    "MapKit_MKDirectionsResponse",
+    "MapKit_MKETAResponse",
+    "MapKit_MKLocalSearchResponse",
+    "MapKit_MKMapSnapshot",
+]
+macos = "10.9"
+maccatalyst = "13.0"
+ios = "3.0"
+tvos = "9.2"
+watchos = "2.0"
 
 [library.Metal]
-imports = ["Metal", "Foundation"]
+imports = ["Foundation"]
+macos = "10.11"
+maccatalyst = "13.0"
+ios = "8.0"
+tvos = "9.0"
 
 [library.MetalFX]
-imports = ["MetalFX", "Metal"]
+imports = ["Metal"]
+macos = "13.0"
+maccatalyst = "16.0"
+ios = "16.0"
 
 [library.MetalKit]
-imports = ["MetalKit", "AppKit", "Foundation", "Metal"]
+imports = ["AppKit", "Foundation", "Metal"]
+# Temporary, since some structs and statics use these
+extra-features = [
+    "Metal_MTLRenderPipelineReflection",
+    "Metal_MTLComputePipelineReflection",
+]
+macos = "10.11"
+maccatalyst = "13.0"
+ios = "9.0"
+tvos = "9.0"
 
 [library.OSAKit]
-imports = ["OSAKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "10.4"
 
 [library.QuartzCore]
 name = "CoreAnimation"
-imports = ["CoreAnimation", "Foundation"]
+imports = ["Foundation"]
+macos = "10.3"
+maccatalyst = "13.0"
+ios = "2.0"
+tvos = "9.0"
 
 [library.SoundAnalysis]
-imports = ["SoundAnalysis", "Foundation"]
+imports = ["Foundation"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "13.0"
+tvos = "13.0"
+watchos = "9.0"
 
 [library.Speech]
-imports = ["Speech", "Foundation"]
+imports = ["Foundation"]
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "10.0"
 
 [library.StoreKit]
-imports = ["StoreKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+macos = "10.7"
+maccatalyst = "13.0"
+ios = "3.0"
+tvos = "9.0"
+watchos = "6.2"
 
 [library.UniformTypeIdentifiers]
-imports = ["UniformTypeIdentifiers", "Foundation"]
+imports = ["Foundation"]
+extra-features = [
+    "UniformTypeIdentifiers_UTType",
+]
+macos = "11.0"
+maccatalyst = "14.0"
+ios = "14.0"
+tvos = "14.0"
+watchos = "7.0"
 
 [library.UserNotifications]
-imports = ["UserNotifications", "CoreLocation", "Foundation"]
+imports = ["CoreLocation", "Foundation"]
+macos = "10.14"
+maccatalyst = "13.0"
+ios = "10.0"
+tvos = "10.0"
+watchos = "3.0"
 
 [library.WebKit]
-imports = ["WebKit", "AppKit", "Foundation"]
+imports = ["AppKit", "Foundation"]
+extra-features = ["Foundation_NSAttributedString"]
+macos = "10.2"
+maccatalyst = "13.0"
+ios = "16.0"
 
 ###
 ### Attributes that change a function/method's calling convention.

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## icrate Unreleased - YYYY-MM-DD
 
 
-## icrate 0.0.2 - 2023-02-03
+## icrate 0.0.2 - 2023-02-07
 
 ### Added
 * Added the following frameworks:

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## icrate Unreleased - YYYY-MM-DD
 
+
+## icrate 0.0.2 - 2023-02-03
+
 ### Added
 * Added the following frameworks:
   - `Accessibility`

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   This means that to use e.g. `Foundation::NSThread::name`, you have to enable
   the `Foundation_NSThread` and `Foundation_NSString` cargo features.
+* **BREAKING**: Updated `objc2` to `v0.3.0-beta.5`.
 
 ### Removed
 * **BREAKING**: The optional `uuid` integration, since one might want to use

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This means that to use e.g. `Foundation::NSThread::name`, you have to enable
   the `Foundation_NSThread` and `Foundation_NSString` cargo features.
 * **BREAKING**: Updated `objc2` to `v0.3.0-beta.5`.
+* **BREAKING**: Updated `block2` to `v0.2.0-alpha.8`.
 
 ### Removed
 * **BREAKING**: The optional `uuid` integration, since one might want to use

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/icrate/"
 license = "MIT"
 
 [dependencies]
-objc2 = { path = "../objc2", version = "=0.3.0-beta.4", default-features = false, optional = true }
+objc2 = { path = "../objc2", version = "=0.3.0-beta.5", default-features = false, optional = true }
 block2 = { path = "../block2", version = "=0.2.0-alpha.7", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrate"
-version = "0.0.1"
+version = "0.0.2" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 
 [dependencies]
 objc2 = { path = "../objc2", version = "=0.3.0-beta.5", default-features = false, optional = true }
-block2 = { path = "../block2", version = "=0.2.0-alpha.7", default-features = false, optional = true }
+block2 = { path = "../block2", version = "=0.2.0-alpha.8", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -159,111 +159,12 @@ unstable-example-browser = [
     "WebKit_WKWebView",
 ]
 
-# Frameworks
-
-Accessibility = ["Foundation"]
-AdServices = ["Foundation"]
-AdSupport = ["Foundation"]
-AppKit = [
-    "Foundation",
-    "CoreData",
-    # Temporary, since some structs and statics use these
-    "AppKit_NSApplication",
-    "AppKit_NSCollectionLayoutSection",
-    "AppKit_NSCollectionLayoutGroupCustomItem",
-    "AppKit_NSCollectionView",
-    "AppKit_NSView",
-    "AppKit_NSTableView",
-    "AppKit_NSTableColumn",
-    "AppKit_NSTableRowView",
-    "Foundation_NSIndexPath",
-    "Foundation_NSArray",
-    "Foundation_NSCoder",
-]
-AuthenticationServices = [
-    "Foundation",
-    # Temporary, since some structs and statics use these
-    "Foundation_NSURL",
-]
-AutomaticAssessmentConfiguration = ["Foundation"]
-Automator = ["AppKit", "Foundation", "OSAKit"]
-BackgroundAssets = ["Foundation"]
-BackgroundTasks = ["Foundation"]
-BusinessChat = ["AppKit", "Foundation"]
-CallKit = ["Foundation"]
-ClassKit = ["Foundation"]
-CloudKit = ["CoreLocation", "Foundation"]
-Contacts = ["Foundation"]
-CoreAnimation = ["Foundation"]
-CoreData = [
-    "Foundation",
-    # Temporary, since some structs and statics use these
-    "CoreData_NSAsynchronousFetchResult",
-]
-CoreLocation = ["Contacts", "Foundation"]
-DataDetection = ["Foundation"]
-DeviceCheck = ["Foundation"]
-EventKit = ["AppKit", "CoreLocation", "Foundation", "MapKit"]
-ExceptionHandling = ["Foundation"]
-ExtensionKit = ["AppKit", "Foundation"]
-ExternalAccessory = ["Foundation"]
-FileProvider = ["AppKit", "Foundation", "UniformTypeIdentifiers"]
-FileProviderUI = ["AppKit", "FileProvider", "Foundation"]
-Foundation = [
-    "objective-c",
-    "block",
-    "Foundation_NSProxy",
-    # Temporary, since some structs and statics use these
-    "Foundation_NSError",
-    "Foundation_NSAppleEventDescriptor",
-    "Foundation_NSHashTable",
-    "Foundation_NSMapTable",
-    "Foundation_NSProgress",
-    # Some fmt::Debug impls require these
-    "Foundation_NSString",
-    "Foundation_NSDictionary",
-    "Foundation_NSEnumerator",
-]
-GameController = ["AppKit", "Foundation"]
-GameKit = ["AppKit", "Foundation"]
-IdentityLookup = ["Foundation"]
-InputMethodKit = ["AppKit", "Foundation"]
-LocalAuthentication = ["Foundation"]
-LocalAuthenticationEmbeddedUI = ["AppKit", "Foundation", "LocalAuthentication"]
-LinkPresentation = ["AppKit", "Foundation"]
-MailKit = ["AppKit", "Foundation"]
-MapKit = ["AppKit", "Contacts", "CoreLocation", "Foundation"]
-Metal = [
-    "Foundation",
-    # Temporary, since some structs and statics use these
-    "Metal_MTLRenderPipelineReflection",
-    "Metal_MTLComputePipelineReflection",
-]
-MetalFX = ["Metal"]
-MetalKit = ["AppKit", "Foundation", "Metal"]
-OSAKit = ["AppKit", "Foundation"]
-SoundAnalysis = ["Foundation"]
-Speech = ["Foundation"]
-StoreKit = ["AppKit", "Foundation"]
-UniformTypeIdentifiers = ["Foundation"]
-UserNotifications = ["CoreLocation", "Foundation"]
-WebKit = [
-    "AppKit",
-    "Foundation",
-    # Temporary, since some structs and statics use these
-    "Foundation_NSAttributedString",
-]
-
 # Helps with CI
-unstable-frameworks-all = ["unstable-frameworks-ios", "unstable-frameworks-macos-13", "unstable-example-basic_usage"]
+unstable-frameworks-all = ["unstable-frameworks-ios", "unstable-frameworks-macos-13"]
 unstable-frameworks-gnustep = ["AppKit_all", "Foundation_all"]
 unstable-frameworks-gnustep-32bit = ["Foundation_all"]
-unstable-frameworks-ios = ["Accessibility_all", "AdServices_all", "AdSupport_all", "AuthenticationServices_all", "AutomaticAssessmentConfiguration_all", "BackgroundAssets_all", "BackgroundTasks_all", "BusinessChat_all", "CallKit_all", "ClassKit_all", "CloudKit_all", "Contacts_all", "CoreData_all", "CoreAnimation_all", "CoreLocation_all", "DataDetection_all", "DeviceCheck_all", "EventKit_all", "ExtensionKit_all", "ExternalAccessory_all", "FileProvider_all", "FileProviderUI_all", "Foundation_all", "GameController_all", "GameKit_all", "IdentityLookup_all", "LocalAuthentication_all", "LinkPresentation_all", "MapKit_all", "Metal_all", "MetalKit_all", "SoundAnalysis_all", "Speech_all", "StoreKit_all", "UniformTypeIdentifiers_all", "UserNotifications_all", "WebKit_all", "unstable-example-speech_synthesis"]
-unstable-frameworks-macos-10-7 = ["Accessibility_all", "AppKit_all", "Automator_all", "CoreAnimation_all", "CoreData_all", "CoreLocation_all", "ExceptionHandling_all", "Foundation_all", "InputMethodKit_all", "OSAKit_all", "StoreKit_all", "unstable-example-delegate", "unstable-example-nspasteboard", "unstable-example-speech_synthesis"]
-unstable-frameworks-macos-10-13 = ["unstable-frameworks-macos-10-7", "BusinessChat_all", "CloudKit_all", "Contacts_all", "EventKit_all", "ExternalAccessory_all", "GameController_all", "GameKit_all", "LocalAuthentication_all", "LocalAuthenticationEmbeddedUI_all", "MapKit_all", "MetalKit_all"]
-unstable-frameworks-macos-11 = ["unstable-frameworks-macos-10-13", "AdServices_all", "AdSupport_all", "AuthenticationServices_all", "AutomaticAssessmentConfiguration_all", "ClassKit_all", "DeviceCheck_all", "FileProvider_all", "FileProviderUI_all", "LinkPresentation_all", "Metal_all", "SoundAnalysis_all", "Speech_all", "UniformTypeIdentifiers_all", "UserNotifications_all"]
-unstable-frameworks-macos-12 = ["unstable-frameworks-macos-11", "DataDetection_all", "LocalAuthenticationEmbeddedUI_all", "MailKit_all", "WebKit_all", "unstable-example-browser"]
-unstable-frameworks-macos-13 = ["unstable-frameworks-macos-12", "BackgroundAssets_all", "BackgroundTasks_all", "CallKit_all", "ExtensionKit_all", "IdentityLookup_all", "MetalFX_all"]
+# TODO: Autogenerate this
+unstable-frameworks-ios = ["Foundation_all", "unstable-example-basic_usage", "unstable-example-speech_synthesis"]
 
 # Temporary fixes until we can autogenerate these
 Foundation_NSProxy = []
@@ -275,6 +176,9 @@ AppKit_NSPopover = ["AppKit_NSResponder"]
 
 # This section has been automatically generated by `objc2`'s `header-translator`.
 # DO NOT EDIT
+Accessibility = [
+    "Foundation",
+]
 Accessibility_AXBrailleMap = []
 Accessibility_AXCategoricalDataAxisDescriptor = []
 Accessibility_AXChartDescriptor = []
@@ -296,15 +200,36 @@ Accessibility_all = [
     "Accessibility_AXLiveAudioGraph",
     "Accessibility_AXNumericDataAxisDescriptor",
 ]
+AdServices = [
+    "Foundation",
+]
 AdServices_AAAttribution = []
 AdServices_all = [
     "AdServices",
     "AdServices_AAAttribution",
 ]
+AdSupport = [
+    "Foundation",
+]
 AdSupport_ASIdentifierManager = []
 AdSupport_all = [
     "AdSupport",
     "AdSupport_ASIdentifierManager",
+]
+AppKit = [
+    "CoreData",
+    "Foundation",
+    "AppKit_NSApplication",
+    "AppKit_NSCollectionLayoutSection",
+    "AppKit_NSCollectionLayoutGroupCustomItem",
+    "AppKit_NSCollectionView",
+    "AppKit_NSView",
+    "AppKit_NSTableView",
+    "AppKit_NSTableColumn",
+    "AppKit_NSTableRowView",
+    "Foundation_NSIndexPath",
+    "Foundation_NSArray",
+    "Foundation_NSCoder",
 ]
 AppKit_NSATSTypesetter = [
     "AppKit_NSTypesetter",
@@ -1173,6 +1098,10 @@ AppKit_all = [
     "AppKit_NSWorkspaceAuthorization",
     "AppKit_NSWorkspaceOpenConfiguration",
 ]
+AuthenticationServices = [
+    "Foundation",
+    "Foundation_NSURL",
+]
 AuthenticationServices_ASAccountAuthenticationModificationController = []
 AuthenticationServices_ASAccountAuthenticationModificationExtensionContext = [
     "Foundation_NSExtensionContext",
@@ -1288,6 +1217,9 @@ AuthenticationServices_all = [
     "AuthenticationServices_ASWebAuthenticationSessionRequest",
     "AuthenticationServices_ASWebAuthenticationSessionWebBrowserSessionManager",
 ]
+AutomaticAssessmentConfiguration = [
+    "Foundation",
+]
 AutomaticAssessmentConfiguration_AEAssessmentApplication = []
 AutomaticAssessmentConfiguration_AEAssessmentConfiguration = []
 AutomaticAssessmentConfiguration_AEAssessmentParticipantConfiguration = []
@@ -1298,6 +1230,11 @@ AutomaticAssessmentConfiguration_all = [
     "AutomaticAssessmentConfiguration_AEAssessmentConfiguration",
     "AutomaticAssessmentConfiguration_AEAssessmentParticipantConfiguration",
     "AutomaticAssessmentConfiguration_AEAssessmentSession",
+]
+Automator = [
+    "AppKit",
+    "Foundation",
+    "OSAKit",
 ]
 Automator_AMAction = []
 Automator_AMAppleScriptAction = [
@@ -1328,6 +1265,9 @@ Automator_all = [
     "Automator_AMWorkflowView",
     "Automator_AMWorkspace",
 ]
+BackgroundAssets = [
+    "Foundation",
+]
 BackgroundAssets_BAAppExtensionInfo = []
 BackgroundAssets_BADownload = []
 BackgroundAssets_BADownloadManager = []
@@ -1340,6 +1280,9 @@ BackgroundAssets_all = [
     "BackgroundAssets_BADownload",
     "BackgroundAssets_BADownloadManager",
     "BackgroundAssets_BAURLDownload",
+]
+BackgroundTasks = [
+    "Foundation",
 ]
 BackgroundTasks_BGAppRefreshTask = [
     "BackgroundTasks_BGTask",
@@ -1366,6 +1309,10 @@ BackgroundTasks_all = [
     "BackgroundTasks_BGTaskRequest",
     "BackgroundTasks_BGTaskScheduler",
 ]
+BusinessChat = [
+    "AppKit",
+    "Foundation",
+]
 BusinessChat_BCChatAction = []
 BusinessChat_BCChatButton = [
     "AppKit_NSControl",
@@ -1374,6 +1321,9 @@ BusinessChat_all = [
     "BusinessChat",
     "BusinessChat_BCChatAction",
     "BusinessChat_BCChatButton",
+]
+CallKit = [
+    "Foundation",
 ]
 CallKit_CXAction = []
 CallKit_CXAnswerCallAction = [
@@ -1436,6 +1386,9 @@ CallKit_all = [
     "CallKit_CXStartCallAction",
     "CallKit_CXTransaction",
 ]
+ClassKit = [
+    "Foundation",
+]
 ClassKit_CLSActivity = [
     "ClassKit_CLSObject",
 ]
@@ -1470,6 +1423,11 @@ ClassKit_all = [
     "ClassKit_CLSProgressReportingCapability",
     "ClassKit_CLSQuantityItem",
     "ClassKit_CLSScoreItem",
+]
+CloudKit = [
+    "CoreLocation",
+    "Foundation",
+    "CloudKit_CKShare",
 ]
 CloudKit_CKAcceptSharesOperation = [
     "CloudKit_CKOperation",
@@ -1640,6 +1598,9 @@ CloudKit_all = [
     "CloudKit_CKUserIdentity",
     "CloudKit_CKUserIdentityLookupInfo",
 ]
+Contacts = [
+    "Foundation",
+]
 Contacts_CNChangeHistoryAddContactEvent = [
     "Contacts_CNChangeHistoryEvent",
 ]
@@ -1749,6 +1710,9 @@ Contacts_all = [
     "Contacts_CNSaveRequest",
     "Contacts_CNSocialProfile",
 ]
+CoreAnimation = [
+    "Foundation",
+]
 CoreAnimation_CAAnimation = []
 CoreAnimation_CAAnimationGroup = [
     "CoreAnimation_CAAnimation",
@@ -1833,6 +1797,10 @@ CoreAnimation_all = [
     "CoreAnimation_CATransformLayer",
     "CoreAnimation_CATransition",
     "CoreAnimation_CAValueFunction",
+]
+CoreData = [
+    "Foundation",
+    "CoreData_NSAsynchronousFetchResult",
 ]
 CoreData_NSAsynchronousFetchRequest = [
     "CoreData_NSPersistentStoreRequest",
@@ -1997,6 +1965,11 @@ CoreData_all = [
     "CoreData_NSRelationshipDescription",
     "CoreData_NSSaveChangesRequest",
 ]
+CoreLocation = [
+    "Contacts",
+    "Foundation",
+    "CoreLocation_CLPlacemark",
+]
 CoreLocation_CLBeacon = []
 CoreLocation_CLBeaconIdentityConstraint = []
 CoreLocation_CLBeaconRegion = [
@@ -2029,6 +2002,9 @@ CoreLocation_all = [
     "CoreLocation_CLPlacemark",
     "CoreLocation_CLRegion",
     "CoreLocation_CLVisit",
+]
+DataDetection = [
+    "Foundation",
 ]
 DataDetection_DDMatch = []
 DataDetection_DDMatchCalendarEvent = [
@@ -2067,12 +2043,22 @@ DataDetection_all = [
     "DataDetection_DDMatchPostalAddress",
     "DataDetection_DDMatchShipmentTrackingNumber",
 ]
+DeviceCheck = [
+    "Foundation",
+]
 DeviceCheck_DCAppAttestService = []
 DeviceCheck_DCDevice = []
 DeviceCheck_all = [
     "DeviceCheck",
     "DeviceCheck_DCAppAttestService",
     "DeviceCheck_DCDevice",
+]
+EventKit = [
+    "AppKit",
+    "CoreLocation",
+    "Foundation",
+    "MapKit",
+    "EventKit_EKEvent",
 ]
 EventKit_EKAlarm = [
     "EventKit_EKObject",
@@ -2129,10 +2115,17 @@ EventKit_all = [
     "EventKit_EKVirtualConferenceRoomTypeDescriptor",
     "EventKit_EKVirtualConferenceURLDescriptor",
 ]
+ExceptionHandling = [
+    "Foundation",
+]
 ExceptionHandling_NSExceptionHandler = []
 ExceptionHandling_all = [
     "ExceptionHandling",
     "ExceptionHandling_NSExceptionHandler",
+]
+ExtensionKit = [
+    "AppKit",
+    "Foundation",
 ]
 ExtensionKit_EXAppExtensionBrowserViewController = [
     "AppKit_NSViewController",
@@ -2144,6 +2137,9 @@ ExtensionKit_all = [
     "ExtensionKit",
     "ExtensionKit_EXAppExtensionBrowserViewController",
     "ExtensionKit_EXHostViewController",
+]
+ExternalAccessory = [
+    "Foundation",
 ]
 ExternalAccessory_EAAccessory = []
 ExternalAccessory_EAAccessoryManager = []
@@ -2157,6 +2153,16 @@ ExternalAccessory_all = [
     "ExternalAccessory_EASession",
     "ExternalAccessory_EAWiFiUnconfiguredAccessory",
     "ExternalAccessory_EAWiFiUnconfiguredAccessoryBrowser",
+]
+FileProvider = [
+    "AppKit",
+    "Foundation",
+    "UniformTypeIdentifiers",
+]
+FileProviderUI = [
+    "AppKit",
+    "FileProvider",
+    "Foundation",
 ]
 FileProviderUI_FPUIActionExtensionContext = [
     "Foundation_NSExtensionContext",
@@ -2183,6 +2189,19 @@ FileProvider_all = [
     "FileProvider_NSFileProviderItemVersion",
     "FileProvider_NSFileProviderManager",
     "FileProvider_NSFileProviderRequest",
+]
+Foundation = [
+    "objective-c",
+    "block",
+    "Foundation_NSProxy",
+    "Foundation_NSError",
+    "Foundation_NSAppleEventDescriptor",
+    "Foundation_NSHashTable",
+    "Foundation_NSMapTable",
+    "Foundation_NSProgress",
+    "Foundation_NSString",
+    "Foundation_NSDictionary",
+    "Foundation_NSEnumerator",
 ]
 Foundation_NSAffineTransform = []
 Foundation_NSAppleEventDescriptor = []
@@ -2949,6 +2968,21 @@ Foundation_all = [
     "Foundation_NSXPCListener",
     "Foundation_NSXPCListenerEndpoint",
 ]
+GameController = [
+    "AppKit",
+    "Foundation",
+    "GameController_GCControllerAxisInput",
+    "GameController_GCControllerButtonInput",
+    "GameController_GCControllerDirectionPad",
+    "GameController_GCControllerTouchpad",
+    "GameController_GCExtendedGamepad",
+    "GameController_GCControllerElement",
+    "GameController_GCGamepad",
+    "GameController_GCKeyboardInput",
+    "GameController_GCMicroGamepad",
+    "GameController_GCMotion",
+    "GameController_GCMouseInput",
+]
 GameController_GCColor = []
 GameController_GCController = []
 GameController_GCControllerAxisInput = [
@@ -3062,6 +3096,11 @@ GameController_all = [
     "GameController_GCSteeringWheelElement",
     "GameController_GCXboxGamepad",
 ]
+GameKit = [
+    "AppKit",
+    "Foundation",
+    "AppKit_NSViewController",
+]
 GameKit_GKAccessPoint = []
 GameKit_GKAchievement = []
 GameKit_GKAchievementChallenge = [
@@ -3169,6 +3208,9 @@ GameKit_all = [
     "GameKit_GKVoiceChat",
     "GameKit_GKVoiceChatService",
 ]
+IdentityLookup = [
+    "Foundation",
+]
 IdentityLookup_ILCallClassificationRequest = [
     "IdentityLookup_ILClassificationRequest",
 ]
@@ -3210,6 +3252,10 @@ IdentityLookup_all = [
     "IdentityLookup_ILMessageFilterQueryResponse",
     "IdentityLookup_ILNetworkResponse",
 ]
+InputMethodKit = [
+    "AppKit",
+    "Foundation",
+]
 InputMethodKit_IMKCandidates = [
     "AppKit_NSResponder",
 ]
@@ -3221,6 +3267,10 @@ InputMethodKit_all = [
     "InputMethodKit_IMKInputController",
     "InputMethodKit_IMKServer",
 ]
+LinkPresentation = [
+    "AppKit",
+    "Foundation",
+]
 LinkPresentation_LPLinkMetadata = []
 LinkPresentation_LPLinkView = [
     "AppKit_NSView",
@@ -3231,6 +3281,15 @@ LinkPresentation_all = [
     "LinkPresentation_LPLinkMetadata",
     "LinkPresentation_LPLinkView",
     "LinkPresentation_LPMetadataProvider",
+]
+LocalAuthentication = [
+    "Foundation",
+]
+LocalAuthenticationEmbeddedUI = [
+    "AppKit",
+    "Foundation",
+    "LocalAuthentication",
+    "AppKit_NSWindow",
 ]
 LocalAuthenticationEmbeddedUI_LAAuthenticationView = [
     "AppKit_NSView",
@@ -3261,6 +3320,10 @@ LocalAuthentication_all = [
     "LocalAuthentication_LARight",
     "LocalAuthentication_LARightStore",
     "LocalAuthentication_LASecret",
+]
+MailKit = [
+    "AppKit",
+    "Foundation",
 ]
 MailKit_MEAddressAnnotation = []
 MailKit_MEComposeContext = []
@@ -3298,6 +3361,16 @@ MailKit_all = [
     "MailKit_MEMessageSecurityInformation",
     "MailKit_MEMessageSigner",
     "MailKit_MEOutgoingMessageEncodingStatus",
+]
+MapKit = [
+    "AppKit",
+    "Contacts",
+    "CoreLocation",
+    "Foundation",
+    "MapKit_MKDirectionsResponse",
+    "MapKit_MKETAResponse",
+    "MapKit_MKLocalSearchResponse",
+    "MapKit_MKMapSnapshot",
 ]
 MapKit_MKAnnotationView = [
     "AppKit_NSView",
@@ -3488,12 +3561,25 @@ MapKit_all = [
     "MapKit_MKUserLocationView",
     "MapKit_MKZoomControl",
 ]
+Metal = [
+    "Foundation",
+]
+MetalFX = [
+    "Metal",
+]
 MetalFX_MTLFXSpatialScalerDescriptor = []
 MetalFX_MTLFXTemporalScalerDescriptor = []
 MetalFX_all = [
     "MetalFX",
     "MetalFX_MTLFXSpatialScalerDescriptor",
     "MetalFX_MTLFXTemporalScalerDescriptor",
+]
+MetalKit = [
+    "AppKit",
+    "Foundation",
+    "Metal",
+    "Metal_MTLRenderPipelineReflection",
+    "Metal_MTLComputePipelineReflection",
 ]
 MetalKit_MTKMesh = []
 MetalKit_MTKMeshBuffer = []
@@ -3731,6 +3817,10 @@ Metal_all = [
     "Metal_MTLVertexDescriptor",
     "Metal_MTLVisibleFunctionTableDescriptor",
 ]
+OSAKit = [
+    "AppKit",
+    "Foundation",
+]
 OSAKit_OSALanguage = []
 OSAKit_OSALanguageInstance = []
 OSAKit_OSAScript = []
@@ -3748,6 +3838,9 @@ OSAKit_all = [
     "OSAKit_OSAScriptController",
     "OSAKit_OSAScriptView",
 ]
+SoundAnalysis = [
+    "Foundation",
+]
 SoundAnalysis_SNAudioFileAnalyzer = []
 SoundAnalysis_SNAudioStreamAnalyzer = []
 SoundAnalysis_SNClassification = []
@@ -3762,6 +3855,9 @@ SoundAnalysis_all = [
     "SoundAnalysis_SNClassificationResult",
     "SoundAnalysis_SNClassifySoundRequest",
     "SoundAnalysis_SNTimeDurationConstraint",
+]
+Speech = [
+    "Foundation",
 ]
 Speech_SFAcousticFeature = []
 Speech_SFSpeechAudioBufferRecognitionRequest = [
@@ -3791,6 +3887,10 @@ Speech_all = [
     "Speech_SFTranscription",
     "Speech_SFTranscriptionSegment",
     "Speech_SFVoiceAnalytics",
+]
+StoreKit = [
+    "AppKit",
+    "Foundation",
 ]
 StoreKit_SKAdImpression = []
 StoreKit_SKAdNetwork = []
@@ -3863,10 +3963,18 @@ StoreKit_all = [
     "StoreKit_SKStoreReviewController",
     "StoreKit_SKStorefront",
 ]
+UniformTypeIdentifiers = [
+    "Foundation",
+    "UniformTypeIdentifiers_UTType",
+]
 UniformTypeIdentifiers_UTType = []
 UniformTypeIdentifiers_all = [
     "UniformTypeIdentifiers",
     "UniformTypeIdentifiers_UTType",
+]
+UserNotifications = [
+    "CoreLocation",
+    "Foundation",
 ]
 UserNotifications_UNCalendarNotificationTrigger = [
     "UserNotifications_UNNotificationTrigger",
@@ -3924,6 +4032,11 @@ UserNotifications_all = [
     "UserNotifications_UNTextInputNotificationResponse",
     "UserNotifications_UNTimeIntervalNotificationTrigger",
     "UserNotifications_UNUserNotificationCenter",
+]
+WebKit = [
+    "AppKit",
+    "Foundation",
+    "Foundation_NSAttributedString",
 ]
 WebKit_DOMAbstractView = [
     "WebKit_DOMObject",
@@ -4461,4 +4574,67 @@ WebKit_all = [
     "WebKit_WebScriptObject",
     "WebKit_WebUndefined",
     "WebKit_WebView",
+]
+unstable-frameworks-macos-10-13 = [
+    "CloudKit_all",
+    "Contacts_all",
+    "CoreLocation_all",
+    "EventKit_all",
+    "ExternalAccessory_all",
+    "GameController_all",
+    "GameKit_all",
+    "LocalAuthentication_all",
+    "MapKit_all",
+    "MetalKit_all",
+    "Metal_all",
+    "unstable-example-delegate",
+    "unstable-example-nspasteboard",
+    "unstable-example-speech_synthesis",
+    "unstable-frameworks-macos-10-7",
+]
+unstable-frameworks-macos-10-7 = [
+    "AppKit_all",
+    "Automator_all",
+    "CoreAnimation_all",
+    "CoreData_all",
+    "ExceptionHandling_all",
+    "Foundation_all",
+    "InputMethodKit_all",
+    "OSAKit_all",
+    "StoreKit_all",
+    "WebKit_all",
+    "unstable-example-basic_usage",
+]
+unstable-frameworks-macos-11 = [
+    "Accessibility_all",
+    "ClassKit_all",
+    "UniformTypeIdentifiers_all",
+    "unstable-frameworks-macos-10-13",
+]
+unstable-frameworks-macos-12 = [
+    "DataDetection_all",
+    "LocalAuthenticationEmbeddedUI_all",
+    "MailKit_all",
+    "unstable-frameworks-macos-11",
+]
+unstable-frameworks-macos-13 = [
+    "AdServices_all",
+    "AdSupport_all",
+    "AuthenticationServices_all",
+    "AutomaticAssessmentConfiguration_all",
+    "BackgroundAssets_all",
+    "BusinessChat_all",
+    "CallKit_all",
+    "DeviceCheck_all",
+    "ExtensionKit_all",
+    "FileProviderUI_all",
+    "FileProvider_all",
+    "IdentityLookup_all",
+    "LinkPresentation_all",
+    "MetalFX_all",
+    "SoundAnalysis_all",
+    "Speech_all",
+    "UserNotifications_all",
+    "unstable-example-browser",
+    "unstable-frameworks-macos-12",
 ]

--- a/crates/icrate/src/MapKit/fixes/mod.rs
+++ b/crates/icrate/src/MapKit/fixes/mod.rs
@@ -1,4 +1,2 @@
-use crate::MapKit::*;
-
 #[cfg(feature = "MapKit_MKMapItem")]
-unsafe impl crate::Foundation::NSCoding for MKMapItem {}
+unsafe impl crate::Foundation::NSCoding for crate::MapKit::MKMapItem {}

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -42,6 +42,9 @@ extern "C" {}
 #[cfg(feature = "objective-c")]
 pub extern crate objc2;
 
+#[cfg(feature = "block")]
+pub extern crate block2;
+
 mod common;
 #[macro_use]
 mod macros;

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -21,7 +21,7 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/icrate/0.0.1")]
+#![doc(html_root_url = "https://docs.rs/icrate/0.0.2")]
 #![recursion_limit = "512"]
 
 #[cfg(feature = "alloc")]

--- a/crates/icrate/tests/struct_encoding.rs
+++ b/crates/icrate/tests/struct_encoding.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(feature = "Foundation_NSProcessInfo")]
+#[cfg(not(feature = "gnustep-1-7"))]
 fn test_operating_system_version() {
     let info = icrate::Foundation::NSProcessInfo::processInfo();
     let _version = info.operatingSystemVersion();

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
-## 0.3.0 - 2023-02-03
+## 0.3.0 - 2023-02-07
 
 ### Changed
 * **BREAKING**: Changed `links` key from `objc_0_2` to `objc_0_3` (so

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
+## 0.3.0 - 2023-02-03
+
+### Changed
+* **BREAKING**: Changed `links` key from `objc_0_2` to `objc_0_3` (so
+  `DEP_OBJC_0_2_CC_ARGS` in build scripts becomes `DEP_OBJC_0_3_CC_ARGS`).
+* **BREAKING**: Renamed `rust_objc_sys_0_2_try_catch_exception` to
+  `try_catch`.
+
+
 ## 0.2.0-beta.3 - 2022-12-24
 
 ### Fixed

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -2,7 +2,10 @@
 name = "objc-sys"
 # Remember to update `html_root_url` in lib.rs, the `links` key, and the
 # exception function name.
-version = "0.2.0-beta.3"
+#
+# Also, beware of using pre-release versions here, since because of the
+# `links` key, two pre-releases requested with `=...` are incompatible.
+version = "0.3.0"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"
@@ -22,7 +25,7 @@ readme = "README.md"
 
 # Downstream users can customize the linking to libobjc!
 # See https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts
-links = "objc_0_2"
+links = "objc_0_3"
 build = "build.rs"
 
 [features]

--- a/crates/objc-sys/README.md
+++ b/crates/objc-sys/README.md
@@ -124,7 +124,7 @@ ABI to the runtime you're using:
 
 This is relevant if you're building and linking to custom Objective-C sources
 in a build script. To assist in compiling Objective-C sources, this crate's
-build script expose the `DEP_OBJC_0_2_CC_ARGS` environment variable to
+build script expose the `DEP_OBJC_0_3_CC_ARGS` environment variable to
 downstream build scripts.
 
 Example usage in your `build.rs` (using the `cc` crate) would be as follows:
@@ -135,7 +135,7 @@ fn main() {
     builder.compiler("clang");
     builder.file("my_objective_c_script.m");
 
-    for flag in std::env::var("DEP_OBJC_0_2_CC_ARGS").unwrap().split(' ') {
+    for flag in std::env::var("DEP_OBJC_0_3_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 

--- a/crates/objc-sys/build.rs
+++ b/crates/objc-sys/build.rs
@@ -254,6 +254,6 @@ fn main() {
             builder.flag(flag);
         }
 
-        builder.compile("librust_objc_sys_0_2_try_catch_exception.a");
+        builder.compile("librust_objc_sys_0_3_try_catch_exception.a");
     }
 }

--- a/crates/objc-sys/extern/exception.m
+++ b/crates/objc-sys/extern/exception.m
@@ -9,7 +9,7 @@ id objc_retain(id value);
 /// Unsure how C name resolution works, so we make sure to version this symbol.
 ///
 /// Return `unsigned char` since it is guaranteed to be `u8` on all platforms.
-unsigned char rust_objc_sys_0_2_try_catch_exception(void (*f)(void *), void *context, id *error) {
+unsigned char rust_objc_sys_0_3_try_catch_exception(void (*f)(void *), void *context, id *error) {
     @try {
         f(context);
         if (error) {

--- a/crates/objc-sys/src/exception.rs
+++ b/crates/objc-sys/src/exception.rs
@@ -91,7 +91,9 @@ extern_c! {
     //
     // #[cfg(any(doc, gnustep))]
     // pub fn objc_set_apple_compatible_objcxx_exceptions(newValue: c_int) -> c_int;
+}
 
+extern "C" {
     /// Call the given function inside an Objective-C `@try/@catch` block.
     ///
     /// Defined in `extern/exception.m` and compiled in `build.rs`.
@@ -108,9 +110,21 @@ extern_c! {
     ///
     /// [manual-asm]: https://gitlab.com/objrs/objrs/-/blob/b4f6598696b3fa622e6fddce7aff281770b0a8c2/src/exception.rs
     #[cfg(feature = "unstable-exception")]
-    pub fn rust_objc_sys_0_2_try_catch_exception(
+    #[link_name = "rust_objc_sys_0_3_try_catch_exception"]
+    pub fn try_catch(
         f: TryCatchClosure,
         context: *mut c_void,
         error: *mut *mut objc_object,
     ) -> c_uchar;
+}
+
+#[cfg(all(test, feature = "unstable-exception"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_catch_linkable() {
+        let fptr: unsafe extern "C" fn(_, _, _) -> _ = try_catch;
+        std::println!("{fptr:p}");
+    }
 }

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -24,7 +24,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.2.0-beta.3")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.0")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
-## 2.0.0-pre.4 - 2023-02-03
+## 2.0.0-pre.4 - 2023-02-07
 
 ### Added
 * Made the crate `no_std` compatible.

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 2.0.0-pre.4 - 2023-02-03
+
 ### Added
 * Made the crate `no_std` compatible.
 * Made the crate platform-agnostic.

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs and README.md
-version = "2.0.0-pre.3"
+version = "2.0.0-pre.4"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -44,7 +44,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-pre.3")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-pre.4")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 
 #[cfg(doctest)]

--- a/crates/objc2-proc-macros/CHANGELOG.md
+++ b/crates/objc2-proc-macros/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.1.1 - 2023-02-03
+
 ### Fixed
 * Allow all types of tokens in internal macro.
 

--- a/crates/objc2-proc-macros/CHANGELOG.md
+++ b/crates/objc2-proc-macros/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
-## 0.1.1 - 2023-02-03
+## 0.1.1 - 2023-02-07
 
 ### Fixed
 * Allow all types of tokens in internal macro.

--- a/crates/objc2-proc-macros/Cargo.toml
+++ b/crates/objc2-proc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-proc-macros"
 # Remember to update html_root_url in lib.rs
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-proc-macros/src/lib.rs
+++ b/crates/objc2-proc-macros/src/lib.rs
@@ -11,7 +11,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-proc-macros/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-proc-macros/0.1.1")]
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -111,6 +111,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   );
 
   ```
+* Updated `ffi` module to `objc-sys v0.3.0`.
 
 ### Fixed
 * Allow empty structs in `declare_class!` macro.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.0-beta.5 - 2023-02-03
+
 ### Added
 * Support `#[cfg(...)]` attributes in `extern_class!` macro.
 * Added support for selectors with multiple colons like `abc::` in the `sel!`,

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -112,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   ```
 * Updated `ffi` module to `objc-sys v0.3.0`.
+* **BREAKING**: Updated `encode` module to `objc2-encode v2.0.0-pre.4`.
 
 ### Fixed
 * Allow empty structs in `declare_class!` macro.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
-## 0.3.0-beta.5 - 2023-02-03
+## 0.3.0-beta.5 - 2023-02-07
 
 ### Added
 * Support `#[cfg(...)]` attributes in `extern_class!` macro.

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -77,7 +77,7 @@ unstable-compiler-rt = ["apple"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.3", default-features = false }
+objc-sys = { path = "../objc-sys", version = "0.3.0", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.3", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -79,7 +79,7 @@ unstable-compiler-rt = ["apple"]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "=0.2.0-beta.3", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.3", default-features = false }
-objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.0", optional = true }
+objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]
 iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callgrind" }

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.3.0-beta.4" # Remember to update html_root_url in lib.rs
+version = "0.3.0-beta.5" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -78,7 +78,7 @@ unstable-compiler-rt = ["apple"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.0", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.3", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.4", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/crates/objc2/src/declare/declare_class_tests.rs
+++ b/crates/objc2/src/declare/declare_class_tests.rs
@@ -445,6 +445,7 @@ fn test_subclass_duplicate_ivar() {
 }
 
 declare_class!(
+    #[derive(Debug)]
     struct OutParam;
 
     unsafe impl ClassType for OutParam {
@@ -467,47 +468,52 @@ declare_class!(
     }
 );
 
-extern_methods!(
-    unsafe impl OutParam {
-        #[method_id(new)]
-        fn new() -> Id<Self, Shared>;
+#[cfg(all(target_pointer_width = "64", not(feature = "catch-all")))]
+mod out_param {
+    use super::*;
 
-        #[method(unsupported1:)]
-        fn unsupported1(_param: &mut Id<Self, Shared>);
+    extern_methods!(
+        unsafe impl OutParam {
+            #[method_id(new)]
+            fn new() -> Id<Self, Shared>;
 
-        #[method(unsupported2:)]
-        fn unsupported2(_param: Option<&mut Id<Self, Shared>>);
+            #[method(unsupported1:)]
+            fn unsupported1(_param: &mut Id<Self, Shared>);
 
-        #[method(unsupported3:)]
-        fn unsupported3(_param: &mut Option<Id<Self, Shared>>);
+            #[method(unsupported2:)]
+            fn unsupported2(_param: Option<&mut Id<Self, Shared>>);
 
-        #[method(unsupported4:)]
-        fn unsupported4(_param: Option<&mut Option<Id<Self, Shared>>>);
+            #[method(unsupported3:)]
+            fn unsupported3(_param: &mut Option<Id<Self, Shared>>);
+
+            #[method(unsupported4:)]
+            fn unsupported4(_param: Option<&mut Option<Id<Self, Shared>>>);
+        }
+    );
+
+    #[test]
+    #[should_panic = "`&mut Id<_, _>` is not supported in `declare_class!` yet"]
+    fn out_param1() {
+        let mut param = OutParam::new();
+        OutParam::unsupported1(&mut param);
     }
-);
 
-#[test]
-#[should_panic = "`&mut Id<_, _>` is not supported in `declare_class!` yet"]
-fn out_param1() {
-    let mut param = OutParam::new();
-    OutParam::unsupported1(&mut param);
-}
+    #[test]
+    #[should_panic = "`Option<&mut Id<_, _>>` is not supported in `declare_class!` yet"]
+    fn out_param2() {
+        OutParam::unsupported2(None);
+    }
 
-#[test]
-#[should_panic = "`Option<&mut Id<_, _>>` is not supported in `declare_class!` yet"]
-fn out_param2() {
-    OutParam::unsupported2(None);
-}
+    #[test]
+    #[should_panic = "`&mut Option<Id<_, _>>` is not supported in `declare_class!` yet"]
+    fn out_param3() {
+        let mut param = Some(OutParam::new());
+        OutParam::unsupported3(&mut param);
+    }
 
-#[test]
-#[should_panic = "`&mut Option<Id<_, _>>` is not supported in `declare_class!` yet"]
-fn out_param3() {
-    let mut param = Some(OutParam::new());
-    OutParam::unsupported3(&mut param);
-}
-
-#[test]
-#[should_panic = "`Option<&mut Option<Id<_, _>>>` is not supported in `declare_class!` yet"]
-fn out_param4() {
-    OutParam::unsupported4(None);
+    #[test]
+    #[should_panic = "`Option<&mut Option<Id<_, _>>>` is not supported in `declare_class!` yet"]
+    fn out_param4() {
+        OutParam::unsupported4(None);
+    }
 }

--- a/crates/objc2/src/exception.rs
+++ b/crates/objc2/src/exception.rs
@@ -232,7 +232,7 @@ unsafe fn try_no_ret<F: FnOnce()>(closure: F) -> Result<(), Option<Id<Exception,
     let context = context.cast();
 
     let mut exception = ptr::null_mut();
-    let success = unsafe { ffi::rust_objc_sys_0_2_try_catch_exception(f, context, &mut exception) };
+    let success = unsafe { ffi::try_catch(f, context, &mut exception) };
 
     if success == 0 {
         Ok(())

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -169,7 +169,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.4")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.5")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");

--- a/crates/objc2/src/rc/test_object.rs
+++ b/crates/objc2/src/rc/test_object.rs
@@ -376,8 +376,12 @@ mod tests {
     // See also `tests/id_retain_autoreleased.rs`.
     //
     // Work around https://github.com/rust-lang/rust-clippy/issues/9737:
+    #[allow(clippy::if_same_then_else)]
     const IF_AUTORELEASE_NOT_SKIPPED: usize = if cfg!(feature = "gnustep-1-7") {
         1
+    } else if cfg!(all(target_arch = "arm", panic = "unwind")) {
+        // 32-bit ARM unwinding interferes with the optimization
+        2
     } else if cfg!(any(debug_assertions, feature = "exception")) {
         2
     } else {

--- a/crates/objc2/src/rc/writeback.rs
+++ b/crates/objc2/src/rc/writeback.rs
@@ -285,7 +285,10 @@ mod tests {
 
     #[test]
     #[cfg_attr(
-        not(debug_assertions),
+        any(
+            not(debug_assertions),
+            all(not(target_pointer_width = "64"), feature = "catch-all")
+        ),
         ignore = "invokes UB which is only caught with debug_assertions"
     )]
     #[should_panic = "found that NULL was written to `&mut Id<_, _>`, which is UB! You should handle this with `&mut Option<Id<_, _>>` instead"]

--- a/crates/objc2/tests/id_retain_autoreleased.rs
+++ b/crates/objc2/tests/id_retain_autoreleased.rs
@@ -28,8 +28,12 @@ fn test_retain_autoreleased() {
         // When compiled in release mode / with optimizations enabled,
         // subsequent usage of `retain_autoreleased` will succeed in retaining
         // the autoreleased value!
+        #[allow(clippy::if_same_then_else)]
         let expected = if cfg!(feature = "gnustep-1-7") {
             1
+        } else if cfg!(all(target_arch = "arm", panic = "unwind")) {
+            // 32-bit ARM unwinding interferes with the optimization
+            2
         } else if cfg!(any(debug_assertions, feature = "exception")) {
             2
         } else {

--- a/crates/objc2/tests/track_caller.rs
+++ b/crates/objc2/tests/track_caller.rs
@@ -1,3 +1,4 @@
+#![cfg(all(target_pointer_width = "64", not(feature = "catch-all")))]
 //! Test that our use of #[track_caller] is making the correct line number
 //! show up.
 use std::panic;

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
@@ -56,18 +56,18 @@ L2$pb:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.section	__OBJC,__image_info
 	.globl	L_OBJC_IMAGE_INFO_016b57e4e6a36961
 	.p2align	2
 L_OBJC_IMAGE_INFO_016b57e4e6a36961:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__TEXT,__objc_methname,cstring_literals
+	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_016b57e4e6a36961
 L_OBJC_METH_VAR_NAME_016b57e4e6a36961:
 	.asciz	"aMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
 	.globl	L_OBJC_SELECTOR_REFERENCES_016b57e4e6a36961
 	.p2align	2
 L_OBJC_SELECTOR_REFERENCES_016b57e4e6a36961:

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -8,7 +8,7 @@ fn main() {
     builder.file("extern/block_utils.c");
     println!("cargo:rerun-if-changed=extern/block_utils.c");
 
-    for flag in env::var("DEP_BLOCK_0_1_CC_ARGS").unwrap().split(' ') {
+    for flag in env::var("DEP_BLOCK_0_2_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 
@@ -29,7 +29,7 @@ fn main() {
     println!("cargo:rerun-if-changed=extern/encode_utils.m");
     println!("cargo:rerun-if-changed=extern/test_object.m");
 
-    for flag in env::var("DEP_BLOCK_0_1_CC_ARGS").unwrap().split(' ') {
+    for flag in env::var("DEP_BLOCK_0_2_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -12,7 +12,7 @@ fn main() {
         builder.flag(flag);
     }
 
-    for flag in env::var("DEP_OBJC_0_2_CC_ARGS").unwrap().split(' ') {
+    for flag in env::var("DEP_OBJC_0_3_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 
@@ -33,7 +33,7 @@ fn main() {
         builder.flag(flag);
     }
 
-    for flag in env::var("DEP_OBJC_0_2_CC_ARGS").unwrap().split(' ') {
+    for flag in env::var("DEP_OBJC_0_3_CC_ARGS").unwrap().split(' ') {
         builder.flag(flag);
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -53,11 +53,11 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.3"
+version = "0.3.0"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.4"
+version = "0.3.0-beta.5"
 dependencies = [
  "objc-sys",
  "objc2-encode",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0-pre.3"
+version = "2.0.0-pre.4"
 
 [[package]]
 name = "once_cell"


### PR DESCRIPTION
Mostly to resolve an issue with `objc-sys`/`block-sys` using the `links` `Cargo.toml` key that I anticipate could occur given that we've released `winit` and `accesskit`, which depend on `objc-sys v0.2.0-beta.2` and `block-sys v0.1.0-beta.1`.

But also so that `winit` and such can start using the new functionality in `icrate`.

Release checklist:
- [x] The branch is named `new-versions`, such that the full CI will run.
- [x] Changelogs have only been modified under the `Unreleased` header.
- [x] Version numbers are bumped in the following order:
    - `objc2-proc-macros`
    - `objc-sys`
    - `objc2-encode`
    - `block-sys`
    - `objc2`
    - `block2`
    - `icrate`
- Local tests have been run (see `helper-scripts/test-local.fish`):
    - [x] macOS 10.14.6 32bit
    - [x] iOS 9.3.6, 1st generation iPad Mini
- [x] Any errors that emerge have been fixed

Post merge:
- [x] A tag is created on the merge commit for each new version.
