### PR TITLE
Fix instance variable object encoding

### DIFF
--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Fixed encoding equivalence between empty structs and unions.
+* Parse (and ignore) extended type information.
 
 
 ## 3.0.0 - 2023-07-31

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -84,6 +84,14 @@ pub enum Encoding {
     /// A C `char *`. Corresponds to the `"*"` code.
     String,
     /// An Objective-C object (`id`). Corresponds to the `"@"` code.
+    ///
+    /// Some compilers may choose to store the name of the class in instance
+    /// variables and properties as `"@" class_name`, see [Extended Type Info
+    /// in Objective-C][ext] (note that this does not include generics).
+    ///
+    /// Such class names are currently ignored by `objc2-encode`.
+    ///
+    /// [ext]: https://bou.io/ExtendedTypeInfoInObjC.html
     Object,
     /// An Objective-C block. Corresponds to the `"@" "?"` code.
     Block,
@@ -378,6 +386,10 @@ mod tests {
             Encoding::Object;
             !Encoding::Block;
             "@";
+            ~"@\"AnyClassName\"";
+            ~"@\"\""; // Empty class name
+            !"@\"MyClassName";
+            !"@MyClassName\"";
             !"@?";
         }
 

--- a/crates/objc2/src/runtime/mod.rs
+++ b/crates/objc2/src/runtime/mod.rs
@@ -917,6 +917,7 @@ impl AnyClass {
         Bool::from_raw(res).as_bool()
     }
 
+    // <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtPropertyIntrospection.html>
     // fn property(&self, name: &str) -> Option<&Property>;
     // fn properties(&self) -> Malloc<[&Property]>;
     // unsafe fn replace_method(&self, name: Sel, imp: Imp, types: &str) -> Imp;


### PR DESCRIPTION
Instance variables include extended type information, we should find some way to represent this.

See: https://bou.io/ExtendedTypeInfoInObjC.html