### PR TITLE
New versions + stop using pre-release versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.2.0-alpha.8"
+version = "0.2.0"
 dependencies = [
  "block-sys",
  "objc2",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "icrate"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "block2",
  "dispatch",
@@ -273,14 +273,14 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.5"
+version = "0.4.0"
 dependencies = [
  "iai",
  "malloc_buf",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0-pre.4"
+version = "2.0.0"
 
 [[package]]
 name = "objc2-proc-macros"

--- a/crates/block-sys/Cargo.toml
+++ b/crates/block-sys/Cargo.toml
@@ -60,7 +60,7 @@ unstable-objfw = []
 unstable-docsrs = ["objc-sys", "objc-sys/unstable-docsrs"]
 
 [dependencies]
-objc-sys = { path = "../objc-sys", version = "0.3.0", default-features = false, optional = true }
+objc-sys = { path = "../objc-sys", version = "0.3.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Updated `objc2` dependency to `v0.4.0`.
+
 
 ## 0.2.0-alpha.8 - 2023-02-07
 

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.0 - 2023-06-20
+
 ### Changed
 * **BREAKING**: Updated `objc2` dependency to `v0.4.0`.
 

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs and README.md
-version = "0.2.0-alpha.8"
+version = "0.2.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -35,7 +35,7 @@ gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0", "objc2/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2/gnustep-2-1"]
 
 [dependencies]
-objc2 = { path = "../objc2", version = "=0.3.0-beta.5", default-features = false }
+objc2 = { path = "../objc2", version = "0.4.0", default-features = false }
 block-sys = { path = "../block-sys", version = "0.2.0", default-features = false }
 
 [package.metadata.docs.rs]

--- a/crates/block2/src/lib.rs
+++ b/crates/block2/src/lib.rs
@@ -83,7 +83,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.2.0-alpha.8")]
+#![doc(html_root_url = "https://docs.rs/block2/0.2.0")]
 
 extern crate alloc;
 extern crate std;

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `iter_values` -> `values`.
 * **BREAKING**: `NSDictionary::keys_retained` and
   `NSDictionary::values_retained` now return an iterator instead.
+* **BREAKING**: Updated `objc2` to `v0.4.0`.
 
 ### Removed
 * **BREAKING**: Removed various redundant `NSProxy` methods.

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: `NSDictionary::keys_retained` and
   `NSDictionary::values_retained` now return an iterator instead.
 * **BREAKING**: Updated `objc2` to `v0.4.0`.
+* **BREAKING**: Updated `block2` to `v0.2.0`.
 
 ### Removed
 * **BREAKING**: Removed various redundant `NSProxy` methods.

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## icrate Unreleased - YYYY-MM-DD
 
+
+## icrate 0.0.3 - 2023-06-20
+
 ### Added
 * Added the following frameworks:
   - `HealthKit`

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/icrate/"
 license = "MIT"
 
 [dependencies]
-objc2 = { path = "../objc2", version = "=0.3.0-beta.5", default-features = false, optional = true }
+objc2 = { path = "../objc2", version = "0.4.0", default-features = false, optional = true }
 block2 = { path = "../block2", version = "=0.2.0-alpha.8", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrate"
-version = "0.0.2" # Remember to update html_root_url in lib.rs
+version = "0.0.3" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 
 [dependencies]
 objc2 = { path = "../objc2", version = "0.4.0", default-features = false, optional = true }
-block2 = { path = "../block2", version = "=0.2.0-alpha.8", default-features = false, optional = true }
+block2 = { path = "../block2", version = "0.2.0", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 
 [dev-dependencies]

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -21,7 +21,7 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/icrate/0.0.2")]
+#![doc(html_root_url = "https://docs.rs/icrate/0.0.3")]
 #![recursion_limit = "512"]
 
 #[cfg(feature = "alloc")]

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.1 - 2023-06-20
+
 ### Added
 * Improved documentation slightly.
+
+### Changed
+* Internal optimizations.
 
 
 ## 0.3.0 - 2023-02-07

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -5,7 +5,7 @@ name = "objc-sys"
 #
 # Also, beware of using pre-release versions here, since because of the
 # `links` key, two pre-releases requested with `=...` are incompatible.
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -24,7 +24,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.1")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
+## 2.0.0 - 2023-06-20
+
+### Added
+* Improved documentation slightly.
+
+
 ## 2.0.0-pre.4 - 2023-02-07
 
 ### Added

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs and README.md
-version = "2.0.0-pre.4"
+version = "2.0.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -44,7 +44,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0-pre.4")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 
 #[cfg(doctest)]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.4.0 - 2023-06-20
+
 ### Added
 * Added `objc2::rc::autoreleasepool_leaking`, and improve performance of
   objects `Debug` impls.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Relaxed a `fmt::Debug` bound on `WeakId`'s own `fmt::Debug` impl.
 * Changed `Debug` impl for `runtime::Class`, `runtime::Sel` and
   `runtime::Protocol` to give more information.
+* **BREAKING**: Updated `encode` module to `objc2-encode v2.0.0`.
 
 ### Fixed
 * Fixed using autorelease pools on 32bit macOS and older macOS versions.

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -77,7 +77,7 @@ unstable-compiler-rt = ["apple"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "0.3.0", default-features = false }
+objc-sys = { path = "../objc-sys", version = "0.3.1", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.4", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -78,7 +78,7 @@ unstable-compiler-rt = ["apple"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.1", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "=2.0.0-pre.4", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "2.0.0", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.3.0-beta.5" # Remember to update html_root_url in lib.rs
+version = "0.4.0" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -166,7 +166,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.3.0-beta.5")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.4.0")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");


### PR DESCRIPTION
We're going to go away from using pre-release versions; while they're nice for signalling instability, they're a real pain when you need to do patch releases, see e.g. https://github.com/rust-windowing/winit/pull/2739.

While we release both `objc2 v0.4` and `block2 v0.2`, these are not expected to be stable, and will still have frequent breaking changes. This is unfortunate, but unavoidable, and still better that we'd be able to patch these if e.g. winit requires it. I'll try to be harsher with `objc2-encode v2` though, since users expect more stability from such a version number, but I will not let it severely hinder development.

Checklist:
- [x] The branch is named `new-versions`, such that the full CI will run.
- [x] Changelogs have only been modified under the `Unreleased` header.
- [x] Version numbers are bumped in the following order:
    - `objc-sys`
    - `objc2-encode`
    - `objc2`
    - `block2`
    - `icrate`
- Local tests have been run (see `helper-scripts/test-local.fish`):
    - [x] macOS 10.14.6 32bit
    - [x] ~iOS 9.3.6, 1st generation iPad Mini~
      - Am not at the same physical location, so will have to be skipped for now
- [x] Any errors that emerge have been fixed in other PRs
  - https://github.com/madsmtm/objc2/pull/465

Post merge:
- [ ] A tag is created on the merge commit for each new version.
