### PR TITLE
Alternatives to `ProtocolObject`

### DIFF
--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -158,6 +158,7 @@
 )]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_cfg, doc_auto_cfg))]
+#![feature(coerce_unsized, unsize)]
 #![warn(elided_lifetimes_in_paths)]
 #![warn(missing_docs)]
 #![deny(non_ascii_idents)]

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -812,7 +812,7 @@ mod tests {
     use super::*;
     use crate::mutability::{Immutable, Mutable};
     use crate::rc::{__RcTestObject, __ThreadTestData, autoreleasepool};
-    use crate::runtime::{NSObject, Object};
+    use crate::runtime::{NSObject, NSObjectProtocol, Object};
     use crate::{declare_class, msg_send};
 
     #[test]
@@ -981,5 +981,20 @@ mod tests {
 
         assert_eq!(size_of::<Id<NSObject>>(), ptr_size);
         assert_eq!(size_of::<Option<Id<NSObject>>>(), ptr_size);
+    }
+
+    #[test]
+    fn test_unsize() {
+        use core::marker::Unsize;
+        use core::ops::CoerceUnsized;
+
+        // Would require a few changes to `Id` for this to actually be safe
+        impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Id<U>> for Id<T> {}
+
+        // Would be _super_ nice to have this impl, but unfortunately, we can't
+        // impl Unsize<Object> for NSObject {}
+
+        let x: Id<NSObject> = NSObject::new();
+        let x: Id<dyn NSObjectProtocol> = x;
     }
 }


### PR DESCRIPTION
I suspect it may be possible for us to basically never need to use `ProtocolObject`, but instead rely on the compiler to do the work of figuring out which traits are valid for which objects.

In this PR I've experimented with `CoercedUnsized` for `Id`, to show that it can indeed work through that. If we also changed message sending such that `&dyn NSObjectProtocol` translates to `NonNull<AnyObject>`, then using protocol objects would look very, _very_ similar to normal Rust code (methods take `&dyn MyProtocol` and end up returning `Id<dyn MyProtocol>`).

One worry is that the vtable may be included in the final binary, that would have to be thoroughly tested beforehand.