### PR TITLE
Redo enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_fast_enumeration"
+version = "0.1.0"
+dependencies = [
+ "icrate",
+ "objc2",
+]
+
+[[package]]
 name = "test_msg_send_error"
 version = "0.1.0"
 dependencies = [

--- a/crates/header-translator/src/data/Foundation.rs
+++ b/crates/header-translator/src/data/Foundation.rs
@@ -12,6 +12,28 @@ data! {
         unsafe -removeAllObjects;
     }
 
+    // SAFETY: `NSEnumerator` and subclasses are safe as mutable because even
+    // though the items it contains are not mutable, the enumerator itself is
+    // (and it is important that the methods below are marked `&mut` as well).
+    //
+    // However, instances of this are only safe for others to create if
+    // they're ready to pass ownership to the enumerator, or if they somehow
+    // add a lifetime parameter (to prevent the original collection from
+    // being modified).
+    //
+    // So e.g. `Id<NSMutableArray<T>> -> Id<NSEnumerator<T>>` is safe, as is
+    // `&Id<NSArray<T: IsCloneable>> -> Id<NSEnumerator<T>>`, and so is
+    // `&'a NSArray<T: IsCloneable> -> Id<NSEnumerator<T>> + 'a`.
+    class NSEnumerator: Mutable {
+        // SAFETY: This removes the object from the internal collection, so it
+        // may safely return `Id<T>`.
+        unsafe -nextObject;
+        // SAFETY: The objects are removed from the internal collection and as
+        // such are safe to give ownership over.
+        unsafe -allObjects;
+    }
+    class NSDirectoryEnumerator: Mutable {}
+
     class NSString: ImmutableWithMutableSubclass<Foundation::NSMutableString> {
         unsafe -init;
         unsafe -compare;

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -574,6 +574,10 @@ skipped = true
 [struct.NSDecimal]
 skipped = true
 
+# Uses `c_ulong` which means we need to specify the encoding manually.
+[struct.NSFastEnumerationState]
+skipped = true
+
 # Uses stuff from core Darwin libraries which we have not yet mapped
 [class.NSAppleEventDescriptor.methods]
 descriptorWithDescriptorType_bytes_length = { skipped = true }
@@ -1550,6 +1554,8 @@ definition-skipped = true
 [class.NSOrderedSet]
 definition-skipped = true
 [class.NSMutableOrderedSet]
+definition-skipped = true
+[class.NSEnumerator]
 definition-skipped = true
 
 # These protocol impls would return the wrong types

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -45,6 +45,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Renamed `NSMutableCopying::mutable_copy` to `::mutableCopy`.
 * **BREAKING**: The default value for `NSUUID` was changed from a nil UUID to
   a new random UUID.
+* **BREAKING**: Changed how iteration works.
+
+  Instead of the single `NSFastEnumerator`, we now have concrete types
+  `array::Iter`, `array::IterMut`, `array::IterRetained` and
+  `array::IntoIter`, which allows iterating over `NSArray` in different ways.
+
+  Combined with proper `IntoIterator` implementations for collection types,
+  you can now do:
+  ```rust
+  let mut array: Id<NSMutableArray<T>> = ...;
+
+  for item in &array {
+      // item: &T
+  }
+
+  // If T: IsMutable
+  for item in &mut array {
+      // item: &mut T
+  }
+
+  // If T: IsIdCloneable
+  for item in array.iter_retained() {
+      // item: Id<T>
+  }
+
+  for item in array {
+      // item: Id<T>
+  }
+  ```
+
+  (similar functionality exist for `NSSet` and `NSDictionary`).
+* **BREAKING**: Renamed `NSDictionary` methods:
+  - `keys` -> `keys_vec`.
+  - `values` -> `values_vec`.
+  - `values_mut` -> `values_vec_mut`.
+  - `keys_and_objects` -> `to_vecs`.
+  - `iter_keys` -> `keys`.
+  - `iter_values` -> `values`.
+* **BREAKING**: `NSDictionary::keys_retained` and
+  `NSDictionary::values_retained` now return an iterator instead.
 
 ### Removed
 * **BREAKING**: Removed various redundant `NSProxy` methods.
@@ -55,6 +95,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `ClassType::Mutability` instead.
 * **BREAKING**: Removed a few `init` methods on subclasses that were declared
   on categories on their superclass. These should be re-added at some point.
+
+### Fixed
+* Soundness issues with enumeration / iteration over collection types.
 
 
 ## icrate 0.0.2 - 2023-02-07

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `MainThreadMarker::alloc` for allocating objects that need to be so on
   the main thread.
 * Added automatically generated `new`/`init` methods for all types.
+* Added `FromIterator` impls for various collection types.
 
 ### Changed
 * **BREAKING**: Renamed the `from_slice` method on `NSArray`, `NSSet`,

--- a/crates/icrate/src/Foundation/additions/array.rs
+++ b/crates/icrate/src/Foundation/additions/array.rs
@@ -7,6 +7,7 @@ use core::ops::{Index, IndexMut, Range};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use objc2::mutability::{IsMutable, IsRetainable};
+use objc2::rc::IdFromIterator;
 
 use super::iter;
 use super::util;
@@ -489,5 +490,35 @@ impl<'a, T: IsRetainable> Extend<&'a T> for NSMutableArray<T> {
         // array to retain the object here.
         iter.into_iter()
             .for_each(move |item| unsafe { self.addObject(item) })
+    }
+}
+
+impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSArray<T> {
+    fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_slice(&vec)
+    }
+}
+
+impl<T: Message> IdFromIterator<Id<T>> for NSArray<T> {
+    fn id_from_iter<I: IntoIterator<Item = Id<T>>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
+    }
+}
+
+#[cfg(feature = "Foundation_NSMutableArray")]
+impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSMutableArray<T> {
+    fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_slice(&vec)
+    }
+}
+
+#[cfg(feature = "Foundation_NSMutableArray")]
+impl<T: Message> IdFromIterator<Id<T>> for NSMutableArray<T> {
+    fn id_from_iter<I: IntoIterator<Item = Id<T>>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
     }
 }

--- a/crates/icrate/src/Foundation/additions/array.rs
+++ b/crates/icrate/src/Foundation/additions/array.rs
@@ -1,3 +1,4 @@
+//! Utilities for the `NSArray` and `NSMutableArray` classes.
 #![cfg(feature = "Foundation_NSArray")]
 use alloc::vec::Vec;
 use core::fmt;
@@ -5,9 +6,9 @@ use core::mem;
 use core::ops::{Index, IndexMut, Range};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
-use objc2::msg_send;
 use objc2::mutability::{IsMutable, IsRetainable};
 
+use super::iter;
 use super::util;
 use crate::common::*;
 #[cfg(feature = "Foundation_NSMutableArray")]
@@ -220,15 +221,6 @@ extern_methods!(
 );
 
 impl<T: Message> NSArray<T> {
-    #[doc(alias = "objectEnumerator")]
-    #[cfg(feature = "Foundation_NSEnumerator")]
-    pub fn iter(&self) -> Foundation::NSEnumerator2<'_, T> {
-        unsafe {
-            let result: *mut Object = msg_send![self, objectEnumerator];
-            Foundation::NSEnumerator2::from_ptr(result)
-        }
-    }
-
     unsafe fn objects_in_range_unchecked(&self, range: Range<usize>) -> Vec<&T> {
         let range = Foundation::NSRange::from(range);
         let mut vec: Vec<NonNull<T>> = Vec::with_capacity(range.length);
@@ -340,33 +332,109 @@ impl<T: Message> NSMutableArray<T> {
     }
 }
 
-unsafe impl<T: Message> Foundation::NSFastEnumeration2 for NSArray<T> {
-    type Item = T;
+impl<T: Message> NSArray<T> {
+    #[doc(alias = "objectEnumerator")]
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter(super::iter::Iter::new(self))
+    }
+
+    #[doc(alias = "objectEnumerator")]
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_, T>
+    where
+        T: IsMutable,
+    {
+        IterMut(super::iter::IterMut::new(self))
+    }
+
+    #[doc(alias = "objectEnumerator")]
+    #[inline]
+    pub fn iter_retained(&self) -> IterRetained<'_, T>
+    where
+        T: IsIdCloneable,
+    {
+        IterRetained(super::iter::IterRetained::new(self))
+    }
 }
 
-#[cfg(feature = "Foundation_NSMutableArray")]
-unsafe impl<T: Message> Foundation::NSFastEnumeration2 for NSMutableArray<T> {
+unsafe impl<T: Message> iter::FastEnumerationHelper for NSArray<T> {
     type Item = T;
-}
 
-impl<'a, T: Message> IntoIterator for &'a NSArray<T> {
-    type Item = &'a T;
-    type IntoIter = Foundation::NSFastEnumerator2<'a, NSArray<T>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        use Foundation::NSFastEnumeration2;
-        self.iter_fast()
+    #[inline]
+    fn maybe_len(&self) -> Option<usize> {
+        Some(self.len())
     }
 }
 
 #[cfg(feature = "Foundation_NSMutableArray")]
-impl<'a, T: Message> IntoIterator for &'a NSMutableArray<T> {
-    type Item = &'a T;
-    type IntoIter = Foundation::NSFastEnumerator2<'a, NSMutableArray<T>>;
+unsafe impl<T: Message> iter::FastEnumerationHelper for NSMutableArray<T> {
+    type Item = T;
 
-    fn into_iter(self) -> Self::IntoIter {
-        use Foundation::NSFastEnumeration2;
-        self.iter_fast()
+    #[inline]
+    fn maybe_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+/// An iterator over the items of a `NSArray`.
+#[derive(Debug)]
+pub struct Iter<'a, T: Message>(iter::Iter<'a, NSArray<T>>);
+
+__impl_iter! {
+    impl<'a, T: Message> Iterator<Item = &'a T> for Iter<'a, T> { ... }
+}
+
+/// A mutable iterator over the items of a `NSArray`.
+#[derive(Debug)]
+pub struct IterMut<'a, T: Message>(iter::IterMut<'a, NSArray<T>>);
+
+__impl_iter! {
+    impl<'a, T: IsMutable> Iterator<Item = &'a mut T> for IterMut<'a, T> { ... }
+}
+
+/// An iterator that retains the items of a `NSArray`.
+#[derive(Debug)]
+pub struct IterRetained<'a, T: Message>(iter::IterRetained<'a, NSArray<T>>);
+
+__impl_iter! {
+    impl<'a, T: IsIdCloneable> Iterator<Item = Id<T>> for IterRetained<'a, T> { ... }
+}
+
+/// A consuming iterator over the items of a `NSArray`.
+#[derive(Debug)]
+pub struct IntoIter<T: Message>(iter::IntoIter<NSArray<T>>);
+
+__impl_iter! {
+    impl<'a, T: Message> Iterator<Item = Id<T>> for IntoIter<T> { ... }
+}
+
+__impl_into_iter! {
+    impl<T: Message> IntoIterator for &NSArray<T> {
+        type IntoIter = Iter<'_, T>;
+    }
+
+    #[cfg(feature = "Foundation_NSMutableArray")]
+    impl<T: Message> IntoIterator for &NSMutableArray<T> {
+        type IntoIter = Iter<'_, T>;
+    }
+
+    impl<T: IsMutable> IntoIterator for &mut NSArray<T> {
+        type IntoIter = IterMut<'_, T>;
+    }
+
+    #[cfg(feature = "Foundation_NSMutableArray")]
+    impl<T: IsMutable> IntoIterator for &mut NSMutableArray<T> {
+        type IntoIter = IterMut<'_, T>;
+    }
+
+    impl<T: IsIdCloneable> IntoIterator for Id<NSArray<T>> {
+        type IntoIter = IntoIter<T>;
+    }
+
+    #[cfg(feature = "Foundation_NSMutableArray")]
+    impl<T: Message> IntoIterator for Id<NSMutableArray<T>> {
+        type IntoIter = IntoIter<T>;
     }
 }
 
@@ -403,8 +471,7 @@ impl<T: IsMutable> IndexMut<usize> for NSMutableArray<T> {
 impl<T: fmt::Debug + Message> fmt::Debug for NSArray<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Foundation::NSFastEnumeration2;
-        f.debug_list().entries(self.iter_fast()).finish()
+        f.debug_list().entries(self).finish()
     }
 }
 

--- a/crates/icrate/src/Foundation/additions/data.rs
+++ b/crates/icrate/src/Foundation/additions/data.rs
@@ -8,6 +8,9 @@ use core::ops::{IndexMut, Range};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::slice::{self, SliceIndex};
 
+#[cfg(feature = "block")]
+use objc2::rc::IdFromIterator;
+
 use crate::common::*;
 #[cfg(feature = "Foundation_NSMutableData")]
 use crate::Foundation::NSMutableData;
@@ -246,18 +249,22 @@ impl std::io::Write for NSMutableData {
     }
 }
 
-// #[cfg(feature = "Foundation_NSMutableData")]
-// impl FromIterator<u8> for Id<NSMutableData> {
-//     fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
-//         let iter = iter.into_iter();
-//         let (lower, _) = iter.size_hint();
-//         let data = Self::with_capacity(lower);
-//         for item in iter {
-//             data.push(item);
-//         }
-//         data
-//     }
-// }
+#[cfg(feature = "block")]
+impl IdFromIterator<u8> for NSData {
+    fn id_from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
+    }
+}
+
+#[cfg(feature = "Foundation_NSMutableData")]
+#[cfg(feature = "block")]
+impl IdFromIterator<u8> for NSMutableData {
+    fn id_from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
+    }
+}
 
 #[cfg(feature = "block")]
 unsafe fn with_vec<T: Message>(obj: Option<Allocated<T>>, bytes: Vec<u8>) -> Id<T> {

--- a/crates/icrate/src/Foundation/additions/enumerator.rs
+++ b/crates/icrate/src/Foundation/additions/enumerator.rs
@@ -1,200 +1,47 @@
-use core::marker::PhantomData;
-use core::mem;
-use core::ptr;
-use core::slice;
-use std::os::raw::c_ulong;
+//! Utilities for the `NSEnumerator` class.
+#![cfg(feature = "Foundation_NSEnumerator")]
+use objc2::mutability::{IsIdCloneable, IsMutable};
 
-use objc2::rc::Id;
-use objc2::runtime::Object;
-use objc2::{msg_send, Encode, Encoding, Message, RefEncode};
+use super::iter;
+use crate::common::*;
+use crate::Foundation::NSEnumerator;
 
-// TODO: https://doc.rust-lang.org/stable/reference/trait-bounds.html#lifetime-bounds
-pub struct NSEnumerator2<'a, T: Message> {
-    id: Id<Object>,
-    item: PhantomData<&'a T>,
-}
+// TODO: Measure whether iterating through `nextObject` or fast enumeration is
+// fastest.
+// impl<T: Message> Iterator for NSEnumerator<T> {
+//     type Item = Id<T>;
+//
+//     #[inline]
+//     fn next(&mut self) -> Option<Id<T>> {
+//         self.nextObject()
+//     }
+// }
 
-impl<'a, T: Message> NSEnumerator2<'a, T> {
-    /// TODO
-    ///
-    /// # Safety
-    ///
-    /// The object pointer must be a valid `NSEnumerator2`.
-    pub unsafe fn from_ptr(ptr: *mut Object) -> Self {
-        Self {
-            id: unsafe { Id::retain_autoreleased(ptr) }.unwrap(),
-            item: PhantomData,
-        }
-    }
-}
+unsafe impl<T: Message> iter::FastEnumerationHelper for NSEnumerator<T> {
+    type Item = T;
 
-impl<'a, T: Message> Iterator for NSEnumerator2<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<&'a T> {
-        unsafe { msg_send![&self.id, nextObject] }
-    }
-}
-
-pub unsafe trait NSFastEnumeration2: Message {
-    type Item: Message;
-
-    fn iter_fast(&self) -> NSFastEnumerator2<'_, Self> {
-        NSFastEnumerator2::new(self)
-    }
-}
-
-#[repr(C)]
-struct NSFastEnumerationState<T: Message> {
-    state: c_ulong, // TODO: Verify this is actually always 64 bit
-    items_ptr: *const *const T,
-    mutations_ptr: *mut c_ulong,
-    extra: [c_ulong; 5],
-}
-
-unsafe impl<T: Message> Encode for NSFastEnumerationState<T> {
-    const ENCODING: Encoding = Encoding::Struct(
-        "?",
-        &[
-            Encoding::C_ULONG,
-            Encoding::Pointer(&Encoding::Object), // <*const *const T>::ENCODING
-            Encoding::Pointer(&Encoding::C_ULONG),
-            Encoding::Array(5, &Encoding::C_ULONG),
-        ],
-    );
-}
-
-unsafe impl<T: Message> RefEncode for NSFastEnumerationState<T> {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-}
-
-fn enumerate<'a, 'b: 'a, C: NSFastEnumeration2 + ?Sized>(
-    object: &'b C,
-    state: &mut NSFastEnumerationState<C::Item>,
-    buf: &'a mut [*const C::Item],
-) -> Option<&'a [*const C::Item]> {
-    let count: usize = unsafe {
-        // Reborrow state so that we don't move it
-        let state = &mut *state;
-        msg_send![
-            object,
-            countByEnumeratingWithState: state,
-            objects: buf.as_mut_ptr(),
-            count: buf.len(),
-        ]
-    };
-
-    if count > 0 {
-        unsafe { Some(slice::from_raw_parts(state.items_ptr, count)) }
-    } else {
+    #[inline]
+    fn maybe_len(&self) -> Option<usize> {
         None
     }
 }
 
-const FAST_ENUM_BUF_SIZE: usize = 16;
+/// A consuming iterator over the items of a `NSEnumerator`.
+#[derive(Debug)]
+pub struct IntoIter<T: Message>(iter::IntoIter<NSEnumerator<T>>);
 
-pub struct NSFastEnumerator2<'a, C: 'a + NSFastEnumeration2 + ?Sized> {
-    object: &'a C,
-
-    ptr: *const *const C::Item,
-    end: *const *const C::Item,
-
-    state: NSFastEnumerationState<C::Item>,
-    buf: [*const C::Item; FAST_ENUM_BUF_SIZE],
+__impl_iter! {
+    impl<'a, T: Message> Iterator<Item = Id<T>> for IntoIter<T> { ... }
 }
 
-impl<'a, C: NSFastEnumeration2 + ?Sized> NSFastEnumerator2<'a, C> {
-    fn new(object: &'a C) -> Self {
-        Self {
-            object,
+impl<T: Message> objc2::rc::IdIntoIterator for NSEnumerator<T> {
+    type Item = Id<T>;
+    type IntoIter = IntoIter<T>;
 
-            ptr: ptr::null(),
-            end: ptr::null(),
-
-            state: unsafe { mem::zeroed() },
-            buf: [ptr::null(); FAST_ENUM_BUF_SIZE],
-        }
-    }
-
-    fn update_buf(&mut self) -> bool {
-        // If this isn't our first time enumerating, record the previous value
-        // from the mutations pointer.
-        let mutations = if !self.ptr.is_null() {
-            Some(unsafe { *self.state.mutations_ptr })
-        } else {
-            None
-        };
-
-        let next_buf = enumerate(self.object, &mut self.state, &mut self.buf);
-        if let Some(buf) = next_buf {
-            // Check if the collection was mutated
-            if let Some(mutations) = mutations {
-                assert_eq!(
-                    mutations,
-                    unsafe { *self.state.mutations_ptr },
-                    "Mutation detected during enumeration of object {:p}",
-                    self.object
-                );
-            }
-
-            self.ptr = buf.as_ptr();
-            self.end = unsafe { self.ptr.add(buf.len()) };
-            true
-        } else {
-            self.ptr = ptr::null();
-            self.end = ptr::null();
-            false
-        }
+    #[inline]
+    fn id_into_iter(this: Id<Self>) -> Self::IntoIter {
+        IntoIter(super::iter::IntoIter::new(this))
     }
 }
 
-impl<'a, C: NSFastEnumeration2 + ?Sized> Iterator for NSFastEnumerator2<'a, C> {
-    type Item = &'a C::Item;
-
-    fn next(&mut self) -> Option<&'a C::Item> {
-        if self.ptr == self.end && !self.update_buf() {
-            None
-        } else {
-            unsafe {
-                // TODO
-                let obj = self.ptr.read_unaligned();
-                self.ptr = self.ptr.offset(1);
-                Some(obj.as_ref().unwrap_unchecked())
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "Foundation_NSArray")]
-#[cfg(feature = "Foundation_NSEnumerator")]
-#[cfg(feature = "Foundation_NSNumber")]
-mod tests {
-    use super::*;
-
-    use crate::Foundation::{NSArray, NSNumber};
-
-    #[test]
-    fn test_enumerator() {
-        let vec = (0..4).map(NSNumber::new_usize).collect();
-        let array = NSArray::from_vec(vec);
-
-        let enumerator = array.iter();
-        assert_eq!(enumerator.count(), 4);
-
-        let enumerator = array.iter();
-        assert!(enumerator.enumerate().all(|(i, obj)| obj.as_usize() == i));
-    }
-
-    #[test]
-    fn test_fast_enumerator() {
-        let vec = (0..4).map(NSNumber::new_usize).collect();
-        let array = NSArray::from_vec(vec);
-
-        let enumerator = array.iter_fast();
-        assert_eq!(enumerator.count(), 4);
-
-        let enumerator = array.iter_fast();
-        assert!(enumerator.enumerate().all(|(i, obj)| obj.as_usize() == i));
-    }
-}
+// TODO: Does fast enumeration modify the enumeration while iterating?

--- a/crates/icrate/src/Foundation/additions/error.rs
+++ b/crates/icrate/src/Foundation/additions/error.rs
@@ -37,12 +37,10 @@ impl NSError {
 
 #[cfg(feature = "Foundation_NSString")]
 #[cfg(feature = "Foundation_NSDictionary")]
-#[cfg(feature = "Foundation_NSEnumerator")]
 impl std::error::Error for Foundation::NSError {}
 
 #[cfg(feature = "Foundation_NSString")]
 #[cfg(feature = "Foundation_NSDictionary")]
-#[cfg(feature = "Foundation_NSEnumerator")]
 impl fmt::Debug for NSError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NSError")

--- a/crates/icrate/src/Foundation/additions/iter.rs
+++ b/crates/icrate/src/Foundation/additions/iter.rs
@@ -1,0 +1,856 @@
+#![allow(dead_code)]
+use core::ptr;
+
+use objc2::mutability::IsMutable;
+
+use super::util;
+use crate::common::*;
+use crate::Foundation::{NSFastEnumeration, NSFastEnumerationState};
+
+/// Swift and Objective-C both have a stack buffer size of 16, so we do that
+/// as well.
+///
+/// TODO: Consider lowering this a bit, since the most common type of
+/// enumeration (e.g. NSArray) doesn't use the buffer:
+/// [CFArray's NSFastEnumeration implementation](https://github.com/apple-oss-distributions/CF/blob/dc54c6bb1c1e5e0b9486c1d26dd5bef110b20bf3/CFArray.c#L618-L642)
+const BUF_SIZE: usize = 16;
+
+/// Helper type for doing fast enumeration.
+///
+/// See the following other implementations of this:
+/// - [Swift](https://github.com/apple/swift-corelibs-foundation/blob/2d23cf3dc07951ed2b988608d08d7a54cc53b26e/Darwin/Foundation-swiftoverlay/NSFastEnumeration.swift#L23)
+/// - [Clang](https://github.com/llvm/llvm-project/blob/28d85d207fc37b5593c17a25f687c91b7afda5b4/clang/lib/Frontend/Rewrite/RewriteModernObjC.cpp#L1653-L1850)
+#[derive(Debug, PartialEq)]
+struct FastEnumeratorHelper {
+    state: NSFastEnumerationState,
+    buf: [*mut Object; BUF_SIZE],
+    // TODO: We could possibly optimize things a bit by doing
+    // `itemsPtr.add(1); items_count -= 1;` on every loop, instead of storing
+    // `current_item` - but it's not really defined whether we're allowed to
+    // mutate `itemsPtr`? All of the GNUStep code and the open sourced Apple
+    // code I've found would work under this scheme, and from a cursory GitHub
+    // search I only found the following that assume that `itemsPtr` is stable
+    // across invocations:
+    // https://github.com/iodefog/VipVideo/blob/52243b893f0004a6880f13c33104e2394b56b7f1/VipVideo/Helper/JSONKit.m#L759-L769
+    //
+    // Though they also assume that the given stack buffer has a stable
+    // address, which is something that would be prohibitively expensive to
+    // ensure, so don't think we should consider that one.
+    current_item: usize,
+    items_count: usize,
+    /// Track mutation mistakes when debug assertions are enabled (they should
+    /// be made impossible by Rust at compile-time, so hence we don't need to
+    /// track them in release mode).
+    ///
+    /// This is set to `None` initially, but later loaded to `Some(_)` after
+    /// the first enumeration.
+    #[cfg(debug_assertions)]
+    mutations_state: Option<c_ulong>,
+}
+
+// SAFETY: Neither `FastEnumeratorHelper`, nor inner the enumeration state,
+// need to be bound to any specific thread (at least, we can generally assume
+// this for the enumerable types in Foundation - but `NSEnumerator` won't be
+// `Send`, and neither will its iterator types).
+unsafe impl Send for FastEnumeratorHelper {}
+
+// SAFETY: `FastEnumeratorHelper` is only mutable behind `&mut`, and as such
+// is safe to share with other threads.
+unsafe impl Sync for FastEnumeratorHelper {}
+
+impl FastEnumeratorHelper {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            state: NSFastEnumerationState {
+                state: 0,
+                itemsPtr: ptr::null_mut(),
+                mutationsPtr: ptr::null_mut(),
+                extra: [0; 5],
+            },
+            buf: [ptr::null_mut(); BUF_SIZE],
+            current_item: 0,
+            items_count: 0,
+            #[cfg(debug_assertions)]
+            mutations_state: None,
+        }
+    }
+
+    #[inline]
+    const fn remaining_items_at_least(&self) -> usize {
+        self.items_count - self.current_item
+    }
+
+    /// Load the next array of items into the enumeration state.
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The collection must be the same on each call.
+    #[inline]
+    #[track_caller]
+    unsafe fn load_next_items(&mut self, collection: &ProtocolObject<dyn NSFastEnumeration>) {
+        // SAFETY: The ptr comes from a slice, which is always non-null.
+        //
+        // The callee may choose to use this or not, see:
+        // <https://www.mikeash.com/pyblog/friday-qa-2010-04-16-implementing-fast-enumeration.html>
+        let buf_ptr = unsafe { NonNull::new_unchecked(self.buf.as_mut_ptr()) };
+        // SAFETY:
+        // - The state is mutable, and we don't touch the `state` and
+        //   `extra` fields.
+        // - The buffer is mutable and its length is correctly set.
+        // - The collection and state are guaranteed by the caller to match.
+        self.items_count = unsafe {
+            collection.countByEnumeratingWithState_objects_count(
+                NonNull::from(&mut self.state),
+                buf_ptr,
+                self.buf.len(),
+            )
+        };
+
+        #[cfg(debug_assertions)]
+        {
+            if self.items_count > 0 && self.state.itemsPtr.is_null() {
+                panic!("`itemsPtr` was NULL");
+            }
+        }
+
+        // For unwind safety, we only set this _after_ the message send has
+        // completed, otherwise, if it unwinded, upon iterating again we might
+        // invalidly assume that the buffer was ready.
+        self.current_item = 0;
+    }
+
+    /// Get the next item from the given collection.
+    ///
+    /// We use a `ProtocolObject` instead of a generic, so that there is only
+    /// one instance of this function in the compilation unit (should improve
+    /// compilation speed).
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The collection must be the same on each call.
+    #[inline]
+    #[track_caller]
+    unsafe fn next_from(
+        &mut self,
+        collection: &ProtocolObject<dyn NSFastEnumeration>,
+    ) -> Option<NonNull<Object>> {
+        // If we've exhausted the current array of items.
+        if self.current_item >= self.items_count {
+            // Get the next array of items.
+            //
+            // SAFETY: Upheld by caller.
+            unsafe { self.load_next_items(collection) };
+
+            // If the next array was also empty.
+            if self.items_count == 0 {
+                // We are done enumerating.
+                return None;
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            // If the mutation ptr is not set, we do nothing.
+            if let Some(ptr) = NonNull::new(self.state.mutationsPtr) {
+                // SAFETY:
+                // - The pointer is not NULL.
+                //
+                // - The enumerator is expected to give back a dereferenceable
+                //   pointer, that is alive for as long as the collection is
+                //   alive.
+                //
+                //   Note that iterating past the first returned `None` is not
+                //   tested by most Objective-C implementations, so it may
+                //   deallocate the mutations ptr in that case?
+                //
+                // - The enumeration should not be modifiable across threads,
+                //   so neither will this pointer be accessed from different
+                //   threads.
+                //
+                //   Note that this assumption is relatively likely to be
+                //   violated, but if that is the case, the program already
+                //   has UB, so then it is better that we detect it.
+                //
+                // - The value is a simple integer, so is always initialized.
+                //
+                //
+                // We do an unaligned read here since we have no guarantees
+                // about this pointer, and efficiency doesn't really matter.
+                let new_state = unsafe { ptr.as_ptr().read_unaligned() };
+                match self.mutations_state {
+                    // On the first iteration, initialize the mutation state
+                    None => {
+                        self.mutations_state = Some(new_state);
+                    }
+                    // On subsequent iterations, verify that the state hasn't
+                    // changed.
+                    Some(current_state) => {
+                        if current_state != new_state {
+                            panic!("mutation detected during enumeration. This is undefined behaviour, and must be avoided");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Compute a pointer to the current item.
+        //
+        // SAFETY: The index is checked above to be in bounds of the returned
+        // array.
+        let ptr = unsafe { self.state.itemsPtr.add(self.current_item) };
+        // Move to the next item.
+        self.current_item += 1;
+        // And read the current item.
+        //
+        // SAFETY:
+        // - The pointer is not NULL, it is guaranteed to have been set
+        //   by `countByEnumeratingWithState:objects:count:`.
+        // - The pointer is within the bounds of the returned array.
+        //
+        // Note: GNUStep may sometimes return unaligned pointers. TODO: Should
+        // we go back to using `read` on Apple systems for better performance?
+        let obj = unsafe { ptr.read_unaligned() };
+        // SAFETY: The returned array contains no NULL pointers.
+        Some(unsafe { NonNull::new_unchecked(obj) })
+    }
+}
+
+// Unfortunately, `NSFastEnumeration` doesn't provide a way for enumerated
+// objects to clean up their work after having being enumerated over.
+//
+// impl Drop for FastEnumeratorHelper { ... }
+
+/// Internal helper trait to figure out the output type of something that
+/// implements `NSFastEnumeration`.
+///
+///
+/// # Safety
+///
+/// The associated `Item` type must be the type that is used in Objective-C's
+/// `for (type elem in collection) { stmts; }` enumeration, and the collection
+/// itself must not contain any lifetime parameter.
+pub(crate) unsafe trait FastEnumerationHelper: Message + NSFastEnumeration {
+    type Item: Message;
+
+    fn maybe_len(&self) -> Option<usize>;
+}
+
+// Iterator implementations we _can't_ do:
+//
+//
+// # `ExactSizeIterator`
+//
+// This could probably be implemented correctly for the concrete class
+// `NSArray`, but not for arbitary `NSArray` subclasses, which are always be
+// valid to convert to `NSArray`.
+//
+//
+// # `FusedIterator`
+//
+// Although most fast enumerators are probably fused, this is not guaranteed
+// by the documentation (actually, some may even use the last iteration as a
+// cleanup step, and do it twice, which we should perhaps protect against?).
+//
+//
+// # `DoubleEndedIterator`
+//
+// `NSArray` has `reverseObjectEnumerator`, but this is a separate object from
+// `objectEnumerator`, and as such it is not possible to enumerate it in the
+// backwards direction.
+
+// Explicit lifetime bound on `C` to future-proof against possible soundness
+// mistakes in the future.
+//
+// TODO: Consider adding `#[repr(C)]`, to allow LLVM to perform better
+// zero-initialization.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Iter<'a, C: ?Sized + 'a> {
+    helper: FastEnumeratorHelper,
+    /// 'a and C are covariant.
+    collection: &'a C,
+}
+
+impl<'a, C: ?Sized + FastEnumerationHelper> Iter<'a, C> {
+    pub(crate) fn new(collection: &'a C) -> Self {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+        }
+    }
+}
+
+impl<'a, C: FastEnumerationHelper> Iterator for Iter<'a, C> {
+    type Item = &'a C::Item;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<&'a C::Item> {
+        // SAFETY: The collection is the same on each iteration.
+        let obj = unsafe {
+            self.helper
+                .next_from(ProtocolObject::from_ref(self.collection))?
+        };
+        // SAFETY: The lifetime is bound to the collection, and the type is
+        // correct.
+        //
+        // [Enumeration variables are externally retained][enum-retained], so
+        // it is okay to return a reference instead of retaining here.
+        //
+        // [enum-retained]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#fast-enumeration-iteration-variables
+        Some(unsafe { obj.cast::<C::Item>().as_ref() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IterMut<'a, C: ?Sized + 'a> {
+    helper: FastEnumeratorHelper,
+    /// 'a and C are covariant.
+    collection: &'a mut C,
+}
+
+impl<'a, C: ?Sized + FastEnumerationHelper> IterMut<'a, C>
+where
+    C::Item: IsMutable,
+{
+    pub(crate) fn new(collection: &'a mut C) -> Self {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+        }
+    }
+}
+
+impl<'a, C: FastEnumerationHelper> Iterator for IterMut<'a, C>
+where
+    C::Item: IsMutable,
+{
+    type Item = &'a mut C::Item;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<&'a mut C::Item> {
+        // SAFETY: The collection is the same on each iteration.
+        //
+        // Passing the collection as immutable here is safe since it isn't
+        // mutated itself, and it is `UnsafeCell` anyhow.
+        let obj = unsafe {
+            self.helper
+                .next_from(ProtocolObject::from_mut(self.collection))?
+        };
+        // SAFETY: That we take the collection by `&mut`, along with the
+        // `C::Item: IsMutable` bound, ensure that the items are safe to
+        // return as mutable.
+        //
+        // Rest is same as `Iter<'a, C>`.
+        Some(unsafe { obj.cast::<C::Item>().as_mut() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IterRetained<'a, C: ?Sized + 'a> {
+    inner: Iter<'a, C>,
+}
+
+impl<'a, C: ?Sized + FastEnumerationHelper> IterRetained<'a, C>
+where
+    C::Item: IsIdCloneable,
+{
+    pub(crate) fn new(collection: &'a C) -> Self {
+        Self {
+            inner: Iter::new(collection),
+        }
+    }
+}
+
+impl<'a, C: FastEnumerationHelper> Iterator for IterRetained<'a, C>
+where
+    C::Item: IsIdCloneable,
+{
+    type Item = Id<C::Item>;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<Id<C::Item>> {
+        let obj = self.inner.next()?;
+        // SAFETY: The object is stored inside the enumerated collection.
+        Some(unsafe { util::collection_retain_id(obj) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+// Note: I first considered having `IntoIter<T>` instead of `IntoIter<C>`, but
+// that would be unsound for `NSDictionary<K, V>`, since if the `V` has a
+// lifetime, that lifetime would have been erased (so we'd have to add an
+// `V: 'static` bound, which is easy to forget).
+//
+// Also, this design allows us to have proper `Send + Sync` implementations,
+// as well as allowing us to implement `FusedIterator` and `ExactSizeIterator`
+// when possible.
+#[derive(Debug, PartialEq)]
+pub(crate) struct IntoIter<C: ?Sized> {
+    helper: FastEnumeratorHelper,
+    /// C is covariant.
+    collection: Id<C>,
+}
+
+impl<C: FastEnumerationHelper> IntoIter<C> {
+    pub(crate) fn new_immutable(collection: Id<C>) -> Self
+    where
+        C: IsIdCloneable,
+        C::Item: IsIdCloneable,
+    {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+        }
+    }
+
+    pub(crate) fn new_mutable<T: IsMutable + ClassType<Super = C>>(collection: Id<T>) -> Self
+    where
+        C: IsIdCloneable,
+    {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection: unsafe { Id::cast(collection) },
+        }
+    }
+
+    pub(crate) fn new(collection: Id<C>) -> Self
+    where
+        C: IsMutable,
+    {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+        }
+    }
+}
+
+impl<C: FastEnumerationHelper> Iterator for IntoIter<C> {
+    type Item = Id<C::Item>;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<Id<C::Item>> {
+        let collection = ProtocolObject::from_ref(&*self.collection);
+        // SAFETY: The collection is the same on each iteration.
+        let obj = unsafe { self.helper.next_from(collection)? };
+        // SAFETY: TODO
+        let obj = unsafe { Id::retain(obj.cast::<C::Item>().as_ptr()) };
+        // SAFETY: The object was `NonNull`, and `retain` returns the same
+        // pointer.
+        Some(unsafe { obj.unwrap_unchecked() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IterWithBackingEnum<'a, C: ?Sized + 'a, E: ?Sized + 'a> {
+    helper: FastEnumeratorHelper,
+    /// 'a and C are covariant.
+    collection: &'a C,
+    /// E is covariant.
+    enumerator: Id<E>,
+}
+
+impl<'a, C, E> IterWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: ?Sized + FastEnumerationHelper,
+{
+    pub(crate) unsafe fn new(collection: &'a C, enumerator: Id<E>) -> Self {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+            enumerator,
+        }
+    }
+}
+
+impl<'a, C, E> Iterator for IterWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: FastEnumerationHelper,
+{
+    type Item = &'a E::Item;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<&'a E::Item> {
+        // SAFETY: The enumerator is the same on each iteration.
+        let obj = unsafe {
+            self.helper
+                .next_from(ProtocolObject::from_ref(&*self.enumerator))?
+        };
+        // SAFETY: TODO
+        Some(unsafe { obj.cast::<E::Item>().as_ref() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            // Assume that the length of the collection matches the length of
+            // the enumerator.
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IterMutWithBackingEnum<'a, C: ?Sized + 'a, E: ?Sized + 'a> {
+    helper: FastEnumeratorHelper,
+    /// 'a and C are covariant.
+    collection: &'a mut C,
+    /// E is covariant.
+    enumerator: Id<E>,
+}
+
+impl<'a, C, E> IterMutWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: ?Sized + FastEnumerationHelper + IsMutable,
+    E::Item: IsMutable,
+{
+    pub(crate) unsafe fn new(collection: &'a mut C, enumerator: Id<E>) -> Self {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+            enumerator,
+        }
+    }
+}
+
+impl<'a, C, E> Iterator for IterMutWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: FastEnumerationHelper + IsMutable,
+    E::Item: IsMutable,
+{
+    type Item = &'a mut E::Item;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<&'a mut E::Item> {
+        // SAFETY: The enumerator is the same on each iteration.
+        let obj = unsafe {
+            self.helper
+                .next_from(ProtocolObject::from_mut(&mut *self.enumerator))?
+        };
+        // SAFETY: TODO
+        Some(unsafe { obj.cast::<E::Item>().as_mut() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            // Assume that the length of the collection matches the length of
+            // the enumerator.
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IterRetainedWithBackingEnum<'a, C: ?Sized + 'a, E: ?Sized + 'a> {
+    inner: IterWithBackingEnum<'a, C, E>,
+}
+
+impl<'a, C, E> IterRetainedWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: ?Sized + FastEnumerationHelper,
+    E::Item: IsIdCloneable,
+{
+    pub(crate) unsafe fn new(collection: &'a C, enumerator: Id<E>) -> Self {
+        // SAFETY: Upheld by caller.
+        let inner = unsafe { IterWithBackingEnum::new(collection, enumerator) };
+        Self { inner }
+    }
+}
+
+impl<'a, C, E> Iterator for IterRetainedWithBackingEnum<'a, C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: FastEnumerationHelper,
+    E::Item: IsIdCloneable,
+{
+    type Item = Id<E::Item>;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<Id<E::Item>> {
+        let obj = self.inner.next()?;
+        // SAFETY: The object is stored inside the enumerated collection.
+        Some(unsafe { util::collection_retain_id(obj) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct IntoIterWithBackingEnum<C: ?Sized, E: ?Sized> {
+    helper: FastEnumeratorHelper,
+    /// C is covariant.
+    collection: Id<C>,
+    /// E is covariant.
+    enumerator: Id<E>,
+}
+
+impl<C, E> IntoIterWithBackingEnum<C, E>
+where
+    C: FastEnumerationHelper,
+    E: ?Sized + FastEnumerationHelper,
+{
+    pub(crate) unsafe fn new_immutable(collection: Id<C>, enumerator: Id<E>) -> Self
+    where
+        C: IsIdCloneable,
+        E::Item: IsIdCloneable,
+    {
+        Self {
+            helper: FastEnumeratorHelper::new(),
+            collection,
+            enumerator,
+        }
+    }
+
+    pub(crate) unsafe fn new_mutable<T: IsMutable + ClassType<Super = C>>(
+        collection: Id<T>,
+        enumerator: Id<E>,
+    ) -> Self
+    where
+        C: IsIdCloneable,
+    {
+        Self {
+            collection: unsafe { Id::cast(collection) },
+            enumerator,
+            helper: FastEnumeratorHelper::new(),
+        }
+    }
+}
+
+impl<C, E> Iterator for IntoIterWithBackingEnum<C, E>
+where
+    C: ?Sized + FastEnumerationHelper,
+    E: FastEnumerationHelper,
+{
+    type Item = Id<E::Item>;
+
+    #[inline]
+    #[track_caller]
+    fn next(&mut self) -> Option<Id<E::Item>> {
+        let enumerator = ProtocolObject::from_ref(&*self.enumerator);
+        // SAFETY: The enumerator is the same on each iteration.
+        let obj = unsafe { self.helper.next_from(enumerator)? };
+        // SAFETY: TODO
+        let obj = unsafe { Id::retain(obj.cast::<E::Item>().as_ptr()) };
+        // SAFETY: TODO
+        Some(unsafe { obj.unwrap_unchecked() })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.helper.remaining_items_at_least(),
+            // Assume that the length of the collection matches the length of
+            // the enumerator.
+            self.collection.maybe_len(),
+        )
+    }
+}
+
+#[doc(hidden)]
+macro_rules! __impl_iter {
+    (
+        impl<$($lifetime:lifetime, )? $t1:ident: $bound1:ident $(, $t2:ident: $bound2:ident)?> Iterator<Item = $item:ty> for $for:ty { ... }
+    ) => {
+        impl<$($lifetime, )? $t1: $bound1 $(, $t2: $bound2)?> Iterator for $for {
+            type Item = $item;
+
+            #[inline]
+            #[track_caller]
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next()
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+macro_rules! __impl_into_iter {
+    () => {};
+    (
+        $(#[$m:meta])*
+        impl<T: Message> IntoIterator for &$ty:ident<T> {
+            type IntoIter = $iter:ident<'_, T>;
+        }
+
+        $($rest:tt)*
+    ) => {
+        $(#[$m])*
+        impl<'a, T: Message> IntoIterator for &'a $ty<T> {
+            type Item = &'a T;
+            type IntoIter = $iter<'a, T>;
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter(super::iter::Iter::new(&self))
+            }
+        }
+
+        __impl_into_iter! {
+            $($rest)*
+        }
+    };
+    (
+        $(#[$m:meta])*
+        impl<T: IsMutable> IntoIterator for &mut $ty:ident<T> {
+            type IntoIter = $iter_mut:ident<'_, T>;
+        }
+
+        $($rest:tt)*
+    ) => {
+        $(#[$m])*
+        impl<'a, T: IsMutable> IntoIterator for &'a mut $ty<T> {
+            type Item = &'a mut T;
+            type IntoIter = $iter_mut<'a, T>;
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_mut(super::iter::IterMut::new(&mut *self))
+            }
+        }
+
+        __impl_into_iter! {
+            $($rest)*
+        }
+    };
+    (
+        $(#[$m:meta])*
+        impl<T: IsIdCloneable> IntoIterator for Id<$ty:ident<T>> {
+            type IntoIter = $into_iter:ident<T>;
+        }
+
+        $($rest:tt)*
+    ) => {
+        $(#[$m])*
+        impl<T: IsIdCloneable> objc2::rc::IdIntoIterator for $ty<T> {
+            type Item = Id<T>;
+            type IntoIter = $into_iter<T>;
+
+            #[inline]
+            fn id_into_iter(this: Id<Self>) -> Self::IntoIter {
+                $into_iter(super::iter::IntoIter::new_immutable(this))
+            }
+        }
+
+        __impl_into_iter! {
+            $($rest)*
+        }
+    };
+    (
+        $(#[$m:meta])*
+        impl<T: Message> IntoIterator for Id<$ty:ident<T>> {
+            type IntoIter = $into_iter:ident<T>;
+        }
+
+        $($rest:tt)*
+    ) => {
+        $(#[$m])*
+        impl<T: Message> objc2::rc::IdIntoIterator for $ty<T> {
+            type Item = Id<T>;
+            type IntoIter = $into_iter<T>;
+
+            #[inline]
+            fn id_into_iter(this: Id<Self>) -> Self::IntoIter {
+                $into_iter(super::iter::IntoIter::new_mutable(this))
+            }
+        }
+
+        __impl_into_iter! {
+            $($rest)*
+        }
+    };
+}
+
+#[cfg(test)]
+#[cfg(feature = "Foundation_NSArray")]
+#[cfg(feature = "Foundation_NSNumber")]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    use crate::Foundation::{NSArray, NSNumber};
+
+    #[test]
+    #[cfg_attr(
+        any(not(target_pointer_width = "64"), debug_assertions),
+        ignore = "assertions assume pointer-width of 64, and the size only really matter in release mode"
+    )]
+    fn test_enumerator_helper() {
+        // We should attempt to reduce these if possible
+        assert_eq!(size_of::<NSFastEnumerationState>(), 64);
+        assert_eq!(size_of::<FastEnumeratorHelper>(), 208);
+        assert_eq!(size_of::<Iter<'_, NSArray<NSNumber>>>(), 216);
+    }
+
+    #[test]
+    fn test_enumerator() {
+        let vec = (0..4).map(NSNumber::new_usize).collect();
+        let array = NSArray::from_vec(vec);
+
+        let enumerator = array.iter();
+        assert_eq!(enumerator.count(), 4);
+
+        let enumerator = array.iter();
+        assert!(enumerator.enumerate().all(|(i, obj)| obj.as_usize() == i));
+    }
+
+    #[test]
+    fn test_into_enumerator() {
+        let vec = (0..4).map(NSNumber::new_usize).collect();
+        let array = NSArray::from_vec(vec);
+
+        let enumerator = array.into_iter();
+        assert!(enumerator.enumerate().all(|(i, obj)| obj.as_usize() == i));
+    }
+}

--- a/crates/icrate/src/Foundation/additions/mod.rs
+++ b/crates/icrate/src/Foundation/additions/mod.rs
@@ -1,5 +1,4 @@
 pub use self::comparison_result::NSComparisonResult;
-pub use self::enumerator::{NSEnumerator2, NSFastEnumeration2, NSFastEnumerator2};
 pub use self::geometry::{
     CGFloat, CGPoint, CGRect, CGSize, NSMaxXEdge, NSMaxYEdge, NSMinXEdge, NSMinYEdge, NSPoint,
     NSRect, NSRectEdge, NSRectEdgeMaxX, NSRectEdgeMaxY, NSRectEdgeMinX, NSRectEdgeMinY, NSSize,
@@ -11,20 +10,22 @@ pub use self::thread::MainThreadBound;
 #[cfg(feature = "Foundation_NSThread")]
 pub use self::thread::{is_main_thread, is_multi_threaded, MainThreadMarker};
 
-mod array;
+#[macro_use]
+mod iter;
+pub mod array;
 mod attributed_string;
 mod bundle;
 mod comparison_result;
 mod data;
-mod dictionary;
-mod enumerator;
+pub mod dictionary;
+pub mod enumerator;
 mod error;
 mod exception;
 mod geometry;
 mod number;
 mod process_info;
 mod range;
-mod set;
+pub mod set;
 mod string;
 mod thread;
 mod util;

--- a/crates/icrate/src/Foundation/additions/set.rs
+++ b/crates/icrate/src/Foundation/additions/set.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
 use objc2::mutability::IsRetainable;
+use objc2::rc::IdFromIterator;
 
 use super::iter;
 use super::util;
@@ -515,5 +516,35 @@ impl<'a, T: IsRetainable + PartialEq> Extend<&'a T> for NSMutableSet<T> {
         // set to retain the object here.
         iter.into_iter()
             .for_each(move |item| unsafe { self.addObject(item) })
+    }
+}
+
+impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSSet<T> {
+    fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_slice(&vec)
+    }
+}
+
+impl<T: Message> IdFromIterator<Id<T>> for NSSet<T> {
+    fn id_from_iter<I: IntoIterator<Item = Id<T>>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
+    }
+}
+
+#[cfg(feature = "Foundation_NSMutableSet")]
+impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSMutableSet<T> {
+    fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_slice(&vec)
+    }
+}
+
+#[cfg(feature = "Foundation_NSMutableSet")]
+impl<T: Message> IdFromIterator<Id<T>> for NSMutableSet<T> {
+    fn id_from_iter<I: IntoIterator<Item = Id<T>>>(iter: I) -> Id<Self> {
+        let vec = Vec::from_iter(iter);
+        Self::from_vec(vec)
     }
 }

--- a/crates/icrate/src/Foundation/additions/util.rs
+++ b/crates/icrate/src/Foundation/additions/util.rs
@@ -65,6 +65,7 @@ pub(crate) fn id_ptr_cast_const<T: ?Sized>(objects: *const Id<T>) -> *mut NonNul
 /// # Safety
 ///
 /// The object must be stored inside a collection.
+#[inline]
 pub(crate) unsafe fn collection_retain_id<T>(obj: &T) -> Id<T>
 where
     T: IsIdCloneable,
@@ -85,6 +86,7 @@ where
 //
 // TODO: Take a pointer here to avoid assuming `T` is immutable - this only
 // works now because `T` is usually `UnsafeCell` anyway.
+#[inline]
 pub(crate) unsafe fn mutable_collection_retain_removed_id<T>(obj: &T) -> Id<T>
 where
     T: Message,

--- a/crates/icrate/src/Foundation/fixes/enumerator.rs
+++ b/crates/icrate/src/Foundation/fixes/enumerator.rs
@@ -1,0 +1,24 @@
+use objc2::encode::Encoding;
+
+use crate::common::*;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NSFastEnumerationState {
+    pub state: c_ulong,
+    pub itemsPtr: *mut *mut Object,
+    pub mutationsPtr: *mut c_ulong,
+    pub extra: [c_ulong; 5],
+}
+
+impl_encode! {
+    NSFastEnumerationState = Encoding::Struct(
+        "?",
+        &[
+            Encoding::C_ULONG,
+            Encoding::Pointer(&Encoding::Object),
+            Encoding::Pointer(&Encoding::C_ULONG),
+            Encoding::Array(5, &Encoding::C_ULONG),
+        ],
+    );
+}

--- a/crates/icrate/src/Foundation/fixes/generics.rs
+++ b/crates/icrate/src/Foundation/fixes/generics.rs
@@ -295,3 +295,36 @@ __inner_extern_class!(
         }
     }
 );
+
+__inner_extern_class!(
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    #[cfg(feature = "Foundation_NSEnumerator")]
+    pub struct NSEnumerator<ObjectType: Message = Object> {
+        // SAFETY: Auto traits specified below.
+        __superclass: UnsafeIgnoreAutoTraits<NSObject>,
+        // Enumerators are basically the same as if we were just storing
+        // `NSMutableArray<ObjectType>`, and removed an element from that on
+        // each iteration.
+        //
+        // This is only true because everything in this file has that type of
+        // ownership; if something didn't, and instead had e.g. `Arc<T>`-like
+        // ownership, we'd have to modify the ownership of enumerators to
+        // match with that (if we wanted to safely use enumerators returned by
+        // that type).
+        __inner: PhantomData<Id<ObjectType>>,
+    }
+
+    #[cfg(feature = "Foundation_NSEnumerator")]
+    unsafe impl<ObjectType: Message> ClassType for NSEnumerator<ObjectType> {
+        type Super = NSObject;
+        type Mutability = Mutable;
+
+        fn as_super(&self) -> &Self::Super {
+            &self.__superclass.0
+        }
+
+        fn as_super_mut(&mut self) -> &mut Self::Super {
+            &mut self.__superclass.0
+        }
+    }
+);

--- a/crates/icrate/src/Foundation/fixes/mod.rs
+++ b/crates/icrate/src/Foundation/fixes/mod.rs
@@ -5,6 +5,7 @@ mod __NSDecimal;
 mod __NSNotFound;
 mod copy;
 mod debug;
+mod enumerator;
 mod exception;
 mod generics;
 mod gnustep;
@@ -12,6 +13,7 @@ mod ns_consumed;
 
 pub use self::__NSDecimal::NSDecimal;
 pub use self::__NSNotFound::NSNotFound;
+pub use self::enumerator::NSFastEnumerationState;
 pub use self::generics::*;
 #[cfg(feature = "Foundation_NSMapTable")]
 pub use self::ns_consumed::NSFreeMapTable;

--- a/crates/icrate/tests/data.rs
+++ b/crates/icrate/tests/data.rs
@@ -31,3 +31,11 @@ fn test_debug() {
     let data = NSData::with_bytes(&bytes);
     assert_eq!(format!("{data:?}"), "[3, 7, 16, 52, 112, 19]");
 }
+
+#[cfg(feature = "block")]
+#[test]
+fn test_collect() {
+    let bytes = [3, 7, 16, 52, 112, 19];
+    let data: objc2::rc::Id<NSData> = bytes.into_iter().collect();
+    assert_eq!(format!("{data:?}"), "[3, 7, 16, 52, 112, 19]");
+}

--- a/crates/icrate/tests/dictionary.rs
+++ b/crates/icrate/tests/dictionary.rs
@@ -30,7 +30,7 @@ fn test_get() {
 #[test]
 fn test_keys() {
     let dict = sample_dict("abcd");
-    let keys = dict.keys();
+    let keys = dict.keys_vec();
 
     assert_eq!(keys.len(), 1);
     autoreleasepool(|pool| {
@@ -41,7 +41,7 @@ fn test_keys() {
 #[test]
 fn test_values() {
     let dict = sample_dict("abcd");
-    let vals = dict.values();
+    let vals = dict.values_vec();
 
     assert_eq!(vals.len(), 1);
 }
@@ -49,7 +49,7 @@ fn test_values() {
 #[test]
 fn test_keys_and_objects() {
     let dict = sample_dict("abcd");
-    let (keys, objs) = dict.keys_and_objects();
+    let (keys, objs) = dict.to_vecs();
 
     assert_eq!(keys.len(), 1);
     assert_eq!(objs.len(), 1);
@@ -63,9 +63,9 @@ fn test_keys_and_objects() {
 #[cfg(feature = "Foundation_NSEnumerator")]
 fn test_iter_keys() {
     let dict = sample_dict("abcd");
-    assert_eq!(dict.iter_keys().count(), 1);
+    assert_eq!(dict.keys().count(), 1);
     autoreleasepool(|pool| {
-        assert_eq!(dict.iter_keys().next().unwrap().as_str(pool), "abcd");
+        assert_eq!(dict.keys().next().unwrap().as_str(pool), "abcd");
     });
 }
 
@@ -73,7 +73,7 @@ fn test_iter_keys() {
 #[cfg(feature = "Foundation_NSEnumerator")]
 fn test_iter_values() {
     let dict = sample_dict("abcd");
-    assert_eq!(dict.iter_values().count(), 1);
+    assert_eq!(dict.values().count(), 1);
 }
 
 #[test]
@@ -92,7 +92,6 @@ fn test_arrays() {
 }
 
 #[test]
-#[cfg(feature = "Foundation_NSEnumerator")]
 fn test_debug() {
     let key = NSString::from_str("a");
     let val = NSString::from_str("b");

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `extern_protocol!` and `extern_methods!`.
 * Allow arbitary expressions in `const NAME` in `extern_class!`,
   `extern_protocol!` and `declare_class!`.
+* Added `rc::IdIntoIterator` helper trait and forwarding `IntoIterator`
+  implementations for `rc::Id`.
 
 ### Changed
 * **BREAKING**: `objc2::rc::AutoreleasePool` is now a zero-sized `Copy` type
@@ -102,6 +104,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Removed `impl<T> TryFrom<WeakId<T>> for Id<T>` impl since it
   did not have a proper error type, making it less useful than just using
   `WeakId::load`.
+* **BREAKING**: Removed forwarding `Iterator` implementation for `Id`, since
+  it conflicts with the `IntoIterator` implementation that it now has instead.
 
 
 ## 0.3.0-beta.5 - 2023-02-07

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `extern_protocol!` and `declare_class!`.
 * Added `rc::IdIntoIterator` helper trait and forwarding `IntoIterator`
   implementations for `rc::Id`.
+* Added `rc::IdFromIterator` helper trait for implementing `IntoIterator`
+  for `rc::Id`.
 
 ### Changed
 * **BREAKING**: `objc2::rc::AutoreleasePool` is now a zero-sized `Copy` type

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -56,13 +56,15 @@ use crate::{ffi, ClassType, Message};
 /// live on the stack, but instead must reside on the heap).
 ///
 /// Note that because of current limitations in the Rust trait system, some
-/// traits like [`Default`] and [`IntoIterator`] are not directly
-/// implementable on `NSString`; for that ues-case, we provide the
-/// [`DefaultId`] and [`IdIntoIterator`] traits, which make the aforementioned
-/// traits available on `Id`.
+/// traits like [`Default`], [`IntoIterator`], [`FromIterator`], [`From`] and
+/// [`Into`] are not directly implementable on `NSString`; for that use-case,
+/// we instead provide the [`DefaultId`], [`IdIntoIterator`] and
+/// [`IdFromIterator`] traits, which make some of the the aforementioned
+/// traits implementable on `Id`.
 ///
-/// [`IdIntoIterator`]: crate::rc::IdIntoIterator
 /// [`DefaultId`]: crate::rc::DefaultId
+/// [`IdIntoIterator`]: crate::rc::IdIntoIterator
+/// [`IdFromIterator`]: crate::rc::IdFromIterator
 ///
 ///
 /// # Memory layout

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -44,6 +44,27 @@ use crate::{ffi, ClassType, Message};
 /// [`Box`]: alloc::boxed::Box
 ///
 ///
+/// # Forwarding implementations
+///
+/// Since `Id<T>` is a smart pointer, it naturally [`Deref`]s to `T`, and
+/// similarly implements [`DerefMut`] when mutable.
+///
+/// On top of this, it also forwards the implementation of a bunch of standard
+/// library traits such as [`PartialEq`], [`AsRef`], and so on, so that it
+/// becomes easy to use e.g. `Id<NSString>` as if it was just an `NSString`.
+/// (Having just `NSString` is not possible since Objective-C objects cannot
+/// live on the stack, but instead must reside on the heap).
+///
+/// Note that because of current limitations in the Rust trait system, some
+/// traits like [`Default`] and [`IntoIterator`] are not directly
+/// implementable on `NSString`; for that ues-case, we provide the
+/// [`DefaultId`] and [`IdIntoIterator`] traits, which make the aforementioned
+/// traits available on `Id`.
+///
+/// [`IdIntoIterator`]: crate::rc::IdIntoIterator
+/// [`DefaultId`]: crate::rc::DefaultId
+///
+///
 /// # Memory layout
 ///
 /// This is guaranteed to have the same size and alignment as a pointer to the

--- a/crates/objc2/src/rc/id_forwarding_impls.rs
+++ b/crates/objc2/src/rc/id_forwarding_impls.rs
@@ -13,7 +13,6 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::future::Future;
 use core::hash;
-use core::iter::FusedIterator;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll};
@@ -130,49 +129,6 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for Id<T> {
         (**self).fmt(f)
     }
 }
-
-impl<I: Iterator + ?Sized + IsMutable> Iterator for Id<I> {
-    type Item = I::Item;
-    fn next(&mut self) -> Option<I::Item> {
-        (**self).next()
-    }
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (**self).size_hint()
-    }
-    fn nth(&mut self, n: usize) -> Option<I::Item> {
-        (**self).nth(n)
-    }
-}
-
-impl<I: DoubleEndedIterator + ?Sized + IsMutable> DoubleEndedIterator for Id<I> {
-    fn next_back(&mut self) -> Option<I::Item> {
-        (**self).next_back()
-    }
-    fn nth_back(&mut self, n: usize) -> Option<I::Item> {
-        (**self).nth_back(n)
-    }
-}
-
-impl<I: ExactSizeIterator + ?Sized + IsMutable> ExactSizeIterator for Id<I> {
-    fn len(&self) -> usize {
-        (**self).len()
-    }
-}
-
-impl<I: FusedIterator + ?Sized + IsMutable> FusedIterator for Id<I> {}
-
-// TODO: Consider this impl
-// impl<'a, T> IntoIterator for &'a Id<T>
-// where
-//     &'a T: IntoIterator,
-// {
-//     type Item = <&'a T as IntoIterator>::Item;
-//     type IntoIter = <&'a T as IntoIterator>::IntoIter;
-//
-//     fn into_iter(self) -> Self::IntoIter {
-//         (**self).into_iter()
-//     }
-// }
 
 impl<T: ?Sized> borrow::Borrow<T> for Id<T> {
     fn borrow(&self) -> &T {

--- a/crates/objc2/src/rc/id_traits.rs
+++ b/crates/objc2/src/rc/id_traits.rs
@@ -1,7 +1,7 @@
 //! Helper traits for Id.
 
 use super::Id;
-use crate::mutability::IsAllocableAnyThread;
+use crate::mutability::{IsAllocableAnyThread, IsMutable};
 
 /// Helper trait to implement [`Default`] on [`Id`].
 // TODO: Maybe make this `unsafe` and provide a default implementation?
@@ -17,5 +17,194 @@ impl<T: ?Sized + DefaultId> Default for Id<T> {
     #[inline]
     fn default() -> Self {
         T::default_id()
+    }
+}
+
+/// Helper trait to implement [`IntoIterator`] on [`Id`].
+///
+/// This should be implemented in exactly the same fashion as if you were
+/// implementing `IntoIterator` for your type normally.
+//
+// Note that [`Box<T>` gets to cheat with regards moves][box-move], so
+// `boxed.into_iter()` is possible, while `id.into_iter()` is not possible
+// without this helper trait.
+//
+// [box-move]: https://doc.rust-lang.org/reference/expressions.html#moved-and-copied-types
+pub trait IdIntoIterator {
+    /// The type of the elements being iterated over.
+    type Item;
+
+    /// Which kind of iterator are we turning this into?
+    type IntoIter: Iterator<Item = Self::Item>;
+
+    /// Creates an iterator from an [`Id`].
+    ///
+    /// You would normally not call this function directly; instead, you'd
+    /// just call [`into_iter`](IntoIterator::into_iter) on an [`Id`].
+    fn id_into_iter(this: Id<Self>) -> Self::IntoIter;
+}
+
+// Note: These `IntoIterator` implementations conflict with an `Iterator`
+// implementation for `Id`.
+//
+// For our case however (in contrast with `Box`), that is the better tradeoff,
+// which I will show with an example:
+//
+// ```
+// let xs = Box::new(vec![]);
+// for x in &xs { // Doesn't compile, `&Box` doesn't implement `IntoIterator`
+//     // ...
+// }
+// ```
+//
+// Here, you're expected to write `xs.iter()` or `&**xs` instead, which is
+// fairly acceptable, since usually people don't wrap things in boxes so much;
+// but in Objective-C, _everything_ is wrapped in an `Id`, and hence we should
+// attempt to make that common case easier:
+//
+// ```
+// let obj = NSArray::new(); // `Id<NSArray<_>>`
+// for item in &obj { // Should compile
+//     // ...
+// }
+// ```
+//
+// The loss of the `Iterator` impl is a bit unfortunate, but not a big deal,
+// since there is only one iterator in Objective-C anyhow, `NSEnumerator`, and
+// for that we can make other abstractions instead.
+impl<T: ?Sized + IdIntoIterator> IntoIterator for Id<T> {
+    type Item = <T as IdIntoIterator>::Item;
+    type IntoIter = <T as IdIntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        T::id_into_iter(self)
+    }
+}
+
+impl<'a, T: ?Sized> IntoIterator for &'a Id<T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        (&**self).into_iter()
+    }
+}
+
+impl<'a, T: ?Sized + IsMutable> IntoIterator for &'a mut Id<T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        (&mut **self).into_iter()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutability::Mutable;
+    use crate::runtime::NSObject;
+    use crate::{declare_class, msg_send_id, ClassType};
+
+    declare_class!(
+        #[derive(PartialEq, Eq, Hash, Debug)]
+        struct Collection;
+
+        unsafe impl ClassType for Collection {
+            type Super = NSObject;
+            type Mutability = Mutable;
+            const NAME: &'static str = "MyCustomCollection";
+        }
+    );
+
+    impl DefaultId for Collection {
+        fn default_id() -> Id<Self> {
+            unsafe { msg_send_id![Collection::class(), new] }
+        }
+    }
+
+    struct Iter<'a>(&'a Collection);
+
+    impl<'a> Iterator for Iter<'a> {
+        type Item = &'a NSObject;
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl<'a> IntoIterator for &'a Collection {
+        type Item = &'a NSObject;
+        type IntoIter = Iter<'a>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            Iter(self)
+        }
+    }
+
+    struct IterMut<'a>(&'a mut Collection);
+
+    impl<'a> Iterator for IterMut<'a> {
+        type Item = &'a mut NSObject;
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl<'a> IntoIterator for &'a mut Collection {
+        // Usually only valid if a mutable object is stored in the collection.
+        type Item = &'a mut NSObject;
+        type IntoIter = IterMut<'a>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            IterMut(self)
+        }
+    }
+
+    struct IntoIter(Id<Collection>);
+
+    impl Iterator for IntoIter {
+        type Item = Id<NSObject>;
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl<'a> IntoIterator for Id<Collection> {
+        type Item = Id<NSObject>;
+        type IntoIter = IntoIter;
+
+        fn into_iter(self) -> Self::IntoIter {
+            IntoIter(self)
+        }
+    }
+
+    #[test]
+    fn test_default() {
+        let obj1: Id<Collection> = Default::default();
+        let obj2 = Collection::default_id();
+        assert_ne!(obj1, obj2);
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let mut obj: Id<Collection> = Default::default();
+
+        for _ in &*obj {}
+        for _ in &obj {}
+
+        for _ in &mut *obj {}
+        for _ in &mut obj {}
+
+        for _ in obj {}
     }
 }

--- a/crates/objc2/src/rc/id_traits.rs
+++ b/crates/objc2/src/rc/id_traits.rs
@@ -231,7 +231,6 @@ mod tests {
         for _ in obj {}
     }
 
-
     #[test]
     fn test_from_iter() {
         let _: Id<Collection> = [NSObject::new()].into_iter().collect();

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -62,6 +62,6 @@ pub use self::autorelease::{
     autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
 };
 pub use self::id::Id;
-pub use self::id_traits::{DefaultId, IdIntoIterator};
+pub use self::id_traits::{DefaultId, IdIntoIterator, IdFromIterator};
 pub use self::test_object::{__RcTestObject, __ThreadTestData};
 pub use self::weak_id::WeakId;

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -62,6 +62,6 @@ pub use self::autorelease::{
     autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
 };
 pub use self::id::Id;
-pub use self::id_traits::DefaultId;
+pub use self::id_traits::{DefaultId, IdIntoIterator};
 pub use self::test_object::{__RcTestObject, __ThreadTestData};
 pub use self::weak_id::WeakId;

--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -62,6 +62,6 @@ pub use self::autorelease::{
     autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
 };
 pub use self::id::Id;
-pub use self::id_traits::{DefaultId, IdIntoIterator, IdFromIterator};
+pub use self::id_traits::{DefaultId, IdFromIterator, IdIntoIterator};
 pub use self::test_object::{__RcTestObject, __ThreadTestData};
 pub use self::weak_id::WeakId;

--- a/crates/test-assembly/crates/test_fast_enumeration/Cargo.toml
+++ b/crates/test-assembly/crates/test_fast_enumeration/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "test_fast_enumeration"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+objc2 = { path = "../../../objc2", default-features = false, optional = true }
+icrate = { path = "../../../icrate", default-features = false, optional = true }
+
+[features]
+default = ["apple", "std", "icrate", "objc2", "Foundation", "Foundation_NSArray"]
+std = ["icrate?/std"]
+
+# Runtime
+apple = ["icrate?/apple"]
+gnustep-1-7 = ["icrate?/gnustep-1-7"]
+gnustep-1-8 = ["gnustep-1-7", "icrate?/gnustep-1-8"]
+gnustep-1-9 = ["gnustep-1-8", "icrate?/gnustep-1-9"]
+gnustep-2-0 = ["gnustep-1-9", "icrate?/gnustep-2-0"]
+gnustep-2-1 = ["gnustep-2-0", "icrate?/gnustep-2-1"]
+
+Foundation = ["icrate/Foundation"]
+Foundation_NSArray = ["icrate/Foundation_NSArray"]
+
+# Hack
+assembly-features = ["Foundation", "Foundation_NSArray", "objc2"] # "objc2?/unstable-static-sel-inlined"

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
@@ -1,0 +1,307 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.globl	_iter_create
+	.p2align	2
+_iter_create:
+	stp	xzr, xzr, [x8, #192]
+	movi.2d	v0, #0000000000000000
+	stp	q0, q0, [x8, #160]
+	stur	q0, [x8, #8]
+	stur	q0, [x8, #24]
+	stur	q0, [x8, #40]
+	stur	q0, [x8, #56]
+	stur	q0, [x8, #72]
+	stur	q0, [x8, #88]
+	stur	q0, [x8, #104]
+	stur	q0, [x8, #120]
+	str	x0, [x8]
+	stp	xzr, xzr, [x8, #144]
+	str	xzr, [x8, #136]
+	str	xzr, [x8, #208]
+	ret
+
+	.globl	_iter_once
+	.p2align	2
+_iter_once:
+	stp	x24, x23, [sp, #-64]!
+	stp	x22, x21, [sp, #16]
+	stp	x20, x19, [sp, #32]
+	stp	x29, x30, [sp, #48]
+	add	x29, sp, #48
+	mov	x19, x0
+	ldp	x8, x9, [x0, #200]
+	cmp	x8, x9
+	b.lo	LBB1_4
+	add	x20, x19, #8
+	ldr	x21, [x19]
+	add	x22, x19, #136
+Lloh0:
+	adrp	x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+Lloh1:
+	ldr	x23, [x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x1, [x23]
+	cbnz	x1, LBB1_3
+Lloh2:
+	adrp	x0, l_anon.[ID].0@PAGE
+Lloh3:
+	add	x0, x0, l_anon.[ID].0@PAGEOFF
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	x1, x0
+	str	x0, [x23]
+LBB1_3:
+	mov	x0, x21
+	mov	x2, x22
+	mov	x3, x20
+	mov	w4, #16
+	bl	_objc_msgSend
+	mov	x8, #0
+	stp	xzr, x0, [x19, #200]
+	cbz	x0, LBB1_5
+LBB1_4:
+	ldr	x9, [x19, #144]
+	add	x10, x8, #1
+	str	x10, [x19, #200]
+	ldr	x0, [x9, x8, lsl #3]
+LBB1_5:
+	ldp	x29, x30, [sp, #48]
+	ldp	x20, x19, [sp, #32]
+	ldp	x22, x21, [sp, #16]
+	ldp	x24, x23, [sp], #64
+	ret
+	.loh AdrpLdrGot	Lloh0, Lloh1
+	.loh AdrpAdd	Lloh2, Lloh3
+
+	.globl	_use_obj
+	.p2align	2
+_use_obj:
+	sub	sp, sp, #16
+	str	x0, [sp, #8]
+	add	x8, sp, #8
+	; InlineAsm Start
+	; InlineAsm End
+	add	sp, sp, #16
+	ret
+
+	.globl	_iter
+	.p2align	2
+_iter:
+	sub	sp, sp, #288
+	stp	x24, x23, [sp, #224]
+	stp	x22, x21, [sp, #240]
+	stp	x20, x19, [sp, #256]
+	stp	x29, x30, [sp, #272]
+	add	x29, sp, #272
+	mov	x21, x0
+	mov	x9, #0
+	mov	x8, #0
+	stp	xzr, xzr, [sp, #200]
+	movi.2d	v0, #0000000000000000
+	stur	q0, [sp, #184]
+	stur	q0, [sp, #168]
+	add	x10, sp, #8
+	add	x19, x10, #8
+	stp	q0, q0, [sp, #16]
+	stp	q0, q0, [sp, #48]
+	stp	q0, q0, [sp, #80]
+	stp	q0, q0, [sp, #112]
+	str	x0, [sp, #8]
+	add	x20, x10, #136
+	stp	xzr, xzr, [sp, #152]
+	str	xzr, [sp, #144]
+	str	xzr, [sp, #216]
+Lloh4:
+	adrp	x22, l_anon.[ID].0@PAGE
+Lloh5:
+	add	x22, x22, l_anon.[ID].0@PAGEOFF
+Lloh6:
+	adrp	x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+Lloh7:
+	ldr	x23, [x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	b	LBB3_2
+LBB3_1:
+	ldr	x9, [sp, #152]
+	add	x10, x8, #1
+	str	x10, [sp, #208]
+	ldr	x0, [x9, x8, lsl #3]
+	bl	_use_obj
+	ldr	x21, [sp, #8]
+	ldp	x8, x9, [sp, #208]
+LBB3_2:
+	cmp	x8, x9
+	b.lo	LBB3_1
+	ldr	x1, [x23]
+	cbnz	x1, LBB3_5
+	mov	x0, x22
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	x1, x0
+	str	x0, [x23]
+LBB3_5:
+	mov	x0, x21
+	mov	x2, x20
+	mov	x3, x19
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbz	x0, LBB3_7
+	mov	x8, #0
+	b	LBB3_1
+LBB3_7:
+	ldp	x29, x30, [sp, #272]
+	ldp	x20, x19, [sp, #256]
+	ldp	x22, x21, [sp, #240]
+	ldp	x24, x23, [sp, #224]
+	add	sp, sp, #288
+	ret
+	.loh AdrpLdrGot	Lloh6, Lloh7
+	.loh AdrpAdd	Lloh4, Lloh5
+
+	.globl	_iter_noop
+	.p2align	2
+_iter_noop:
+	sub	sp, sp, #288
+	stp	x24, x23, [sp, #224]
+	stp	x22, x21, [sp, #240]
+	stp	x20, x19, [sp, #256]
+	stp	x29, x30, [sp, #272]
+	add	x29, sp, #272
+	mov	x20, x0
+	mov	x0, #0
+	mov	x8, #0
+	stp	xzr, xzr, [sp, #200]
+	movi.2d	v0, #0000000000000000
+	stur	q0, [sp, #184]
+	stur	q0, [sp, #168]
+	add	x9, sp, #8
+	add	x19, x9, #8
+	stp	q0, q0, [sp, #16]
+	stp	q0, q0, [sp, #48]
+	stp	q0, q0, [sp, #80]
+	stp	q0, q0, [sp, #112]
+	str	x20, [sp, #8]
+	add	x21, x9, #136
+	stp	xzr, xzr, [sp, #152]
+	str	xzr, [sp, #144]
+	str	xzr, [sp, #216]
+Lloh8:
+	adrp	x22, l_anon.[ID].0@PAGE
+Lloh9:
+	add	x22, x22, l_anon.[ID].0@PAGEOFF
+Lloh10:
+	adrp	x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+Lloh11:
+	ldr	x23, [x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	b	LBB4_2
+LBB4_1:
+	add	x8, x8, #1
+	str	x8, [sp, #208]
+LBB4_2:
+	cmp	x8, x0
+	b.lo	LBB4_1
+	ldr	x1, [x23]
+	cbnz	x1, LBB4_5
+	mov	x0, x22
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	x1, x0
+	str	x0, [x23]
+LBB4_5:
+	mov	x0, x20
+	mov	x2, x21
+	mov	x3, x19
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbz	x0, LBB4_7
+	mov	x8, #0
+	ldr	x20, [sp, #8]
+	b	LBB4_1
+LBB4_7:
+	ldp	x29, x30, [sp, #272]
+	ldp	x20, x19, [sp, #256]
+	ldp	x22, x21, [sp, #240]
+	ldp	x24, x23, [sp, #224]
+	add	sp, sp, #288
+	ret
+	.loh AdrpLdrGot	Lloh10, Lloh11
+	.loh AdrpAdd	Lloh8, Lloh9
+
+	.globl	_iter_retained
+	.p2align	2
+_iter_retained:
+	sub	sp, sp, #288
+	stp	x24, x23, [sp, #224]
+	stp	x22, x21, [sp, #240]
+	stp	x20, x19, [sp, #256]
+	stp	x29, x30, [sp, #272]
+	add	x29, sp, #272
+	mov	x22, x0
+	mov	x9, #0
+	mov	x8, #0
+	stp	xzr, xzr, [sp, #200]
+	movi.2d	v0, #0000000000000000
+	stur	q0, [sp, #184]
+	stur	q0, [sp, #168]
+	add	x10, sp, #8
+	add	x19, x10, #8
+	stp	q0, q0, [sp, #16]
+	stp	q0, q0, [sp, #48]
+	stp	q0, q0, [sp, #80]
+	stp	q0, q0, [sp, #112]
+	str	x0, [sp, #8]
+	add	x20, x10, #136
+	stp	xzr, xzr, [sp, #152]
+	str	xzr, [sp, #144]
+	str	xzr, [sp, #216]
+Lloh12:
+	adrp	x21, l_anon.[ID].0@PAGE
+Lloh13:
+	add	x21, x21, l_anon.[ID].0@PAGEOFF
+Lloh14:
+	adrp	x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+Lloh15:
+	ldr	x23, [x23, SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	b	LBB5_2
+LBB5_1:
+	ldr	x9, [sp, #152]
+	add	x10, x8, #1
+	str	x10, [sp, #208]
+	ldr	x0, [x9, x8, lsl #3]
+	bl	_objc_retain
+	mov	x22, x0
+	bl	_use_obj
+	mov	x0, x22
+	bl	_objc_release
+	ldr	x22, [sp, #8]
+	ldp	x8, x9, [sp, #208]
+LBB5_2:
+	cmp	x8, x9
+	b.lo	LBB5_1
+	ldr	x1, [x23]
+	cbnz	x1, LBB5_5
+	mov	x0, x21
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	x1, x0
+	str	x0, [x23]
+LBB5_5:
+	mov	x0, x22
+	mov	x2, x20
+	mov	x3, x19
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbz	x0, LBB5_7
+	mov	x8, #0
+	b	LBB5_1
+LBB5_7:
+	ldp	x29, x30, [sp, #272]
+	ldp	x20, x19, [sp, #256]
+	ldp	x22, x21, [sp, #240]
+	ldp	x24, x23, [sp, #224]
+	add	sp, sp, #288
+	ret
+	.loh AdrpLdrGot	Lloh14, Lloh15
+	.loh AdrpAdd	Lloh12, Lloh13
+
+	.section	__TEXT,__const
+l_anon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+
+.subsections_via_symbols

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7.s
@@ -1,0 +1,319 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.syntax unified
+	.globl	_iter_create
+	.p2align	2
+	.code	32
+_iter_create:
+	vmov.i32	q8, #0x0
+	mov	r2, #0
+	str	r1, [r0]
+	add	r1, r0, #80
+	str	r2, [r0, #100]
+	str	r2, [r0, #104]
+	str	r2, [r0, #72]
+	str	r2, [r0, #76]
+	add	r0, r0, #4
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r0]!
+	str	r2, [r1]
+	str	r2, [r0]
+	bx	lr
+
+	.globl	_iter_once
+	.p2align	2
+	.code	32
+_iter_once:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10}
+	sub	sp, sp, #4
+	mov	r4, r0
+	ldrd	r0, r1, [r0, #100]
+	cmp	r0, r1
+	blo	LBB1_4
+	ldr	r6, [r4]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC1_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC1_0+8))
+	add	r8, r4, #4
+LPC1_0:
+	ldr	r10, [pc, r10]
+	add	r5, r4, #68
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB1_3
+	movw	r0, :lower16:(l_anon.[ID].0-(LPC1_1+8))
+	movt	r0, :upper16:(l_anon.[ID].0-(LPC1_1+8))
+LPC1_1:
+	add	r0, pc, r0
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+LBB1_3:
+	mov	r0, #16
+	mov	r2, r5
+	str	r0, [sp]
+	mov	r0, r6
+	mov	r3, r8
+	bl	_objc_msgSend
+	mov	r1, r0
+	mov	r0, #0
+	cmp	r1, #0
+	strd	r0, r1, [r4, #100]
+	beq	LBB1_5
+LBB1_4:
+	ldr	r1, [r4, #72]
+	add	r2, r0, #1
+	str	r2, [r4, #100]
+	ldr	r0, [r1, r0, lsl #2]
+LBB1_5:
+	sub	sp, r7, #20
+	pop	{r8, r10}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_use_obj
+	.p2align	2
+	.code	32
+_use_obj:
+	sub	sp, sp, #4
+	str	r0, [sp]
+	mov	r0, sp
+	@ InlineAsm Start
+	@ InlineAsm End
+	add	sp, sp, #4
+	bx	lr
+
+	.globl	_iter
+	.p2align	2
+	.code	32
+_iter:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r6, r0
+	mov	r0, #0
+	mov	r5, r4
+	vst1.64	{d16, d17}, [r2]!
+	mov	r11, #16
+	mov	r1, #0
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC3_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC3_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC3_1+8))
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC3_1+8))
+LPC3_0:
+	ldr	r10, [pc, r10]
+LPC3_1:
+	add	r8, pc, r8
+	b	LBB3_3
+LBB3_1:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	mov	r1, #0
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB3_6
+LBB3_2:
+	ldr	r0, [sp, #80]
+	add	r2, r1, #1
+	str	r2, [sp, #108]
+	ldr	r0, [r0, r1, lsl #2]
+	bl	_use_obj
+	ldr	r6, [sp, #8]
+	ldr	r1, [sp, #108]
+	ldr	r0, [sp, #112]
+LBB3_3:
+	cmp	r1, r0
+	blo	LBB3_2
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB3_1
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+	b	LBB3_1
+LBB3_6:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_iter_noop
+	.p2align	2
+	.code	32
+_iter_noop:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r6, r0
+	mov	r0, #0
+	mov	r5, r4
+	vst1.64	{d16, d17}, [r2]!
+	mov	r11, #16
+	mov	r1, #0
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC4_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC4_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC4_1+8))
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC4_1+8))
+LPC4_0:
+	ldr	r10, [pc, r10]
+LPC4_1:
+	add	r8, pc, r8
+	b	LBB4_2
+LBB4_1:
+	add	r1, r1, #1
+	str	r1, [sp, #108]
+LBB4_2:
+	cmp	r1, r0
+	blo	LBB4_1
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB4_5
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+LBB4_5:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB4_7
+	ldr	r6, [sp, #8]
+	mov	r1, #0
+	b	LBB4_1
+LBB4_7:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_iter_retained
+	.p2align	2
+	.code	32
+_iter_retained:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r6, r0
+	mov	r0, #0
+	mov	r5, r4
+	vst1.64	{d16, d17}, [r2]!
+	mov	r11, #16
+	mov	r1, #0
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC5_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr-(LPC5_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC5_1+8))
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC5_1+8))
+LPC5_0:
+	ldr	r10, [pc, r10]
+LPC5_1:
+	add	r8, pc, r8
+	b	LBB5_3
+LBB5_1:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	mov	r1, #0
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB5_6
+LBB5_2:
+	ldr	r0, [sp, #80]
+	add	r2, r1, #1
+	str	r2, [sp, #108]
+	ldr	r0, [r0, r1, lsl #2]
+	bl	_objc_retain
+	mov	r6, r0
+	bl	_use_obj
+	mov	r0, r6
+	bl	_objc_release
+	ldr	r6, [sp, #8]
+	ldr	r1, [sp, #108]
+	ldr	r0, [sp, #112]
+LBB5_3:
+	cmp	r1, r0
+	blo	LBB5_2
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB5_1
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+	b	LBB5_1
+LBB5_6:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.section	__TEXT,__const
+l_anon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2, 0x0
+L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h37ea10daa3c347f7E$non_lazy_ptr:
+	.indirect_symbol	SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)
+	.long	0
+
+.subsections_via_symbols

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
@@ -1,0 +1,319 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.syntax unified
+	.globl	_iter_create
+	.p2align	2
+	.code	32
+_iter_create:
+	vmov.i32	q8, #0x0
+	mov	r2, #0
+	str	r1, [r0]
+	add	r1, r0, #80
+	str	r2, [r0, #100]
+	str	r2, [r0, #104]
+	str	r2, [r0, #72]
+	str	r2, [r0, #76]
+	add	r0, r0, #4
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r0]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r0]!
+	str	r2, [r1]
+	str	r2, [r0]
+	bx	lr
+
+	.globl	_iter_once
+	.p2align	2
+	.code	32
+_iter_once:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10}
+	sub	sp, sp, #4
+	mov	r4, r0
+	ldrd	r0, r1, [r0, #100]
+	cmp	r0, r1
+	blo	LBB1_4
+	ldr	r6, [r4]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC1_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC1_0+8))
+	add	r8, r4, #4
+LPC1_0:
+	ldr	r10, [pc, r10]
+	add	r5, r4, #68
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB1_3
+	movw	r0, :lower16:(l_anon.[ID].0-(LPC1_1+8))
+	movt	r0, :upper16:(l_anon.[ID].0-(LPC1_1+8))
+LPC1_1:
+	add	r0, pc, r0
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+LBB1_3:
+	mov	r0, #16
+	mov	r2, r5
+	str	r0, [sp]
+	mov	r0, r6
+	mov	r3, r8
+	bl	_objc_msgSend
+	mov	r1, r0
+	mov	r0, #0
+	cmp	r1, #0
+	strd	r0, r1, [r4, #100]
+	beq	LBB1_5
+LBB1_4:
+	ldr	r1, [r4, #72]
+	add	r2, r0, #1
+	str	r2, [r4, #100]
+	ldr	r0, [r1, r0, lsl #2]
+LBB1_5:
+	sub	sp, r7, #20
+	pop	{r8, r10}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_use_obj
+	.p2align	2
+	.code	32
+_use_obj:
+	sub	sp, sp, #4
+	str	r0, [sp]
+	mov	r0, sp
+	@ InlineAsm Start
+	@ InlineAsm End
+	add	sp, sp, #4
+	bx	lr
+
+	.globl	_iter
+	.p2align	2
+	.code	32
+_iter:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r5, r4
+	mov	r6, r0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r0, #0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r11, #16
+	vst1.32	{d16, d17}, [r5]!
+	mov	r1, #0
+	vst1.64	{d16, d17}, [r2]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC3_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC3_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC3_1+8))
+LPC3_0:
+	ldr	r10, [pc, r10]
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC3_1+8))
+LPC3_1:
+	add	r8, pc, r8
+	b	LBB3_3
+LBB3_1:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	mov	r1, #0
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB3_6
+LBB3_2:
+	ldr	r0, [sp, #80]
+	add	r2, r1, #1
+	str	r2, [sp, #108]
+	ldr	r0, [r0, r1, lsl #2]
+	bl	_use_obj
+	ldr	r6, [sp, #8]
+	ldr	r1, [sp, #108]
+	ldr	r0, [sp, #112]
+LBB3_3:
+	cmp	r1, r0
+	blo	LBB3_2
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB3_1
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+	b	LBB3_1
+LBB3_6:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_iter_noop
+	.p2align	2
+	.code	32
+_iter_noop:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r5, r4
+	mov	r6, r0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r0, #0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r11, #16
+	vst1.32	{d16, d17}, [r5]!
+	mov	r1, #0
+	vst1.64	{d16, d17}, [r2]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC4_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC4_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC4_1+8))
+LPC4_0:
+	ldr	r10, [pc, r10]
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC4_1+8))
+LPC4_1:
+	add	r8, pc, r8
+	b	LBB4_2
+LBB4_1:
+	add	r1, r1, #1
+	str	r1, [sp, #108]
+LBB4_2:
+	cmp	r1, r0
+	blo	LBB4_1
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB4_5
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+LBB4_5:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB4_7
+	ldr	r6, [sp, #8]
+	mov	r1, #0
+	b	LBB4_1
+LBB4_7:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.globl	_iter_retained
+	.p2align	2
+	.code	32
+_iter_retained:
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
+	push	{r8, r10, r11}
+	sub	sp, sp, #120
+	bfc	sp, #0, #3
+	add	r1, sp, #8
+	vmov.i32	q8, #0x0
+	orr	r4, r1, #4
+	add	r2, r1, #80
+	mov	r5, r4
+	mov	r6, r0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r0, #0
+	vst1.32	{d16, d17}, [r5]!
+	mov	r11, #16
+	vst1.32	{d16, d17}, [r5]!
+	mov	r1, #0
+	vst1.64	{d16, d17}, [r2]!
+	vst1.32	{d16, d17}, [r5]!
+	str	r0, [r2]
+	str	r0, [r5]
+	str	r0, [sp, #112]
+	str	r0, [sp, #108]
+	str	r0, [sp, #84]
+	str	r0, [sp, #80]
+	str	r6, [sp, #8]
+	movw	r10, :lower16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC5_0+8))
+	movt	r10, :upper16:(L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr-(LPC5_0+8))
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC5_1+8))
+LPC5_0:
+	ldr	r10, [pc, r10]
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC5_1+8))
+LPC5_1:
+	add	r8, pc, r8
+	b	LBB5_3
+LBB5_1:
+	mov	r0, r6
+	mov	r2, r5
+	mov	r3, r4
+	str	r11, [sp]
+	bl	_objc_msgSend
+	mov	r1, #0
+	cmp	r0, #0
+	str	r0, [sp, #112]
+	beq	LBB5_6
+LBB5_2:
+	ldr	r0, [sp, #80]
+	add	r2, r1, #1
+	str	r2, [sp, #108]
+	ldr	r0, [r0, r1, lsl #2]
+	bl	_objc_retain
+	mov	r6, r0
+	bl	_use_obj
+	mov	r0, r6
+	bl	_objc_release
+	ldr	r6, [sp, #8]
+	ldr	r1, [sp, #108]
+	ldr	r0, [sp, #112]
+LBB5_3:
+	cmp	r1, r0
+	blo	LBB5_2
+	ldr	r1, [r10]
+	cmp	r1, #0
+	bne	LBB5_1
+	mov	r0, r8
+	bl	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	r1, r0
+	str	r0, [r10]
+	b	LBB5_1
+LBB5_6:
+	sub	sp, r7, #24
+	pop	{r8, r10, r11}
+	pop	{r4, r5, r6, r7, pc}
+
+	.section	__TEXT,__const
+l_anon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+
+	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
+	.p2align	2, 0x0
+L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h6140e5efd2948e03E$non_lazy_ptr:
+	.indirect_symbol	SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)
+	.long	0
+
+.subsections_via_symbols

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
@@ -1,0 +1,397 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_iter_create
+	.p2align	4, 0x90
+_iter_create:
+	push	ebp
+	mov	ebp, esp
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 12]
+	mov	dword ptr [eax + 84], 0
+	mov	dword ptr [eax + 80], 0
+	mov	dword ptr [eax + 92], 0
+	mov	dword ptr [eax + 88], 0
+	mov	dword ptr [eax + 96], 0
+	mov	dword ptr [eax], ecx
+	mov	dword ptr [eax + 8], 0
+	mov	dword ptr [eax + 4], 0
+	mov	dword ptr [eax + 16], 0
+	mov	dword ptr [eax + 12], 0
+	mov	dword ptr [eax + 24], 0
+	mov	dword ptr [eax + 20], 0
+	mov	dword ptr [eax + 32], 0
+	mov	dword ptr [eax + 28], 0
+	mov	dword ptr [eax + 40], 0
+	mov	dword ptr [eax + 36], 0
+	mov	dword ptr [eax + 48], 0
+	mov	dword ptr [eax + 44], 0
+	mov	dword ptr [eax + 56], 0
+	mov	dword ptr [eax + 52], 0
+	mov	dword ptr [eax + 64], 0
+	mov	dword ptr [eax + 60], 0
+	mov	dword ptr [eax + 72], 0
+	mov	dword ptr [eax + 68], 0
+	mov	dword ptr [eax + 76], 0
+	mov	dword ptr [eax + 100], 0
+	mov	dword ptr [eax + 104], 0
+	pop	ebp
+	ret	4
+
+	.globl	_iter_once
+	.p2align	4, 0x90
+_iter_once:
+	push	ebp
+	mov	ebp, esp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 12
+	call	L1$pb
+L1$pb:
+	pop	ecx
+	mov	esi, dword ptr [ebp + 8]
+	mov	eax, dword ptr [esi + 100]
+	cmp	eax, dword ptr [esi + 104]
+	jb	LBB1_1
+	lea	eax, [esi + 4]
+	mov	dword ptr [ebp - 20], eax
+	mov	edx, dword ptr [esi]
+	lea	edi, [esi + 68]
+	mov	ebx, dword ptr [ecx + L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h230d5b6091d37064E$non_lazy_ptr-L1$pb]
+	mov	eax, dword ptr [ebx]
+	test	eax, eax
+	jne	LBB1_4
+	sub	esp, 12
+	lea	eax, [ecx + l_anon.[ID].0-L1$pb]
+	push	eax
+	mov	dword ptr [ebp - 16], edx
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	edx, dword ptr [ebp - 16]
+	add	esp, 16
+	mov	dword ptr [ebx], eax
+LBB1_4:
+	sub	esp, 12
+	push	16
+	push	dword ptr [ebp - 20]
+	push	edi
+	push	eax
+	push	edx
+	call	_objc_msgSend
+	add	esp, 32
+	mov	ecx, eax
+	mov	dword ptr [esi + 104], eax
+	mov	dword ptr [esi + 100], 0
+	xor	eax, eax
+	test	ecx, ecx
+	je	LBB1_5
+LBB1_1:
+	mov	ecx, dword ptr [esi + 72]
+	lea	edx, [eax + 1]
+	mov	dword ptr [esi + 100], edx
+	mov	eax, dword ptr [ecx + 4*eax]
+LBB1_5:
+	add	esp, 12
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+
+	.globl	_use_obj
+	.p2align	4, 0x90
+_use_obj:
+	push	ebp
+	mov	ebp, esp
+	push	eax
+	mov	eax, dword ptr [ebp + 8]
+	mov	dword ptr [ebp - 4], eax
+	lea	eax, [ebp - 4]
+	## InlineAsm Start
+	## InlineAsm End
+	add	esp, 4
+	pop	ebp
+	ret
+
+	.globl	_iter
+	.p2align	4, 0x90
+_iter:
+	push	ebp
+	mov	ebp, esp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 124
+	call	L3$pb
+L3$pb:
+	pop	eax
+	mov	ebx, dword ptr [ebp + 8]
+	mov	dword ptr [ebp - 44], 0
+	mov	dword ptr [ebp - 48], 0
+	mov	dword ptr [ebp - 36], 0
+	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 32], 0
+	mov	dword ptr [ebp - 128], ebx
+	lea	edi, [ebp - 60]
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 124], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 24], 0
+	mov	esi, dword ptr [eax + L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h230d5b6091d37064E$non_lazy_ptr-L3$pb]
+	lea	eax, [eax + l_anon.[ID].0-L3$pb]
+	mov	dword ptr [ebp - 16], eax
+	xor	eax, eax
+	xor	ecx, ecx
+	jmp	LBB3_1
+	.p2align	4, 0x90
+LBB3_4:
+	sub	esp, 12
+	push	16
+	lea	ecx, [ebp - 124]
+	push	ecx
+	push	edi
+	push	eax
+	push	ebx
+	call	_objc_msgSend
+	add	esp, 32
+	mov	dword ptr [ebp - 24], eax
+	xor	ecx, ecx
+	test	eax, eax
+	je	LBB3_5
+LBB3_6:
+	mov	eax, dword ptr [ebp - 56]
+	lea	edx, [ecx + 1]
+	mov	dword ptr [ebp - 28], edx
+	sub	esp, 12
+	push	dword ptr [eax + 4*ecx]
+	call	_use_obj
+	add	esp, 16
+	mov	ebx, dword ptr [ebp - 128]
+	mov	ecx, dword ptr [ebp - 28]
+	mov	eax, dword ptr [ebp - 24]
+LBB3_1:
+	cmp	ecx, eax
+	jb	LBB3_6
+	mov	eax, dword ptr [esi]
+	test	eax, eax
+	jne	LBB3_4
+	sub	esp, 12
+	push	dword ptr [ebp - 16]
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	add	esp, 16
+	mov	dword ptr [esi], eax
+	jmp	LBB3_4
+LBB3_5:
+	add	esp, 124
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+
+	.globl	_iter_noop
+	.p2align	4, 0x90
+_iter_noop:
+	push	ebp
+	mov	ebp, esp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 124
+	call	L4$pb
+L4$pb:
+	pop	eax
+	mov	ebx, dword ptr [ebp + 8]
+	mov	dword ptr [ebp - 44], 0
+	mov	dword ptr [ebp - 48], 0
+	mov	dword ptr [ebp - 36], 0
+	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 32], 0
+	mov	dword ptr [ebp - 128], ebx
+	lea	edi, [ebp - 60]
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 124], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 24], 0
+	mov	esi, dword ptr [eax + L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h230d5b6091d37064E$non_lazy_ptr-L4$pb]
+	lea	eax, [eax + l_anon.[ID].0-L4$pb]
+	mov	dword ptr [ebp - 16], eax
+	xor	eax, eax
+	xor	ecx, ecx
+	jmp	LBB4_1
+	.p2align	4, 0x90
+LBB4_6:
+	inc	ecx
+	mov	dword ptr [ebp - 28], ecx
+LBB4_1:
+	cmp	ecx, eax
+	jb	LBB4_6
+	mov	eax, dword ptr [esi]
+	test	eax, eax
+	jne	LBB4_4
+	sub	esp, 12
+	push	dword ptr [ebp - 16]
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	add	esp, 16
+	mov	dword ptr [esi], eax
+LBB4_4:
+	sub	esp, 12
+	push	16
+	lea	ecx, [ebp - 124]
+	push	ecx
+	push	edi
+	push	eax
+	push	ebx
+	call	_objc_msgSend
+	add	esp, 32
+	mov	dword ptr [ebp - 24], eax
+	test	eax, eax
+	je	LBB4_7
+	xor	ecx, ecx
+	mov	ebx, dword ptr [ebp - 128]
+	jmp	LBB4_6
+LBB4_7:
+	add	esp, 124
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+
+	.globl	_iter_retained
+	.p2align	4, 0x90
+_iter_retained:
+	push	ebp
+	mov	ebp, esp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 140
+	call	L5$pb
+L5$pb:
+	pop	eax
+	mov	esi, dword ptr [ebp + 8]
+	mov	dword ptr [ebp - 44], 0
+	mov	dword ptr [ebp - 48], 0
+	mov	dword ptr [ebp - 36], 0
+	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 32], 0
+	mov	dword ptr [ebp - 128], esi
+	lea	ebx, [ebp - 60]
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 124], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 24], 0
+	mov	edi, dword ptr [eax + L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h230d5b6091d37064E$non_lazy_ptr-L5$pb]
+	lea	eax, [eax + l_anon.[ID].0-L5$pb]
+	mov	dword ptr [ebp - 16], eax
+	xor	eax, eax
+	xor	ecx, ecx
+	jmp	LBB5_1
+	.p2align	4, 0x90
+LBB5_4:
+	lea	ecx, [ebp - 124]
+	mov	dword ptr [esp + 12], ecx
+	mov	dword ptr [esp + 8], ebx
+	mov	dword ptr [esp + 4], eax
+	mov	dword ptr [esp], esi
+	mov	dword ptr [esp + 16], 16
+	call	_objc_msgSend
+	mov	dword ptr [ebp - 24], eax
+	xor	ecx, ecx
+	test	eax, eax
+	je	LBB5_5
+LBB5_6:
+	mov	eax, dword ptr [ebp - 56]
+	lea	edx, [ecx + 1]
+	mov	dword ptr [ebp - 28], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	mov	dword ptr [esp], eax
+	call	_objc_retain
+	mov	esi, eax
+	mov	dword ptr [esp], eax
+	call	_use_obj
+	mov	dword ptr [esp], esi
+	call	_objc_release
+	mov	esi, dword ptr [ebp - 128]
+	mov	ecx, dword ptr [ebp - 28]
+	mov	eax, dword ptr [ebp - 24]
+LBB5_1:
+	cmp	ecx, eax
+	jb	LBB5_6
+	mov	eax, dword ptr [edi]
+	test	eax, eax
+	jne	LBB5_4
+	mov	eax, dword ptr [ebp - 16]
+	mov	dword ptr [esp], eax
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	dword ptr [edi], eax
+	jmp	LBB5_4
+LBB5_5:
+	add	esp, 140
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+
+	.section	__TEXT,__const
+l_anon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+
+	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
+L__ZN6icrate10Foundation9generated14__NSEnumerator17NSFastEnumeration41countByEnumeratingWithState_objects_count10CACHED_SEL17h230d5b6091d37064E$non_lazy_ptr:
+	.indirect_symbol	SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)
+	.long	0
+
+.subsections_via_symbols

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
@@ -1,0 +1,369 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.intel_syntax noprefix
+	.globl	_iter_create
+	.p2align	4, 0x90
+_iter_create:
+	push	rbp
+	mov	rbp, rsp
+	mov	rax, rdi
+	mov	qword ptr [rdi + 192], 0
+	mov	qword ptr [rdi + 184], 0
+	mov	qword ptr [rdi + 176], 0
+	mov	qword ptr [rdi + 168], 0
+	mov	qword ptr [rdi + 160], 0
+	mov	qword ptr [rdi + 8], 0
+	mov	qword ptr [rdi + 16], 0
+	mov	qword ptr [rdi + 24], 0
+	mov	qword ptr [rdi + 32], 0
+	mov	qword ptr [rdi + 40], 0
+	mov	qword ptr [rdi + 48], 0
+	mov	qword ptr [rdi + 56], 0
+	mov	qword ptr [rdi + 64], 0
+	mov	qword ptr [rdi + 72], 0
+	mov	qword ptr [rdi + 80], 0
+	mov	qword ptr [rdi + 88], 0
+	mov	qword ptr [rdi + 96], 0
+	mov	qword ptr [rdi + 104], 0
+	mov	qword ptr [rdi + 112], 0
+	mov	qword ptr [rdi + 120], 0
+	mov	qword ptr [rdi + 128], 0
+	mov	qword ptr [rdi], rsi
+	mov	qword ptr [rdi + 152], 0
+	mov	qword ptr [rdi + 144], 0
+	mov	qword ptr [rdi + 136], 0
+	mov	qword ptr [rdi + 208], 0
+	mov	qword ptr [rdi + 200], 0
+	pop	rbp
+	ret
+
+	.globl	_iter_once
+	.p2align	4, 0x90
+_iter_once:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	push	rax
+	mov	rbx, rdi
+	mov	rax, qword ptr [rdi + 200]
+	cmp	rax, qword ptr [rdi + 208]
+	jb	LBB1_1
+	lea	r14, [rbx + 8]
+	mov	r15, qword ptr [rbx]
+	lea	r12, [rbx + 136]
+	mov	r13, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	rsi, qword ptr [r13]
+	test	rsi, rsi
+	jne	LBB1_4
+	lea	rdi, [rip + l_anon.[ID].0]
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	rsi, rax
+	mov	qword ptr [r13], rax
+LBB1_4:
+	mov	r8d, 16
+	mov	rdi, r15
+	mov	rdx, r12
+	mov	rcx, r14
+	call	_objc_msgSend
+	mov	rcx, rax
+	mov	qword ptr [rbx + 208], rax
+	mov	qword ptr [rbx + 200], 0
+	xor	eax, eax
+	test	rcx, rcx
+	je	LBB1_5
+LBB1_1:
+	mov	rcx, qword ptr [rbx + 144]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbx + 200], rdx
+	mov	rax, qword ptr [rcx + 8*rax]
+LBB1_5:
+	add	rsp, 8
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.globl	_use_obj
+	.p2align	4, 0x90
+_use_obj:
+	push	rbp
+	mov	rbp, rsp
+	mov	qword ptr [rbp - 8], rdi
+	lea	rax, [rbp - 8]
+	## InlineAsm Start
+	## InlineAsm End
+	pop	rbp
+	ret
+
+	.globl	_iter
+	.p2align	4, 0x90
+_iter:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r14, rdi
+	mov	qword ptr [rbp - 64], 0
+	mov	qword ptr [rbp - 72], 0
+	mov	qword ptr [rbp - 80], 0
+	mov	qword ptr [rbp - 88], 0
+	mov	qword ptr [rbp - 96], 0
+	lea	rbx, [rbp - 248]
+	mov	qword ptr [rbp - 248], 0
+	mov	qword ptr [rbp - 240], 0
+	mov	qword ptr [rbp - 232], 0
+	mov	qword ptr [rbp - 224], 0
+	mov	qword ptr [rbp - 216], 0
+	mov	qword ptr [rbp - 208], 0
+	mov	qword ptr [rbp - 200], 0
+	mov	qword ptr [rbp - 192], 0
+	mov	qword ptr [rbp - 184], 0
+	mov	qword ptr [rbp - 176], 0
+	mov	qword ptr [rbp - 168], 0
+	mov	qword ptr [rbp - 160], 0
+	mov	qword ptr [rbp - 152], 0
+	mov	qword ptr [rbp - 144], 0
+	mov	qword ptr [rbp - 136], 0
+	mov	qword ptr [rbp - 128], 0
+	mov	qword ptr [rbp - 256], rdi
+	lea	r15, [rbp - 120]
+	mov	qword ptr [rbp - 104], 0
+	mov	qword ptr [rbp - 112], 0
+	mov	qword ptr [rbp - 120], 0
+	mov	qword ptr [rbp - 48], 0
+	mov	qword ptr [rbp - 56], 0
+	xor	ecx, ecx
+	mov	r13, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
+	xor	eax, eax
+	jmp	LBB3_1
+	.p2align	4, 0x90
+LBB3_6:
+	mov	rcx, qword ptr [rbp - 112]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbp - 56], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	call	_use_obj
+	mov	r14, qword ptr [rbp - 256]
+	mov	rax, qword ptr [rbp - 56]
+	mov	rcx, qword ptr [rbp - 48]
+LBB3_1:
+	cmp	rax, rcx
+	jb	LBB3_6
+	mov	rsi, qword ptr [r13]
+	test	rsi, rsi
+	jne	LBB3_4
+	mov	rdi, r12
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	rsi, rax
+	mov	qword ptr [r13], rax
+LBB3_4:
+	mov	r8d, 16
+	mov	rdi, r14
+	mov	rdx, r15
+	mov	rcx, rbx
+	call	_objc_msgSend
+	mov	qword ptr [rbp - 48], rax
+	test	rax, rax
+	je	LBB3_7
+	xor	eax, eax
+	jmp	LBB3_6
+LBB3_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.globl	_iter_noop
+	.p2align	4, 0x90
+_iter_noop:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r14, rdi
+	mov	qword ptr [rbp - 64], 0
+	mov	qword ptr [rbp - 72], 0
+	mov	qword ptr [rbp - 80], 0
+	mov	qword ptr [rbp - 88], 0
+	mov	qword ptr [rbp - 96], 0
+	lea	rbx, [rbp - 248]
+	mov	qword ptr [rbp - 248], 0
+	mov	qword ptr [rbp - 240], 0
+	mov	qword ptr [rbp - 232], 0
+	mov	qword ptr [rbp - 224], 0
+	mov	qword ptr [rbp - 216], 0
+	mov	qword ptr [rbp - 208], 0
+	mov	qword ptr [rbp - 200], 0
+	mov	qword ptr [rbp - 192], 0
+	mov	qword ptr [rbp - 184], 0
+	mov	qword ptr [rbp - 176], 0
+	mov	qword ptr [rbp - 168], 0
+	mov	qword ptr [rbp - 160], 0
+	mov	qword ptr [rbp - 152], 0
+	mov	qword ptr [rbp - 144], 0
+	mov	qword ptr [rbp - 136], 0
+	mov	qword ptr [rbp - 128], 0
+	mov	qword ptr [rbp - 256], rdi
+	lea	r15, [rbp - 120]
+	mov	qword ptr [rbp - 104], 0
+	mov	qword ptr [rbp - 112], 0
+	mov	qword ptr [rbp - 120], 0
+	mov	qword ptr [rbp - 48], 0
+	mov	qword ptr [rbp - 56], 0
+	xor	eax, eax
+	mov	r13, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
+	xor	ecx, ecx
+	jmp	LBB4_1
+	.p2align	4, 0x90
+LBB4_6:
+	inc	rcx
+	mov	qword ptr [rbp - 56], rcx
+LBB4_1:
+	cmp	rcx, rax
+	jb	LBB4_6
+	mov	rsi, qword ptr [r13]
+	test	rsi, rsi
+	jne	LBB4_4
+	mov	rdi, r12
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	rsi, rax
+	mov	qword ptr [r13], rax
+LBB4_4:
+	mov	r8d, 16
+	mov	rdi, r14
+	mov	rdx, r15
+	mov	rcx, rbx
+	call	_objc_msgSend
+	mov	qword ptr [rbp - 48], rax
+	test	rax, rax
+	je	LBB4_7
+	mov	r14, qword ptr [rbp - 256]
+	xor	ecx, ecx
+	jmp	LBB4_6
+LBB4_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.globl	_iter_retained
+	.p2align	4, 0x90
+_iter_retained:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r15, rdi
+	mov	qword ptr [rbp - 64], 0
+	mov	qword ptr [rbp - 72], 0
+	mov	qword ptr [rbp - 80], 0
+	mov	qword ptr [rbp - 88], 0
+	mov	qword ptr [rbp - 96], 0
+	lea	rbx, [rbp - 248]
+	mov	qword ptr [rbp - 248], 0
+	mov	qword ptr [rbp - 240], 0
+	mov	qword ptr [rbp - 232], 0
+	mov	qword ptr [rbp - 224], 0
+	mov	qword ptr [rbp - 216], 0
+	mov	qword ptr [rbp - 208], 0
+	mov	qword ptr [rbp - 200], 0
+	mov	qword ptr [rbp - 192], 0
+	mov	qword ptr [rbp - 184], 0
+	mov	qword ptr [rbp - 176], 0
+	mov	qword ptr [rbp - 168], 0
+	mov	qword ptr [rbp - 160], 0
+	mov	qword ptr [rbp - 152], 0
+	mov	qword ptr [rbp - 144], 0
+	mov	qword ptr [rbp - 136], 0
+	mov	qword ptr [rbp - 128], 0
+	mov	qword ptr [rbp - 256], rdi
+	lea	r14, [rbp - 120]
+	mov	qword ptr [rbp - 104], 0
+	mov	qword ptr [rbp - 112], 0
+	mov	qword ptr [rbp - 120], 0
+	mov	qword ptr [rbp - 48], 0
+	mov	qword ptr [rbp - 56], 0
+	xor	ecx, ecx
+	mov	r13, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
+	xor	eax, eax
+	jmp	LBB5_1
+	.p2align	4, 0x90
+LBB5_6:
+	mov	rcx, qword ptr [rbp - 112]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbp - 56], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	call	_objc_retain
+	mov	r15, rax
+	mov	rdi, rax
+	call	_use_obj
+	mov	rdi, r15
+	call	_objc_release
+	mov	r15, qword ptr [rbp - 256]
+	mov	rax, qword ptr [rbp - 56]
+	mov	rcx, qword ptr [rbp - 48]
+LBB5_1:
+	cmp	rax, rcx
+	jb	LBB5_6
+	mov	rsi, qword ptr [r13]
+	test	rsi, rsi
+	jne	LBB5_4
+	mov	rdi, r12
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)
+	mov	rsi, rax
+	mov	qword ptr [r13], rax
+LBB5_4:
+	mov	r8d, 16
+	mov	rdi, r15
+	mov	rdx, r14
+	mov	rcx, rbx
+	call	_objc_msgSend
+	mov	qword ptr [rbp - 48], rax
+	test	rax, rax
+	je	LBB5_7
+	xor	eax, eax
+	jmp	LBB5_6
+LBB5_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.section	__TEXT,__const
+l_anon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+
+.subsections_via_symbols

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
@@ -1,0 +1,437 @@
+	.text
+	.intel_syntax noprefix
+	.section	.text.iter_create,"ax",@progbits
+	.globl	iter_create
+	.p2align	4, 0x90
+	.type	iter_create,@function
+iter_create:
+	mov	eax, dword ptr [esp + 4]
+	mov	ecx, dword ptr [esp + 8]
+	mov	dword ptr [eax + 84], 0
+	mov	dword ptr [eax + 80], 0
+	mov	dword ptr [eax + 92], 0
+	mov	dword ptr [eax + 88], 0
+	mov	dword ptr [eax + 96], 0
+	mov	dword ptr [eax], ecx
+	mov	dword ptr [eax + 8], 0
+	mov	dword ptr [eax + 4], 0
+	mov	dword ptr [eax + 16], 0
+	mov	dword ptr [eax + 12], 0
+	mov	dword ptr [eax + 24], 0
+	mov	dword ptr [eax + 20], 0
+	mov	dword ptr [eax + 32], 0
+	mov	dword ptr [eax + 28], 0
+	mov	dword ptr [eax + 40], 0
+	mov	dword ptr [eax + 36], 0
+	mov	dword ptr [eax + 48], 0
+	mov	dword ptr [eax + 44], 0
+	mov	dword ptr [eax + 56], 0
+	mov	dword ptr [eax + 52], 0
+	mov	dword ptr [eax + 64], 0
+	mov	dword ptr [eax + 60], 0
+	mov	dword ptr [eax + 72], 0
+	mov	dword ptr [eax + 68], 0
+	mov	dword ptr [eax + 76], 0
+	mov	dword ptr [eax + 100], 0
+	mov	dword ptr [eax + 104], 0
+	ret	4
+.Lfunc_end0:
+	.size	iter_create, .Lfunc_end0-iter_create
+
+	.section	.text.iter_once,"ax",@progbits
+	.globl	iter_once
+	.p2align	4, 0x90
+	.type	iter_once,@function
+iter_once:
+	push	ebp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 12
+	mov	edi, dword ptr [esp + 32]
+	call	.L1$pb
+.L1$pb:
+	pop	ebx
+.Ltmp0:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp0-.L1$pb)
+	mov	eax, dword ptr [edi + 100]
+	cmp	eax, dword ptr [edi + 104]
+	jb	.LBB1_1
+	mov	ebp, dword ptr [ebx + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
+	lea	eax, [edi + 4]
+	lea	ecx, [edi + 68]
+	mov	dword ptr [esp + 8], eax
+	mov	dword ptr [esp + 4], ecx
+	mov	eax, dword ptr [edi]
+	mov	esi, dword ptr [ebp]
+	test	esi, esi
+	jne	.LBB1_4
+	sub	esp, 12
+	mov	dword ptr [esp + 12], eax
+	lea	eax, [ebx + .Lanon.[ID].0@GOTOFF]
+	push	eax
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@PLT
+	add	esp, 16
+	mov	esi, eax
+	mov	eax, dword ptr [esp]
+	mov	dword ptr [ebp], esi
+.LBB1_4:
+	sub	esp, 8
+	push	esi
+	push	eax
+	mov	ebp, eax
+	call	objc_msg_lookup@PLT
+	add	esp, 4
+	push	16
+	push	dword ptr [esp + 24]
+	push	dword ptr [esp + 24]
+	push	esi
+	push	ebp
+	call	eax
+	add	esp, 32
+	mov	ecx, eax
+	mov	dword ptr [edi + 104], eax
+	xor	eax, eax
+	mov	dword ptr [edi + 100], 0
+	test	ecx, ecx
+	je	.LBB1_5
+.LBB1_1:
+	mov	ecx, dword ptr [edi + 72]
+	lea	edx, [eax + 1]
+	mov	dword ptr [edi + 100], edx
+	mov	eax, dword ptr [ecx + 4*eax]
+.LBB1_5:
+	add	esp, 12
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+.Lfunc_end1:
+	.size	iter_once, .Lfunc_end1-iter_once
+
+	.section	.text.use_obj,"ax",@progbits
+	.globl	use_obj
+	.p2align	4, 0x90
+	.type	use_obj,@function
+use_obj:
+	push	eax
+	mov	eax, dword ptr [esp + 8]
+	mov	dword ptr [esp], eax
+	mov	eax, esp
+	#APP
+	#NO_APP
+	pop	eax
+	ret
+.Lfunc_end2:
+	.size	use_obj, .Lfunc_end2-use_obj
+
+	.section	.text.iter,"ax",@progbits
+	.globl	iter
+	.p2align	4, 0x90
+	.type	iter,@function
+iter:
+	push	ebp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 124
+	call	.L3$pb
+.L3$pb:
+	pop	ebx
+	mov	edi, dword ptr [esp + 144]
+	xor	eax, eax
+	mov	dword ptr [esp + 100], 0
+	mov	dword ptr [esp + 96], 0
+	mov	dword ptr [esp + 108], 0
+	mov	dword ptr [esp + 104], 0
+	mov	dword ptr [esp + 112], 0
+.Ltmp1:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp1-.L3$pb)
+	mov	ebp, dword ptr [ebx + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
+	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
+	mov	dword ptr [esp + 12], ecx
+	xor	ecx, ecx
+	mov	dword ptr [esp + 16], edi
+	mov	dword ptr [esp + 24], 0
+	mov	dword ptr [esp + 20], 0
+	mov	dword ptr [esp + 32], 0
+	mov	dword ptr [esp + 28], 0
+	mov	dword ptr [esp + 40], 0
+	mov	dword ptr [esp + 36], 0
+	mov	dword ptr [esp + 48], 0
+	mov	dword ptr [esp + 44], 0
+	mov	dword ptr [esp + 56], 0
+	mov	dword ptr [esp + 52], 0
+	mov	dword ptr [esp + 64], 0
+	mov	dword ptr [esp + 60], 0
+	mov	dword ptr [esp + 72], 0
+	mov	dword ptr [esp + 68], 0
+	mov	dword ptr [esp + 80], 0
+	mov	dword ptr [esp + 76], 0
+	mov	dword ptr [esp + 88], 0
+	mov	dword ptr [esp + 84], 0
+	mov	dword ptr [esp + 92], 0
+	mov	dword ptr [esp + 116], 0
+	mov	dword ptr [esp + 120], 0
+	jmp	.LBB3_1
+	.p2align	4, 0x90
+.LBB3_4:
+	sub	esp, 8
+	push	esi
+	push	edi
+	call	objc_msg_lookup@PLT
+	add	esp, 4
+	push	16
+	lea	ecx, [esp + 36]
+	push	ecx
+	lea	ecx, [esp + 104]
+	push	ecx
+	push	esi
+	push	edi
+	call	eax
+	add	esp, 32
+	xor	ecx, ecx
+	test	eax, eax
+	mov	dword ptr [esp + 120], eax
+	je	.LBB3_5
+.LBB3_6:
+	mov	eax, dword ptr [esp + 88]
+	lea	edx, [ecx + 1]
+	mov	dword ptr [esp + 116], edx
+	sub	esp, 12
+	push	dword ptr [eax + 4*ecx]
+	call	use_obj@PLT
+	add	esp, 16
+	mov	edi, dword ptr [esp + 16]
+	mov	ecx, dword ptr [esp + 116]
+	mov	eax, dword ptr [esp + 120]
+.LBB3_1:
+	cmp	ecx, eax
+	jb	.LBB3_6
+	mov	esi, dword ptr [ebp]
+	test	esi, esi
+	jne	.LBB3_4
+	sub	esp, 12
+	push	dword ptr [esp + 24]
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@PLT
+	add	esp, 16
+	mov	esi, eax
+	mov	dword ptr [ebp], eax
+	jmp	.LBB3_4
+.LBB3_5:
+	add	esp, 124
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+.Lfunc_end3:
+	.size	iter, .Lfunc_end3-iter
+
+	.section	.text.iter_noop,"ax",@progbits
+	.globl	iter_noop
+	.p2align	4, 0x90
+	.type	iter_noop,@function
+iter_noop:
+	push	ebp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 124
+	call	.L4$pb
+.L4$pb:
+	pop	ebx
+	mov	edi, dword ptr [esp + 144]
+	xor	eax, eax
+	mov	dword ptr [esp + 100], 0
+	mov	dword ptr [esp + 96], 0
+	mov	dword ptr [esp + 108], 0
+	mov	dword ptr [esp + 104], 0
+	mov	dword ptr [esp + 112], 0
+.Ltmp2:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp2-.L4$pb)
+	mov	ebp, dword ptr [ebx + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
+	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
+	mov	dword ptr [esp + 12], ecx
+	xor	ecx, ecx
+	mov	dword ptr [esp + 16], edi
+	mov	dword ptr [esp + 24], 0
+	mov	dword ptr [esp + 20], 0
+	mov	dword ptr [esp + 32], 0
+	mov	dword ptr [esp + 28], 0
+	mov	dword ptr [esp + 40], 0
+	mov	dword ptr [esp + 36], 0
+	mov	dword ptr [esp + 48], 0
+	mov	dword ptr [esp + 44], 0
+	mov	dword ptr [esp + 56], 0
+	mov	dword ptr [esp + 52], 0
+	mov	dword ptr [esp + 64], 0
+	mov	dword ptr [esp + 60], 0
+	mov	dword ptr [esp + 72], 0
+	mov	dword ptr [esp + 68], 0
+	mov	dword ptr [esp + 80], 0
+	mov	dword ptr [esp + 76], 0
+	mov	dword ptr [esp + 88], 0
+	mov	dword ptr [esp + 84], 0
+	mov	dword ptr [esp + 92], 0
+	mov	dword ptr [esp + 116], 0
+	mov	dword ptr [esp + 120], 0
+	jmp	.LBB4_1
+	.p2align	4, 0x90
+.LBB4_6:
+	inc	ecx
+	mov	dword ptr [esp + 116], ecx
+.LBB4_1:
+	cmp	ecx, eax
+	jb	.LBB4_6
+	mov	esi, dword ptr [ebp]
+	test	esi, esi
+	jne	.LBB4_4
+	sub	esp, 12
+	push	dword ptr [esp + 24]
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@PLT
+	add	esp, 16
+	mov	esi, eax
+	mov	dword ptr [ebp], eax
+.LBB4_4:
+	sub	esp, 8
+	push	esi
+	push	edi
+	call	objc_msg_lookup@PLT
+	add	esp, 4
+	push	16
+	lea	ecx, [esp + 36]
+	push	ecx
+	lea	ecx, [esp + 104]
+	push	ecx
+	push	esi
+	push	edi
+	call	eax
+	add	esp, 32
+	test	eax, eax
+	mov	dword ptr [esp + 120], eax
+	je	.LBB4_7
+	mov	edi, dword ptr [esp + 16]
+	xor	ecx, ecx
+	jmp	.LBB4_6
+.LBB4_7:
+	add	esp, 124
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+.Lfunc_end4:
+	.size	iter_noop, .Lfunc_end4-iter_noop
+
+	.section	.text.iter_retained,"ax",@progbits
+	.globl	iter_retained
+	.p2align	4, 0x90
+	.type	iter_retained,@function
+iter_retained:
+	push	ebp
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 140
+	call	.L5$pb
+.L5$pb:
+	pop	ebx
+	mov	ebp, dword ptr [esp + 160]
+	xor	eax, eax
+	mov	dword ptr [esp + 116], 0
+	mov	dword ptr [esp + 112], 0
+	mov	dword ptr [esp + 124], 0
+	mov	dword ptr [esp + 120], 0
+	mov	dword ptr [esp + 128], 0
+.Ltmp3:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp3-.L5$pb)
+	mov	edi, dword ptr [ebx + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
+	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
+	mov	dword ptr [esp + 28], ecx
+	xor	ecx, ecx
+	mov	dword ptr [esp + 32], ebp
+	mov	dword ptr [esp + 40], 0
+	mov	dword ptr [esp + 36], 0
+	mov	dword ptr [esp + 48], 0
+	mov	dword ptr [esp + 44], 0
+	mov	dword ptr [esp + 56], 0
+	mov	dword ptr [esp + 52], 0
+	mov	dword ptr [esp + 64], 0
+	mov	dword ptr [esp + 60], 0
+	mov	dword ptr [esp + 72], 0
+	mov	dword ptr [esp + 68], 0
+	mov	dword ptr [esp + 80], 0
+	mov	dword ptr [esp + 76], 0
+	mov	dword ptr [esp + 88], 0
+	mov	dword ptr [esp + 84], 0
+	mov	dword ptr [esp + 96], 0
+	mov	dword ptr [esp + 92], 0
+	mov	dword ptr [esp + 104], 0
+	mov	dword ptr [esp + 100], 0
+	mov	dword ptr [esp + 108], 0
+	mov	dword ptr [esp + 132], 0
+	mov	dword ptr [esp + 136], 0
+	jmp	.LBB5_1
+	.p2align	4, 0x90
+.LBB5_4:
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ebp
+	call	objc_msg_lookup@PLT
+	lea	ecx, [esp + 36]
+	lea	edx, [esp + 100]
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ebp
+	mov	dword ptr [esp + 16], 16
+	mov	dword ptr [esp + 12], ecx
+	mov	dword ptr [esp + 8], edx
+	call	eax
+	xor	ecx, ecx
+	test	eax, eax
+	mov	dword ptr [esp + 136], eax
+	je	.LBB5_5
+.LBB5_6:
+	mov	eax, dword ptr [esp + 104]
+	lea	edx, [ecx + 1]
+	mov	dword ptr [esp + 132], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	mov	dword ptr [esp], eax
+	call	objc_retain@PLT
+	mov	esi, eax
+	mov	dword ptr [esp], eax
+	call	use_obj@PLT
+	mov	dword ptr [esp], esi
+	call	objc_release@PLT
+	mov	ebp, dword ptr [esp + 32]
+	mov	ecx, dword ptr [esp + 132]
+	mov	eax, dword ptr [esp + 136]
+.LBB5_1:
+	cmp	ecx, eax
+	jb	.LBB5_6
+	mov	esi, dword ptr [edi]
+	test	esi, esi
+	jne	.LBB5_4
+	mov	eax, dword ptr [esp + 28]
+	mov	dword ptr [esp], eax
+	call	SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@PLT
+	mov	esi, eax
+	mov	dword ptr [edi], eax
+	jmp	.LBB5_4
+.LBB5_5:
+	add	esp, 140
+	pop	esi
+	pop	edi
+	pop	ebx
+	pop	ebp
+	ret
+.Lfunc_end5:
+	.size	iter_retained, .Lfunc_end5-iter_retained
+
+	.type	.Lanon.[ID].0,@object
+	.section	.rodata..Lanon.[ID].0,"a",@progbits
+.Lanon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+	.size	.Lanon.[ID].0, 43
+
+	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
@@ -1,0 +1,357 @@
+	.text
+	.intel_syntax noprefix
+	.section	.text.iter_create,"ax",@progbits
+	.globl	iter_create
+	.p2align	4, 0x90
+	.type	iter_create,@function
+iter_create:
+	mov	rax, rdi
+	xorps	xmm0, xmm0
+	movups	xmmword ptr [rdi + 176], xmm0
+	movups	xmmword ptr [rdi + 160], xmm0
+	mov	qword ptr [rdi + 192], 0
+	movups	xmmword ptr [rdi + 8], xmm0
+	movups	xmmword ptr [rdi + 24], xmm0
+	movups	xmmword ptr [rdi + 40], xmm0
+	movups	xmmword ptr [rdi + 56], xmm0
+	movups	xmmword ptr [rdi + 72], xmm0
+	movups	xmmword ptr [rdi + 88], xmm0
+	movups	xmmword ptr [rdi + 104], xmm0
+	movups	xmmword ptr [rdi + 120], xmm0
+	mov	qword ptr [rdi], rsi
+	movups	xmmword ptr [rdi + 136], xmm0
+	mov	qword ptr [rdi + 152], 0
+	movups	xmmword ptr [rdi + 200], xmm0
+	ret
+.Lfunc_end0:
+	.size	iter_create, .Lfunc_end0-iter_create
+
+	.section	.text.iter_once,"ax",@progbits
+	.globl	iter_once
+	.p2align	4, 0x90
+	.type	iter_once,@function
+iter_once:
+	push	rbp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	push	rax
+	mov	rbx, rdi
+	mov	rax, qword ptr [rdi + 200]
+	cmp	rax, qword ptr [rdi + 208]
+	jb	.LBB1_1
+	lea	r14, [rbx + 8]
+	mov	r15, qword ptr [rbx]
+	lea	r12, [rbx + 136]
+	mov	rbp, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	r13, qword ptr [rbp]
+	test	r13, r13
+	jne	.LBB1_4
+	lea	rdi, [rip + .Lanon.[ID].0]
+	call	qword ptr [rip + SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@GOTPCREL]
+	mov	r13, rax
+	mov	qword ptr [rbp], rax
+.LBB1_4:
+	mov	rdi, r15
+	mov	rsi, r13
+	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
+	mov	r8d, 16
+	mov	rdi, r15
+	mov	rsi, r13
+	mov	rdx, r12
+	mov	rcx, r14
+	call	rax
+	mov	rcx, rax
+	mov	qword ptr [rbx + 208], rax
+	mov	qword ptr [rbx + 200], 0
+	xor	eax, eax
+	test	rcx, rcx
+	je	.LBB1_5
+.LBB1_1:
+	mov	rcx, qword ptr [rbx + 144]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbx + 200], rdx
+	mov	rax, qword ptr [rcx + 8*rax]
+.LBB1_5:
+	add	rsp, 8
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+.Lfunc_end1:
+	.size	iter_once, .Lfunc_end1-iter_once
+
+	.section	.text.use_obj,"ax",@progbits
+	.globl	use_obj
+	.p2align	4, 0x90
+	.type	use_obj,@function
+use_obj:
+	mov	qword ptr [rsp - 8], rdi
+	lea	rax, [rsp - 8]
+	#APP
+	#NO_APP
+	ret
+.Lfunc_end2:
+	.size	use_obj, .Lfunc_end2-use_obj
+
+	.section	.text.iter,"ax",@progbits
+	.globl	iter
+	.p2align	4, 0x90
+	.type	iter,@function
+iter:
+	push	rbp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r15, rdi
+	xorps	xmm0, xmm0
+	movups	xmmword ptr [rsp + 176], xmm0
+	movups	xmmword ptr [rsp + 160], xmm0
+	mov	qword ptr [rsp + 192], 0
+	movups	xmmword ptr [rsp + 8], xmm0
+	movups	xmmword ptr [rsp + 24], xmm0
+	movups	xmmword ptr [rsp + 40], xmm0
+	movups	xmmword ptr [rsp + 56], xmm0
+	movups	xmmword ptr [rsp + 72], xmm0
+	movups	xmmword ptr [rsp + 88], xmm0
+	movups	xmmword ptr [rsp + 104], xmm0
+	movups	xmmword ptr [rsp + 120], xmm0
+	mov	qword ptr [rsp], rdi
+	lea	r14, [rsp + 136]
+	movups	xmmword ptr [rsp + 136], xmm0
+	mov	qword ptr [rsp + 152], 0
+	movups	xmmword ptr [rsp + 200], xmm0
+	xor	ecx, ecx
+	mov	rbp, qword ptr [rip + use_obj@GOTPCREL]
+	mov	r12, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	rbx, qword ptr [rip + objc_msg_lookup@GOTPCREL]
+	xor	eax, eax
+	jmp	.LBB3_1
+	.p2align	4, 0x90
+.LBB3_6:
+	mov	rcx, qword ptr [rsp + 144]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rsp + 200], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	call	rbp
+	mov	r15, qword ptr [rsp]
+	mov	rax, qword ptr [rsp + 200]
+	mov	rcx, qword ptr [rsp + 208]
+.LBB3_1:
+	cmp	rax, rcx
+	jb	.LBB3_6
+	mov	r13, qword ptr [r12]
+	test	r13, r13
+	jne	.LBB3_4
+	lea	rdi, [rip + .Lanon.[ID].0]
+	call	qword ptr [rip + SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@GOTPCREL]
+	mov	r13, rax
+	mov	qword ptr [r12], rax
+.LBB3_4:
+	mov	rdi, r15
+	mov	rsi, r13
+	call	rbx
+	mov	r8d, 16
+	mov	rdi, r15
+	mov	rsi, r13
+	mov	rdx, r14
+	lea	rcx, [rsp + 8]
+	call	rax
+	mov	qword ptr [rsp + 208], rax
+	test	rax, rax
+	je	.LBB3_7
+	xor	eax, eax
+	jmp	.LBB3_6
+.LBB3_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+.Lfunc_end3:
+	.size	iter, .Lfunc_end3-iter
+
+	.section	.text.iter_noop,"ax",@progbits
+	.globl	iter_noop
+	.p2align	4, 0x90
+	.type	iter_noop,@function
+iter_noop:
+	push	rbp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r14, rdi
+	xorps	xmm0, xmm0
+	movups	xmmword ptr [rsp + 176], xmm0
+	movups	xmmword ptr [rsp + 160], xmm0
+	mov	qword ptr [rsp + 192], 0
+	lea	rbx, [rsp + 8]
+	movups	xmmword ptr [rsp + 8], xmm0
+	movups	xmmword ptr [rsp + 24], xmm0
+	movups	xmmword ptr [rsp + 40], xmm0
+	movups	xmmword ptr [rsp + 56], xmm0
+	movups	xmmword ptr [rsp + 72], xmm0
+	movups	xmmword ptr [rsp + 88], xmm0
+	movups	xmmword ptr [rsp + 104], xmm0
+	movups	xmmword ptr [rsp + 120], xmm0
+	mov	qword ptr [rsp], rdi
+	lea	r15, [rsp + 136]
+	movups	xmmword ptr [rsp + 136], xmm0
+	mov	qword ptr [rsp + 152], 0
+	movups	xmmword ptr [rsp + 200], xmm0
+	xor	eax, eax
+	mov	rbp, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	r12, qword ptr [rip + objc_msg_lookup@GOTPCREL]
+	xor	ecx, ecx
+	jmp	.LBB4_1
+	.p2align	4, 0x90
+.LBB4_6:
+	inc	rcx
+	mov	qword ptr [rsp + 200], rcx
+.LBB4_1:
+	cmp	rcx, rax
+	jb	.LBB4_6
+	mov	r13, qword ptr [rbp]
+	test	r13, r13
+	jne	.LBB4_4
+	lea	rdi, [rip + .Lanon.[ID].0]
+	call	qword ptr [rip + SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@GOTPCREL]
+	mov	r13, rax
+	mov	qword ptr [rbp], rax
+.LBB4_4:
+	mov	rdi, r14
+	mov	rsi, r13
+	call	r12
+	mov	r8d, 16
+	mov	rdi, r14
+	mov	rsi, r13
+	mov	rdx, r15
+	mov	rcx, rbx
+	call	rax
+	mov	qword ptr [rsp + 208], rax
+	test	rax, rax
+	je	.LBB4_7
+	mov	r14, qword ptr [rsp]
+	xor	ecx, ecx
+	jmp	.LBB4_6
+.LBB4_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+.Lfunc_end4:
+	.size	iter_noop, .Lfunc_end4-iter_noop
+
+	.section	.text.iter_retained,"ax",@progbits
+	.globl	iter_retained
+	.p2align	4, 0x90
+	.type	iter_retained,@function
+iter_retained:
+	push	rbp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	r12, rdi
+	xorps	xmm0, xmm0
+	movups	xmmword ptr [rsp + 176], xmm0
+	movups	xmmword ptr [rsp + 160], xmm0
+	mov	qword ptr [rsp + 192], 0
+	movups	xmmword ptr [rsp + 8], xmm0
+	movups	xmmword ptr [rsp + 24], xmm0
+	movups	xmmword ptr [rsp + 40], xmm0
+	movups	xmmword ptr [rsp + 56], xmm0
+	movups	xmmword ptr [rsp + 72], xmm0
+	movups	xmmword ptr [rsp + 88], xmm0
+	movups	xmmword ptr [rsp + 104], xmm0
+	movups	xmmword ptr [rsp + 120], xmm0
+	mov	qword ptr [rsp], rdi
+	movups	xmmword ptr [rsp + 136], xmm0
+	mov	qword ptr [rsp + 152], 0
+	movups	xmmword ptr [rsp + 200], xmm0
+	xor	ecx, ecx
+	mov	rbp, qword ptr [rip + objc_retain@GOTPCREL]
+	mov	r15, qword ptr [rip + use_obj@GOTPCREL]
+	mov	rbx, qword ptr [rip + objc_release@GOTPCREL]
+	mov	r14, qword ptr [rip + SYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	xor	eax, eax
+	jmp	.LBB5_1
+	.p2align	4, 0x90
+.LBB5_6:
+	mov	rcx, qword ptr [rsp + 144]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rsp + 200], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	call	rbp
+	mov	r12, rax
+	mov	rdi, rax
+	call	r15
+	mov	rdi, r12
+	call	rbx
+	mov	r12, qword ptr [rsp]
+	mov	rax, qword ptr [rsp + 200]
+	mov	rcx, qword ptr [rsp + 208]
+.LBB5_1:
+	cmp	rax, rcx
+	jb	.LBB5_6
+	mov	r13, qword ptr [r14]
+	test	r13, r13
+	jne	.LBB5_4
+	lea	rdi, [rip + .Lanon.[ID].0]
+	call	qword ptr [rip + SYM(objc2::runtime::Sel::register_unchecked::GENERATED_ID, 0)@GOTPCREL]
+	mov	r13, rax
+	mov	qword ptr [r14], rax
+.LBB5_4:
+	mov	rdi, r12
+	mov	rsi, r13
+	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
+	mov	r8d, 16
+	mov	rdi, r12
+	mov	rsi, r13
+	lea	rdx, [rsp + 136]
+	lea	rcx, [rsp + 8]
+	call	rax
+	mov	qword ptr [rsp + 208], rax
+	test	rax, rax
+	je	.LBB5_7
+	xor	eax, eax
+	jmp	.LBB5_6
+.LBB5_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+.Lfunc_end5:
+	.size	iter_retained, .Lfunc_end5-iter_retained
+
+	.type	.Lanon.[ID].0,@object
+	.section	.rodata..Lanon.[ID].0,"a",@progbits
+.Lanon.[ID].0:
+	.asciz	"countByEnumeratingWithState:objects:count:"
+	.size	.Lanon.[ID].0, 43
+
+	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_fast_enumeration/lib.rs
+++ b/crates/test-assembly/crates/test_fast_enumeration/lib.rs
@@ -1,0 +1,42 @@
+//! Test that fast enumeration is handled efficiently.
+#![cfg(feature = "Foundation_NSArray")]
+use core::hint::black_box;
+
+use icrate::Foundation::array::Iter;
+use icrate::Foundation::{NSArray, NSObject};
+
+// Should ideally just be zero-initialized.
+#[no_mangle]
+fn iter_create(array: &NSArray<NSObject>) -> Iter<'_, NSObject> {
+    array.iter()
+}
+
+#[no_mangle]
+fn iter_once<'a>(iter: &mut Iter<'a, NSObject>) -> Option<&'a NSObject> {
+    iter.next()
+}
+
+#[inline(never)]
+#[no_mangle]
+fn use_obj(obj: &NSObject) {
+    black_box(obj);
+}
+
+#[no_mangle]
+fn iter(array: &NSArray<NSObject>) {
+    for obj in array {
+        use_obj(obj);
+    }
+}
+
+#[no_mangle]
+fn iter_noop(array: &NSArray<NSObject>) {
+    for _ in array {}
+}
+
+#[no_mangle]
+fn iter_retained(array: &NSArray<NSObject>) {
+    for obj in array.iter_retained() {
+        use_obj(&obj);
+    }
+}

--- a/crates/test-ui/Cargo.toml
+++ b/crates/test-ui/Cargo.toml
@@ -15,6 +15,7 @@ default = [
     "std",
     "icrate/Foundation",
     "icrate/Foundation_NSString",
+    "icrate/Foundation_NSMutableString",
     "icrate/Foundation_NSThread",
     "icrate/Foundation_NSError",
     "icrate/Foundation_NSArray",

--- a/crates/test-ui/ui/array_iter_correct_lifetime.rs
+++ b/crates/test-ui/ui/array_iter_correct_lifetime.rs
@@ -1,0 +1,18 @@
+use icrate::Foundation::{NSArray, NSCopying, NSMutableArray, NSMutableString, NSString};
+
+fn main() {
+    let arr: &mut NSArray<NSMutableString> = &mut NSMutableArray::new();
+    for _ in &mut *arr {
+        let _ = &arr[0];
+    }
+
+    let arr: &mut NSMutableArray<NSString> = &mut NSMutableArray::new();
+    for s in arr.iter_retained() {
+        arr.push(s);
+    }
+
+    let arr: &mut NSMutableArray<NSString> = &mut NSMutableArray::new();
+    for s in &*arr {
+        arr.push(s.copy());
+    }
+}

--- a/crates/test-ui/ui/array_iter_correct_lifetime.stderr
+++ b/crates/test-ui/ui/array_iter_correct_lifetime.stderr
@@ -1,0 +1,32 @@
+error[E0502]: cannot borrow `*arr` as immutable because it is also borrowed as mutable
+ --> ui/array_iter_correct_lifetime.rs
+  |
+  |     for _ in &mut *arr {
+  |              ---------
+  |              |
+  |              mutable borrow occurs here
+  |              mutable borrow later used here
+  |         let _ = &arr[0];
+  |                  ^^^ immutable borrow occurs here
+
+error[E0502]: cannot borrow `*arr` as mutable because it is also borrowed as immutable
+ --> ui/array_iter_correct_lifetime.rs
+  |
+  |     for s in arr.iter_retained() {
+  |              -------------------
+  |              |
+  |              immutable borrow occurs here
+  |              immutable borrow later used here
+  |         arr.push(s);
+  |         ^^^^^^^^^^^ mutable borrow occurs here
+
+error[E0502]: cannot borrow `*arr` as mutable because it is also borrowed as immutable
+ --> ui/array_iter_correct_lifetime.rs
+  |
+  |     for s in &*arr {
+  |              -----
+  |              |
+  |              immutable borrow occurs here
+  |              immutable borrow later used here
+  |         arr.push(s.copy());
+  |         ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here

--- a/crates/test-ui/ui/array_iter_invalid.rs
+++ b/crates/test-ui/ui/array_iter_invalid.rs
@@ -1,0 +1,29 @@
+use icrate::Foundation::{NSArray, NSMutableArray, NSMutableString, NSString};
+use objc2::rc::Id;
+
+fn main() {
+    let arr: Id<NSArray<NSString>> = NSArray::new();
+    for s in &mut arr {
+        let s: &mut NSString = s;
+    }
+
+    let arr: Id<NSArray<NSMutableString>> = NSArray::new();
+    for s in &mut arr {
+        let s: &mut NSMutableString = s;
+    }
+
+    let arr: Id<NSMutableArray<NSString>> = NSMutableArray::new();
+    for s in &mut arr {
+        let s: &mut NSString = s;
+    }
+
+    // Should succeed, included for completeness
+    let arr: Id<NSMutableArray<NSMutableString>> = NSMutableArray::new();
+    for s in &mut arr {
+        let s: &mut NSString = s;
+    }
+
+    // IdIntoIterator not available for mutable children
+    let arr: Id<NSArray<NSMutableString>> = NSArray::new();
+    for _ in arr {}
+}

--- a/crates/test-ui/ui/array_iter_invalid.stderr
+++ b/crates/test-ui/ui/array_iter_invalid.stderr
@@ -1,0 +1,48 @@
+error[E0277]: the trait bound `&mut Id<NSArray<NSString>>: IntoIterator` is not satisfied
+ --> ui/array_iter_invalid.rs
+  |
+  |     for s in &mut arr {
+  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSString>>`
+  |
+  = note: `IntoIterator` is implemented for `&objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSString>>`, but not for `&mut objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSString>>`
+help: consider removing the leading `&`-reference
+  |
+6 -     for s in &mut arr {
+6 +     for s in arr {
+  |
+
+error[E0277]: the trait bound `&mut Id<NSArray<NSMutableString>>: IntoIterator` is not satisfied
+ --> ui/array_iter_invalid.rs
+  |
+  |     for s in &mut arr {
+  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSMutableString>>`
+  |
+  = help: the following other types implement trait `IntoIterator`:
+            &'a Id<T>
+            &'a mut Id<T>
+            Id<T>
+  = note: `IntoIterator` is implemented for `&objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSMutableString>>`, but not for `&mut objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSMutableString>>`
+
+error[E0277]: the trait bound `&mut Id<NSMutableArray<NSString>>: IntoIterator` is not satisfied
+ --> ui/array_iter_invalid.rs
+  |
+  |     for s in &mut arr {
+  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSMutableArray<NSString>>`
+  |
+  = note: `IntoIterator` is implemented for `&objc2::rc::Id<icrate::Foundation::NSMutableArray<icrate::Foundation::NSString>>`, but not for `&mut objc2::rc::Id<icrate::Foundation::NSMutableArray<icrate::Foundation::NSString>>`
+help: consider removing the leading `&`-reference
+   |
+16 -     for s in &mut arr {
+16 +     for s in arr {
+   |
+
+error[E0277]: the trait bound `Id<NSArray<NSMutableString>>: IntoIterator` is not satisfied
+ --> ui/array_iter_invalid.rs
+  |
+  |     for _ in arr {}
+  |              ^^^ the trait `IntoIterator` is not implemented for `Id<NSArray<NSMutableString>>`
+  |
+  = help: the following other types implement trait `IntoIterator`:
+            &'a Id<T>
+            &'a mut Id<T>
+            Id<T>

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -41,13 +41,13 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
   |
   = help: the following other types implement trait `Message`:
             Exception
-            Foundation::generated::__NSString::NSMutableString
             NSAppleEventDescriptor
             NSArray<ObjectType>
             NSDictionary<KeyType, ObjectType>
             NSEnumerator<ObjectType>
             NSError
             NSHashTable<ObjectType>
+            NSMapTable<KeyType, ObjectType>
           and $N others
 note: required by a bound in `__send_message_error`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs


### PR DESCRIPTION
- Add `IdFromIterator` and `IdIntoIterator` helper traits for implementing iteration over `Id`-contained types.
- Redo enumeration of `icrate` collection types `NSArray`, `NSSet` and `NSDictionary`.

See the changelog for details.

Fixes https://github.com/madsmtm/objc2/issues/304