### PR TITLE
Fix generating documentation for structs containing `objc2::rc::Id`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,6 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: cargo doc
-      # Disable cargo doc checking for now, `NSEnumerator2<'a, T>` is broken
-      # on current nightly.
-      if: false
       run: cargo doc --no-deps --document-private-items ${{ matrix.args }}
 
     - name: cargo clippy

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -4,8 +4,9 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |     needs_sync::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
   = note: required because it appears within the type `UnknownStorage<NSObject>`
+  = note: required because it appears within the type `EquivalentType<NSObject>`
   = note: required for `Id<NSObject>` to implement `Sync`
   = note: required because it appears within the type `PhantomData<Id<NSObject>>`
   = note: required because it appears within the type `NSArray<NSObject>`
@@ -40,8 +41,9 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |     needs_send::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
   = note: required because it appears within the type `UnknownStorage<NSObject>`
+  = note: required because it appears within the type `EquivalentType<NSObject>`
   = note: required for `Id<NSObject>` to implement `Send`
   = note: required because it appears within the type `PhantomData<Id<NSObject>>`
   = note: required because it appears within the type `NSArray<NSObject>`
@@ -79,8 +81,9 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |     needs_sync::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
   = note: required because it appears within the type `UnknownStorage<NSObject>`
+  = note: required because it appears within the type `EquivalentType<NSObject>`
   = note: required for `Id<NSObject>` to implement `Sync`
   = note: required because it appears within the type `PhantomData<Id<NSObject>>`
   = note: required because it appears within the type `NSArray<NSObject>`
@@ -117,8 +120,9 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |     needs_send::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
   = note: required because it appears within the type `UnknownStorage<NSObject>`
+  = note: required because it appears within the type `EquivalentType<NSObject>`
   = note: required for `Id<NSObject>` to implement `Send`
   = note: required because it appears within the type `PhantomData<Id<NSObject>>`
   = note: required because it appears within the type `NSArray<NSObject>`


### PR DESCRIPTION
Introduced in #419, but at the time I couldn't find a workaround for this issue, so I just decided to punt the issue, since I was going to be looking into changing iteration in https://github.com/madsmtm/objc2/issues/304 anyhow.

Today while working on https://github.com/madsmtm/objc2/pull/443, I stumbled upon a way to fix the problematic `rustdoc` ICE, so let's just do that!