### PR TITLE
Redo autorelease pools

### DIFF
--- a/crates/icrate/src/Foundation/additions/string.rs
+++ b/crates/icrate/src/Foundation/additions/string.rs
@@ -110,7 +110,7 @@ impl NSString {
     ///
     /// TODO: Further explain this.
     #[doc(alias = "UTF8String")]
-    pub fn as_str<'r, 's: 'r, 'p: 'r>(&'s self, pool: &'p AutoreleasePool) -> &'r str {
+    pub fn as_str<'r, 's: 'r, 'p: 'r>(&'s self, pool: AutoreleasePool<'p>) -> &'r str {
         // SAFETY: This is an instance of `NSString`
         unsafe { nsstring_to_str(self, pool) }
     }

--- a/crates/icrate/src/Foundation/additions/string.rs
+++ b/crates/icrate/src/Foundation/additions/string.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "Foundation_NSString")]
-use alloc::borrow::ToOwned;
 use core::cmp;
 use core::ffi::c_void;
 use core::fmt;
@@ -14,7 +13,7 @@ use core::str;
 use std::os::raw::c_char;
 
 use objc2::msg_send;
-use objc2::rc::{autoreleasepool, AutoreleasePool, DefaultId, Id, Shared};
+use objc2::rc::{autoreleasepool_leaking, AutoreleasePool, DefaultId, Id, Shared};
 use objc2::runtime::__nsstring::{nsstring_len, nsstring_to_str, UTF8_ENCODING};
 
 use crate::common::*;
@@ -180,20 +179,12 @@ impl DefaultId for NSString {
 
 impl fmt::Display for NSString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The call to `to_owned` is unfortunate, but is required to work
-        // around `f` not being AutoreleaseSafe.
-        // TODO: Fix this!
-        let s = autoreleasepool(|pool| self.as_str(pool).to_owned());
-        fmt::Display::fmt(&s, f)
+        autoreleasepool_leaking(|pool| fmt::Display::fmt(self.as_str(pool), f))
     }
 }
 
 impl fmt::Debug for NSString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The call to `to_owned` is unfortunate, but is required to work
-        // around `f` not being AutoreleaseSafe.
-        // TODO: Fix this!
-        let s = autoreleasepool(|pool| self.as_str(pool).to_owned());
-        fmt::Debug::fmt(&s, f)
+        autoreleasepool_leaking(|pool| fmt::Debug::fmt(self.as_str(pool), f))
     }
 }

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   Additionally, rename the mutable version to `Id::autorelease_mut`.
 
+### Fixed
+* Fixed using autorelease pools on 32bit macOS and older macOS versions.
+
 
 ## 0.3.0-beta.5 - 2023-02-07
 

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `objc2::rc::autoreleasepool_leaking`, and improve performance of
+  objects `Debug` impls.
+
 ### Changed
 * Made the default ownership in `Id` be `Shared`. This means that you can now
   write `Id<NSString>`, and it'll mean `Id<NSString, Shared>`.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Made the default ownership in `Id` be `Shared`. This means that you can now
   write `Id<NSString>`, and it'll mean `Id<NSString, Shared>`.
+* **BREAKING**: `objc2::rc::AutoreleasePool` is now a zero-sized `Copy` type
+  with a lifetime parameter, instead of the lifetime parameter being the
+  reference it was behind.
 
 
 ## 0.3.0-beta.5 - 2023-02-07

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: `objc2::rc::AutoreleasePool` is now a zero-sized `Copy` type
   with a lifetime parameter, instead of the lifetime parameter being the
   reference it was behind.
+* **BREAKING**: Made `Id::autorelease` and `Id::autorelease_return` be
+  associated functions instead of methods. This means they now have to be
+  called as `Id::autorelease(obj, pool)` instead of `obj.autorelease(pool)`.
+
+  Additionally, rename the mutable version to `Id::autorelease_mut`.
 
 
 ## 0.3.0-beta.5 - 2023-02-07

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -54,7 +54,7 @@ unstable-static-sel-inlined = ["unstable-static-sel"]
 unstable-static-class = ["objc2-proc-macros"]
 unstable-static-class-inlined = ["unstable-static-class"]
 
-# Uses nightly features to make AutoreleasePool sound
+# Uses nightly features to make autorelease pools fully sound
 unstable-autoreleasesafe = []
 
 # Uses the nightly c_unwind feature to make throwing safe

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -54,7 +54,7 @@ unstable-static-sel-inlined = ["unstable-static-sel"]
 unstable-static-class = ["objc2-proc-macros"]
 unstable-static-class-inlined = ["unstable-static-class"]
 
-# Uses nightly features to make AutoreleasePool zero-cost even in debug mode
+# Uses nightly features to make AutoreleasePool sound
 unstable-autoreleasesafe = []
 
 # Uses the nightly c_unwind feature to make throwing safe

--- a/crates/objc2/src/declare.rs
+++ b/crates/objc2/src/declare.rs
@@ -60,7 +60,7 @@
 //!                 initWithNumber: number,
 //!             ]
 //!         };
-//!         obj.map(|obj| obj.autorelease_return()).unwrap_or(std::ptr::null_mut())
+//!         obj.map(Id::autorelease_return).unwrap_or(std::ptr::null_mut())
 //!     }
 //!     unsafe {
 //!         builder.add_class_method(

--- a/crates/objc2/src/rc/autorelease.rs
+++ b/crates/objc2/src/rc/autorelease.rs
@@ -288,7 +288,7 @@ impl !AutoreleaseSafe for AutoreleasePool<'_> {}
 ///
 ///     // Or simply
 ///     // let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new] };
-///     // obj.autorelease(pool)
+///     // Id::autorelease_mut(obj, pool)
 /// }
 ///
 /// autoreleasepool(|pool| {
@@ -309,7 +309,7 @@ impl !AutoreleaseSafe for AutoreleasePool<'_> {}
 /// #
 /// # fn needs_lifetime_from_pool<'p>(pool: AutoreleasePool<'p>) -> &'p mut Object {
 /// #     let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new] };
-/// #     obj.autorelease(pool)
+/// #     Id::autorelease_mut(obj, pool)
 /// # }
 /// #
 /// let obj = autoreleasepool(|pool| {
@@ -330,7 +330,7 @@ impl !AutoreleaseSafe for AutoreleasePool<'_> {}
 /// #
 /// # fn needs_lifetime_from_pool<'p>(pool: AutoreleasePool<'p>) -> &'p mut Object {
 /// #     let obj: Id<Object, Owned> = unsafe { msg_send_id![class!(NSObject), new] };
-/// #     obj.autorelease(pool)
+/// #     Id::autorelease_mut(obj, pool)
 /// # }
 /// #
 /// autoreleasepool(|outer_pool| {

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -550,8 +550,7 @@ impl<T: Message> Id<T, Owned> {
     #[must_use = "If you don't intend to use the object any more, just drop it as usual"]
     #[inline]
     #[allow(clippy::needless_lifetimes)]
-    #[allow(clippy::mut_from_ref)]
-    pub fn autorelease<'p>(self, pool: &'p AutoreleasePool) -> &'p mut T {
+    pub fn autorelease<'p>(self, pool: AutoreleasePool<'p>) -> &'p mut T {
         let ptr = self.autorelease_inner();
         // SAFETY: The pointer is valid as a reference, and we've consumed
         // the unique access to the `Id` so mutability is safe.
@@ -603,7 +602,7 @@ impl<T: Message> Id<T, Shared> {
     #[must_use = "If you don't intend to use the object any more, just drop it as usual"]
     #[inline]
     #[allow(clippy::needless_lifetimes)]
-    pub fn autorelease<'p>(self, pool: &'p AutoreleasePool) -> &'p T {
+    pub fn autorelease<'p>(self, pool: AutoreleasePool<'p>) -> &'p T {
         let ptr = self.autorelease_inner();
         // SAFETY: The pointer is valid as a reference
         unsafe { pool.ptr_as_ref(ptr) }

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -46,7 +46,7 @@
 //! autoreleasepool(|pool| {
 //!     // Autorelease consumes the Id, but won't
 //!     // actually release until the end of an autoreleasepool
-//!     let obj_ref: &Object = cloned.autorelease(pool);
+//!     let obj_ref: &Object = Id::autorelease(cloned, pool);
 //! });
 //!
 //! // Weak references won't retain the object

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -66,7 +66,9 @@ mod weak_id;
 mod writeback;
 
 pub use self::allocated::Allocated;
-pub use self::autorelease::{autoreleasepool, AutoreleasePool, AutoreleaseSafe};
+pub use self::autorelease::{
+    autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
+};
 pub use self::id::Id;
 pub use self::id_traits::{DefaultId, SliceId, SliceIdMut};
 pub use self::ownership::{Owned, Ownership, Shared};

--- a/crates/objc2/src/rc/test_object.rs
+++ b/crates/objc2/src/rc/test_object.rs
@@ -167,7 +167,7 @@ declare_class!(
         fn class_error_bool(should_error: bool, err: Option<&mut *mut __RcTestObject>) -> bool {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 false
             } else {
@@ -183,7 +183,7 @@ declare_class!(
         ) -> bool {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 false
             } else {
@@ -198,7 +198,7 @@ declare_class!(
         ) -> Option<Id<Self, Owned>> {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 None
             } else {
@@ -214,7 +214,7 @@ declare_class!(
         ) -> Option<Id<Self, Owned>> {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 None
             } else {
@@ -229,7 +229,7 @@ declare_class!(
         ) -> Option<Id<Self, Owned>> {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 None
             } else {
@@ -241,7 +241,7 @@ declare_class!(
         fn alloc_error(should_error: bool, err: Option<&mut *mut __RcTestObject>) -> *mut Self {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 ptr::null_mut()
             } else {
@@ -257,7 +257,7 @@ declare_class!(
         ) -> Option<Id<Self, Owned>> {
             if should_error {
                 if let Some(err) = err {
-                    *err = __RcTestObject::new().autorelease_inner();
+                    *err = Id::autorelease_inner(__RcTestObject::new());
                 }
                 None
             } else {

--- a/crates/objc2/src/runtime/__nsstring.rs
+++ b/crates/objc2/src/runtime/__nsstring.rs
@@ -28,7 +28,7 @@ pub unsafe fn nsstring_len(obj: &NSObject) -> NSUInteger {
 /// The object must be an instance of `NSString`.
 pub unsafe fn nsstring_to_str<'r, 's: 'r, 'p: 'r>(
     obj: &'s NSObject,
-    pool: &'p AutoreleasePool,
+    pool: AutoreleasePool<'p>,
 ) -> &'r str {
     // This is necessary until `auto` types stabilizes.
     pool.__verify_is_inner();

--- a/crates/test-ui/ui/autoreleasepool_not_send_sync.rs
+++ b/crates/test-ui/ui/autoreleasepool_not_send_sync.rs
@@ -7,6 +7,6 @@ fn needs_sync<T: ?Sized + Sync>() {}
 fn needs_send<T: ?Sized + Send>() {}
 
 fn main() {
-    needs_sync::<AutoreleasePool>();
-    needs_send::<AutoreleasePool>();
+    needs_sync::<AutoreleasePool<'_>>();
+    needs_send::<AutoreleasePool<'_>>();
 }

--- a/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
+++ b/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
@@ -1,55 +1,29 @@
 error[E0277]: `*mut c_void` cannot be shared between threads safely
  --> ui/autoreleasepool_not_send_sync.rs
   |
-  |     needs_sync::<AutoreleasePool>();
-  |                  ^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
+  |     needs_sync::<AutoreleasePool<'_>>();
+  |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
-  = help: within `AutoreleasePool`, the trait `Sync` is not implemented for `*mut c_void`
-  = note: required because it appears within the type `AutoreleasePool`
+  = help: within `AutoreleasePool<'_>`, the trait `Sync` is not implemented for `*mut c_void`
+  = note: required because it appears within the type `Pool`
+  = note: required because it appears within the type `&Pool`
+  = note: required because it appears within the type `AutoreleasePool<'_>`
 note: required by a bound in `needs_sync`
  --> ui/autoreleasepool_not_send_sync.rs
   |
   | fn needs_sync<T: ?Sized + Sync>() {}
   |                           ^^^^ required by this bound in `needs_sync`
 
-error[E0277]: `*mut UnsafeCell<c_void>` cannot be shared between threads safely
+error[E0277]: `*mut c_void` cannot be shared between threads safely
  --> ui/autoreleasepool_not_send_sync.rs
   |
-  |     needs_sync::<AutoreleasePool>();
-  |                  ^^^^^^^^^^^^^^^ `*mut UnsafeCell<c_void>` cannot be shared between threads safely
+  |     needs_send::<AutoreleasePool<'_>>();
+  |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
-  = help: within `AutoreleasePool`, the trait `Sync` is not implemented for `*mut UnsafeCell<c_void>`
-  = note: required because it appears within the type `PhantomData<*mut UnsafeCell<c_void>>`
-  = note: required because it appears within the type `AutoreleasePool`
-note: required by a bound in `needs_sync`
- --> ui/autoreleasepool_not_send_sync.rs
-  |
-  | fn needs_sync<T: ?Sized + Sync>() {}
-  |                           ^^^^ required by this bound in `needs_sync`
-
-error[E0277]: `*mut c_void` cannot be sent between threads safely
- --> ui/autoreleasepool_not_send_sync.rs
-  |
-  |     needs_send::<AutoreleasePool>();
-  |                  ^^^^^^^^^^^^^^^ `*mut c_void` cannot be sent between threads safely
-  |
-  = help: within `AutoreleasePool`, the trait `Send` is not implemented for `*mut c_void`
-  = note: required because it appears within the type `AutoreleasePool`
-note: required by a bound in `needs_send`
- --> ui/autoreleasepool_not_send_sync.rs
-  |
-  | fn needs_send<T: ?Sized + Send>() {}
-  |                           ^^^^ required by this bound in `needs_send`
-
-error[E0277]: `*mut UnsafeCell<c_void>` cannot be sent between threads safely
- --> ui/autoreleasepool_not_send_sync.rs
-  |
-  |     needs_send::<AutoreleasePool>();
-  |                  ^^^^^^^^^^^^^^^ `*mut UnsafeCell<c_void>` cannot be sent between threads safely
-  |
-  = help: within `AutoreleasePool`, the trait `Send` is not implemented for `*mut UnsafeCell<c_void>`
-  = note: required because it appears within the type `PhantomData<*mut UnsafeCell<c_void>>`
-  = note: required because it appears within the type `AutoreleasePool`
+  = help: within `objc2::rc::autorelease::Pool`, the trait `Sync` is not implemented for `*mut c_void`
+  = note: required because it appears within the type `Pool`
+  = note: required for `&objc2::rc::autorelease::Pool` to implement `Send`
+  = note: required because it appears within the type `AutoreleasePool<'_>`
 note: required by a bound in `needs_send`
  --> ui/autoreleasepool_not_send_sync.rs
   |

--- a/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
+++ b/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
@@ -7,6 +7,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   = help: within `AutoreleasePool<'_>`, the trait `Sync` is not implemented for `*mut c_void`
   = note: required because it appears within the type `Pool`
   = note: required because it appears within the type `&Pool`
+  = note: required because it appears within the type `Option<&Pool>`
   = note: required because it appears within the type `AutoreleasePool<'_>`
 note: required by a bound in `needs_sync`
  --> ui/autoreleasepool_not_send_sync.rs
@@ -23,6 +24,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   = help: within `objc2::rc::autorelease::Pool`, the trait `Sync` is not implemented for `*mut c_void`
   = note: required because it appears within the type `Pool`
   = note: required for `&objc2::rc::autorelease::Pool` to implement `Send`
+  = note: required because it appears within the type `Option<&Pool>`
   = note: required because it appears within the type `AutoreleasePool<'_>`
 note: required by a bound in `needs_send`
  --> ui/autoreleasepool_not_send_sync.rs

--- a/crates/test-ui/ui/nsstring_as_str_use_outside_pool.stderr
+++ b/crates/test-ui/ui/nsstring_as_str_use_outside_pool.stderr
@@ -5,4 +5,4 @@ error: lifetime may not live long enough
   |                               ----- ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                               |   |
   |                               |   return type of closure is &'2 str
-  |                               has type `&'1 AutoreleasePool`
+  |                               has type `AutoreleasePool<'1>`

--- a/crates/tests/src/test_object.rs
+++ b/crates/tests/src/test_object.rs
@@ -112,8 +112,7 @@ impl MyTestObject {
         unsafe { msg_send_id![cls, new] }
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    fn new_autoreleased<'p>(pool: &'p AutoreleasePool) -> &'p Self {
+    fn new_autoreleased<'p>(pool: AutoreleasePool<'p>) -> &'p Self {
         let cls = Self::class();
         let ptr: *const Self = unsafe { msg_send![cls, getAutoreleasedInstance] };
         unsafe { pool.ptr_as_ref(ptr) }


### PR DESCRIPTION
- Move lifetime parameter onto the type (`&'p AutoreleasePool` -> `AutoreleasePool<'p>`)
- Make `Id` autorelease methods associated functions
- Add `autoreleasepool_leaking`
- Fix autorelease pools on unwind
- Further expand autorelease pool docs