### PR TITLE
Rename `Class`, `Object` and `Protocol` to `AnyClass`, `AnyObject` and `AnyProtocol`

### DIFF
--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -358,10 +358,10 @@ impl fmt::Display for IdType {
                 Ok(())
             }
             Self::AnyObject { protocols } => match &**protocols {
-                [] => write!(f, "Object"),
+                [] => write!(f, "AnyObject"),
                 [id] if id.is_nsobject() => write!(f, "NSObject"),
                 [id] if id.name == "NSCopying" || id.name == "NSMutableCopying" => {
-                    write!(f, "Object")
+                    write!(f, "AnyObject")
                 }
                 [id] => write!(f, "ProtocolObject<dyn {}>", id.path()),
                 // TODO: Handle this better
@@ -369,7 +369,7 @@ impl fmt::Display for IdType {
             },
             Self::TypeDef { id, .. } => write!(f, "{}", id.path()),
             Self::GenericParam { name } => write!(f, "{name}"),
-            Self::AnyProtocol => write!(f, "Protocol"),
+            Self::AnyProtocol => write!(f, "AnyProtocol"),
             // TODO: Handle this better
             Self::AnyClass { .. } => write!(f, "TodoClass"),
             Self::Self_ { .. } => write!(f, "Self"),
@@ -1052,9 +1052,9 @@ impl fmt::Display for Inner {
             }
             Class { nullability } => {
                 if *nullability == Nullability::NonNull {
-                    write!(f, "NonNull<Class>")
+                    write!(f, "NonNull<AnyClass>")
                 } else {
-                    write!(f, "*const Class")
+                    write!(f, "*const AnyClass")
                 }
             }
             Sel { nullability } => {
@@ -1546,9 +1546,9 @@ impl fmt::Display for Ty {
                     }
                     Inner::Class { nullability } => {
                         if *nullability == Nullability::NonNull {
-                            write!(f, "&'static Class")
+                            write!(f, "&'static AnyClass")
                         } else {
-                            write!(f, "Option<&'static Class>")
+                            write!(f, "Option<&'static AnyClass>")
                         }
                     }
                     Inner::C99Bool => {
@@ -1648,9 +1648,9 @@ impl fmt::Display for Ty {
                 }
                 Inner::Class { nullability } => {
                     if *nullability == Nullability::NonNull {
-                        write!(f, "&Class")
+                        write!(f, "&AnyClass")
                     } else {
-                        write!(f, "Option<&Class>")
+                        write!(f, "Option<&AnyClass>")
                     }
                 }
                 Inner::C99Bool if self.kind == TyKind::MethodArgument => {

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1280,7 +1280,7 @@ impl fmt::Display for Stmt {
                 if !generics.is_empty() {
                     write!(f, "<")?;
                     for generic in generics {
-                        write!(f, "{generic}: Message = Object, ")?;
+                        write!(f, "{generic}: Message = AnyObject, ")?;
                     }
                     write!(f, ">")?;
                 };

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -1235,7 +1235,7 @@ skipped = true
 menuHasKeyEquivalent_forEvent_target_action = { skipped = true }
 
 # These subclass a generic struct, and hence the type parameter defaults to
-# `Object`, which is not PartialEq, Eq nor Hash.
+# `AnyObject`, which is not PartialEq, Eq nor Hash.
 [class.NSLayoutXAxisAnchor]
 derives = "Debug"
 [class.NSLayoutYAxisAnchor]

--- a/crates/icrate/examples/browser.rs
+++ b/crates/icrate/examples/browser.rs
@@ -19,7 +19,7 @@ use objc2::{
     declare_class, extern_methods, msg_send,
     mutability::InteriorMutable,
     rc::{Allocated, Id},
-    runtime::{Object, ProtocolObject, Sel},
+    runtime::{AnyObject, ProtocolObject, Sel},
     sel, ClassType,
 };
 
@@ -169,7 +169,7 @@ fn main() {
     let back_button = {
         // configure the button to navigate the webview backward
         let title = ns_string!("back");
-        let target = Some::<&Object>(&web_view);
+        let target = Some::<&AnyObject>(&web_view);
         let action = Some(sel!(goBack));
         let this = unsafe { NSButton::buttonWithTitle_target_action(title, target, action) };
         unsafe { this.setBezelStyle(NSBezelStyleShadowlessSquare) };
@@ -180,7 +180,7 @@ fn main() {
     let forward_button = {
         // configure the button to navigate the web view forward
         let title = ns_string!("forward");
-        let target = Some::<&Object>(&web_view);
+        let target = Some::<&AnyObject>(&web_view);
         let action = Some(sel!(goForward));
         let this = unsafe { NSButton::buttonWithTitle_target_action(title, target, action) };
         unsafe { this.setBezelStyle(NSBezelStyleShadowlessSquare) };

--- a/crates/icrate/examples/delegate.rs
+++ b/crates/icrate/examples/delegate.rs
@@ -6,7 +6,7 @@ use icrate::ns_string;
 use icrate::Foundation::{NSCopying, NSObject, NSString};
 use objc2::declare::{Ivar, IvarBool, IvarDrop, IvarEncode};
 use objc2::rc::Id;
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 use objc2::{declare_class, msg_send, msg_send_id, mutability, ClassType};
 
 #[cfg(target_os = "macos")]
@@ -71,7 +71,7 @@ declare_class!(
     unsafe impl CustomAppDelegate {
         /// This is `unsafe` because it expects `sender` to be valid
         #[method(applicationDidFinishLaunching:)]
-        unsafe fn did_finish_launching(&self, sender: *mut Object) {
+        unsafe fn did_finish_launching(&self, sender: *mut AnyObject) {
             println!("Did finish launching!");
             // Do something with `sender`
             dbg!(sender);
@@ -80,7 +80,7 @@ declare_class!(
         /// Some comment before `sel`.
         #[method(applicationWillTerminate:)]
         /// Some comment after `sel`.
-        fn will_terminate(&self, _: *mut Object) {
+        fn will_terminate(&self, _: *mut AnyObject) {
             println!("Will terminate!");
         }
     }

--- a/crates/icrate/examples/nspasteboard.rs
+++ b/crates/icrate/examples/nspasteboard.rs
@@ -6,7 +6,7 @@
 use icrate::AppKit::{NSPasteboard, NSPasteboardTypeString};
 use icrate::Foundation::{NSArray, NSCopying, NSString};
 use objc2::rc::Id;
-use objc2::runtime::{Class, Object, ProtocolObject};
+use objc2::runtime::{AnyClass, AnyObject, ProtocolObject};
 use objc2::ClassType;
 
 /// Simplest implementation
@@ -20,18 +20,18 @@ pub fn get_text_1(pasteboard: &NSPasteboard) -> Option<Id<NSString>> {
 pub fn get_text_2(pasteboard: &NSPasteboard) -> Option<Id<NSString>> {
     // The NSPasteboard API is a bit weird, it requires you to pass classes as
     // objects, which `icrate::Foundation::NSArray` was not really made for -
-    // so we convert the class to an `Object` type instead.
+    // so we convert the class to an `AnyObject` type instead.
     //
     // TODO: Investigate and find a better way to express this in `objc2`.
     let string_class = {
-        let cls: *const Class = NSString::class();
-        let cls = cls as *mut Object;
+        let cls: *const AnyClass = NSString::class();
+        let cls = cls as *mut AnyObject;
         unsafe { Id::new(cls).unwrap() }
     };
     let class_array = NSArray::from_vec(vec![string_class]);
     let objects = unsafe { pasteboard.readObjectsForClasses_options(&class_array, None) };
 
-    let obj: *const Object = objects?.first()?;
+    let obj: *const AnyObject = objects?.first()?;
     // And this part is weird as well, since we now have to convert the object
     // into an NSString, which we know it to be since that's what we told
     // `readObjectsForClasses:options:`.

--- a/crates/icrate/src/AppKit/fixes/mod.rs
+++ b/crates/icrate/src/AppKit/fixes/mod.rs
@@ -43,7 +43,7 @@ extern_class!(
 __inner_extern_class!(
     #[cfg(feature = "AppKit_NSLayoutAnchor")]
     #[derive(Debug, PartialEq, Eq, Hash)]
-    pub struct NSLayoutAnchor<AnchorType: Message = Object> {
+    pub struct NSLayoutAnchor<AnchorType: Message = AnyObject> {
         __superclass: NSObject,
         _inner0: PhantomData<*mut AnchorType>,
         notunwindsafe: PhantomData<&'static mut ()>,

--- a/crates/icrate/src/Foundation/__macro_helpers/ns_string.rs
+++ b/crates/icrate/src/Foundation/__macro_helpers/ns_string.rs
@@ -16,7 +16,7 @@
 use core::ffi::c_void;
 
 use crate::Foundation::NSString;
-use objc2::runtime::Class;
+use objc2::runtime::AnyClass;
 
 // This is defined in CoreFoundation, but we don't emit a link attribute
 // here because it is already linked via Foundation.
@@ -24,7 +24,7 @@ use objc2::runtime::Class;
 // Although this is a "private" (underscored) symbol, it is directly
 // referenced in Objective-C binaries. So it's safe for us to reference.
 extern "C" {
-    pub static __CFConstantStringClassReference: Class;
+    pub static __CFConstantStringClassReference: AnyClass;
 }
 
 /// Structure used to describe a constant `CFString`.
@@ -38,7 +38,7 @@ extern "C" {
 /// [`CF_CONST_STRING`]: <https://github.com/apple-oss-distributions/CF/blob/CF-1153.18/CFInternal.h#L332-L336>
 #[repr(C)]
 pub struct CFConstString {
-    isa: &'static Class,
+    isa: &'static AnyClass,
     // Important that we don't use `usize` here, since that would be wrong on
     // big-endian systems!
     cfinfo: u32,
@@ -66,7 +66,7 @@ impl CFConstString {
     const FLAGS_ASCII: u32 = 0x07_C8;
     const FLAGS_UTF16: u32 = 0x07_D0;
 
-    pub const unsafe fn new_ascii(isa: &'static Class, data: &'static [u8]) -> Self {
+    pub const unsafe fn new_ascii(isa: &'static AnyClass, data: &'static [u8]) -> Self {
         Self {
             isa,
             cfinfo: Self::FLAGS_ASCII,
@@ -78,7 +78,7 @@ impl CFConstString {
         }
     }
 
-    pub const unsafe fn new_utf16(isa: &'static Class, data: &'static [u16]) -> Self {
+    pub const unsafe fn new_utf16(isa: &'static AnyClass, data: &'static [u16]) -> Self {
         Self {
             isa,
             cfinfo: Self::FLAGS_UTF16,

--- a/crates/icrate/src/Foundation/additions/array.rs
+++ b/crates/icrate/src/Foundation/additions/array.rs
@@ -26,7 +26,7 @@ impl<T: Message> NSArray<T> {
         // now safely take ownership (even if `T` is mutable).
         unsafe { Self::initWithObjects_count(Self::alloc(), ptr, len) }
         // The drop of `Vec` here would invalidate our mutable pointer,
-        // except for the fact that we're using `UnsafeCell` in `Object`.
+        // except for the fact that we're using `UnsafeCell` in `AnyObject`.
     }
 
     pub fn from_id_slice(slice: &[Id<T>]) -> Id<Self>

--- a/crates/icrate/src/Foundation/additions/attributed_string.rs
+++ b/crates/icrate/src/Foundation/additions/attributed_string.rs
@@ -29,7 +29,7 @@ impl NSAttributedString {
     #[cfg(feature = "Foundation_NSString")]
     pub unsafe fn new_with_attributes(
         string: &Foundation::NSString,
-        attributes: &Foundation::NSDictionary<NSAttributedStringKey, Object>,
+        attributes: &Foundation::NSDictionary<NSAttributedStringKey, AnyObject>,
     ) -> Id<Self> {
         unsafe { Self::initWithString_attributes(Self::alloc(), string, Some(attributes)) }
     }

--- a/crates/icrate/src/Foundation/additions/bundle.rs
+++ b/crates/icrate/src/Foundation/additions/bundle.rs
@@ -20,7 +20,7 @@ impl NSBundle {
         let info = self.infoDictionary()?;
         // TODO: Use ns_string!
         let name = info.get(&NSString::from_str("CFBundleName"))?;
-        let ptr: *const Object = name;
+        let ptr: *const AnyObject = name;
         let ptr: *const NSString = ptr.cast();
         // SAFETY: TODO
         let name = unsafe { ptr.as_ref().unwrap_unchecked() };

--- a/crates/icrate/src/Foundation/additions/dictionary.rs
+++ b/crates/icrate/src/Foundation/additions/dictionary.rs
@@ -9,7 +9,6 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::{self, NonNull};
 
 use objc2::mutability::IsMutable;
-use objc2::runtime::Object;
 
 use super::iter;
 use super::util;
@@ -27,7 +26,7 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
         let count = min(keys.len(), vals.len());
 
         let keys: *mut NonNull<T> = util::ref_ptr_cast_const(keys.as_ptr());
-        let keys: *mut NonNull<Object> = keys.cast();
+        let keys: *mut NonNull<AnyObject> = keys.cast();
         let vals = util::id_ptr_cast(vals.as_mut_ptr());
 
         unsafe { Self::initWithObjects_forKeys_count(Self::alloc(), vals, keys, count) }
@@ -44,7 +43,7 @@ impl<K: Message, V: Message> NSMutableDictionary<K, V> {
         let count = min(keys.len(), vals.len());
 
         let keys: *mut NonNull<T> = util::ref_ptr_cast_const(keys.as_ptr());
-        let keys: *mut NonNull<Object> = keys.cast();
+        let keys: *mut NonNull<AnyObject> = keys.cast();
         let vals = util::id_ptr_cast(vals.as_mut_ptr());
 
         unsafe { Self::initWithObjects_forKeys_count(Self::alloc(), vals, keys, count) }
@@ -215,8 +214,8 @@ impl<K: Message, V: Message> NSMutableDictionary<K, V> {
             .get(&key)
             .map(|old_obj| unsafe { util::mutable_collection_retain_removed_id(old_obj) });
 
-        // SAFETY: It is always safe to transmute an `Id` to `Object`.
-        let key: Id<Object> = unsafe { Id::cast(key) };
+        // SAFETY: It is always safe to transmute an `Id` to `AnyObject`.
+        let key: Id<AnyObject> = unsafe { Id::cast(key) };
         // SAFETY: We have ownership over both the key and the value.
         unsafe { self.setObject_forKey(&value, &key) };
         old_obj

--- a/crates/icrate/src/Foundation/additions/exception.rs
+++ b/crates/icrate/src/Foundation/additions/exception.rs
@@ -27,7 +27,7 @@ impl NSException {
     pub fn new(
         name: &NSExceptionName,
         reason: Option<&Foundation::NSString>,
-        user_info: Option<&Foundation::NSDictionary<Object, Object>>,
+        user_info: Option<&Foundation::NSDictionary<AnyObject, AnyObject>>,
     ) -> Option<Id<Self>> {
         unsafe {
             msg_send_id![
@@ -91,7 +91,7 @@ impl NSException {
 #[cfg(feature = "Foundation_NSString")]
 impl fmt::Debug for NSException {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let obj: &Object = self.as_ref();
+        let obj: &AnyObject = self.as_ref();
         write!(f, "{obj:?} '{}'", self.name())?;
         if let Some(reason) = self.reason() {
             write!(f, " reason:{reason}")?;

--- a/crates/icrate/src/Foundation/additions/iter.rs
+++ b/crates/icrate/src/Foundation/additions/iter.rs
@@ -23,7 +23,7 @@ const BUF_SIZE: usize = 16;
 #[derive(Debug, PartialEq)]
 struct FastEnumeratorHelper {
     state: NSFastEnumerationState,
-    buf: [*mut Object; BUF_SIZE],
+    buf: [*mut AnyObject; BUF_SIZE],
     // TODO: We could possibly optimize things a bit by doing
     // `itemsPtr.add(1); items_count -= 1;` on every loop, instead of storing
     // `current_item` - but it's not really defined whether we're allowed to
@@ -136,7 +136,7 @@ impl FastEnumeratorHelper {
     unsafe fn next_from(
         &mut self,
         collection: &ProtocolObject<dyn NSFastEnumeration>,
-    ) -> Option<NonNull<Object>> {
+    ) -> Option<NonNull<AnyObject>> {
         // If we've exhausted the current array of items.
         if self.current_item >= self.items_count {
             // Get the next array of items.

--- a/crates/icrate/src/Foundation/additions/thread.rs
+++ b/crates/icrate/src/Foundation/additions/thread.rs
@@ -56,14 +56,13 @@ fn make_multithreaded() {
 /// Use when designing APIs that are only safe to use on the main thread:
 ///
 /// ```no_run
-/// use icrate::Foundation::MainThreadMarker;
-/// use icrate::objc2::runtime::Object;
+/// use icrate::Foundation::{MainThreadMarker, NSObject};
 /// use icrate::objc2::msg_send;
-/// # let obj = 0 as *const Object;
+/// # let obj = 0 as *const NSObject;
 ///
 /// // This action requires the main thread, so we take a marker as parameter.
 /// // It signals clearly to users "this requires the main thread".
-/// unsafe fn do_thing(obj: *const Object, _mtm: MainThreadMarker) {
+/// unsafe fn do_thing(obj: *const NSObject, _mtm: MainThreadMarker) {
 ///     msg_send![obj, someActionThatRequiresTheMainThread]
 /// }
 ///

--- a/crates/icrate/src/Foundation/fixes/enumerator.rs
+++ b/crates/icrate/src/Foundation/fixes/enumerator.rs
@@ -6,7 +6,7 @@ use crate::common::*;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NSFastEnumerationState {
     pub state: c_ulong,
-    pub itemsPtr: *mut *mut Object,
+    pub itemsPtr: *mut *mut AnyObject,
     pub mutationsPtr: *mut c_ulong,
     pub extra: [c_ulong; 5],
 }

--- a/crates/icrate/src/Foundation/fixes/generics.rs
+++ b/crates/icrate/src/Foundation/fixes/generics.rs
@@ -18,7 +18,7 @@ impl<T: ?Sized> UnwindSafe for UnsafeIgnoreAutoTraits<T> {}
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSArray")]
-    pub struct NSArray<ObjectType: Message = Object> {
+    pub struct NSArray<ObjectType: Message = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         /// `NSArray` and `NSMutableArray` have `Id`-like storage.
@@ -101,7 +101,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSArray")]
-    pub struct NSMutableArray<ObjectType: Message = Object> {
+    pub struct NSMutableArray<ObjectType: Message = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSArray<ObjectType>,
     }
@@ -125,7 +125,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSDictionary")]
-    pub struct NSDictionary<KeyType: Message = Object, ObjectType: Message = Object> {
+    pub struct NSDictionary<KeyType: Message = AnyObject, ObjectType: Message = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the dictionary was implemented with:
@@ -151,7 +151,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSDictionary")]
-    pub struct NSMutableDictionary<KeyType: Message = Object, ObjectType: Message = Object> {
+    pub struct NSMutableDictionary<KeyType: Message = AnyObject, ObjectType: Message = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSDictionary<KeyType, ObjectType>,
     }
@@ -177,7 +177,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSSet")]
-    pub struct NSSet<ObjectType: Message = Object> {
+    pub struct NSSet<ObjectType: Message = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the set was implemented as `NSArray<ObjectType>`.
@@ -202,7 +202,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSSet")]
-    pub struct NSMutableSet<ObjectType: Message = Object> {
+    pub struct NSMutableSet<ObjectType: Message = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSSet<ObjectType>,
     }
@@ -226,7 +226,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(Debug, PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSCountedSet")]
-    pub struct NSCountedSet<ObjectType: Message = Object> {
+    pub struct NSCountedSet<ObjectType: Message = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSMutableSet<ObjectType>,
     }
@@ -250,7 +250,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    pub struct NSOrderedSet<ObjectType: Message = Object> {
+    pub struct NSOrderedSet<ObjectType: Message = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the set was implemented with `NSArray<ObjectType>`.
@@ -275,7 +275,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    pub struct NSMutableOrderedSet<ObjectType: Message = Object> {
+    pub struct NSMutableOrderedSet<ObjectType: Message = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSOrderedSet<ObjectType>,
     }
@@ -299,7 +299,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(Debug, PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSEnumerator")]
-    pub struct NSEnumerator<ObjectType: Message = Object> {
+    pub struct NSEnumerator<ObjectType: Message = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Enumerators are basically the same as if we were storing

--- a/crates/icrate/src/Metal/private.rs
+++ b/crates/icrate/src/Metal/private.rs
@@ -41,7 +41,7 @@ extern_methods!(
         pub unsafe fn newSerializedVertexDataWithFlags_error(
             &self,
             flags: u64,
-        ) -> Result<Id<Object>, Id<Foundation::NSError>>;
+        ) -> Result<Id<AnyObject>, Id<Foundation::NSError>>;
 
         #[method(serializeFragmentData)]
         pub unsafe fn serializeFragmentData(&self) -> *mut c_void;
@@ -60,6 +60,6 @@ extern_methods!(
     #[cfg(feature = "Metal_MTLVertexDescriptor")]
     unsafe impl Metal::MTLVertexDescriptor {
         #[method_id(newSerializedDescriptor)]
-        pub unsafe fn newSerializedDescriptor(&self) -> Option<Id<Object>>;
+        pub unsafe fn newSerializedDescriptor(&self) -> Option<Id<AnyObject>>;
     }
 );

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -20,7 +20,7 @@ pub(crate) use objc2::mutability::{
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::rc::{Allocated, DefaultId, Id};
 #[cfg(feature = "objective-c")]
-pub(crate) use objc2::runtime::{Bool, Class, Object, Sel};
+pub(crate) use objc2::runtime::{AnyClass, AnyObject, Bool, Sel};
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
 #[cfg(feature = "objective-c")]
@@ -34,12 +34,12 @@ pub(crate) use block2::Block;
 
 // TODO
 #[cfg(feature = "objective-c")]
-pub(crate) type Protocol = Object;
+pub(crate) type AnyProtocol = AnyObject;
 pub(crate) type TodoFunction = *const c_void;
 #[cfg(feature = "objective-c")]
-pub(crate) type TodoClass = Object;
+pub(crate) type TodoClass = AnyObject;
 #[cfg(feature = "objective-c")]
-pub(crate) type TodoProtocols = Object;
+pub(crate) type TodoProtocols = AnyObject;
 
 // MacTypes.h
 pub(crate) type Boolean = u8; // unsigned char

--- a/crates/icrate/tests/attributed_string.rs
+++ b/crates/icrate/tests/attributed_string.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "Foundation_NSAttributedString")]
 #![cfg(feature = "Foundation_NSString")]
 use objc2::rc::{autoreleasepool, Id};
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 use icrate::Foundation::{self, NSAttributedString, NSObject, NSString};
 
@@ -55,8 +55,8 @@ fn test_debug() {
     };
     assert_eq!(format!("{s:?}"), expected);
 
-    let obj: Id<Object> = unsafe { Id::cast(NSObject::new()) };
-    let ptr: *const Object = &*obj;
+    let obj = Id::into_super(NSObject::new());
+    let ptr: *const AnyObject = &*obj;
     let s = unsafe {
         NSAttributedString::new_with_attributes(
             &NSString::from_str("abc"),

--- a/crates/icrate/tests/auto_traits.rs
+++ b/crates/icrate/tests/auto_traits.rs
@@ -6,7 +6,7 @@ use static_assertions::{assert_impl_all, assert_not_impl_any};
 use icrate::Foundation::*;
 use objc2::mutability::{Immutable, Mutable};
 use objc2::rc::Id;
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 use objc2::{declare_class, ClassType};
 
 // We expect most Foundation types to be UnwindSafe and RefUnwindSafe,
@@ -102,9 +102,9 @@ fn test_generic_auto_traits() {
     }
 
     // TODO
-    assert_not_impl_any!(NSArray<Object>: Unpin);
-    assert_not_impl_any!(NSMutableArray<Object>: Unpin);
-    assert_not_impl_any!(NSDictionary<Object, Object>: Unpin);
+    assert_not_impl_any!(NSArray<AnyObject>: Unpin);
+    assert_not_impl_any!(NSMutableArray<AnyObject>: Unpin);
+    assert_not_impl_any!(NSDictionary<AnyObject, AnyObject>: Unpin);
 
     assert_id_like!(NSArray<T>);
     #[allow(dead_code)]

--- a/crates/icrate/tests/mutable_data.rs
+++ b/crates/icrate/tests/mutable_data.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "Foundation_NSMutableData")]
 
 use objc2::rc::Id;
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 use icrate::Foundation::{NSData, NSMutableData, NSObject};
 
@@ -91,15 +91,15 @@ fn test_as_ref_borrow() {
     impls_borrow_mut::<NSMutableData, NSData>(&mut obj);
     impls_borrow::<NSMutableData, NSObject>(&obj);
     impls_borrow_mut::<NSMutableData, NSObject>(&mut obj);
-    impls_borrow::<NSMutableData, Object>(&obj);
-    impls_borrow_mut::<NSMutableData, Object>(&mut obj);
+    impls_borrow::<NSMutableData, AnyObject>(&obj);
+    impls_borrow_mut::<NSMutableData, AnyObject>(&mut obj);
 
     impls_borrow::<NSData, NSData>(&obj);
     impls_borrow_mut::<NSData, NSData>(&mut obj);
     impls_borrow::<NSData, NSObject>(&obj);
     impls_borrow_mut::<NSData, NSObject>(&mut obj);
-    impls_borrow::<NSData, Object>(&obj);
-    impls_borrow_mut::<NSData, Object>(&mut obj);
+    impls_borrow::<NSData, AnyObject>(&obj);
+    impls_borrow_mut::<NSData, AnyObject>(&mut obj);
 
     fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
     fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}

--- a/crates/objc-sys/src/types.rs
+++ b/crates/objc-sys/src/types.rs
@@ -210,5 +210,5 @@ pub type SEL = *const objc_selector;
 /// - `icrate::Foundation::NS[...]` for when you know the class of the object
 ///   you're dealing with.
 /// - `objc2::rc::Id` for a proper way of doing memory management.
-/// - `objc2::runtime::Object` for a bit safer representation of this.
+/// - `objc2::runtime::AnyObject` for a bit safer representation of this.
 pub type id = *mut objc_object;

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* Renamed `runtime` types:
+  - `Object` to `AnyObject`.
+  - `Class` to `AnyClass`.
+  - `Protocol` to `AnyProtocol`.
+
+  To better fit with Swift's naming scheme. The types are still available
+  under the old names as deprecated aliases.
+
 
 ## 0.4.0 - 2023-06-20
 

--- a/crates/objc2/benches/autorelease.rs
+++ b/crates/objc2/benches/autorelease.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 use std::mem::ManuallyDrop;
 
 use objc2::rc::{autoreleasepool, Id};
-use objc2::runtime::{Class, Object, Sel};
+use objc2::runtime::{AnyClass, NSObject, Sel};
 use objc2::{class, msg_send, sel};
 
 const BYTES: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -13,7 +13,7 @@ fn pool_cleanup() {
     autoreleasepool(|_| {})
 }
 
-fn class() -> &'static Class {
+fn class() -> &'static AnyClass {
     class!(NSObject)
 }
 
@@ -21,24 +21,24 @@ fn sel() -> Sel {
     sel!(alloc)
 }
 
-fn send_message() -> &'static Class {
+fn send_message() -> &'static AnyClass {
     unsafe { msg_send![class!(NSObject), class] }
 }
 
-fn alloc_nsobject() -> *mut Object {
+fn alloc_nsobject() -> *mut NSObject {
     unsafe { msg_send![class!(NSObject), alloc] }
 }
 
-fn new_nsobject() -> Id<Object> {
+fn new_nsobject() -> Id<NSObject> {
     let obj = alloc_nsobject();
-    let obj: *mut Object = unsafe { msg_send![obj, init] };
+    let obj: *mut NSObject = unsafe { msg_send![obj, init] };
     unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
-fn new_nsdata() -> Id<Object> {
+fn new_nsdata() -> Id<NSObject> {
     let bytes_ptr = BYTES.as_ptr() as *const c_void;
-    let obj: *mut Object = unsafe { msg_send![class!(NSData), alloc] };
-    let obj: *mut Object = unsafe {
+    let obj: *mut NSObject = unsafe { msg_send![class!(NSData), alloc] };
+    let obj: *mut NSObject = unsafe {
         msg_send![
             obj,
             initWithBytes: bytes_ptr,
@@ -48,11 +48,11 @@ fn new_nsdata() -> Id<Object> {
     unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
-fn new_leaked_nsdata() -> *const Object {
+fn new_leaked_nsdata() -> *const NSObject {
     Id::as_ptr(&*ManuallyDrop::new(new_nsdata()))
 }
 
-fn autoreleased_nsdata() -> *const Object {
+fn autoreleased_nsdata() -> *const NSObject {
     // let bytes_ptr = BYTES.as_ptr() as *const c_void;
     // unsafe {
     //     msg_send![
@@ -64,46 +64,46 @@ fn autoreleased_nsdata() -> *const Object {
     unsafe { msg_send![new_leaked_nsdata(), autorelease] }
 }
 
-fn new_nsstring() -> Id<Object> {
-    let obj: *mut Object = unsafe { msg_send![class!(NSString), alloc] };
-    let obj: *mut Object = unsafe { msg_send![obj, init] };
+fn new_nsstring() -> Id<NSObject> {
+    let obj: *mut NSObject = unsafe { msg_send![class!(NSString), alloc] };
+    let obj: *mut NSObject = unsafe { msg_send![obj, init] };
     unsafe { Id::new(obj).unwrap_unchecked() }
 }
 
-fn new_leaked_nsstring() -> *const Object {
+fn new_leaked_nsstring() -> *const NSObject {
     Id::as_ptr(&*ManuallyDrop::new(new_nsstring()))
 }
 
-fn autoreleased_nsstring() -> *const Object {
+fn autoreleased_nsstring() -> *const NSObject {
     // unsafe { msg_send![class!(NSString), string] }
     unsafe { msg_send![new_leaked_nsstring(), autorelease] }
 }
 
-fn retain_autoreleased(obj: *const Object) -> Id<Object> {
-    unsafe { Id::retain_autoreleased((obj as *mut Object).cast()).unwrap_unchecked() }
+fn retain_autoreleased(obj: *const NSObject) -> Id<NSObject> {
+    unsafe { Id::retain_autoreleased((obj as *mut NSObject).cast()).unwrap_unchecked() }
 }
 
-fn autoreleased_nsdata_pool_cleanup() -> *const Object {
+fn autoreleased_nsdata_pool_cleanup() -> *const NSObject {
     autoreleasepool(|_| autoreleased_nsdata())
 }
 
-fn autoreleased_nsdata_fast_caller_cleanup() -> Id<Object> {
+fn autoreleased_nsdata_fast_caller_cleanup() -> Id<NSObject> {
     retain_autoreleased(autoreleased_nsdata())
 }
 
-fn autoreleased_nsdata_fast_caller_cleanup_pool_cleanup() -> Id<Object> {
+fn autoreleased_nsdata_fast_caller_cleanup_pool_cleanup() -> Id<NSObject> {
     autoreleasepool(|_| retain_autoreleased(autoreleased_nsdata()))
 }
 
-fn autoreleased_nsstring_pool_cleanup() -> *const Object {
+fn autoreleased_nsstring_pool_cleanup() -> *const NSObject {
     autoreleasepool(|_| autoreleased_nsstring())
 }
 
-fn autoreleased_nsstring_fast_caller_cleanup() -> Id<Object> {
+fn autoreleased_nsstring_fast_caller_cleanup() -> Id<NSObject> {
     retain_autoreleased(autoreleased_nsstring())
 }
 
-fn autoreleased_nsstring_fast_caller_cleanup_pool_cleanup() -> Id<Object> {
+fn autoreleased_nsstring_fast_caller_cleanup_pool_cleanup() -> Id<NSObject> {
     autoreleasepool(|_| retain_autoreleased(autoreleased_nsstring()))
 }
 

--- a/crates/objc2/examples/class_with_lifetime.rs
+++ b/crates/objc2/examples/class_with_lifetime.rs
@@ -7,7 +7,7 @@ use std::sync::Once;
 use objc2::declare::{ClassBuilder, Ivar, IvarEncode, IvarType};
 use objc2::mutability::Mutable;
 use objc2::rc::Id;
-use objc2::runtime::{Class, NSObject, Sel};
+use objc2::runtime::{AnyClass, NSObject, Sel};
 use objc2::{msg_send, msg_send_id, sel};
 use objc2::{ClassType, Encoding, Message, RefEncode};
 
@@ -76,7 +76,7 @@ unsafe impl<'a> ClassType for MyObject<'a> {
     type Mutability = Mutable;
     const NAME: &'static str = "MyObject";
 
-    fn class() -> &'static Class {
+    fn class() -> &'static AnyClass {
         // TODO: Use std::lazy::LazyCell
         static REGISTER_CLASS: Once = Once::new();
 
@@ -96,7 +96,7 @@ unsafe impl<'a> ClassType for MyObject<'a> {
             let _cls = builder.register();
         });
 
-        Class::get("MyObject").unwrap()
+        AnyClass::get("MyObject").unwrap()
     }
 
     fn as_super(&self) -> &Self::Super {

--- a/crates/objc2/examples/encode_nsstring.rs
+++ b/crates/objc2/examples/encode_nsstring.rs
@@ -1,15 +1,15 @@
 use objc2::encode::{Encode, Encoding, RefEncode};
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 #[repr(transparent)]
 struct NSString {
-    // `NSString` has the same layout / works the same as `Object`.
-    _priv: Object,
+    // `NSString` has the same layout / works the same as `AnyObject`.
+    _priv: AnyObject,
 }
 
 // We don't know the size of NSString, so we can only hold pointers to it.
 //
-// SAFETY: The string is `repr(transparent)` over `Object`.
+// SAFETY: The string is `repr(transparent)` over `AnyObject`.
 unsafe impl RefEncode for NSString {
     const ENCODING_REF: Encoding = Encoding::Object;
 }

--- a/crates/objc2/examples/introspection.rs
+++ b/crates/objc2/examples/introspection.rs
@@ -1,4 +1,4 @@
-use objc2::runtime::{Class, NSObject};
+use objc2::runtime::{AnyClass, NSObject};
 use objc2::{sel, ClassType, Encode};
 
 fn main() {
@@ -29,7 +29,7 @@ fn main() {
         ivar.name(),
         ivar.type_encoding()
     );
-    assert!(<*const Class>::ENCODING.equivalent_to_str(ivar.type_encoding()));
+    assert!(<*const AnyClass>::ENCODING.equivalent_to_str(ivar.type_encoding()));
 
     // Inspect a method of the class
     let method = cls.instance_method(sel!(hash)).unwrap();
@@ -52,6 +52,6 @@ fn main() {
     // Access an ivar of the object
     //
     // As before, you should not rely on the `isa` ivar being available!
-    let isa = unsafe { *obj.ivar::<*const Class>("isa") };
+    let isa = unsafe { *obj.ivar::<*const AnyClass>("isa") };
     println!("NSObject isa: {isa:?}");
 }

--- a/crates/objc2/src/__macro_helpers/cache.rs
+++ b/crates/objc2/src/__macro_helpers/cache.rs
@@ -2,7 +2,7 @@ use core::ptr;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
 use crate::ffi;
-use crate::runtime::{Class, Sel};
+use crate::runtime::{AnyClass, Sel};
 
 /// Allows storing a [`Sel`] in a static and lazily loading it.
 #[doc(hidden)]
@@ -40,10 +40,10 @@ impl CachedSel {
     }
 }
 
-/// Allows storing a [`Class`] reference in a static and lazily loading it.
+/// Allows storing a [`AnyClass`] reference in a static and lazily loading it.
 #[doc(hidden)]
 pub struct CachedClass {
-    ptr: AtomicPtr<Class>,
+    ptr: AtomicPtr<AnyClass>,
 }
 
 impl CachedClass {
@@ -58,14 +58,14 @@ impl CachedClass {
     /// the given name and stores it.
     #[inline]
     #[doc(hidden)]
-    pub unsafe fn get(&self, name: &str) -> Option<&'static Class> {
+    pub unsafe fn get(&self, name: &str) -> Option<&'static AnyClass> {
         // `Relaxed` should be fine since `objc_getClass` is thread-safe.
         let ptr = self.ptr.load(Ordering::Relaxed);
         if let Some(cls) = unsafe { ptr.as_ref() } {
             Some(cls)
         } else {
-            let ptr: *const Class = unsafe { ffi::objc_getClass(name.as_ptr().cast()) }.cast();
-            self.ptr.store(ptr as *mut Class, Ordering::Relaxed);
+            let ptr: *const AnyClass = unsafe { ffi::objc_getClass(name.as_ptr().cast()) }.cast();
+            self.ptr.store(ptr as *mut AnyClass, Ordering::Relaxed);
             unsafe { ptr.as_ref() }
         }
     }

--- a/crates/objc2/src/class_type.rs
+++ b/crates/objc2/src/class_type.rs
@@ -1,7 +1,7 @@
 use crate::msg_send_id;
 use crate::mutability::{IsAllocableAnyThread, IsRetainable, Mutability};
 use crate::rc::{Allocated, Id};
-use crate::runtime::Class;
+use crate::runtime::AnyClass;
 use crate::Message;
 
 /// Marks types that represent specific classes.
@@ -21,7 +21,7 @@ use crate::Message;
 ///
 /// 1. The type must represent a specific class.
 /// 2. [`Self::Super`] must be a superclass of the class (or something that
-///    represents any object, like [`Object`][crate::runtime::Object]).
+///    represents any object, like [`AnyObject`][crate::runtime::AnyObject]).
 /// 3. [`Self::Mutability`] must be specified correctly.
 ///
 ///    Note that very little Objective-C code follows Rust's usual ownership
@@ -40,7 +40,7 @@ use crate::Message;
 ///
 /// # Examples
 ///
-/// Use the trait to access the [`Class`] of an object.
+/// Use the trait to access the [`AnyClass`] of an object.
 ///
 /// ```
 /// use objc2::{ClassType, msg_send_id};
@@ -112,11 +112,11 @@ pub unsafe trait ClassType: Message {
     /// If you have implemented [`Deref`] for your type, it is highly
     /// recommended that this is equal to [`Deref::Target`].
     ///
-    /// This may be [`Object`] if the class is a root class.
+    /// This may be [`AnyObject`] if the class is a root class.
     ///
     /// [`Deref`]: std::ops::Deref
     /// [`Deref::Target`]: std::ops::Deref::Target
-    /// [`Object`]: crate::runtime::Object
+    /// [`AnyObject`]: crate::runtime::AnyObject
     type Super: Message;
 
     /// Whether the type is mutable or immutable.
@@ -140,7 +140,7 @@ pub unsafe trait ClassType: Message {
     /// This may panic if something went wrong with getting or declaring the
     /// class, e.g. if the program is not properly linked to the framework
     /// that defines the class.
-    fn class() -> &'static Class;
+    fn class() -> &'static AnyClass;
 
     /// Get an immutable reference to the superclass.
     // Note: It'd be safe to provide a default impl using transmute here if

--- a/crates/objc2/src/macros/__rewrite_self_arg.rs
+++ b/crates/objc2/src/macros/__rewrite_self_arg.rs
@@ -211,9 +211,9 @@ macro_rules! __rewrite_self_arg_inner {
 
             (add_class_method)
             (<Self as $crate::ClassType>::class())
-            (&$crate::runtime::Class)
+            (&$crate::runtime::AnyClass)
             (
-                _: &$crate::runtime::Class,
+                _: &$crate::runtime::AnyClass,
                 _: $crate::runtime::Sel,
             )
             ($($args_rest)*)

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -523,7 +523,7 @@ macro_rules! __inner_declare_class {
         $crate::__extern_class_impl_traits! {
             // SAFETY: Upheld by caller
             unsafe impl () for $for {
-                INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::Object];
+                INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::AnyObject];
 
                 fn as_super(&self) {
                     &*self.__superclass
@@ -541,7 +541,7 @@ macro_rules! __inner_declare_class {
             type Mutability = $mutability;
             const NAME: &'static $crate::__macro_helpers::str = $name_const;
 
-            fn class() -> &'static $crate::runtime::Class {
+            fn class() -> &'static $crate::runtime::AnyClass {
                 $crate::__macro_helpers::assert_mutability_matches_superclass_mutability::<Self>();
 
                 // TODO: Use `core::cell::LazyCell`
@@ -610,7 +610,7 @@ macro_rules! __inner_declare_class {
                 });
 
                 // We just registered the class, so it should be available
-                $crate::runtime::Class::get(<Self as ClassType>::NAME).unwrap()
+                $crate::runtime::AnyClass::get(<Self as ClassType>::NAME).unwrap()
             }
 
             #[inline]

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -350,7 +350,7 @@ macro_rules! __inner_extern_class {
         $crate::__extern_class_impl_traits! {
             $(#[$impl_m])*
             unsafe impl ($($t_for $(: $b_for)?),*) for $for {
-                INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::Object];
+                INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::AnyObject];
 
                 fn as_super(&$as_super_self) $as_super
                 fn as_super_mut(&mut $as_super_mut_self) $as_super_mut
@@ -364,7 +364,7 @@ macro_rules! __inner_extern_class {
             const NAME: &'static $crate::__macro_helpers::str = $crate::__select_name!($name; $($name_const)?);
 
             #[inline]
-            fn class() -> &'static $crate::runtime::Class {
+            fn class() -> &'static $crate::runtime::AnyClass {
                 $crate::__macro_helpers::assert_mutability_matches_superclass_mutability::<Self>();
 
                 $crate::__class_inner!(
@@ -414,8 +414,8 @@ macro_rules! __extern_class_impl_traits {
                 = <$superclass as $crate::RefEncode>::ENCODING_REF;
         }
 
-        // SAFETY: This is a newtype wrapper over `Object` (we even ensure
-        // that `Object` is always last in our inheritance tree), so it is
+        // SAFETY: This is a newtype wrapper over `AnyObject` (we even ensure
+        // that `AnyObject` is always last in our inheritance tree), so it is
         // always safe to reinterpret as that.
         //
         // That the object must work with standard memory management is

--- a/crates/objc2/src/message/apple/mod.rs
+++ b/crates/objc2/src/message/apple/mod.rs
@@ -1,6 +1,6 @@
 use crate::encode::__unstable::EncodeReturn;
 use crate::ffi;
-use crate::runtime::{Class, Imp, Object, Sel};
+use crate::runtime::{AnyClass, AnyObject, Imp, Sel};
 use crate::MessageArguments;
 
 #[cfg(target_arch = "x86")]
@@ -26,7 +26,7 @@ unsafe trait MsgSendFn: EncodeReturn {
 
 #[inline]
 #[track_caller]
-pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut Object, sel: Sel, args: A) -> R
+pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut AnyObject, sel: Sel, args: A) -> R
 where
     A: MessageArguments,
     R: EncodeReturn,
@@ -38,8 +38,8 @@ where
 #[inline]
 #[track_caller]
 pub(crate) unsafe fn send_super_unverified<A, R>(
-    receiver: *mut Object,
-    superclass: &Class,
+    receiver: *mut AnyObject,
+    superclass: &AnyClass,
     sel: Sel,
     args: A,
 ) -> R
@@ -47,7 +47,7 @@ where
     A: MessageArguments,
     R: EncodeReturn,
 {
-    let superclass: *const Class = superclass;
+    let superclass: *const AnyClass = superclass;
     let mut sup = ffi::objc_super {
         receiver: receiver.cast(),
         super_class: superclass.cast(),

--- a/crates/objc2/src/message/gnustep.rs
+++ b/crates/objc2/src/message/gnustep.rs
@@ -3,7 +3,7 @@ use core::mem;
 
 use crate::encode::__unstable::EncodeReturn;
 use crate::ffi;
-use crate::runtime::{Class, Imp, Object, Sel};
+use crate::runtime::{AnyClass, AnyObject, Imp, Sel};
 use crate::MessageArguments;
 
 #[inline]
@@ -21,7 +21,7 @@ fn unwrap_msg_send_fn(msg_send_fn: Option<Imp>) -> Imp {
 }
 
 #[track_caller]
-pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut Object, sel: Sel, args: A) -> R
+pub(crate) unsafe fn send_unverified<A, R>(receiver: *mut AnyObject, sel: Sel, args: A) -> R
 where
     A: MessageArguments,
     R: EncodeReturn,
@@ -43,8 +43,8 @@ where
 
 #[track_caller]
 pub(crate) unsafe fn send_super_unverified<A, R>(
-    receiver: *mut Object,
-    superclass: &Class,
+    receiver: *mut AnyObject,
+    superclass: &AnyClass,
     sel: Sel,
     args: A,
 ) -> R
@@ -57,7 +57,7 @@ where
         return unsafe { mem::zeroed() };
     }
 
-    let superclass: *const Class = superclass;
+    let superclass: *const AnyClass = superclass;
     let sup = ffi::objc_super {
         receiver: receiver.cast(),
         super_class: superclass.cast(),

--- a/crates/objc2/src/protocol_type.rs
+++ b/crates/objc2/src/protocol_type.rs
@@ -1,4 +1,4 @@
-use crate::runtime::Protocol;
+use crate::runtime::AnyProtocol;
 
 /// Marks types that represent specific protocols.
 ///
@@ -19,7 +19,7 @@ use crate::runtime::Protocol;
 ///
 /// # Examples
 ///
-/// Use the trait to access the [`Protocol`] of different objects.
+/// Use the trait to access the [`AnyProtocol`] of different objects.
 ///
 /// ```
 /// use objc2::ProtocolType;
@@ -62,8 +62,8 @@ pub unsafe trait ProtocolType {
     /// This may panic if something went wrong with getting or declaring the
     /// protocol, e.g. if the program is not properly linked to the framework
     /// that defines the protocol.
-    fn protocol() -> Option<&'static Protocol> {
-        Protocol::get(Self::NAME)
+    fn protocol() -> Option<&'static AnyProtocol> {
+        AnyProtocol::get(Self::NAME)
     }
 
     #[doc(hidden)]

--- a/crates/objc2/src/rc/autorelease.rs
+++ b/crates/objc2/src/rc/autorelease.rs
@@ -525,7 +525,7 @@ mod tests {
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     use super::{AutoreleasePool, AutoreleaseSafe};
-    use crate::runtime::Object;
+    use crate::runtime::AnyObject;
 
     #[test]
     fn auto_traits() {
@@ -533,8 +533,8 @@ mod tests {
         assert_not_impl_any!(AutoreleasePool<'static>: Send, Sync);
 
         assert_impl_all!(usize: AutoreleaseSafe);
-        assert_impl_all!(*mut Object: AutoreleaseSafe);
-        assert_impl_all!(&mut Object: AutoreleaseSafe);
+        assert_impl_all!(*mut AnyObject: AutoreleaseSafe);
+        assert_impl_all!(&mut AnyObject: AutoreleaseSafe);
         #[cfg(feature = "unstable-autoreleasesafe")]
         assert_not_impl_any!(AutoreleasePool<'static>: AutoreleaseSafe);
     }

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -3,7 +3,7 @@ use core::hash;
 
 use crate::mutability::Root;
 use crate::rc::{DefaultId, Id};
-use crate::runtime::{Class, ImplementedBy, Object, Protocol, ProtocolObject};
+use crate::runtime::{AnyClass, AnyObject, AnyProtocol, ImplementedBy, ProtocolObject};
 use crate::{extern_methods, msg_send, msg_send_id, Message};
 use crate::{ClassType, ProtocolType};
 
@@ -25,13 +25,13 @@ crate::__emit_struct! {
     (pub)
     (NSObject)
     (
-        __inner: Object,
+        __inner: AnyObject,
     )
 }
 
 crate::__extern_class_impl_traits! {
     unsafe impl () for NSObject {
-        INHERITS = [Object];
+        INHERITS = [AnyObject];
 
         fn as_super(&self) {
             &self.__inner
@@ -44,12 +44,12 @@ crate::__extern_class_impl_traits! {
 }
 
 unsafe impl ClassType for NSObject {
-    type Super = Object;
+    type Super = AnyObject;
     type Mutability = Root;
     const NAME: &'static str = "NSObject";
 
     #[inline]
-    fn class() -> &'static Class {
+    fn class() -> &'static AnyClass {
         #[cfg(feature = "apple")]
         {
             crate::class!(NSObject)
@@ -60,7 +60,7 @@ unsafe impl ClassType for NSObject {
                 // The linking changed in libobjc2 v2.0
                 #[cfg_attr(feature = "gnustep-2-0", link_name = "._OBJC_CLASS_NSObject")]
                 #[cfg_attr(not(feature = "gnustep-2-0"), link_name = "_OBJC_CLASS_NSObject")]
-                static OBJC_CLASS_NSObject: Class;
+                static OBJC_CLASS_NSObject: AnyClass;
                 // Others:
                 // __objc_class_name_NSObject
                 // _OBJC_CLASS_REF_NSObject
@@ -127,7 +127,7 @@ pub unsafe trait NSObjectProtocol {
     }
 
     #[doc(hidden)]
-    fn __isKindOfClass(&self, cls: &Class) -> bool
+    fn __isKindOfClass(&self, cls: &AnyClass) -> bool
     where
         Self: Sized + Message,
     {
@@ -169,8 +169,11 @@ unsafe impl NSObjectProtocol for NSObject {}
 unsafe impl ProtocolType for NSObject {
     const NAME: &'static str = "NSObject";
 
-    fn protocol() -> Option<&'static Protocol> {
-        Some(Protocol::get(<Self as ProtocolType>::NAME).expect("could not find NSObject protocol"))
+    fn protocol() -> Option<&'static AnyProtocol> {
+        Some(
+            AnyProtocol::get(<Self as ProtocolType>::NAME)
+                .expect("could not find NSObject protocol"),
+        )
     }
 
     const __INNER: () = ();
@@ -269,7 +272,7 @@ mod tests {
     fn test_deref() {
         let obj: Id<NSObject> = NSObject::new();
         let _: &NSObject = &obj;
-        let _: &Object = &obj;
+        let _: &AnyObject = &obj;
     }
 
     #[test]
@@ -279,8 +282,8 @@ mod tests {
         let _: &mut NSObjectMutable = &mut obj;
         let _: &NSObject = &obj;
         let _: &mut NSObject = &mut obj;
-        let _: &Object = &obj;
-        let _: &mut Object = &mut obj;
+        let _: &AnyObject = &obj;
+        let _: &mut AnyObject = &mut obj;
     }
 
     #[test]
@@ -297,13 +300,13 @@ mod tests {
         impls_as_mut::<NSObjectMutable, NSObjectMutable>(&mut obj);
         impls_as_ref::<NSObject, NSObject>(&obj);
         impls_as_mut::<NSObject, NSObject>(&mut obj);
-        impls_as_ref::<NSObject, Object>(&obj);
-        impls_as_mut::<NSObject, Object>(&mut obj);
+        impls_as_ref::<NSObject, AnyObject>(&obj);
+        impls_as_mut::<NSObject, AnyObject>(&mut obj);
 
         let obj = NSObject::new();
         impls_as_ref::<Id<NSObject>, NSObject>(&obj);
         impls_as_ref::<NSObject, NSObject>(&obj);
-        impls_as_ref::<NSObject, Object>(&obj);
+        impls_as_ref::<NSObject, AnyObject>(&obj);
     }
 
     #[test]

--- a/crates/objc2/src/runtime/nsproxy.rs
+++ b/crates/objc2/src/runtime/nsproxy.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::hash;
 
 use crate::mutability::Root;
-use crate::runtime::{Class, NSObject, NSObjectProtocol, Object, ProtocolObject};
+use crate::runtime::{AnyClass, AnyObject, NSObject, NSObjectProtocol, ProtocolObject};
 use crate::ClassType;
 
 crate::__emit_struct! {
@@ -17,13 +17,13 @@ crate::__emit_struct! {
     (pub)
     (NSProxy)
     (
-        __inner: Object,
+        __inner: AnyObject,
     )
 }
 
 crate::__extern_class_impl_traits! {
     unsafe impl () for NSProxy {
-        INHERITS = [Object];
+        INHERITS = [AnyObject];
 
         fn as_super(&self) {
             &self.__inner
@@ -36,12 +36,12 @@ crate::__extern_class_impl_traits! {
 }
 
 unsafe impl ClassType for NSProxy {
-    type Super = Object;
+    type Super = AnyObject;
     type Mutability = Root;
     const NAME: &'static str = "NSProxy";
 
     #[inline]
-    fn class() -> &'static Class {
+    fn class() -> &'static AnyClass {
         #[cfg(feature = "apple")]
         {
             crate::class!(NSProxy)
@@ -52,7 +52,7 @@ unsafe impl ClassType for NSProxy {
                 // The linking changed in libobjc2 v2.0
                 #[cfg_attr(feature = "gnustep-2-0", link_name = "._OBJC_CLASS_NSProxy")]
                 #[cfg_attr(not(feature = "gnustep-2-0"), link_name = "_OBJC_CLASS_NSProxy")]
-                static OBJC_CLASS_NSProxy: Class;
+                static OBJC_CLASS_NSProxy: AnyClass;
                 // Others:
                 // __objc_class_name_NSProxy
                 // _OBJC_CLASS_REF_NSProxy

--- a/crates/objc2/src/runtime/protocol_object.rs
+++ b/crates/objc2/src/runtime/protocol_object.rs
@@ -6,7 +6,7 @@ use core::ptr::NonNull;
 use crate::encode::{Encoding, RefEncode};
 use crate::rc::{autoreleasepool_leaking, Id};
 use crate::runtime::__nsstring::nsstring_to_str;
-use crate::runtime::{NSObjectProtocol, Object};
+use crate::runtime::{AnyObject, NSObjectProtocol};
 use crate::{Message, ProtocolType};
 
 /// An internal helper trait for [`ProtocolObject`].
@@ -58,17 +58,17 @@ pub unsafe trait ImplementedBy<T: ?Sized + Message> {
 #[doc(alias = "id")]
 #[repr(C)]
 pub struct ProtocolObject<P: ?Sized + ProtocolType> {
-    inner: Object,
+    inner: AnyObject,
     p: PhantomData<P>,
 }
 
-// SAFETY: The type is `#[repr(C)]` and `Object` internally
+// SAFETY: The type is `#[repr(C)]` and `AnyObject` internally
 unsafe impl<P: ?Sized + ProtocolType> RefEncode for ProtocolObject<P> {
     const ENCODING_REF: Encoding = Encoding::Object;
 }
 
-// SAFETY: The type is `Object` internally, and is mean to be messaged as-if
-// it's an object.
+// SAFETY: The type is `AnyObject` internally, and is mean to be messaged
+// as-if it's an object.
 unsafe impl<P: ?Sized + ProtocolType> Message for ProtocolObject<P> {}
 
 impl<P: ?Sized + ProtocolType> ProtocolObject<P> {
@@ -154,9 +154,10 @@ impl<P: ?Sized + ProtocolType + NSObjectProtocol> fmt::Debug for ProtocolObject<
                     fmt::Display::fmt(s, f)
                 })
             }
-            // If description was `NULL`, use `Object`'s `Debug` impl instead
+            // If description was `NULL`, use `AnyObject`'s `Debug` impl
+            // instead
             None => {
-                let obj: &Object = &self.inner;
+                let obj: &AnyObject = &self.inner;
                 fmt::Debug::fmt(obj, f)
             }
         }

--- a/crates/objc2/src/verify.rs
+++ b/crates/objc2/src/verify.rs
@@ -40,13 +40,13 @@ impl fmt::Display for Inner {
 
 /// Failed verifying selector on a class.
 ///
-/// This is returned in the error case of [`Class::verify_sel`], see that for
-/// details.
+/// This is returned in the error case of [`AnyClass::verify_sel`], see that
+/// for details.
 ///
 /// This implements [`Error`], and a description of the error can be retrieved
 /// using [`fmt::Display`].
 ///
-/// [`Class::verify_sel`]: crate::runtime::Class::verify_sel
+/// [`AnyClass::verify_sel`]: crate::runtime::AnyClass::verify_sel
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct VerificationError(Inner);
 

--- a/crates/objc2/tests/no_prelude.rs
+++ b/crates/objc2/tests/no_prelude.rs
@@ -162,11 +162,11 @@ pub fn test_msg_send(obj: &CustomObject) {
     let _: () = unsafe { new_objc2::msg_send![super(obj, superclass), a: obj, b: obj] };
 }
 
-pub fn test_msg_send_id(obj: &new_objc2::runtime::Object) {
-    let _: new_objc2::rc::Id<new_objc2::runtime::Object> =
+pub fn test_msg_send_id(obj: &new_objc2::runtime::AnyObject) {
+    let _: new_objc2::rc::Id<new_objc2::runtime::AnyObject> =
         unsafe { new_objc2::msg_send_id![obj, a] };
-    let _: new_objc2::__macro_helpers::Option<new_objc2::rc::Id<new_objc2::runtime::Object>> =
+    let _: new_objc2::__macro_helpers::Option<new_objc2::rc::Id<new_objc2::runtime::AnyObject>> =
         unsafe { new_objc2::msg_send_id![obj, a] };
-    let _: new_objc2::rc::Id<new_objc2::runtime::Object> =
+    let _: new_objc2::rc::Id<new_objc2::runtime::AnyObject> =
         unsafe { new_objc2::msg_send_id![obj, a: obj, b: obj] };
 }

--- a/crates/objc2/tests/track_caller.rs
+++ b/crates/objc2/tests/track_caller.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 
 use objc2::encode::Encode;
 use objc2::rc::{Allocated, Id, __RcTestObject};
-use objc2::runtime::{NSObject, Object};
+use objc2::runtime::NSObject;
 use objc2::{class, declare_class, msg_send, msg_send_id, mutability, ClassType};
 
 static EXPECTED_MESSAGE: Mutex<String> = Mutex::new(String::new());
@@ -88,17 +88,17 @@ fn test_track_caller() {
 }
 
 pub fn test_nil(checker: &PanicChecker) {
-    let nil: *mut Object = ptr::null_mut();
+    let nil: *mut NSObject = ptr::null_mut();
 
     let msg = "messsaging description to nil";
     checker.assert_panics(msg, line!() + 1, || {
-        let _: *mut Object = unsafe { msg_send![nil, description] };
+        let _: *mut NSObject = unsafe { msg_send![nil, description] };
     });
     checker.assert_panics(msg, line!() + 1, || {
-        let _: *mut Object = unsafe { msg_send![super(nil, NSObject::class()), description] };
+        let _: *mut NSObject = unsafe { msg_send![super(nil, NSObject::class()), description] };
     });
     checker.assert_panics(msg, line!() + 1, || {
-        let _: Option<Id<Object>> = unsafe { msg_send_id![nil, description] };
+        let _: Option<Id<NSObject>> = unsafe { msg_send_id![nil, description] };
     });
 }
 
@@ -112,12 +112,12 @@ pub fn test_verify(checker: &PanicChecker) {
 
     let msg = format!("invalid message send to -[NSObject hash]: expected return to have type code '{}', but found '@'", usize::ENCODING);
     checker.assert_panics(&msg, line!() + 1, || {
-        let _: Option<Id<Object>> = unsafe { msg_send_id![&obj, hash] };
+        let _: Option<Id<NSObject>> = unsafe { msg_send_id![&obj, hash] };
     });
 }
 
 pub fn test_error_methods(checker: &PanicChecker) {
-    let nil: *mut Object = ptr::null_mut();
+    let nil: *mut NSObject = ptr::null_mut();
 
     let msg = "messsaging someSelectorWithError: to nil";
     checker.assert_panics(msg, line!() + 1, || {
@@ -128,7 +128,7 @@ pub fn test_error_methods(checker: &PanicChecker) {
             unsafe { msg_send![super(nil, NSObject::class()), someSelectorWithError: _] };
     });
     checker.assert_panics(msg, line!() + 2, || {
-        let _: Result<Id<Object>, Id<NSObject>> =
+        let _: Result<Id<NSObject>, Id<NSObject>> =
             unsafe { msg_send_id![nil, someSelectorWithError: _] };
     });
 
@@ -176,12 +176,12 @@ pub fn test_catch_all(checker: &PanicChecker) {
 
     let msg = "NSRangeException";
     checker.assert_panics(msg, line!() + 1, || {
-        let _: *mut Object = unsafe { msg_send![&obj, objectAtIndex: 0usize] };
+        let _: *mut NSObject = unsafe { msg_send![&obj, objectAtIndex: 0usize] };
     });
 
     let msg = "NSRangeException";
     checker.assert_panics(msg, line!() + 1, || {
-        let _: Id<Object> = unsafe { msg_send_id![&obj, objectAtIndex: 0usize] };
+        let _: Id<NSObject> = unsafe { msg_send_id![&obj, objectAtIndex: 0usize] };
     });
 }
 
@@ -206,9 +206,9 @@ pub fn test_unwind(checker: &PanicChecker) {
     let msg = "panic in PanickingClass";
     let line = line!() - 7;
     checker.assert_panics(msg, line, || {
-        let _: *mut Object = unsafe { msg_send![PanickingClass::class(), panic] };
+        let _: *mut NSObject = unsafe { msg_send![PanickingClass::class(), panic] };
     });
     checker.assert_panics(msg, line, || {
-        let _: Id<Object> = unsafe { msg_send_id![PanickingClass::class(), panic] };
+        let _: Id<NSObject> = unsafe { msg_send_id![PanickingClass::class(), panic] };
     });
 }

--- a/crates/objc2/tests/use_macros.rs
+++ b/crates/objc2/tests/use_macros.rs
@@ -1,5 +1,5 @@
 use objc2::mutability::Immutable;
-use objc2::runtime::{Class, NSObject, Object};
+use objc2::runtime::{AnyClass, NSObject};
 use objc2::{class, declare_class, msg_send, sel, ClassType};
 
 declare_class!(
@@ -16,7 +16,7 @@ declare_class!(
 fn use_class_and_msg_send() {
     unsafe {
         let cls = class!(NSObject);
-        let obj: *mut Object = msg_send![cls, new];
+        let obj: *mut NSObject = msg_send![cls, new];
         let _hash: usize = msg_send![obj, hash];
         let _: () = msg_send![obj, release];
     }
@@ -29,7 +29,7 @@ fn use_sel() {
 }
 
 #[allow(unused)]
-fn test_msg_send_comma_handling(obj: &MyObject, superclass: &Class) {
+fn test_msg_send_comma_handling(obj: &MyObject, superclass: &AnyClass) {
     unsafe {
         let _: () = msg_send![obj, a];
         let _: () = msg_send![obj, a,];

--- a/crates/test-assembly/crates/test_autorelease_return/lib.rs
+++ b/crates/test-assembly/crates/test_autorelease_return/lib.rs
@@ -2,15 +2,15 @@
 
 use objc2::__macro_helpers::{MsgSendId, New};
 use objc2::rc::Id;
-use objc2::runtime::{Class, Object, Sel};
+use objc2::runtime::{AnyClass, AnyObject, Sel};
 
 #[no_mangle]
-fn simple(obj: Id<Object>) -> *mut Object {
+fn simple(obj: Id<AnyObject>) -> *mut AnyObject {
     Id::autorelease_return(obj)
 }
 
 #[no_mangle]
-unsafe fn with_body(cls: &Class, sel: Sel) -> *mut Object {
-    let obj: Option<Id<Object>> = New::send_message_id(cls, sel, ());
+unsafe fn with_body(cls: &AnyClass, sel: Sel) -> *mut AnyObject {
+    let obj: Option<Id<AnyObject>> = New::send_message_id(cls, sel, ());
     Id::autorelease_return(obj.unwrap_unchecked())
 }

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
@@ -7,16 +7,16 @@ Lloh0:
 Lloh1:
 	add	x0, x0, l_anon.[ID].0@PAGEOFF
 	mov	w1, #10
-	b	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	b	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh0, Lloh1
 
 	.globl	_dyn_call
 	.p2align	2
 _dyn_call:
 Lloh2:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f@PAGE
 Lloh3:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f@PAGEOFF]
 	b	_objc_msgSend
 	.loh AdrpLdr	Lloh2, Lloh3
 
@@ -28,9 +28,9 @@ _dyn_consume:
 	add	x29, sp, #16
 	mov	x19, x0
 Lloh4:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f@PAGE
 Lloh5:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f@PAGEOFF]
 	bl	_objc_msgSend
 	mov	x0, x19
 	ldp	x29, x30, [sp, #16]
@@ -43,20 +43,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.quad	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.quad	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7.s
@@ -9,14 +9,14 @@ _get_protocol:
 	movt	r0, :upper16:(l_anon.[ID].0-(LPC0_0+8))
 LPC0_0:
 	add	r0, pc, r0
-	b	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	b	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 
 	.globl	_dyn_call
 	.p2align	2
 	.code	32
 _dyn_call:
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC1_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC1_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC1_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC1_0+8))
 LPC1_0:
 	ldr	r1, [pc, r1]
 	b	_objc_msgSend
@@ -27,9 +27,9 @@ LPC1_0:
 _dyn_consume:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC2_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC2_0+8))
 	mov	r4, r0
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC2_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC2_0+8))
 LPC2_0:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
@@ -42,20 +42,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.long	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
@@ -11,7 +11,7 @@ _get_protocol:
 	movt	r0, :upper16:(l_anon.[ID].0-(LPC0_0+8))
 LPC0_0:
 	add	r0, pc, r0
-	bl	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	bl	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	pop	{r7, pc}
 
 	.globl	_dyn_call
@@ -20,8 +20,8 @@ LPC0_0:
 _dyn_call:
 	push	{r7, lr}
 	mov	r7, sp
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC1_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC1_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC1_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC1_0+8))
 LPC1_0:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
@@ -33,9 +33,9 @@ LPC1_0:
 _dyn_consume:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC2_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC2_0+8))
 	mov	r4, r0
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-(LPC2_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-(LPC2_0+8))
 LPC2_0:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
@@ -48,20 +48,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.long	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
@@ -13,7 +13,7 @@ L0$pb:
 	lea	eax, [eax + l_anon.[ID].0-L0$pb]
 	push	10
 	push	eax
-	call	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	add	esp, 24
 	pop	ebp
 	ret
@@ -28,7 +28,7 @@ _dyn_call:
 L1$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-L1$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-L1$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -45,7 +45,7 @@ _dyn_consume:
 L2$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-L2$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-L2$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -57,20 +57,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.long	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
@@ -13,7 +13,7 @@ L0$pb:
 	lea	eax, [eax + l_anon.[ID].0-L0$pb]
 	push	10
 	push	eax
-	call	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	add	esp, 24
 	pop	ebp
 	ret
@@ -28,7 +28,7 @@ _dyn_call:
 L1$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-L1$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-L1$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -45,7 +45,7 @@ _dyn_consume:
 L2$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69-L2$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f-L2$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -57,20 +57,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.long	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
@@ -8,14 +8,14 @@ _get_protocol:
 	lea	rdi, [rip + l_anon.[ID].0]
 	mov	esi, 10
 	pop	rbp
-	jmp	SYM(objc2::runtime::Protocol::get::GENERATED_ID, 0)
+	jmp	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 
 	.globl	_dyn_call
 	.p2align	4, 0x90
 _dyn_call:
 	push	rbp
 	mov	rbp, rsp
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f]
 	pop	rbp
 	jmp	_objc_msgSend
 
@@ -27,7 +27,7 @@ _dyn_consume:
 	push	rbx
 	push	rax
 	mov	rbx, rdi
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f]
 	call	_objc_msgSend
 	mov	rdi, rbx
 	add	rsp, 8
@@ -40,20 +40,20 @@ l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d7a070d5c55b8e69
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d7a070d5c55b8e69:
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
-L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69:
+	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.asciz	"aMethod"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69
+	.globl	L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_d7a070d5c55b8e69:
-	.quad	L_OBJC_METH_VAR_NAME_d7a070d5c55b8e69
+L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
+	.quad	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/lib.rs
+++ b/crates/test-assembly/crates/test_extern_protocol/lib.rs
@@ -3,7 +3,7 @@
 use core::mem::ManuallyDrop;
 
 use objc2::rc::Id;
-use objc2::runtime::{Protocol, ProtocolObject};
+use objc2::runtime::{AnyProtocol, ProtocolObject};
 use objc2::{extern_protocol, ProtocolType};
 
 extern_protocol!(
@@ -18,7 +18,7 @@ extern_protocol!(
 );
 
 #[no_mangle]
-unsafe fn get_protocol() -> &'static Protocol {
+unsafe fn get_protocol() -> &'static AnyProtocol {
     <dyn MyProtocol>::protocol().unwrap_unchecked()
 }
 

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-aarch64.s
@@ -1,6 +1,6 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.p2align	2
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	stp	x20, x19, [sp, #-32]!
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -21,7 +21,7 @@ Lloh1:
 	.loh AdrpAdd	Lloh0, Lloh1
 
 	.p2align	2
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_retain
@@ -59,7 +59,7 @@ _error_bool:
 	ret
 LBB2_2:
 	ldr	x0, [sp, #8]
-	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
 	ret
@@ -85,7 +85,7 @@ Lloh6:
 	adrp	x1, l_anon.[ID].4@PAGE
 Lloh7:
 	add	x1, x1, l_anon.[ID].4@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	x1, x0
 	mov	w0, #1
 	ldp	x29, x30, [sp, #16]
@@ -114,7 +114,7 @@ Lloh8:
 	adrp	x1, l_anon.[ID].5@PAGE
 Lloh9:
 	add	x1, x1, l_anon.[ID].5@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	x1, x0
 	mov	w0, #1
 	ldp	x29, x30, [sp, #16]
@@ -143,7 +143,7 @@ Lloh10:
 	adrp	x1, l_anon.[ID].6@PAGE
 Lloh11:
 	add	x1, x1, l_anon.[ID].6@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	x1, x0
 	mov	w0, #1
 	ldp	x29, x30, [sp, #16]
@@ -172,7 +172,7 @@ Lloh12:
 	adrp	x1, l_anon.[ID].7@PAGE
 Lloh13:
 	add	x1, x1, l_anon.[ID].7@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	x1, x0
 	mov	w0, #1
 	ldp	x29, x30, [sp, #16]
@@ -205,7 +205,7 @@ Lloh14:
 	adrp	x1, l_anon.[ID].8@PAGE
 Lloh15:
 	add	x1, x1, l_anon.[ID].8@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	x1, x0
 	mov	w0, #1
 	ldp	x29, x30, [sp, #16]

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7.s
@@ -2,7 +2,7 @@
 	.syntax unified
 	.p2align	2
 	.code	32
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	mov	r4, r1
@@ -21,7 +21,7 @@ LPC0_0:
 
 	.p2align	2
 	.code	32
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_retain
@@ -58,7 +58,7 @@ _error_bool:
 	pop	{r4, r7, pc}
 LBB2_2:
 	ldr	r0, [sp]
-	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r4, r0
 	mov	r0, r4
 	sub	sp, r7, #4
@@ -87,7 +87,7 @@ LBB3_2:
 	movt	r1, :upper16:(l_anon.[ID].4-(LPC3_0+8))
 LPC3_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -117,7 +117,7 @@ LBB4_2:
 	movt	r1, :upper16:(l_anon.[ID].5-(LPC4_0+8))
 LPC4_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -147,7 +147,7 @@ LBB5_2:
 	movt	r1, :upper16:(l_anon.[ID].6-(LPC5_0+8))
 LPC5_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -177,7 +177,7 @@ LBB6_2:
 	movt	r1, :upper16:(l_anon.[ID].7-(LPC6_0+8))
 LPC6_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -211,7 +211,7 @@ LBB7_2:
 	movt	r1, :upper16:(l_anon.[ID].8-(LPC7_0+8))
 LPC7_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7s.s
@@ -2,7 +2,7 @@
 	.syntax unified
 	.p2align	2
 	.code	32
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	mov	r4, r1
@@ -21,7 +21,7 @@ LPC0_0:
 
 	.p2align	2
 	.code	32
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	{r7, lr}
 	mov	r7, sp
 	bl	_objc_retain
@@ -58,7 +58,7 @@ _error_bool:
 	pop	{r4, r7, pc}
 LBB2_2:
 	ldr	r0, [sp]
-	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r4, r0
 	mov	r0, r4
 	sub	sp, r7, #4
@@ -87,7 +87,7 @@ LBB3_2:
 	ldr	r0, [sp]
 LPC3_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -117,7 +117,7 @@ LBB4_2:
 	ldr	r0, [sp]
 LPC4_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -147,7 +147,7 @@ LBB5_2:
 	ldr	r0, [sp]
 LPC5_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -177,7 +177,7 @@ LBB6_2:
 	ldr	r0, [sp]
 LPC6_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4
@@ -211,7 +211,7 @@ LBB7_2:
 	ldr	r0, [sp]
 LPC7_0:
 	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	bl	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
 	mov	r4, #1
 	mov	r0, r4

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86.s
@@ -1,7 +1,7 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.intel_syntax noprefix
 	.p2align	4, 0x90
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	ebp
 	mov	ebp, esp
 	push	edi
@@ -29,7 +29,7 @@ LBB0_2:
 	call	SYM(core::option::expect_failed::GENERATED_ID, 0)
 
 	.p2align	4, 0x90
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	ebp
 	mov	ebp, esp
 	push	esi
@@ -84,7 +84,7 @@ _error_bool:
 	ret
 LBB2_1:
 	mov	ecx, dword ptr [ebp - 8]
-	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	add	esp, 4
 	pop	esi
 	pop	ebp
@@ -121,7 +121,7 @@ L3$pb:
 LBB3_2:
 	mov	ecx, dword ptr [ebp - 8]
 	lea	edx, [esi + l_anon.[ID].4-L3$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	add	esp, 4
@@ -160,7 +160,7 @@ L4$pb:
 LBB4_2:
 	mov	ecx, dword ptr [ebp - 8]
 	lea	edx, [esi + l_anon.[ID].5-L4$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	add	esp, 4
@@ -199,7 +199,7 @@ L5$pb:
 LBB5_2:
 	mov	ecx, dword ptr [ebp - 8]
 	lea	edx, [esi + l_anon.[ID].6-L5$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	add	esp, 4
@@ -238,7 +238,7 @@ L6$pb:
 LBB6_2:
 	mov	ecx, dword ptr [ebp - 8]
 	lea	edx, [esi + l_anon.[ID].7-L6$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	add	esp, 4
@@ -286,7 +286,7 @@ L7$pb:
 LBB7_2:
 	mov	ecx, dword ptr [ebp - 8]
 	lea	edx, [esi + l_anon.[ID].8-L7$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	add	esp, 4

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86_64.s
@@ -1,7 +1,7 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.intel_syntax noprefix
 	.p2align	4, 0x90
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	rbp
 	mov	rbp, rsp
 	push	rbx
@@ -21,7 +21,7 @@ LBB0_2:
 	call	SYM(core::option::expect_failed::GENERATED_ID, 0)
 
 	.p2align	4, 0x90
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	rbp
 	mov	rbp, rsp
 	call	_objc_retain
@@ -52,7 +52,7 @@ _error_bool:
 	ret
 LBB2_2:
 	mov	rdi, qword ptr [rbp - 8]
-	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	add	rsp, 16
 	pop	rbp
 	ret
@@ -76,7 +76,7 @@ _error_new:
 LBB3_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].4]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 16
@@ -102,7 +102,7 @@ _error_alloc:
 LBB4_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].5]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 16
@@ -128,7 +128,7 @@ _error_init:
 LBB5_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].6]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 16
@@ -154,7 +154,7 @@ _error_copy:
 LBB6_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].7]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 16
@@ -187,7 +187,7 @@ _error_autoreleased:
 LBB7_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].8]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 16

--- a/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86.s
@@ -1,9 +1,9 @@
 	.text
 	.intel_syntax noprefix
-	.section	.text.unlikely.SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),"ax",@progbits
+	.section	.text.unlikely.SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),"ax",@progbits
 	.p2align	4, 0x90
-	.type	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),@function
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+	.type	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),@function
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	ebx
 	push	esi
 	push	eax
@@ -33,12 +33,12 @@ SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runti
 	add	esp, 16
 	ud2
 .Lfunc_end0:
-	.size	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0), .Lfunc_end0-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	.size	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0), .Lfunc_end0-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 
-	.section	.text.unlikely.SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),"ax",@progbits
+	.section	.text.unlikely.SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),"ax",@progbits
 	.p2align	4, 0x90
-	.type	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),@function
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+	.type	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),@function
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	ebx
 	sub	esp, 8
 	call	.L1$pb
@@ -66,7 +66,7 @@ SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Obje
 	add	esp, 16
 	ud2
 .Lfunc_end1:
-	.size	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0), .Lfunc_end1-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	.size	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0), .Lfunc_end1-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 
 	.section	.text.error_bool,"ax",@progbits
 	.globl	error_bool
@@ -112,7 +112,7 @@ error_bool:
 	ret
 .LBB2_1:
 	mov	ecx, dword ptr [esp + 8]
-	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	jmp	.LBB2_2
 .Lfunc_end2:
 	.size	error_bool, .Lfunc_end2-error_bool
@@ -158,7 +158,7 @@ error_new:
 .LBB3_2:
 	mov	ecx, dword ptr [esp + 12]
 	lea	edx, [ebx + .Lanon.[ID].4@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	jmp	.LBB3_3
@@ -206,7 +206,7 @@ error_alloc:
 .LBB4_2:
 	mov	ecx, dword ptr [esp + 12]
 	lea	edx, [ebx + .Lanon.[ID].5@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	jmp	.LBB4_3
@@ -260,7 +260,7 @@ error_init:
 	mov	ecx, dword ptr [esp + 12]
 .LBB5_5:
 	lea	edx, [ebx + .Lanon.[ID].6@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	jmp	.LBB5_6
@@ -308,7 +308,7 @@ error_copy:
 .LBB6_2:
 	mov	ecx, dword ptr [esp + 12]
 	lea	edx, [ebx + .Lanon.[ID].7@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	jmp	.LBB6_3
@@ -359,7 +359,7 @@ error_autoreleased:
 .LBB7_2:
 	mov	ecx, dword ptr [esp + 12]
 	lea	edx, [ebx + .Lanon.[ID].8@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
 	jmp	.LBB7_3

--- a/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
@@ -1,9 +1,9 @@
 	.text
 	.intel_syntax noprefix
-	.section	.text.unlikely.SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),"ax",@progbits
+	.section	.text.unlikely.SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),"ax",@progbits
 	.p2align	4, 0x90
-	.type	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),@function
-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+	.type	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),@function
+SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	rbx
 	mov	rbx, rsi
 	call	qword ptr [rip + objc_retain@GOTPCREL]
@@ -18,12 +18,12 @@ SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runti
 	call	qword ptr [rip + SYM(core::option::expect_failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end0:
-	.size	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0), .Lfunc_end0-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	.size	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0), .Lfunc_end0-SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 
-	.section	.text.unlikely.SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),"ax",@progbits
+	.section	.text.unlikely.SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),"ax",@progbits
 	.p2align	4, 0x90
-	.type	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0),@function
-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0):
+	.type	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0),@function
+SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0):
 	push	rax
 	call	qword ptr [rip + objc_retain@GOTPCREL]
 	test	rax, rax
@@ -37,7 +37,7 @@ SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Obje
 	call	qword ptr [rip + SYM(core::option::expect_failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
 .Lfunc_end1:
-	.size	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0), .Lfunc_end1-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	.size	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0), .Lfunc_end1-SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 
 	.section	.text.error_bool,"ax",@progbits
 	.globl	error_bool
@@ -69,7 +69,7 @@ error_bool:
 	ret
 .LBB2_2:
 	mov	rdi, qword ptr [rsp + 8]
-	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::message::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	jmp	.LBB2_3
 .Lfunc_end2:
 	.size	error_bool, .Lfunc_end2-error_bool
@@ -101,7 +101,7 @@ error_new:
 .LBB3_2:
 	mov	rdi, qword ptr [rsp]
 	lea	rsi, [rip + .Lanon.[ID].4]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 8
@@ -138,7 +138,7 @@ error_alloc:
 .LBB4_2:
 	mov	rdi, qword ptr [rsp]
 	lea	rsi, [rip + .Lanon.[ID].5]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 8
@@ -181,7 +181,7 @@ error_init:
 	mov	rdi, qword ptr [rsp]
 .LBB5_5:
 	lea	rsi, [rip + .Lanon.[ID].6]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 8
@@ -218,7 +218,7 @@ error_copy:
 .LBB6_2:
 	mov	rdi, qword ptr [rsp]
 	lea	rsi, [rip + .Lanon.[ID].7]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 8
@@ -257,7 +257,7 @@ error_autoreleased:
 .LBB7_2:
 	mov	rdi, qword ptr [rsp]
 	lea	rsi, [rip + .Lanon.[ID].8]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::Object>, 0)
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
 	add	rsp, 8

--- a/crates/test-assembly/crates/test_msg_send_error/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_error/lib.rs
@@ -1,37 +1,37 @@
 //! Test that error parameters are handled correctly.
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{Class, Object, Sel};
+use objc2::runtime::{AnyClass, AnyObject, Sel};
 use objc2::MessageReceiver;
 use objc2::__macro_helpers::{Alloc, CopyOrMutCopy, Init, MsgSendId, New, Other};
 
-type Result<T> = std::result::Result<T, Id<Object>>;
+type Result<T> = std::result::Result<T, Id<AnyObject>>;
 
 #[no_mangle]
-unsafe fn error_bool(obj: &Object, sel: Sel, param: u32) -> Result<()> {
+unsafe fn error_bool(obj: &AnyObject, sel: Sel, param: u32) -> Result<()> {
     MessageReceiver::__send_message_error(obj, sel, (param,))
 }
 
 #[no_mangle]
-unsafe fn error_new(cls: &Class, sel: Sel) -> Result<Id<Object>> {
+unsafe fn error_new(cls: &AnyClass, sel: Sel) -> Result<Id<AnyObject>> {
     New::send_message_id_error(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn error_alloc(cls: &Class, sel: Sel) -> Result<Allocated<Object>> {
+unsafe fn error_alloc(cls: &AnyClass, sel: Sel) -> Result<Allocated<AnyObject>> {
     Alloc::send_message_id_error(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn error_init(obj: Option<Allocated<Object>>, sel: Sel) -> Result<Id<Object>> {
+unsafe fn error_init(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Result<Id<AnyObject>> {
     Init::send_message_id_error(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn error_copy(obj: &Object, sel: Sel) -> Result<Id<Object>> {
+unsafe fn error_copy(obj: &AnyObject, sel: Sel) -> Result<Id<AnyObject>> {
     CopyOrMutCopy::send_message_id_error(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn error_autoreleased(obj: &Object, sel: Sel) -> Result<Id<Object>> {
+unsafe fn error_autoreleased(obj: &AnyObject, sel: Sel) -> Result<Id<AnyObject>> {
     Other::send_message_id_error(obj, sel, ())
 }

--- a/crates/test-assembly/crates/test_msg_send_id/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_id/lib.rs
@@ -1,83 +1,83 @@
 //! Test assembly output of `msg_send_id!` internals.
 use objc2::__macro_helpers::{Alloc, CopyOrMutCopy, Init, MsgSendId, New, Other};
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{Class, Object, Sel};
+use objc2::runtime::{AnyClass, AnyObject, Sel};
 
 #[no_mangle]
-unsafe fn handle_new(cls: &Class, sel: Sel) -> Option<Id<Object>> {
+unsafe fn handle_new(cls: &AnyClass, sel: Sel) -> Option<Id<AnyObject>> {
     New::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_new_fallible(cls: &Class, sel: Sel) -> Id<Object> {
+unsafe fn handle_new_fallible(cls: &AnyClass, sel: Sel) -> Id<AnyObject> {
     New::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_alloc(cls: &Class, sel: Sel) -> Option<Allocated<Object>> {
+unsafe fn handle_alloc(cls: &AnyClass, sel: Sel) -> Option<Allocated<AnyObject>> {
     Alloc::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_fallible(cls: &Class, sel: Sel) -> Allocated<Object> {
+unsafe fn handle_alloc_fallible(cls: &AnyClass, sel: Sel) -> Allocated<AnyObject> {
     Alloc::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_init(obj: Option<Allocated<Object>>, sel: Sel) -> Option<Id<Object>> {
+unsafe fn handle_init(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Option<Id<AnyObject>> {
     Init::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_init_fallible(obj: Option<Allocated<Object>>, sel: Sel) -> Id<Object> {
+unsafe fn handle_init_fallible(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Id<AnyObject> {
     Init::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_init(cls: &Class, sel1: Sel, sel2: Sel) -> Option<Id<Object>> {
+unsafe fn handle_alloc_init(cls: &AnyClass, sel1: Sel, sel2: Sel) -> Option<Id<AnyObject>> {
     let obj = Alloc::send_message_id(cls, sel1, ());
     Init::send_message_id(obj, sel2, ())
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_release(cls: &Class, sel: Sel) {
-    let obj: Option<Allocated<Object>> = Alloc::send_message_id(cls, sel, ());
+unsafe fn handle_alloc_release(cls: &AnyClass, sel: Sel) {
+    let obj: Option<Allocated<AnyObject>> = Alloc::send_message_id(cls, sel, ());
     let _obj = obj.unwrap_unchecked();
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_init_release(cls: &Class, sel1: Sel, sel2: Sel) {
+unsafe fn handle_alloc_init_release(cls: &AnyClass, sel1: Sel, sel2: Sel) {
     let obj = Alloc::send_message_id(cls, sel1, ());
-    let obj: Option<Id<Object>> = Init::send_message_id(obj, sel2, ());
+    let obj: Option<Id<AnyObject>> = Init::send_message_id(obj, sel2, ());
     let _obj = obj.unwrap_unchecked();
 }
 
 #[no_mangle]
-unsafe fn handle_copy(obj: &Object, sel: Sel) -> Option<Id<Object>> {
+unsafe fn handle_copy(obj: &AnyObject, sel: Sel) -> Option<Id<AnyObject>> {
     CopyOrMutCopy::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_copy_fallible(obj: &Object, sel: Sel) -> Id<Object> {
+unsafe fn handle_copy_fallible(obj: &AnyObject, sel: Sel) -> Id<AnyObject> {
     CopyOrMutCopy::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_autoreleased(obj: &Object, sel: Sel) -> Option<Id<Object>> {
+unsafe fn handle_autoreleased(obj: &AnyObject, sel: Sel) -> Option<Id<AnyObject>> {
     Other::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_autoreleased_fallible(obj: &Object, sel: Sel) -> Id<Object> {
+unsafe fn handle_autoreleased_fallible(obj: &AnyObject, sel: Sel) -> Id<AnyObject> {
     Other::send_message_id(obj, sel, ())
 }
 
 // TODO: The optimization does not happen here, fix this!
 #[no_mangle]
 unsafe fn handle_with_out_param(
-    obj: &Object,
+    obj: &AnyObject,
     sel: Sel,
-    param: &mut Id<Object>,
-) -> Option<Id<Object>> {
+    param: &mut Id<AnyObject>,
+) -> Option<Id<AnyObject>> {
     Other::send_message_id(obj, sel, (param,))
 }

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
@@ -3,9 +3,9 @@
 	.p2align	2
 _handle_with_sel:
 Lloh0:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_ad1b815073641351@PAGE
 Lloh1:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_ad1b815073641351@PAGEOFF]
 	b	_objc_msgSend
 	.loh AdrpLdr	Lloh0, Lloh1
 
@@ -55,24 +55,24 @@ _use_generic:
 	add	x29, sp, #16
 	mov	x19, x0
 Lloh10:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138@PAGE
 Lloh11:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da@PAGEOFF]
-	adrp	x20, L_OBJC_SELECTOR_REFERENCES_379095321e06c060@PAGE
-	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_379095321e06c060@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138@PAGEOFF]
+	adrp	x20, L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05@PAGE
+	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05@PAGEOFF]
 	bl	_objc_msgSend
 Lloh12:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da@PAGE
 Lloh13:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1@PAGEOFF]
-	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_379095321e06c060@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da@PAGEOFF]
+	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05@PAGEOFF]
 	mov	x0, x19
 	bl	_objc_msgSend
 Lloh14:
-	adrp	x8, L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d@PAGE
+	adrp	x8, L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a@PAGE
 Lloh15:
-	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d@PAGEOFF]
-	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_379095321e06c060@PAGEOFF]
+	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a@PAGEOFF]
+	ldr	x2, [x20, L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05@PAGEOFF]
 	mov	x0, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
@@ -92,88 +92,88 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\000\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.quad	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.quad	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.quad	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.quad	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.quad	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.quad	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.quad	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.quad	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.quad	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.quad	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
@@ -4,8 +4,8 @@
 	.p2align	2
 	.code	32
 _handle_with_sel:
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-(LPC0_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-(LPC0_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-(LPC0_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-(LPC0_0+8))
 LPC0_0:
 	ldr	r1, [pc, r1]
 	b	_objc_msgSend
@@ -48,33 +48,33 @@ LPC1_2:
 _use_generic:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_0+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_0+8))
 	mov	r4, r0
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_0+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_0+8))
 LPC2_0:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-(LPC2_1+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-(LPC2_1+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-(LPC2_1+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-(LPC2_1+8))
 LPC2_1:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_2+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_2+8))
 	mov	r0, r4
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_2+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_2+8))
 LPC2_2:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-(LPC2_3+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-(LPC2_3+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-(LPC2_3+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-(LPC2_3+8))
 LPC2_3:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_4+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_4+8))
 	mov	r0, r4
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_4+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_4+8))
 LPC2_4:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-(LPC2_5+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-(LPC2_5+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-(LPC2_5+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-(LPC2_5+8))
 LPC2_5:
 	ldr	r1, [pc, r1]
 	pop	{r4, r7, lr}
@@ -91,89 +91,89 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.long	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.long	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.long	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.long	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.long	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -6,8 +6,8 @@
 _handle_with_sel:
 	push	{r7, lr}
 	mov	r7, sp
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-(LPC0_0+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-(LPC0_0+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-(LPC0_0+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-(LPC0_0+8))
 LPC0_0:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
@@ -51,33 +51,33 @@ LPC1_2:
 _use_generic:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_0+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_0+8))
 	mov	r4, r0
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_0+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_0+8))
 LPC2_0:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-(LPC2_1+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-(LPC2_1+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-(LPC2_1+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-(LPC2_1+8))
 LPC2_1:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_2+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_2+8))
 	mov	r0, r4
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_2+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_2+8))
 LPC2_2:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-(LPC2_3+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-(LPC2_3+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-(LPC2_3+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-(LPC2_3+8))
 LPC2_3:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
-	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_4+8))
+	movw	r2, :lower16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_4+8))
 	mov	r0, r4
-	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_379095321e06c060-(LPC2_4+8))
+	movt	r2, :upper16:(L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-(LPC2_4+8))
 LPC2_4:
 	ldr	r2, [pc, r2]
-	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-(LPC2_5+8))
-	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-(LPC2_5+8))
+	movw	r1, :lower16:(L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-(LPC2_5+8))
+	movt	r1, :upper16:(L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-(LPC2_5+8))
 LPC2_5:
 	ldr	r1, [pc, r1]
 	bl	_objc_msgSend
@@ -94,89 +94,89 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.long	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.long	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.long	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.long	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.long	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
@@ -10,7 +10,7 @@ _handle_with_sel:
 L0$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-L0$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-L0$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -71,18 +71,18 @@ L2$pb:
 	pop	esi
 	mov	edi, dword ptr [ebp + 8]
 	sub	esp, 4
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 12
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 12
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 16
@@ -102,89 +102,89 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.long	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.long	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.long	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.long	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.long	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
@@ -10,7 +10,7 @@ _handle_with_sel:
 L0$pb:
 	pop	eax
 	sub	esp, 8
-	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c-L0$pb]
+	push	dword ptr [eax + L_OBJC_SELECTOR_REFERENCES_ad1b815073641351-L0$pb]
 	push	dword ptr [ebp + 8]
 	call	_objc_msgSend
 	add	esp, 24
@@ -71,18 +71,18 @@ L2$pb:
 	pop	esi
 	mov	edi, dword ptr [ebp + 8]
 	sub	esp, 4
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 12
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 12
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_379095321e06c060-L2$pb]
-	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05-L2$pb]
+	push	dword ptr [esi + L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a-L2$pb]
 	push	edi
 	call	_objc_msgSend
 	add	esp, 16
@@ -102,89 +102,89 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.long	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.long	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.long	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.long	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.long	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
@@ -5,7 +5,7 @@
 _handle_with_sel:
 	push	rbp
 	mov	rbp, rsp
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_ad1b815073641351]
 	pop	rbp
 	jmp	_objc_msgSend
 
@@ -45,15 +45,15 @@ _use_generic:
 	push	rbx
 	push	rax
 	mov	rbx, rdi
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da]
-	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_379095321e06c060]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138]
+	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05]
 	call	_objc_msgSend
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1]
-	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_379095321e06c060]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da]
+	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05]
 	mov	rdi, rbx
 	call	_objc_msgSend
-	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d]
-	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_379095321e06c060]
+	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a]
+	mov	rdx, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05]
 	mov	rdi, rbx
 	add	rsp, 8
 	pop	rbx
@@ -71,88 +71,88 @@ l_anon.[ID].1:
 	.asciz	";\000\000\000\000\000\000\000\016\000\000\000\005\000\000"
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_77d2b75bddfbef7c
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_77d2b75bddfbef7c:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
-L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c:
+	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
+L_OBJC_METH_VAR_NAME_ad1b815073641351:
 	.asciz	"someSelector"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c
+	.globl	L_OBJC_SELECTOR_REFERENCES_ad1b815073641351
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_77d2b75bddfbef7c:
-	.quad	L_OBJC_METH_VAR_NAME_77d2b75bddfbef7c
+L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
+	.quad	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_379095321e06c060
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_379095321e06c060:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_379095321e06c060
-L_OBJC_METH_VAR_NAME_379095321e06c060:
+	.globl	L_OBJC_METH_VAR_NAME_5ace898e385eba05
+L_OBJC_METH_VAR_NAME_5ace898e385eba05:
 	.asciz	"generic:selector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_379095321e06c060
+	.globl	L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_379095321e06c060:
-	.quad	L_OBJC_METH_VAR_NAME_379095321e06c060
+L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
+	.quad	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_038d21a6277de1da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_038d21a6277de1da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_038d21a6277de1da
-L_OBJC_METH_VAR_NAME_038d21a6277de1da:
+	.globl	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
+L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da
+	.globl	L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_038d21a6277de1da:
-	.quad	L_OBJC_METH_VAR_NAME_038d21a6277de1da
+L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
+	.quad	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_573c1e9c42ae1ea1:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
-L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1:
+	.globl	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
+L_OBJC_METH_VAR_NAME_eb5b4d2de37744da:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1
+	.globl	L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_573c1e9c42ae1ea1:
-	.quad	L_OBJC_METH_VAR_NAME_573c1e9c42ae1ea1
+L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
+	.quad	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_9885c1be4d03110d
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_9885c1be4d03110d:
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-	.globl	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
-L_OBJC_METH_VAR_NAME_9885c1be4d03110d:
+	.globl	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.asciz	"performSelector:"
 
 	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d
+	.globl	L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a
 	.p2align	3, 0x0
-L_OBJC_SELECTOR_REFERENCES_9885c1be4d03110d:
-	.quad	L_OBJC_METH_VAR_NAME_9885c1be4d03110d
+L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
+	.quad	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_static_sel/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/lib.rs
@@ -1,16 +1,16 @@
 //! Test how static selectors work in relation to `msg_send!` and `msg_send_id!`
 #![cfg(feature = "apple")]
 use objc2::rc::Id;
-use objc2::runtime::{Class, Object, Sel};
+use objc2::runtime::{AnyClass, AnyObject, Sel};
 use objc2::{msg_send, msg_send_id, sel};
 
 #[no_mangle]
-unsafe fn handle_with_sel(obj: &Object) -> *mut Object {
+unsafe fn handle_with_sel(obj: &AnyObject) -> *mut AnyObject {
     msg_send![obj, someSelector]
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_init(cls: &Class) -> Id<Object> {
+unsafe fn handle_alloc_init(cls: &AnyClass) -> Id<AnyObject> {
     msg_send_id![msg_send_id![cls, alloc], init]
 }
 
@@ -19,7 +19,7 @@ fn generic<T>() -> Sel {
 }
 
 #[no_mangle]
-unsafe fn use_generic(obj: &Object) {
+unsafe fn use_generic(obj: &AnyObject) {
     let _: () = msg_send![obj, performSelector: generic::<i32>()];
     let _: () = msg_send![obj, performSelector: generic::<u32>()];
     let _: () = msg_send![obj, performSelector: generic::<f32>()];

--- a/crates/test-assembly/crates/test_msg_send_zero_cost/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_zero_cost/lib.rs
@@ -2,11 +2,11 @@
 use core::mem;
 use core::ptr;
 
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{AnyObject, Sel};
 use objc2::MessageReceiver;
 
 #[no_mangle]
-unsafe fn handle(obj: &Object, sel: Sel) -> *mut Object {
+unsafe fn handle(obj: &AnyObject, sel: Sel) -> *mut AnyObject {
     MessageReceiver::send_message(obj, sel, ())
 }
 
@@ -22,6 +22,6 @@ fn selector() -> Sel {
 }
 
 #[no_mangle]
-unsafe fn handle_with_sel(obj: &Object) -> *mut Object {
+unsafe fn handle_with_sel(obj: &AnyObject) -> *mut AnyObject {
     MessageReceiver::send_message(obj, selector(), ())
 }

--- a/crates/test-assembly/crates/test_out_parameters/lib.rs
+++ b/crates/test-assembly/crates/test_out_parameters/lib.rs
@@ -1,34 +1,34 @@
 //! Test that out parameters are handled correctly.
 use objc2::rc::Id;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{NSObject, Sel};
 use objc2::MessageReceiver;
 
 #[no_mangle]
-unsafe fn nonnull_nonnull(obj: &Object, sel: Sel, param: &mut Id<Object>) -> usize {
+unsafe fn nonnull_nonnull(obj: &NSObject, sel: Sel, param: &mut Id<NSObject>) -> usize {
     MessageReceiver::send_message(obj, sel, (param,))
 }
 
 #[no_mangle]
-unsafe fn null_nonnull(obj: &Object, sel: Sel, param: Option<&mut Id<Object>>) -> usize {
+unsafe fn null_nonnull(obj: &NSObject, sel: Sel, param: Option<&mut Id<NSObject>>) -> usize {
     MessageReceiver::send_message(obj, sel, (param,))
 }
 
 #[no_mangle]
-unsafe fn nonnull_null(obj: &Object, sel: Sel, param: &mut Option<Id<Object>>) -> usize {
+unsafe fn nonnull_null(obj: &NSObject, sel: Sel, param: &mut Option<Id<NSObject>>) -> usize {
     MessageReceiver::send_message(obj, sel, (param,))
 }
 
 #[no_mangle]
-unsafe fn null_null(obj: &Object, sel: Sel, param: Option<&mut Option<Id<Object>>>) -> usize {
+unsafe fn null_null(obj: &NSObject, sel: Sel, param: Option<&mut Option<Id<NSObject>>>) -> usize {
     MessageReceiver::send_message(obj, sel, (param,))
 }
 
 #[no_mangle]
 unsafe fn two_nonnull_nonnull(
-    obj: &Object,
+    obj: &NSObject,
     sel: Sel,
-    param1: &mut Id<Object>,
-    param2: &mut Id<Object>,
+    param1: &mut Id<NSObject>,
+    param2: &mut Id<NSObject>,
 ) -> usize {
     MessageReceiver::send_message(obj, sel, (param1, param2))
 }
@@ -39,25 +39,25 @@ unsafe fn two_nonnull_nonnull(
 
 // These should fully avoid any extra `retain/release`
 #[no_mangle]
-unsafe fn call_with_none1(obj: &Object, sel: Sel) -> usize {
+unsafe fn call_with_none1(obj: &NSObject, sel: Sel) -> usize {
     null_nonnull(obj, sel, None)
 }
 #[no_mangle]
-unsafe fn call_with_none2(obj: &Object, sel: Sel) -> usize {
+unsafe fn call_with_none2(obj: &NSObject, sel: Sel) -> usize {
     null_null(obj, sel, None)
 }
 
-type Res = (usize, Option<Id<Object>>);
+type Res = (usize, Option<Id<NSObject>>);
 
 // These should only need a `retain`
 #[no_mangle]
-unsafe fn call_with_none3(obj: &Object, sel: Sel) -> Res {
+unsafe fn call_with_none3(obj: &NSObject, sel: Sel) -> Res {
     let mut param = None;
     let res = nonnull_null(obj, sel, &mut param);
     (res, param)
 }
 #[no_mangle]
-unsafe fn call_with_none4(obj: &Object, sel: Sel) -> Res {
+unsafe fn call_with_none4(obj: &NSObject, sel: Sel) -> Res {
     let mut param = None;
     let res = null_null(obj, sel, Some(&mut param));
     (res, param)
@@ -65,18 +65,18 @@ unsafe fn call_with_none4(obj: &Object, sel: Sel) -> Res {
 
 // These should need `retain/release`, but not have any branches
 #[no_mangle]
-unsafe fn call_with_some1(obj: &Object, sel: Sel, mut param: Id<Object>) -> Res {
+unsafe fn call_with_some1(obj: &NSObject, sel: Sel, mut param: Id<NSObject>) -> Res {
     let res = null_nonnull(obj, sel, Some(&mut param));
     (res, Some(param))
 }
 #[no_mangle]
-unsafe fn call_with_some2(obj: &Object, sel: Sel, param: Id<Object>) -> Res {
+unsafe fn call_with_some2(obj: &NSObject, sel: Sel, param: Id<NSObject>) -> Res {
     let mut param = Some(param);
     let res = nonnull_null(obj, sel, &mut param);
     (res, param)
 }
 #[no_mangle]
-unsafe fn call_with_some3(obj: &Object, sel: Sel, param: Id<Object>) -> Res {
+unsafe fn call_with_some3(obj: &NSObject, sel: Sel, param: Id<NSObject>) -> Res {
     let mut param = Some(param);
     let res = null_null(obj, sel, Some(&mut param));
     (res, param)

--- a/crates/test-assembly/crates/test_retain_autoreleased/lib.rs
+++ b/crates/test-assembly/crates/test_retain_autoreleased/lib.rs
@@ -1,11 +1,11 @@
 //! Test that `Id::retain_autoreleased` is inlined properly.
 
 use objc2::rc::Id;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{AnyObject, Sel};
 use objc2::MessageReceiver;
 
 #[no_mangle]
-unsafe fn handle(obj: &Object, sel: Sel) -> Option<Id<Object>> {
-    let ptr: *mut Object = MessageReceiver::send_message(obj, sel, ());
+unsafe fn handle(obj: &AnyObject, sel: Sel) -> Option<Id<AnyObject>> {
+    let ptr: *mut AnyObject = MessageReceiver::send_message(obj, sel, ());
     Id::retain_autoreleased(ptr)
 }

--- a/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
@@ -3,9 +3,9 @@
 	.p2align	2
 _get_class:
 Lloh0:
-	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGE
+	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGE
 Lloh1:
-	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGEOFF]
+	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGEOFF]
 	ret
 	.loh AdrpLdr	Lloh0, Lloh1
 
@@ -13,9 +13,9 @@ Lloh1:
 	.p2align	2
 _get_same_class:
 Lloh2:
-	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6@PAGE
+	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07@PAGE
 Lloh3:
-	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6@PAGEOFF]
+	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07@PAGEOFF]
 	ret
 	.loh AdrpLdr	Lloh2, Lloh3
 
@@ -23,9 +23,9 @@ Lloh3:
 	.p2align	2
 _get_different_class:
 Lloh4:
-	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4@PAGE
+	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b@PAGE
 Lloh5:
-	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4@PAGEOFF]
+	ldr	x0, [x8, L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b@PAGEOFF]
 	ret
 	.loh AdrpLdr	Lloh4, Lloh5
 
@@ -38,21 +38,21 @@ _unused_sel:
 	.p2align	2
 _use_fns:
 Lloh6:
-	adrp	x9, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGE
+	adrp	x9, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGE
 Lloh7:
-	ldr	x9, [x9, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGEOFF]
+	ldr	x9, [x9, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGEOFF]
 Lloh8:
-	adrp	x10, L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6@PAGE
+	adrp	x10, L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07@PAGE
 Lloh9:
-	ldr	x10, [x10, L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6@PAGEOFF]
+	ldr	x10, [x10, L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07@PAGEOFF]
 Lloh10:
-	adrp	x11, L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4@PAGE
+	adrp	x11, L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b@PAGE
 Lloh11:
-	ldr	x11, [x11, L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4@PAGEOFF]
+	ldr	x11, [x11, L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b@PAGEOFF]
 Lloh12:
-	adrp	x12, L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3@PAGE
+	adrp	x12, L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb@PAGE
 Lloh13:
-	ldr	x12, [x12, L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3@PAGEOFF]
+	ldr	x12, [x12, L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb@PAGEOFF]
 	stp	x9, x10, [x8]
 	stp	x11, x12, [x8, #16]
 	ret
@@ -65,9 +65,9 @@ Lloh13:
 	.p2align	2
 _use_same_twice:
 Lloh14:
-	adrp	x9, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGE
+	adrp	x9, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGE
 Lloh15:
-	ldr	x9, [x9, L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474@PAGEOFF]
+	ldr	x9, [x9, L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777@PAGEOFF]
 	stp	x9, x9, [x8]
 	ret
 	.loh AdrpLdr	Lloh14, Lloh15
@@ -78,75 +78,75 @@ _use_in_loop:
 	ret
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474:
+L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6:
+L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4:
+L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.quad	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706:
+L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219:
 	.quad	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3:
+L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb:
 	.quad	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf:
+L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a:
 	.quad	_OBJC_CLASS_$_NSLock
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-armv7.s
@@ -4,8 +4,8 @@
 	.p2align	2
 	.code	32
 _get_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC0_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC0_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC0_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC0_0+8))
 LPC0_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -14,8 +14,8 @@ LPC0_0:
 	.p2align	2
 	.code	32
 _get_same_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC1_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC1_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC1_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC1_0+8))
 LPC1_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -24,8 +24,8 @@ LPC1_0:
 	.p2align	2
 	.code	32
 _get_different_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC2_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC2_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC2_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC2_0+8))
 LPC2_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -40,20 +40,20 @@ _unused_sel:
 	.p2align	2
 	.code	32
 _use_fns:
-	movw	r9, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3-(LPC4_0+8))
-	movt	r9, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3-(LPC4_0+8))
+	movw	r9, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb-(LPC4_0+8))
+	movt	r9, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb-(LPC4_0+8))
 LPC4_0:
 	ldr	r9, [pc, r9]
-	movw	r2, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC4_1+8))
-	movt	r2, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC4_1+8))
+	movw	r2, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC4_1+8))
+	movt	r2, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC4_1+8))
 LPC4_1:
 	ldr	r2, [pc, r2]
-	movw	r3, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC4_2+8))
-	movt	r3, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC4_2+8))
+	movw	r3, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC4_2+8))
+	movt	r3, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC4_2+8))
 LPC4_2:
 	ldr	r3, [pc, r3]
-	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC4_3+8))
-	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC4_3+8))
+	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC4_3+8))
+	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC4_3+8))
 	str	r2, [r0, #8]
 LPC4_3:
 	ldr	r1, [pc, r1]
@@ -65,8 +65,8 @@ LPC4_3:
 	.p2align	2
 	.code	32
 _use_same_twice:
-	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC5_0+8))
-	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC5_0+8))
+	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC5_0+8))
+	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC5_0+8))
 LPC5_0:
 	ldr	r1, [pc, r1]
 	str	r1, [r0]
@@ -80,75 +80,75 @@ _use_in_loop:
 	bx	lr
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474:
+L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6:
+L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4:
+L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706:
+L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3:
+L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf:
+L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a:
 	.long	_OBJC_CLASS_$_NSLock
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
@@ -4,8 +4,8 @@
 	.p2align	2
 	.code	32
 _get_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC0_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC0_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC0_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC0_0+8))
 LPC0_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -14,8 +14,8 @@ LPC0_0:
 	.p2align	2
 	.code	32
 _get_same_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC1_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC1_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC1_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC1_0+8))
 LPC1_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -24,8 +24,8 @@ LPC1_0:
 	.p2align	2
 	.code	32
 _get_different_class:
-	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC2_0+8))
-	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC2_0+8))
+	movw	r0, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC2_0+8))
+	movt	r0, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC2_0+8))
 LPC2_0:
 	ldr	r0, [pc, r0]
 	bx	lr
@@ -40,20 +40,20 @@ _unused_sel:
 	.p2align	2
 	.code	32
 _use_fns:
-	movw	r9, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3-(LPC4_0+8))
-	movt	r9, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3-(LPC4_0+8))
+	movw	r9, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb-(LPC4_0+8))
+	movt	r9, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb-(LPC4_0+8))
 LPC4_0:
 	ldr	r9, [pc, r9]
-	movw	r2, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC4_1+8))
-	movt	r2, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-(LPC4_1+8))
+	movw	r2, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC4_1+8))
+	movt	r2, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-(LPC4_1+8))
 LPC4_1:
 	ldr	r2, [pc, r2]
-	movw	r3, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC4_2+8))
-	movt	r3, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-(LPC4_2+8))
+	movw	r3, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC4_2+8))
+	movt	r3, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-(LPC4_2+8))
 LPC4_2:
 	ldr	r3, [pc, r3]
-	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC4_3+8))
-	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC4_3+8))
+	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC4_3+8))
+	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC4_3+8))
 	str	r2, [r0, #8]
 LPC4_3:
 	ldr	r1, [pc, r1]
@@ -65,8 +65,8 @@ LPC4_3:
 	.p2align	2
 	.code	32
 _use_same_twice:
-	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC5_0+8))
-	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-(LPC5_0+8))
+	movw	r1, :lower16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC5_0+8))
+	movt	r1, :upper16:(L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-(LPC5_0+8))
 LPC5_0:
 	ldr	r1, [pc, r1]
 	str	r1, [r0]
@@ -80,75 +80,75 @@ _use_in_loop:
 	bx	lr
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474:
+L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6:
+L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4:
+L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706:
+L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3:
+L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf:
+L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a:
 	.long	_OBJC_CLASS_$_NSLock
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
@@ -8,7 +8,7 @@ _get_class:
 	call	L0$pb
 L0$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_49a0cd2a35b9a474-L0$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_928cf03fcc497777-L0$pb]
 	pop	ebp
 	ret
 
@@ -20,7 +20,7 @@ _get_same_class:
 	call	L1$pb
 L1$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_60860b498061fbc6-L1$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_2fe1990982915f07-L1$pb]
 	pop	ebp
 	ret
 
@@ -32,7 +32,7 @@ _get_different_class:
 	call	L2$pb
 L2$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_089cee9fe04089a4-L2$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASS_REFERENCES_dfff3a06c0bf722b-L2$pb]
 	pop	ebp
 	ret
 
@@ -55,10 +55,10 @@ _use_fns:
 L4$pb:
 	pop	ecx
 	mov	eax, dword ptr [ebp + 8]
-	mov	edx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_49a0cd2a35b9a474-L4$pb]
-	mov	esi, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_60860b498061fbc6-L4$pb]
-	mov	edi, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_089cee9fe04089a4-L4$pb]
-	mov	ecx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_15b3f8b356e4fdb3-L4$pb]
+	mov	edx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_928cf03fcc497777-L4$pb]
+	mov	esi, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_2fe1990982915f07-L4$pb]
+	mov	edi, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_dfff3a06c0bf722b-L4$pb]
+	mov	ecx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_5ab5a81fcf2763fb-L4$pb]
 	mov	dword ptr [eax], edx
 	mov	dword ptr [eax + 4], esi
 	mov	dword ptr [eax + 8], edi
@@ -77,7 +77,7 @@ _use_same_twice:
 L5$pb:
 	pop	ecx
 	mov	eax, dword ptr [ebp + 8]
-	mov	ecx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_49a0cd2a35b9a474-L5$pb]
+	mov	ecx, dword ptr [ecx + L_OBJC_CLASS_REFERENCES_928cf03fcc497777-L5$pb]
 	mov	dword ptr [eax], ecx
 	mov	dword ptr [eax + 4], ecx
 	pop	ebp
@@ -92,183 +92,183 @@ _use_in_loop:
 	ret
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_49a0cd2a35b9a474
-L_OBJC_CLASS_NAME_49a0cd2a35b9a474:
+	.globl	L_OBJC_CLASS_NAME_928cf03fcc497777
+L_OBJC_CLASS_NAME_928cf03fcc497777:
 	.ascii	"NSObject"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASS_REFERENCES_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_49a0cd2a35b9a474:
-	.long	L_OBJC_CLASS_NAME_49a0cd2a35b9a474
+L_OBJC_CLASS_REFERENCES_928cf03fcc497777:
+	.long	L_OBJC_CLASS_NAME_928cf03fcc497777
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_49a0cd2a35b9a474_MODULE_INFO
-L_OBJC_CLASS_NAME_49a0cd2a35b9a474_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_928cf03fcc497777_MODULE_INFO
+L_OBJC_CLASS_NAME_928cf03fcc497777_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_49a0cd2a35b9a474
+	.globl	L_OBJC_MODULES_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_MODULES_49a0cd2a35b9a474:
+L_OBJC_MODULES_928cf03fcc497777:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_49a0cd2a35b9a474_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_928cf03fcc497777_MODULE_INFO
 	.space	4
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_60860b498061fbc6
-L_OBJC_CLASS_NAME_60860b498061fbc6:
+	.globl	L_OBJC_CLASS_NAME_2fe1990982915f07
+L_OBJC_CLASS_NAME_2fe1990982915f07:
 	.ascii	"NSObject"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_60860b498061fbc6
+	.globl	L_OBJC_CLASS_REFERENCES_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_60860b498061fbc6:
-	.long	L_OBJC_CLASS_NAME_60860b498061fbc6
+L_OBJC_CLASS_REFERENCES_2fe1990982915f07:
+	.long	L_OBJC_CLASS_NAME_2fe1990982915f07
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_60860b498061fbc6_MODULE_INFO
-L_OBJC_CLASS_NAME_60860b498061fbc6_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_2fe1990982915f07_MODULE_INFO
+L_OBJC_CLASS_NAME_2fe1990982915f07_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_60860b498061fbc6
+	.globl	L_OBJC_MODULES_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_MODULES_60860b498061fbc6:
+L_OBJC_MODULES_2fe1990982915f07:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_60860b498061fbc6_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_2fe1990982915f07_MODULE_INFO
 	.space	4
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_089cee9fe04089a4
-L_OBJC_CLASS_NAME_089cee9fe04089a4:
+	.globl	L_OBJC_CLASS_NAME_dfff3a06c0bf722b
+L_OBJC_CLASS_NAME_dfff3a06c0bf722b:
 	.ascii	"NSString"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_089cee9fe04089a4
+	.globl	L_OBJC_CLASS_REFERENCES_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_089cee9fe04089a4:
-	.long	L_OBJC_CLASS_NAME_089cee9fe04089a4
+L_OBJC_CLASS_REFERENCES_dfff3a06c0bf722b:
+	.long	L_OBJC_CLASS_NAME_dfff3a06c0bf722b
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_089cee9fe04089a4_MODULE_INFO
-L_OBJC_CLASS_NAME_089cee9fe04089a4_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_dfff3a06c0bf722b_MODULE_INFO
+L_OBJC_CLASS_NAME_dfff3a06c0bf722b_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_089cee9fe04089a4
+	.globl	L_OBJC_MODULES_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_MODULES_089cee9fe04089a4:
+L_OBJC_MODULES_dfff3a06c0bf722b:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_089cee9fe04089a4_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_dfff3a06c0bf722b_MODULE_INFO
 	.space	4
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_5331bb309754c706
-L_OBJC_CLASS_NAME_5331bb309754c706:
+	.globl	L_OBJC_CLASS_NAME_f6e054106fdbe219
+L_OBJC_CLASS_NAME_f6e054106fdbe219:
 	.ascii	"NSData"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_5331bb309754c706
+	.globl	L_OBJC_CLASS_REFERENCES_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_5331bb309754c706:
-	.long	L_OBJC_CLASS_NAME_5331bb309754c706
+L_OBJC_CLASS_REFERENCES_f6e054106fdbe219:
+	.long	L_OBJC_CLASS_NAME_f6e054106fdbe219
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_5331bb309754c706_MODULE_INFO
-L_OBJC_CLASS_NAME_5331bb309754c706_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_f6e054106fdbe219_MODULE_INFO
+L_OBJC_CLASS_NAME_f6e054106fdbe219_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_5331bb309754c706
+	.globl	L_OBJC_MODULES_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_MODULES_5331bb309754c706:
+L_OBJC_MODULES_f6e054106fdbe219:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_5331bb309754c706_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_f6e054106fdbe219_MODULE_INFO
 	.space	4
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_15b3f8b356e4fdb3
-L_OBJC_CLASS_NAME_15b3f8b356e4fdb3:
+	.globl	L_OBJC_CLASS_NAME_5ab5a81fcf2763fb
+L_OBJC_CLASS_NAME_5ab5a81fcf2763fb:
 	.ascii	"NSException"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASS_REFERENCES_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_15b3f8b356e4fdb3:
-	.long	L_OBJC_CLASS_NAME_15b3f8b356e4fdb3
+L_OBJC_CLASS_REFERENCES_5ab5a81fcf2763fb:
+	.long	L_OBJC_CLASS_NAME_5ab5a81fcf2763fb
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_15b3f8b356e4fdb3_MODULE_INFO
-L_OBJC_CLASS_NAME_15b3f8b356e4fdb3_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_5ab5a81fcf2763fb_MODULE_INFO
+L_OBJC_CLASS_NAME_5ab5a81fcf2763fb_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_15b3f8b356e4fdb3
+	.globl	L_OBJC_MODULES_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_MODULES_15b3f8b356e4fdb3:
+L_OBJC_MODULES_5ab5a81fcf2763fb:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_15b3f8b356e4fdb3_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_5ab5a81fcf2763fb_MODULE_INFO
 	.space	4
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf
-L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf:
+	.globl	L_OBJC_CLASS_NAME_54ecac6d305d112a
+L_OBJC_CLASS_NAME_54ecac6d305d112a:
 	.ascii	"NSLock"
 
 	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
-	.globl	L_OBJC_CLASS_REFERENCES_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASS_REFERENCES_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_CLASS_REFERENCES_4fe8a7873c5b5bcf:
-	.long	L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf
+L_OBJC_CLASS_REFERENCES_54ecac6d305d112a:
+	.long	L_OBJC_CLASS_NAME_54ecac6d305d112a
 
 	.section	__TEXT,__cstring,cstring_literals
-	.globl	L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf_MODULE_INFO
-L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf_MODULE_INFO:
+	.globl	L_OBJC_CLASS_NAME_54ecac6d305d112a_MODULE_INFO
+L_OBJC_CLASS_NAME_54ecac6d305d112a_MODULE_INFO:
 	.space	1
 
 	.section	__OBJC,__module_info,regular,no_dead_strip
-	.globl	L_OBJC_MODULES_4fe8a7873c5b5bcf
+	.globl	L_OBJC_MODULES_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_MODULES_4fe8a7873c5b5bcf:
+L_OBJC_MODULES_54ecac6d305d112a:
 	.asciz	"\007\000\000\000\020\000\000"
-	.long	L_OBJC_CLASS_NAME_4fe8a7873c5b5bcf_MODULE_INFO
+	.long	L_OBJC_CLASS_NAME_54ecac6d305d112a_MODULE_INFO
 	.space	4
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
@@ -8,7 +8,7 @@ _get_class:
 	call	L0$pb
 L0$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-L0$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-L0$pb]
 	pop	ebp
 	ret
 
@@ -20,7 +20,7 @@ _get_same_class:
 	call	L1$pb
 L1$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-L1$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-L1$pb]
 	pop	ebp
 	ret
 
@@ -32,7 +32,7 @@ _get_different_class:
 	call	L2$pb
 L2$pb:
 	pop	eax
-	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-L2$pb]
+	mov	eax, dword ptr [eax + L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-L2$pb]
 	pop	ebp
 	ret
 
@@ -55,10 +55,10 @@ _use_fns:
 L4$pb:
 	pop	ecx
 	mov	eax, dword ptr [ebp + 8]
-	mov	edx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-L4$pb]
-	mov	esi, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6-L4$pb]
-	mov	edi, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4-L4$pb]
-	mov	ecx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3-L4$pb]
+	mov	edx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-L4$pb]
+	mov	esi, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07-L4$pb]
+	mov	edi, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b-L4$pb]
+	mov	ecx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb-L4$pb]
 	mov	dword ptr [eax], edx
 	mov	dword ptr [eax + 4], esi
 	mov	dword ptr [eax + 8], edi
@@ -77,7 +77,7 @@ _use_same_twice:
 L5$pb:
 	pop	ecx
 	mov	eax, dword ptr [ebp + 8]
-	mov	ecx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474-L5$pb]
+	mov	ecx, dword ptr [ecx + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777-L5$pb]
 	mov	dword ptr [eax], ecx
 	mov	dword ptr [eax + 4], ecx
 	pop	ebp
@@ -92,75 +92,75 @@ _use_in_loop:
 	ret
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474:
+L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6:
+L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4:
+L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706:
+L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3:
+L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf:
+L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a:
 	.long	_OBJC_CLASS_$_NSLock
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
@@ -5,7 +5,7 @@
 _get_class:
 	push	rbp
 	mov	rbp, rsp
-	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474]
+	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777]
 	pop	rbp
 	ret
 
@@ -14,7 +14,7 @@ _get_class:
 _get_same_class:
 	push	rbp
 	mov	rbp, rsp
-	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6]
+	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07]
 	pop	rbp
 	ret
 
@@ -23,7 +23,7 @@ _get_same_class:
 _get_different_class:
 	push	rbp
 	mov	rbp, rsp
-	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4]
+	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b]
 	pop	rbp
 	ret
 
@@ -41,10 +41,10 @@ _use_fns:
 	push	rbp
 	mov	rbp, rsp
 	mov	rax, rdi
-	mov	rcx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474]
-	mov	rdx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6]
-	mov	rsi, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4]
-	mov	rdi, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3]
+	mov	rcx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777]
+	mov	rdx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07]
+	mov	rsi, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b]
+	mov	rdi, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb]
 	mov	qword ptr [rax], rcx
 	mov	qword ptr [rax + 8], rdx
 	mov	qword ptr [rax + 16], rsi
@@ -58,7 +58,7 @@ _use_same_twice:
 	push	rbp
 	mov	rbp, rsp
 	mov	rax, rdi
-	mov	rcx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474]
+	mov	rcx, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777]
 	mov	qword ptr [rdi], rcx
 	mov	qword ptr [rdi + 8], rcx
 	pop	rbp
@@ -73,75 +73,75 @@ _use_in_loop:
 	ret
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_49a0cd2a35b9a474
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_49a0cd2a35b9a474:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_49a0cd2a35b9a474:
+L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_60860b498061fbc6
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_60860b498061fbc6:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_60860b498061fbc6:
+L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_089cee9fe04089a4
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_089cee9fe04089a4:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_089cee9fe04089a4:
+L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.quad	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5331bb309754c706
+	.globl	L_OBJC_IMAGE_INFO_f6e054106fdbe219
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5331bb309754c706:
+L_OBJC_IMAGE_INFO_f6e054106fdbe219:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_5331bb309754c706:
+L_OBJC_CLASSLIST_REFERENCES_$_f6e054106fdbe219:
 	.quad	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3
+	.globl	L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_15b3f8b356e4fdb3:
+L_OBJC_IMAGE_INFO_5ab5a81fcf2763fb:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_15b3f8b356e4fdb3:
+L_OBJC_CLASSLIST_REFERENCES_$_5ab5a81fcf2763fb:
 	.quad	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf
+	.globl	L_OBJC_IMAGE_INFO_54ecac6d305d112a
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4fe8a7873c5b5bcf:
+L_OBJC_IMAGE_INFO_54ecac6d305d112a:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
-	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf
+	.globl	L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a
 	.p2align	3, 0x0
-L_OBJC_CLASSLIST_REFERENCES_$_4fe8a7873c5b5bcf:
+L_OBJC_CLASSLIST_REFERENCES_$_54ecac6d305d112a:
 	.quad	_OBJC_CLASS_$_NSLock
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/lib.rs
+++ b/crates/test-assembly/crates/test_static_class/lib.rs
@@ -1,20 +1,20 @@
 //! Test the output of the `class!` macro.
 #![cfg(feature = "apple")]
 use objc2::class;
-use objc2::runtime::Class;
+use objc2::runtime::AnyClass;
 
 #[no_mangle]
-fn get_class() -> &'static Class {
+fn get_class() -> &'static AnyClass {
     class!(NSObject)
 }
 
 #[no_mangle]
-fn get_same_class() -> &'static Class {
+fn get_same_class() -> &'static AnyClass {
     class!(NSObject)
 }
 
 #[no_mangle]
-fn get_different_class() -> &'static Class {
+fn get_different_class() -> &'static AnyClass {
     class!(NSString)
 }
 
@@ -24,7 +24,7 @@ fn unused_sel() {
 }
 
 #[no_mangle]
-fn use_fns() -> [&'static Class; 4] {
+fn use_fns() -> [&'static AnyClass; 4] {
     let s1 = get_class();
     let s2 = get_same_class();
     let s3 = get_different_class();
@@ -33,7 +33,7 @@ fn use_fns() -> [&'static Class; 4] {
 }
 
 #[no_mangle]
-fn use_same_twice() -> [&'static Class; 2] {
+fn use_same_twice() -> [&'static AnyClass; 2] {
     // Should not need to load twice
     [get_class(), get_class()]
 }

--- a/crates/test-fuzz/fuzz_targets/class.rs
+++ b/crates/test-fuzz/fuzz_targets/class.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use objc2::runtime::Class;
+use objc2::runtime::AnyClass;
 use std::ffi::CString;
 
 fuzz_target!(|s: &str| {
@@ -9,7 +9,7 @@ fuzz_target!(|s: &str| {
 
     if CString::new(s).is_ok() {
         #[allow(clippy::eq_op)]
-        if let Some(cls) = Class::get(s) {
+        if let Some(cls) = AnyClass::get(s) {
             assert_eq!(s, cls.name());
             assert_eq!(cls, cls);
         }

--- a/crates/test-ui/ui/add_method_no_bool.rs
+++ b/crates/test-ui/ui/add_method_no_bool.rs
@@ -2,12 +2,12 @@
 //!
 //! This is not sound without a conversion step.
 use objc2::declare::ClassBuilder;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{NSObject, Sel};
 use objc2::sel;
 
-extern "C" fn my_bool_taking_method(obj: &Object, sel: Sel, arg: bool) {}
+extern "C" fn my_bool_taking_method(obj: &NSObject, sel: Sel, arg: bool) {}
 
-extern "C" fn my_bool_returning_method(obj: &Object, sel: Sel) -> bool {
+extern "C" fn my_bool_returning_method(obj: &NSObject, sel: Sel) -> bool {
     true
 }
 

--- a/crates/test-ui/ui/add_method_no_bool.stderr
+++ b/crates/test-ui/ui/add_method_no_bool.stderr
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
             AtomicI16
             AtomicI32
           and $N others
-  = note: required for `unsafe extern "C" fn(&objc2::runtime::Object, objc2::runtime::Sel, bool)` to implement `MethodImplementation`
+  = note: required for `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel, bool)` to implement `MethodImplementation`
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
   |
@@ -45,7 +45,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
             AtomicI32
           and $N others
   = note: required for `bool` to implement `EncodeReturn`
-  = note: required for `unsafe extern "C" fn(&objc2::runtime::Object, objc2::runtime::Sel) -> bool` to implement `MethodImplementation`
+  = note: required for `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel) -> bool` to implement `MethodImplementation`
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
   |

--- a/crates/test-ui/ui/declare_add_bad_method.stderr
+++ b/crates/test-ui/ui/declare_add_bad_method.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `fn(_, _): MethodImplementation` is not satisfied
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -34,14 +34,14 @@ error[E0277]: the trait bound `fn(_, _): MethodImplementation` is not satisfied
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -61,14 +61,14 @@ error[E0277]: the trait bound `fn(_, _) -> _: MethodImplementation` is not satis
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -88,14 +88,14 @@ error[E0277]: the trait bound `fn(_, _) -> _: MethodImplementation` is not satis
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -115,14 +115,14 @@ error[E0277]: the trait bound `fn(_, _, _): MethodImplementation` is not satisfi
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs

--- a/crates/test-ui/ui/declare_class_invalid_receiver.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_receiver.stderr
@@ -14,14 +14,14 @@ error[E0277]: the trait bound `extern "C" fn(Box<CustomObject>, objc2::runtime::
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -49,14 +49,14 @@ error[E0277]: the trait bound `extern "C" fn(Id<CustomObject>, objc2::runtime::S
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -84,14 +84,14 @@ error[E0277]: the trait bound `extern "C" fn(CustomObject, objc2::runtime::Sel):
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -119,14 +119,14 @@ error[E0277]: the trait bound `extern "C" fn(Box<CustomObject>, objc2::runtime::
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -154,14 +154,14 @@ error[E0277]: the trait bound `extern "C" fn(Id<CustomObject>, objc2::runtime::S
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -189,14 +189,14 @@ error[E0277]: the trait bound `extern "C" fn(CustomObject, objc2::runtime::Sel) 
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -221,13 +221,13 @@ error[E0277]: the trait bound `Box<CustomObject>: MessageReceiver` is not satisf
   | |_^ the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
   |
   = help: the following other types implement trait `MessageReceiver`:
+            &'a AnyClass
             &'a Id<T>
             &'a T
             &'a mut Id<T>
             &'a mut T
-            &'a objc2::runtime::Class
+            *const AnyClass
             *const T
-            *const objc2::runtime::Class
             *mut T
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<Box<CustomObject>, Id<CustomObject>>`
@@ -264,13 +264,13 @@ error[E0277]: the trait bound `CustomObject: MessageReceiver` is not satisfied
   | |_^ the trait `MessageReceiver` is not implemented for `CustomObject`
   |
   = help: the following other types implement trait `MessageReceiver`:
+            &'a AnyClass
             &'a Id<T>
             &'a T
             &'a mut Id<T>
             &'a mut T
-            &'a objc2::runtime::Class
+            *const AnyClass
             *const T
-            *const objc2::runtime::Class
             *mut T
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<CustomObject, Id<CustomObject>>`
@@ -289,13 +289,13 @@ error[E0277]: the trait bound `Allocated<CustomObject>: MessageReceiver` is not 
   | |_^ the trait `MessageReceiver` is not implemented for `Allocated<CustomObject>`
   |
   = help: the following other types implement trait `MessageReceiver`:
+            &'a AnyClass
             &'a Id<T>
             &'a T
             &'a mut Id<T>
             &'a mut T
-            &'a objc2::runtime::Class
+            *const AnyClass
             *const T
-            *const objc2::runtime::Class
             *mut T
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<Allocated<CustomObject>, Id<CustomObject>>`

--- a/crates/test-ui/ui/declare_class_invalid_syntax.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_syntax.stderr
@@ -313,7 +313,7 @@ error[E0599]: no function or associated item named `test_self` found for struct 
   | | );
   | |_- function or associated item `test_self` not found for this struct
 
-error[E0277]: the trait bound `RetainSemantics<2>: MessageRecieveId<&objc2::runtime::Class, Id<CustomObject>>` is not satisfied
+error[E0277]: the trait bound `RetainSemantics<2>: MessageRecieveId<&AnyClass, Id<CustomObject>>` is not satisfied
  --> ui/declare_class_invalid_syntax.rs
   |
   | / declare_class!(
@@ -323,7 +323,7 @@ error[E0277]: the trait bound `RetainSemantics<2>: MessageRecieveId<&objc2::runt
 ... |
   | |     }
   | | );
-  | |_^ the trait `MessageRecieveId<&objc2::runtime::Class, Id<CustomObject>>` is not implemented for `RetainSemantics<2>`
+  | |_^ the trait `MessageRecieveId<&AnyClass, Id<CustomObject>>` is not implemented for `RetainSemantics<2>`
   |
   = help: the following other types implement trait `MessageRecieveId<Receiver, Ret>`:
             <RetainSemantics<1> as MessageRecieveId<Receiver, Ret>>

--- a/crates/test-ui/ui/extern_class_root.rs
+++ b/crates/test-ui/ui/extern_class_root.rs
@@ -1,11 +1,11 @@
 use core::ops::{Deref, DerefMut};
 
 use objc2::encode::{Encoding, RefEncode};
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 use objc2::{extern_class, mutability, ClassType, Message};
 
 #[repr(transparent)]
-struct MyObject(Object);
+struct MyObject(AnyObject);
 
 unsafe impl RefEncode for MyObject {
     const ENCODING_REF: Encoding = Encoding::Object;
@@ -14,15 +14,15 @@ unsafe impl RefEncode for MyObject {
 unsafe impl Message for MyObject {}
 
 impl Deref for MyObject {
-    type Target = Object;
+    type Target = AnyObject;
 
-    fn deref(&self) -> &Object {
+    fn deref(&self) -> &AnyObject {
         &self.0
     }
 }
 
 impl DerefMut for MyObject {
-    fn deref_mut(&mut self) -> &mut Object {
+    fn deref_mut(&mut self) -> &mut AnyObject {
         &mut self.0
     }
 }

--- a/crates/test-ui/ui/extern_class_subclass_object.rs
+++ b/crates/test-ui/ui/extern_class_subclass_object.rs
@@ -1,11 +1,11 @@
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 use objc2::{extern_class, mutability, ClassType};
 
 extern_class!(
     pub struct MyRootClass;
 
     unsafe impl ClassType for MyRootClass {
-        type Super = Object;
+        type Super = AnyObject;
         type Mutability = mutability::InteriorMutable;
     }
 );

--- a/crates/test-ui/ui/extern_class_subclass_object.stderr
+++ b/crates/test-ui/ui/extern_class_subclass_object.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `AsRef<objc2::runtime::Object>` for type `MyRootClass`
+error[E0119]: conflicting implementations of trait `AsRef<AnyObject>` for type `MyRootClass`
  --> ui/extern_class_subclass_object.rs
   |
   | / extern_class!(
@@ -15,7 +15,7 @@ error[E0119]: conflicting implementations of trait `AsRef<objc2::runtime::Object
   |
   = note: this error originates in the macro `$crate::__impl_as_ref_borrow` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `AsMut<objc2::runtime::Object>` for type `MyRootClass`
+error[E0119]: conflicting implementations of trait `AsMut<AnyObject>` for type `MyRootClass`
  --> ui/extern_class_subclass_object.rs
   |
   | / extern_class!(
@@ -32,7 +32,7 @@ error[E0119]: conflicting implementations of trait `AsMut<objc2::runtime::Object
   |
   = note: this error originates in the macro `$crate::__impl_as_ref_borrow` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `Borrow<objc2::runtime::Object>` for type `MyRootClass`
+error[E0119]: conflicting implementations of trait `Borrow<AnyObject>` for type `MyRootClass`
  --> ui/extern_class_subclass_object.rs
   |
   | / extern_class!(
@@ -49,7 +49,7 @@ error[E0119]: conflicting implementations of trait `Borrow<objc2::runtime::Objec
   |
   = note: this error originates in the macro `$crate::__impl_as_ref_borrow` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `BorrowMut<objc2::runtime::Object>` for type `MyRootClass`
+error[E0119]: conflicting implementations of trait `BorrowMut<AnyObject>` for type `MyRootClass`
  --> ui/extern_class_subclass_object.rs
   |
   | / extern_class!(

--- a/crates/test-ui/ui/fn_ptr_reference_method.rs
+++ b/crates/test-ui/ui/fn_ptr_reference_method.rs
@@ -6,10 +6,10 @@
 //! (`_` can be used to work around this, by letting the compiler choose an
 //! appropriate lifetime '0 that the trait is implemented for).
 use objc2::declare::ClassBuilder;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{NSObject, Sel};
 use objc2::{class, sel};
 
-extern "C" fn my_fn(_this: &Object, _cmd: Sel, _x: &Object) {}
+extern "C" fn my_fn(_this: &NSObject, _cmd: Sel, _x: &NSObject) {}
 
 fn main() {
     let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
@@ -18,10 +18,10 @@ fn main() {
         builder.add_method(sel!(none:), my_fn as extern "C" fn(_, _, _));
 
         // Fails
-        builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &Object));
+        builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &NSObject));
 
         // Also fails, properly tested in `fn_ptr_reference_method2`
-        builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
-        builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, _, &Object));
+        builder.add_method(sel!(first:), my_fn as extern "C" fn(&NSObject, _, _));
+        builder.add_method(sel!(both:), my_fn as extern "C" fn(&NSObject, _, &NSObject));
     }
 }

--- a/crates/test-ui/ui/fn_ptr_reference_method.stderr
+++ b/crates/test-ui/ui/fn_ptr_reference_method.stderr
@@ -1,20 +1,20 @@
-error[E0277]: the trait bound `for<'a> extern "C" fn(_, _, &'a objc2::runtime::Object): MethodImplementation` is not satisfied
+error[E0277]: the trait bound `for<'a> extern "C" fn(_, _, &'a NSObject): MethodImplementation` is not satisfied
  --> ui/fn_ptr_reference_method.rs
   |
-  |         builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &Object));
-  |                 ----------               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MethodImplementation` is not implemented for `for<'a> extern "C" fn(_, _, &'a objc2::runtime::Object)`
+  |         builder.add_method(sel!(third:), my_fn as extern "C" fn(_, _, &NSObject));
+  |                 ----------               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MethodImplementation` is not implemented for `for<'a> extern "C" fn(_, _, &'a NSObject)`
   |                 |
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a T, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a T, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
+            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs

--- a/crates/test-ui/ui/fn_ptr_reference_method2.rs
+++ b/crates/test-ui/ui/fn_ptr_reference_method2.rs
@@ -1,15 +1,15 @@
 //! Extra test for `fn_ptr_reference_method`
 //! (They fail at different compilation passes).
 use objc2::declare::ClassBuilder;
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::{NSObject, Sel};
 use objc2::{class, sel};
 
-extern "C" fn my_fn(_this: &Object, _cmd: Sel, _x: &Object) {}
+extern "C" fn my_fn(_this: &NSObject, _cmd: Sel, _x: &NSObject) {}
 
 fn main() {
     let mut builder = ClassBuilder::new("SomeTestClass", class!(NSObject)).unwrap();
     unsafe {
-        builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
-        builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
+        builder.add_method(sel!(first:), my_fn as extern "C" fn(&NSObject, _, _));
+        builder.add_method(sel!(both:), my_fn as extern "C" fn(&NSObject, Sel, &NSObject));
     }
 }

--- a/crates/test-ui/ui/fn_ptr_reference_method2.stderr
+++ b/crates/test-ui/ui/fn_ptr_reference_method2.stderr
@@ -1,26 +1,26 @@
 error: implementation of `MethodImplementation` is not general enough
  --> ui/fn_ptr_reference_method2.rs
   |
-  |         builder.add_method(sel!(first:), my_fn as extern "C" fn(&Object, _, _));
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+  |         builder.add_method(sel!(first:), my_fn as extern "C" fn(&NSObject, _, _));
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
   |
-  = note: `MethodImplementation` would have to be implemented for the type `for<'a> extern "C" fn(&'a objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`
-  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`, for some specific lifetime `'0`
+  = note: `MethodImplementation` would have to be implemented for the type `for<'a> extern "C" fn(&'a NSObject, objc2::runtime::Sel, &NSObject)`
+  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 NSObject, objc2::runtime::Sel, &NSObject)`, for some specific lifetime `'0`
 
 error: implementation of `MethodImplementation` is not general enough
  --> ui/fn_ptr_reference_method2.rs
   |
-  |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+  |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&NSObject, Sel, &NSObject));
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
   |
-  = note: `MethodImplementation` would have to be implemented for the type `for<'a, 'b> extern "C" fn(&'a objc2::runtime::Object, objc2::runtime::Sel, &'b objc2::runtime::Object)`
-  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 objc2::runtime::Object, objc2::runtime::Sel, &objc2::runtime::Object)`, for some specific lifetime `'0`
+  = note: `MethodImplementation` would have to be implemented for the type `for<'a, 'b> extern "C" fn(&'a NSObject, objc2::runtime::Sel, &'b NSObject)`
+  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&'0 NSObject, objc2::runtime::Sel, &NSObject)`, for some specific lifetime `'0`
 
 error: implementation of `MethodImplementation` is not general enough
  --> ui/fn_ptr_reference_method2.rs
   |
-  |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&Object, Sel, &Object));
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
+  |         builder.add_method(sel!(both:), my_fn as extern "C" fn(&NSObject, Sel, &NSObject));
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MethodImplementation` is not general enough
   |
-  = note: `MethodImplementation` would have to be implemented for the type `for<'a, 'b> extern "C" fn(&'a objc2::runtime::Object, objc2::runtime::Sel, &'b objc2::runtime::Object)`
-  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&objc2::runtime::Object, objc2::runtime::Sel, &'0 objc2::runtime::Object)`, for some specific lifetime `'0`
+  = note: `MethodImplementation` would have to be implemented for the type `for<'a, 'b> extern "C" fn(&'a NSObject, objc2::runtime::Sel, &'b NSObject)`
+  = note: ...but `MethodImplementation` is actually implemented for the type `extern "C" fn(&NSObject, objc2::runtime::Sel, &'0 NSObject)`, for some specific lifetime `'0`

--- a/crates/test-ui/ui/invalid_msg_send.rs
+++ b/crates/test-ui/ui/invalid_msg_send.rs
@@ -1,10 +1,10 @@
 //! Test invalid msg_send syntax
 use objc2::msg_send;
 use objc2::rc::Id;
-use objc2::runtime::Object;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let obj: &Object;
+    let obj: &NSObject;
     let b = 32i32;
     let d = 32i32;
     let _: () = unsafe { msg_send![obj] };
@@ -16,5 +16,5 @@ fn main() {
     let _: () = unsafe { msg_send![obj, a: b: c] };
     let _: () = unsafe { msg_send![obj, a: b c: d,] };
 
-    let _: Result<(), Id<Object>> = unsafe { msg_send![obj, a: _, b: _] };
+    let _: Result<(), Id<NSObject>> = unsafe { msg_send![obj, a: _, b: _] };
 }

--- a/crates/test-ui/ui/invalid_msg_send.stderr
+++ b/crates/test-ui/ui/invalid_msg_send.stderr
@@ -97,8 +97,8 @@ note: while trying to match `)`
 error: no rules expected the token `b`
  --> ui/invalid_msg_send.rs
   |
-  |     let _: Result<(), Id<Object>> = unsafe { msg_send![obj, a: _, b: _] };
-  |                                                                   ^ no rules expected this token in macro call
+  |     let _: Result<(), Id<NSObject>> = unsafe { msg_send![obj, a: _, b: _] };
+  |                                                                     ^ no rules expected this token in macro call
   |
 note: while trying to match `)`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs

--- a/crates/test-ui/ui/invalid_msg_send_super.rs
+++ b/crates/test-ui/ui/invalid_msg_send_super.rs
@@ -1,10 +1,10 @@
 //! Test invalid msg_send![super(...)] syntax
 use objc2::msg_send;
-use objc2::runtime::{Class, Object};
+use objc2::runtime::{AnyClass, NSObject};
 
 fn main() {
-    let obj: &Object;
-    let superclass: &Class;
+    let obj: &NSObject;
+    let superclass: &AnyClass;
 
     let _: () = unsafe { msg_send![super, init] };
     let _: () = unsafe { msg_send![super(), init] };

--- a/crates/test-ui/ui/msg_send_id_alloc_init_different.rs
+++ b/crates/test-ui/ui/msg_send_id_alloc_init_different.rs
@@ -1,11 +1,11 @@
 //! Ensure that `init` returns the same type as given from `alloc`.
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{NSObject, Object};
+use objc2::runtime::{NSObject, AnyObject};
 use objc2::{class, msg_send_id};
 
 fn main() {
     let cls = class!(NSObject);
     let obj: Option<Allocated<NSObject>> = unsafe { msg_send_id![cls, alloc] };
 
-    let _: Id<Object> = unsafe { msg_send_id![obj, init] };
+    let _: Id<AnyObject> = unsafe { msg_send_id![obj, init] };
 }

--- a/crates/test-ui/ui/msg_send_id_alloc_init_different.stderr
+++ b/crates/test-ui/ui/msg_send_id_alloc_init_different.stderr
@@ -1,11 +1,11 @@
-error[E0271]: type mismatch resolving `<Id<Object> as MaybeUnwrap>::Input == Id<NSObject>`
+error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == Id<NSObject>`
  --> ui/msg_send_id_alloc_init_different.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, init] };
-  |                                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<NSObject>`, found `Id<Object>`
+  |     let _: Id<AnyObject> = unsafe { msg_send_id![obj, init] };
+  |                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<NSObject>`, found `Id<AnyObject>`
   |
   = note: expected struct `Id<NSObject>`
-             found struct `Id<objc2::runtime::Object>`
+             found struct `Id<AnyObject>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |

--- a/crates/test-ui/ui/msg_send_id_invalid_method.rs
+++ b/crates/test-ui/ui/msg_send_id_invalid_method.rs
@@ -4,10 +4,10 @@
 //! this is better than having it show up as part of the `msg_send_id!` macro
 //! itself!
 use objc2::msg_send_id;
-use objc2::runtime::Object;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let object: &Object;
+    let object: &NSObject;
     unsafe { msg_send_id![object, retain] };
     unsafe { msg_send_id![object, release] };
     unsafe { msg_send_id![object, autorelease] };

--- a/crates/test-ui/ui/msg_send_id_invalid_receiver.rs
+++ b/crates/test-ui/ui/msg_send_id_invalid_receiver.rs
@@ -1,22 +1,22 @@
 //! Test compiler output with invalid msg_send_id receivers.
 use objc2::msg_send_id;
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{Class, Object};
+use objc2::runtime::{AnyClass, NSObject};
 
 fn main() {
-    let obj: &Object;
-    let _: Allocated<Object> = unsafe { msg_send_id![obj, alloc] };
-    let _: Id<Object> = unsafe { msg_send_id![obj, init] };
+    let obj: &NSObject;
+    let _: Allocated<NSObject> = unsafe { msg_send_id![obj, alloc] };
+    let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
 
-    let cls: &Class;
-    let _: Id<Object> = unsafe { msg_send_id![cls, init] };
-    let obj: Id<Object>;
-    let _: Id<Object> = unsafe { msg_send_id![obj, init] };
-    let obj: Option<Id<Object>>;
-    let _: Id<Object> = unsafe { msg_send_id![obj, init] };
+    let cls: &AnyClass;
+    let _: Id<NSObject> = unsafe { msg_send_id![cls, init] };
+    let obj: Id<NSObject>;
+    let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
+    let obj: Option<Id<NSObject>>;
+    let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
 
-    let obj: Id<Object>;
-    let _: Id<Object> = unsafe { msg_send_id![obj, new] };
-    let obj: Id<Object>;
-    let _: Id<Object> = unsafe { msg_send_id![obj, copy] };
+    let obj: Id<NSObject>;
+    let _: Id<NSObject> = unsafe { msg_send_id![obj, new] };
+    let obj: Id<NSObject>;
+    let _: Id<NSObject> = unsafe { msg_send_id![obj, copy] };
 }

--- a/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -1,14 +1,14 @@
 error[E0308]: mismatched types
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Allocated<Object> = unsafe { msg_send_id![obj, alloc] };
-  |                                         -------------^^^--------
-  |                                         |            |
-  |                                         |            expected `&Class`, found `&Object`
-  |                                         arguments to this function are incorrect
+  |     let _: Allocated<NSObject> = unsafe { msg_send_id![obj, alloc] };
+  |                                           -------------^^^--------
+  |                                           |            |
+  |                                           |            expected `&AnyClass`, found `&NSObject`
+  |                                           arguments to this function are incorrect
   |
-  = note: expected reference `&objc2::runtime::Class`
-             found reference `&objc2::runtime::Object`
+  = note: expected reference `&AnyClass`
+             found reference `&NSObject`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -18,14 +18,14 @@ note: associated function defined here
 error[E0308]: mismatched types
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, init] };
-  |                                  -------------^^^-------
-  |                                  |            |
-  |                                  |            expected `Option<Allocated<_>>`, found `&Object`
-  |                                  arguments to this function are incorrect
+  |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
+  |                                    -------------^^^-------
+  |                                    |            |
+  |                                    |            expected `Option<Allocated<_>>`, found `&NSObject`
+  |                                    arguments to this function are incorrect
   |
   = note:   expected enum `Option<Allocated<_>>`
-          found reference `&objc2::runtime::Object`
+          found reference `&NSObject`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -35,14 +35,14 @@ note: associated function defined here
 error[E0308]: mismatched types
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![cls, init] };
-  |                                  -------------^^^-------
-  |                                  |            |
-  |                                  |            expected `Option<Allocated<_>>`, found `&Class`
-  |                                  arguments to this function are incorrect
+  |     let _: Id<NSObject> = unsafe { msg_send_id![cls, init] };
+  |                                    -------------^^^-------
+  |                                    |            |
+  |                                    |            expected `Option<Allocated<_>>`, found `&AnyClass`
+  |                                    arguments to this function are incorrect
   |
   = note:   expected enum `Option<Allocated<_>>`
-          found reference `&objc2::runtime::Class`
+          found reference `&AnyClass`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -52,14 +52,14 @@ note: associated function defined here
 error[E0308]: mismatched types
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, init] };
-  |                                  -------------^^^-------
-  |                                  |            |
-  |                                  |            expected `Option<Allocated<_>>`, found `Id<Object>`
-  |                                  arguments to this function are incorrect
+  |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
+  |                                    -------------^^^-------
+  |                                    |            |
+  |                                    |            expected `Option<Allocated<_>>`, found `Id<NSObject>`
+  |                                    arguments to this function are incorrect
   |
   = note: expected enum `Option<Allocated<_>>`
-           found struct `Id<objc2::runtime::Object>`
+           found struct `Id<NSObject>`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -69,44 +69,44 @@ note: associated function defined here
 error[E0308]: mismatched types
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, init] };
-  |                                  -------------^^^-------
-  |                                  |            |
-  |                                  |            expected `Option<Allocated<_>>`, found `Option<Id<Object>>`
-  |                                  arguments to this function are incorrect
+  |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
+  |                                    -------------^^^-------
+  |                                    |            |
+  |                                    |            expected `Option<Allocated<_>>`, found `Option<Id<NSObject>>`
+  |                                    arguments to this function are incorrect
   |
   = note: expected enum `Option<Allocated<_>>`
-             found enum `Option<Id<objc2::runtime::Object>>`
+             found enum `Option<Id<NSObject>>`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |               ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Id<objc2::runtime::Object>: MessageReceiver` is not satisfied
+error[E0277]: the trait bound `Id<NSObject>: MessageReceiver` is not satisfied
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, new] };
-  |                                  -------------^^^------
-  |                                  |            |
-  |                                  |            the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object>`
-  |                                  required by a bound introduced by this call
+  |     let _: Id<NSObject> = unsafe { msg_send_id![obj, new] };
+  |                                    -------------^^^------
+  |                                    |            |
+  |                                    |            the trait `MessageReceiver` is not implemented for `Id<NSObject>`
+  |                                    required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T>
             &'a mut Id<T>
-  = note: required for `RetainSemantics<1>` to implement `MsgSendId<Id<objc2::runtime::Object>, Id<_>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<Id<NSObject>, Id<_>>`
 
-error[E0277]: the trait bound `Id<objc2::runtime::Object>: MessageReceiver` is not satisfied
+error[E0277]: the trait bound `Id<NSObject>: MessageReceiver` is not satisfied
  --> ui/msg_send_id_invalid_receiver.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![obj, copy] };
-  |                                  -------------^^^-------
-  |                                  |            |
-  |                                  |            the trait `MessageReceiver` is not implemented for `Id<objc2::runtime::Object>`
-  |                                  required by a bound introduced by this call
+  |     let _: Id<NSObject> = unsafe { msg_send_id![obj, copy] };
+  |                                    -------------^^^-------
+  |                                    |            |
+  |                                    |            the trait `MessageReceiver` is not implemented for `Id<NSObject>`
+  |                                    required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T>
             &'a mut Id<T>
-  = note: required for `RetainSemantics<4>` to implement `MsgSendId<Id<objc2::runtime::Object>, Id<_>>`
+  = note: required for `RetainSemantics<4>` to implement `MsgSendId<Id<NSObject>, Id<_>>`

--- a/crates/test-ui/ui/msg_send_id_invalid_return.rs
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.rs
@@ -1,30 +1,30 @@
 //! Test compiler output with invalid msg_send_id return values.
 use objc2::msg_send_id;
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{Class, NSObject, Object};
+use objc2::runtime::{AnyClass, NSObject, AnyObject};
 
 fn main() {
-    let cls: &Class;
-    let _: &Object = unsafe { msg_send_id![cls, new] };
-    let _: Id<Class> = unsafe { msg_send_id![cls, new] };
-    let _: Option<Id<Class>> = unsafe { msg_send_id![cls, new] };
+    let cls: &AnyClass;
+    let _: &AnyObject = unsafe { msg_send_id![cls, new] };
+    let _: Id<AnyClass> = unsafe { msg_send_id![cls, new] };
+    let _: Option<Id<AnyClass>> = unsafe { msg_send_id![cls, new] };
 
-    let _: &Object = unsafe { msg_send_id![cls, alloc] };
-    let _: Allocated<Class> = unsafe { msg_send_id![cls, alloc] };
-    let _: Id<Object> = unsafe { msg_send_id![cls, alloc] };
+    let _: &AnyObject = unsafe { msg_send_id![cls, alloc] };
+    let _: Allocated<AnyClass> = unsafe { msg_send_id![cls, alloc] };
+    let _: Id<AnyObject> = unsafe { msg_send_id![cls, alloc] };
     // Earlier design worked like this
-    let _: Id<Allocated<Object>> = unsafe { msg_send_id![cls, alloc] };
+    let _: Id<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
 
-    let obj: Option<Allocated<Object>>;
-    let _: &Object = unsafe { msg_send_id![obj, init] };
-    let obj: Option<Allocated<Object>>;
-    let _: Id<Class> = unsafe { msg_send_id![obj, init] };
-    let obj: Option<Allocated<Object>>;
+    let obj: Option<Allocated<AnyObject>>;
+    let _: &AnyObject = unsafe { msg_send_id![obj, init] };
+    let obj: Option<Allocated<AnyObject>>;
+    let _: Id<AnyClass> = unsafe { msg_send_id![obj, init] };
+    let obj: Option<Allocated<AnyObject>>;
     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
 
-    let obj: &Object;
-    let _: &Object = unsafe { msg_send_id![obj, copy] };
+    let obj: &AnyObject;
+    let _: &AnyObject = unsafe { msg_send_id![obj, copy] };
 
-    let _: &Object = unsafe { msg_send_id![obj, description] };
-    let _: Option<&Object> = unsafe { msg_send_id![obj, description] };
+    let _: &AnyObject = unsafe { msg_send_id![obj, description] };
+    let _: Option<&AnyObject> = unsafe { msg_send_id![obj, description] };
 }

--- a/crates/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: &Object = unsafe { msg_send_id![cls, new] };
-  |                               ^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&objc2::runtime::Object`
+  |     let _: &AnyObject = unsafe { msg_send_id![cls, new] };
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Allocated<T>
@@ -16,47 +16,47 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
+error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Id<Class> = unsafe { msg_send_id![cls, new] };
-  |                                 -------------^^^------
-  |                                 |            |
-  |                                 |            the trait `Message` is not implemented for `objc2::runtime::Class`
-  |                                 required by a bound introduced by this call
+  |     let _: Id<AnyClass> = unsafe { msg_send_id![cls, new] };
+  |                                    -------------^^^------
+  |                                    |            |
+  |                                    |            the trait `Message` is not implemented for `AnyClass`
+  |                                    required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
+            AnyObject
             Exception
             NSObject
             ProtocolObject<P>
             __NSProxy
             __RcTestObject
-            objc2::runtime::Object
-  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
 
-error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
+error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Option<Id<Class>> = unsafe { msg_send_id![cls, new] };
-  |                                         -------------^^^------
-  |                                         |            |
-  |                                         |            the trait `Message` is not implemented for `objc2::runtime::Class`
-  |                                         required by a bound introduced by this call
+  |     let _: Option<Id<AnyClass>> = unsafe { msg_send_id![cls, new] };
+  |                                            -------------^^^------
+  |                                            |            |
+  |                                            |            the trait `Message` is not implemented for `AnyClass`
+  |                                            required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
+            AnyObject
             Exception
             NSObject
             ProtocolObject<P>
             __NSProxy
             __RcTestObject
-            objc2::runtime::Object
-  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&objc2::runtime::Class, Id<objc2::runtime::Class>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
 
-error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: &Object = unsafe { msg_send_id![cls, alloc] };
-  |                               ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&objc2::runtime::Object`
+  |     let _: &AnyObject = unsafe { msg_send_id![cls, alloc] };
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Allocated<T>
@@ -70,32 +70,32 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `objc2::runtime::Class: Message` is not satisfied
+error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Allocated<Class> = unsafe { msg_send_id![cls, alloc] };
-  |                                        -------------^^^--------
-  |                                        |            |
-  |                                        |            the trait `Message` is not implemented for `objc2::runtime::Class`
-  |                                        required by a bound introduced by this call
+  |     let _: Allocated<AnyClass> = unsafe { msg_send_id![cls, alloc] };
+  |                                           -------------^^^--------
+  |                                           |            |
+  |                                           |            the trait `Message` is not implemented for `AnyClass`
+  |                                           required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
+            AnyObject
             Exception
             NSObject
             ProtocolObject<P>
             __NSProxy
             __RcTestObject
-            objc2::runtime::Object
-  = note: required for `RetainSemantics<2>` to implement `MsgSendId<&objc2::runtime::Class, Allocated<objc2::runtime::Class>>`
+  = note: required for `RetainSemantics<2>` to implement `MsgSendId<&AnyClass, Allocated<AnyClass>>`
 
-error[E0271]: type mismatch resolving `<Id<Object> as MaybeUnwrap>::Input == Allocated<_>`
+error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == Allocated<_>`
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![cls, alloc] };
-  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<Object>`
+  |     let _: Id<AnyObject> = unsafe { msg_send_id![cls, alloc] };
+  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<AnyObject>`
   |
   = note: expected struct `Allocated<_>`
-             found struct `Id<objc2::runtime::Object>`
+             found struct `Id<AnyObject>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -103,14 +103,14 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<Id<Allocated<Object>> as MaybeUnwrap>::Input == Allocated<_>`
+error[E0271]: type mismatch resolving `<Id<Allocated<AnyObject>> as MaybeUnwrap>::Input == Allocated<_>`
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Id<Allocated<Object>> = unsafe { msg_send_id![cls, alloc] };
-  |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<Allocated<Object>>`
+  |     let _: Id<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<Allocated<AnyObject>>`
   |
   = note: expected struct `Allocated<_>`
-             found struct `Id<Allocated<objc2::runtime::Object>>`
+             found struct `Id<Allocated<AnyObject>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -118,11 +118,11 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: &Object = unsafe { msg_send_id![obj, init] };
-  |                               ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&objc2::runtime::Object`
+  |     let _: &AnyObject = unsafe { msg_send_id![obj, init] };
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Allocated<T>
@@ -136,14 +136,14 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<Id<Class> as MaybeUnwrap>::Input == Id<Object>`
+error[E0271]: type mismatch resolving `<Id<AnyClass> as MaybeUnwrap>::Input == Id<AnyObject>`
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Id<Class> = unsafe { msg_send_id![obj, init] };
-  |                                 ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<Object>`, found `Id<Class>`
+  |     let _: Id<AnyClass> = unsafe { msg_send_id![obj, init] };
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<AnyObject>`, found `Id<AnyClass>`
   |
-  = note: expected struct `Id<objc2::runtime::Object>`
-             found struct `Id<objc2::runtime::Class>`
+  = note: expected struct `Id<AnyObject>`
+             found struct `Id<AnyClass>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -151,13 +151,13 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Id<Object>`
+error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Id<AnyObject>`
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<Object>`, found `Id<NSObject>`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<AnyObject>`, found `Id<NSObject>`
   |
-  = note: expected struct `Id<objc2::runtime::Object>`
+  = note: expected struct `Id<AnyObject>`
              found struct `Id<NSObject>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
@@ -166,11 +166,11 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: &Object = unsafe { msg_send_id![obj, copy] };
-  |                               ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&objc2::runtime::Object`
+  |     let _: &AnyObject = unsafe { msg_send_id![obj, copy] };
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Allocated<T>
@@ -184,11 +184,11 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `&objc2::runtime::Object: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: &Object = unsafe { msg_send_id![obj, description] };
-  |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&objc2::runtime::Object`
+  |     let _: &AnyObject = unsafe { msg_send_id![obj, description] };
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Allocated<T>
@@ -202,11 +202,11 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Option<&objc2::runtime::Object>: MaybeUnwrap` is not satisfied
+error[E0277]: the trait bound `Option<&AnyObject>: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
-  |     let _: Option<&Object> = unsafe { msg_send_id![obj, description] };
-  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `Option<&objc2::runtime::Object>`
+  |     let _: Option<&AnyObject> = unsafe { msg_send_id![obj, description] };
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `Option<&AnyObject>`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
             Option<Allocated<T>>

--- a/crates/test-ui/ui/msg_send_id_underspecified.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified.rs
@@ -1,8 +1,8 @@
 //! Test compiler output of msg_send_id when ownership is not specified.
 use objc2::msg_send_id;
-use objc2::runtime::Object;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let obj: &Object;
-    let _: &Object = &*unsafe { msg_send_id![obj, description] };
+    let obj: &NSObject;
+    let _: &NSObject = &*unsafe { msg_send_id![obj, description] };
 }

--- a/crates/test-ui/ui/msg_send_id_underspecified.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
  --> ui/msg_send_id_underspecified.rs
   |
-  |     let _: &Object = &*unsafe { msg_send_id![obj, description] };
-  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+  |     let _: &NSObject = &*unsafe { msg_send_id![obj, description] };
+  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type

--- a/crates/test-ui/ui/msg_send_id_unwrap.rs
+++ b/crates/test-ui/ui/msg_send_id_unwrap.rs
@@ -1,9 +1,9 @@
 //! Test calling something on return from msg_send_id!.
 use objc2::rc::Id;
-use objc2::runtime::Object;
+use objc2::runtime::NSObject;
 use objc2::{class, msg_send_id};
 
 fn main() {
     let cls = class!(NSObject);
-    let _: Id<Object> = unsafe { msg_send_id![cls, new].unwrap() };
+    let _: Id<NSObject> = unsafe { msg_send_id![cls, new].unwrap() };
 }

--- a/crates/test-ui/ui/msg_send_id_unwrap.stderr
+++ b/crates/test-ui/ui/msg_send_id_unwrap.stderr
@@ -1,7 +1,7 @@
 error[E0282]: type annotations needed
  --> ui/msg_send_id_unwrap.rs
   |
-  |     let _: Id<Object> = unsafe { msg_send_id![cls, new].unwrap() };
-  |                                  ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+  |     let _: Id<NSObject> = unsafe { msg_send_id![cls, new].unwrap() };
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
   |
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -40,6 +40,7 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
   |                                           ^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
   |
   = help: the following other types implement trait `Message`:
+            AnyObject
             Exception
             NSAppleEventDescriptor
             NSArray<ObjectType>
@@ -47,7 +48,6 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
             NSEnumerator<ObjectType>
             NSError
             NSHashTable<ObjectType>
-            NSMapTable<KeyType, ObjectType>
           and $N others
 note: required by a bound in `__send_message_error`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs

--- a/crates/test-ui/ui/msg_send_mutable.rs
+++ b/crates/test-ui/ui/msg_send_mutable.rs
@@ -1,12 +1,12 @@
 //! Test that `msg_send!` consumes their arguments, including the receiver.
 //!
 //! Ideally, it shouldn't be so, but that's how it works currently.
-use objc2::runtime::Object;
+use objc2::runtime::NSObject;
 use objc2::{class, msg_send};
 
 fn main() {
     let cls = class!(NSObject);
-    let obj: &mut Object = unsafe { msg_send![cls, new] };
+    let obj: &mut NSObject = unsafe { msg_send![cls, new] };
 
     let _: () = unsafe { msg_send![obj, selector] };
     // Could be solved with a reborrow

--- a/crates/test-ui/ui/msg_send_mutable.stderr
+++ b/crates/test-ui/ui/msg_send_mutable.stderr
@@ -1,8 +1,8 @@
 error[E0382]: use of moved value: `obj`
  --> ui/msg_send_mutable.rs
   |
-  |     let obj: &mut Object = unsafe { msg_send![cls, new] };
-  |         --- move occurs because `obj` has type `&mut objc2::runtime::Object`, which does not implement the `Copy` trait
+  |     let obj: &mut NSObject = unsafe { msg_send![cls, new] };
+  |         --- move occurs because `obj` has type `&mut NSObject`, which does not implement the `Copy` trait
   |
   |     let _: () = unsafe { msg_send![obj, selector] };
   |                                    --- value moved here

--- a/crates/test-ui/ui/msg_send_only_message.stderr
+++ b/crates/test-ui/ui/msg_send_only_message.stderr
@@ -8,12 +8,12 @@ error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
   |              required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
+            &'a AnyClass
             &'a Id<T>
             &'a T
             &'a mut Id<T>
             &'a mut T
-            &'a objc2::runtime::Class
+            *const AnyClass
             *const T
-            *const objc2::runtime::Class
             *mut T
           and $N others

--- a/crates/test-ui/ui/msg_send_super_not_classtype.rs
+++ b/crates/test-ui/ui/msg_send_super_not_classtype.rs
@@ -1,9 +1,9 @@
 //! Invalid receiver to msg_send![super(obj), ...], missing ClassType impl.
 use objc2::msg_send;
-use objc2::runtime::{NSObject, Object};
+use objc2::runtime::{NSObject, AnyObject};
 
 fn main() {
-    let obj: &Object;
+    let obj: &AnyObject;
     let _: () = unsafe { msg_send![super(obj), method] };
 
     let obj: &NSObject; // impls ClassType, but it's superclass does not

--- a/crates/test-ui/ui/msg_send_super_not_classtype.stderr
+++ b/crates/test-ui/ui/msg_send_super_not_classtype.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfied
+error[E0277]: the trait bound `AnyObject: ClassType` is not satisfied
  --> ui/msg_send_super_not_classtype.rs
   |
   |     let _: () = unsafe { msg_send![super(obj), method] };
   |                          ----------------^^^----------
   |                          |               |
-  |                          |               the trait `ClassType` is not implemented for `objc2::runtime::Object`
+  |                          |               the trait `ClassType` is not implemented for `AnyObject`
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
@@ -20,13 +20,13 @@ note: required by a bound in `__send_super_message_static`
   |         Self::__Inner: ClassType,
   |                        ^^^^^^^^^ required by this bound in `MessageReceiver::__send_super_message_static`
 
-error[E0277]: the trait bound `objc2::runtime::Object: ClassType` is not satisfied
+error[E0277]: the trait bound `AnyObject: ClassType` is not satisfied
  --> ui/msg_send_super_not_classtype.rs
   |
   |     let _: () = unsafe { msg_send![super(obj), method] };
   |                          ----------------^^^----------
   |                          |               |
-  |                          |               the trait `ClassType` is not implemented for `objc2::runtime::Object`
+  |                          |               the trait `ClassType` is not implemented for `AnyObject`
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:

--- a/crates/test-ui/ui/not_encode.stderr
+++ b/crates/test-ui/ui/not_encode.stderr
@@ -55,8 +55,8 @@ error[E0277]: the trait bound `(): RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `&()` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -78,8 +78,8 @@ error[E0277]: the trait bound `(): RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `*const ()` to implement `Encode`
 note: required by a bound in `is_encode`

--- a/crates/test-ui/ui/not_writeback.stderr
+++ b/crates/test-ui/ui/not_writeback.stderr
@@ -11,8 +11,8 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `&mut Id<NSObject>` to implement `Encode`
   = note: required for `&mut Id<NSObject>` to implement `EncodeReturn`
@@ -74,8 +74,8 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `&Id<NSObject>` to implement `Encode`
   = note: required for `&Id<NSObject>` to implement `EncodeConvertArgument`
@@ -106,8 +106,8 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `&Id<NSObject>` to implement `Encode`
   = note: 1 redundant requirement hidden
@@ -140,8 +140,8 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `*mut Id<NSObject>` to implement `Encode`
   = note: required for `*mut Id<NSObject>` to implement `EncodeConvertArgument`
@@ -172,8 +172,8 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
             *const c_void
             *mut T
             *mut c_void
-            AtomicI16
-            AtomicI32
+            AnyClass
+            AnyObject
           and $N others
   = note: required for `&mut Id<NSObject>` to implement `RefEncode`
   = note: required for `&mut &mut Id<NSObject>` to implement `Encode`

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -8,7 +8,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
-  |     pub struct UnknownStorage<T: ?Sized>(*const T, Object);
+  |     pub struct UnknownStorage<T: ?Sized>(*const T, AnyObject);
   |                ^^^^^^^^^^^^^^
 note: required because it appears within the type `EquivalentType<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
@@ -24,7 +24,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -44,11 +44,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -63,7 +63,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -81,7 +81,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
-  |     pub struct UnknownStorage<T: ?Sized>(*const T, Object);
+  |     pub struct UnknownStorage<T: ?Sized>(*const T, AnyObject);
   |                ^^^^^^^^^^^^^^
 note: required because it appears within the type `EquivalentType<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
@@ -97,7 +97,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -128,11 +128,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -147,7 +147,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -165,7 +165,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
-  |     pub struct UnknownStorage<T: ?Sized>(*const T, Object);
+  |     pub struct UnknownStorage<T: ?Sized>(*const T, AnyObject);
   |                ^^^^^^^^^^^^^^
 note: required because it appears within the type `EquivalentType<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
@@ -181,12 +181,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = Object> {
+  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -206,11 +206,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -225,12 +225,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = Object> {
+  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -248,7 +248,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
-  |     pub struct UnknownStorage<T: ?Sized>(*const T, Object);
+  |     pub struct UnknownStorage<T: ?Sized>(*const T, AnyObject);
   |                ^^^^^^^^^^^^^^
 note: required because it appears within the type `EquivalentType<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
@@ -264,12 +264,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = Object> {
+  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -300,11 +300,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -319,12 +319,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = Object> {
+  |     pub struct NSArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/Foundation/fixes/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = Object> {
+  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs

--- a/crates/test-ui/ui/object_not_send_sync.rs
+++ b/crates/test-ui/ui/object_not_send_sync.rs
@@ -1,17 +1,17 @@
-//! Test that Object and NSObject are not Send and Sync, because their
+//! Test that AnyObject and NSObject are not Send and Sync, because their
 //! subclasses might not be.
 //!
 //! Also test that `NSValue` is not Send nor Sync, because its contained value
 //! might not be.
 use icrate::Foundation::NSValue;
-use objc2::runtime::{NSObject, Object};
+use objc2::runtime::{NSObject, AnyObject};
 
 fn needs_sync<T: ?Sized + Sync>() {}
 fn needs_send<T: ?Sized + Send>() {}
 
 fn main() {
-    needs_sync::<Object>();
-    needs_send::<Object>();
+    needs_sync::<AnyObject>();
+    needs_send::<AnyObject>();
     needs_sync::<NSObject>();
     needs_send::<NSObject>();
     needs_sync::<NSValue>();

--- a/crates/test-ui/ui/object_not_send_sync.stderr
+++ b/crates/test-ui/ui/object_not_send_sync.stderr
@@ -1,20 +1,20 @@
 error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
  --> ui/object_not_send_sync.rs
   |
-  |     needs_sync::<Object>();
-  |                  ^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
+  |     needs_sync::<AnyObject>();
+  |                  ^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `objc2::runtime::Object`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `AnyObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/object_not_send_sync.rs
   |
@@ -24,10 +24,10 @@ note: required by a bound in `needs_sync`
 error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
  --> ui/object_not_send_sync.rs
   |
-  |     needs_send::<Object>();
-  |                  ^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
+  |     needs_send::<AnyObject>();
+  |                  ^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `objc2::runtime::Object`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `AnyObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -44,11 +44,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/object_not_send_sync.rs
   |
@@ -67,11 +67,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -106,11 +106,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -134,11 +134,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |
@@ -178,11 +178,11 @@ note: required because it appears within the type `objc_object`
   |
   | pub struct objc_object {
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Object`
+note: required because it appears within the type `AnyObject`
  --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
   |
-  | pub struct Object(ffi::objc_object);
-  |            ^^^^^^
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
 note: required because it appears within the type `NSObject`
  --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
   |

--- a/crates/tests/src/exception.rs
+++ b/crates/tests/src/exception.rs
@@ -4,10 +4,10 @@ use icrate::Foundation::{NSArray, NSException, NSString};
 use objc2::exception::{catch, throw};
 use objc2::msg_send;
 use objc2::rc::{autoreleasepool, Id};
-use objc2::runtime::Object;
+use objc2::runtime::{AnyObject, NSObject};
 
 #[track_caller]
-fn assert_retain_count(obj: &Object, expected: usize) {
+fn assert_retain_count(obj: &AnyObject, expected: usize) {
     let retain_count: usize = unsafe { msg_send![obj, retainCount] };
     assert_eq!(retain_count, expected);
 }
@@ -126,8 +126,8 @@ fn raise_catch() {
 fn catch_actual() {
     let res = unsafe {
         catch(|| {
-            let arr: Id<NSArray<Object>> = NSArray::new();
-            let _obj: *mut Object = msg_send![&arr, objectAtIndex: 0usize];
+            let arr: Id<NSArray<NSObject>> = NSArray::new();
+            let _obj: *mut NSObject = msg_send![&arr, objectAtIndex: 0usize];
         })
     };
     let exc = res.unwrap_err().unwrap();

--- a/crates/tests/src/test_encode_utils.rs
+++ b/crates/tests/src/test_encode_utils.rs
@@ -2,7 +2,7 @@
 use core::fmt::Display;
 use core::sync::atomic::{AtomicI32, AtomicPtr};
 use objc2::ffi::{NSInteger, NSUInteger};
-use objc2::runtime::{Bool, Class, Object, Sel};
+use objc2::runtime::{AnyClass, AnyObject, Bool, Sel};
 use objc2::{Encode, Encoding};
 use paste::paste;
 use std::ffi::CStr;
@@ -258,8 +258,8 @@ assert_types! {
     // Objective-C
 
     OBJC_BOOL => Bool,
-    ID => enc <*mut Object>::ENCODING,
-    CLASS => enc <&Class>::ENCODING,
+    ID => enc <*mut AnyObject>::ENCODING,
+    CLASS => enc <&AnyClass>::ENCODING,
     // Sel is (intentionally) not RefEncode
     SEL => enc <Sel>::ENCODING,
     NS_INTEGER => NSInteger,


### PR DESCRIPTION
To match Swift's naming, which also matches Rust pretty well in this case; both languages are very strongly typed, so prefixing these type with `Any` highlights the fact that they're very dynamic.

Other benefits:
- We'll be able to call the `ClassType` trait for just `Class` in the future.
- Error messages no longer include `objc2::runtime::`, since the names are unique enough that the compiler doesn't have to.

Part of https://github.com/madsmtm/objc2/issues/284.
