### PR TITLE
Added target_os cfg feature to header translator

### DIFF
--- a/crates/header-translator/src/availability.rs
+++ b/crates/header-translator/src/availability.rs
@@ -15,6 +15,31 @@ struct Unavailable {
     watchos: bool,
     tvos: bool,
 }
+impl fmt::Display for Unavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut unavailable_oses = Vec::new();
+        if self.ios {
+            unavailable_oses.push("target_os = \"ios\"");
+        }
+
+        if self.macos {
+            unavailable_oses.push("target_os = \"macos\"");
+        }
+        if self.watchos {
+            unavailable_oses.push("target_os = \"tvos\"");
+        }
+
+        if self.watchos {
+            unavailable_oses.push("target_os = \"watchos\"");
+        }
+
+        if !unavailable_oses.is_empty() {
+            let unavailable_oses = unavailable_oses.join(",");
+            writeln!(f, "#[cfg(not(any({unavailable_oses})))]")?;
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Default)]
 struct Versions {
@@ -157,6 +182,8 @@ impl fmt::Display for Availability {
                 }
             }
         }
+        writeln!(f, "{}", self.unavailable)?;
+
         // TODO: Emit `cfg` attributes based on `self.unavailable`
         // TODO: Emit availability checks based on `self.introduced`
         Ok(())


### PR DESCRIPTION
I was looking at #408 and this seemed like a nice small unit of work to do on this. I'm not sure what to do with the `ios_app_extension` and `macos_app_extension` booleans in the `Unavailable` struct. To disallow the maccatalyst targets, the nice way to do it is with the [not yet stabilized `target_abi` feature](https://github.com/rust-lang/rust/issues/80970).