### PR TITLE
Add the `CoreAudioTypes` framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "four-char-code"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c661315fd366b2a1f970df7b7cb1a28d2678d49ef4872f7dcc19b4a83150f20b"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,7 @@ dependencies = [
  "basic-toml",
  "clang",
  "clang-sys",
+ "four-char-code",
  "heck",
  "proc-macro2",
  "semver",

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -20,3 +20,4 @@ proc-macro2 = "1.0.49"
 syn = { version = "2.0", features = ["parsing"] }
 heck = "0.4"
 semver = { version = "1.0", features = ["serde"] }
+four-char-code = "2.2.0"

--- a/crates/header-translator/framework-includes.h
+++ b/crates/header-translator/framework-includes.h
@@ -37,6 +37,8 @@
 
 #import <Contacts/Contacts.h>
 
+#import <CoreAudioTypes/CoreAudioTypes.h>
+
 #import <CoreData/CoreData.h>
 
 #import <CoreLocation/CoreLocation.h>

--- a/crates/header-translator/src/expr.rs
+++ b/crates/header-translator/src/expr.rs
@@ -132,6 +132,14 @@ impl Expr {
             s = s.trim_start_matches('(').trim_end_matches(')').to_string();
         }
 
+        // Handle four character codes
+        if s.len() == 6 && s.starts_with('\'') && s.ends_with('\'') {
+            let fcc = four_char_code::FourCharCode::from_str(&s[1..5])
+                .expect("Invalid four character code");
+
+            return Some(Self::Unsigned(fcc.as_u32().into()));
+        }
+
         Some(Self::String(s))
     }
 }

--- a/crates/header-translator/src/unexposed_attr.rs
+++ b/crates/header-translator/src/unexposed_attr.rs
@@ -68,7 +68,7 @@ impl UnexposedAttr {
             "__unused" => None,
             // We assume that a function is inline if it has a body, so not
             // interesting.
-            "NS_INLINE" => None,
+            "CF_INLINE" | "NS_INLINE" => None,
             // We don't synthethize properties, so irrelevant for us.
             "NS_REQUIRES_PROPERTY_DEFINITIONS" => None,
             // Weak specifiers - would be interesting if Rust supported weak statics
@@ -129,6 +129,7 @@ impl UnexposedAttr {
             | "__WATCHOS_PROHIBITED"
             | "__WATCHOS_UNAVAILABLE"
             | "APPKIT_API_UNAVAILABLE_BEGIN_MACCATALYST"
+            | "CA_CANONICAL_DEPRECATED"
             | "MP_INIT_UNAVAILABLE"
             | "NS_AUTOMATED_REFCOUNT_UNAVAILABLE"
             | "NS_AUTOMATED_REFCOUNT_WEAK_UNAVAILABLE"

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -1575,3 +1575,7 @@ skipped-protocols = ["NSCopying", "NSMutableCopying"]
 skipped-protocols = ["NSCopying", "NSMutableCopying"]
 [class.NSPurgeableData]
 skipped-protocols = ["NSCopying", "NSMutableCopying"]
+
+# Requires a cast
+[enum.anonymous.constants.AVAudioSessionErrorInsufficientPriority]
+skipped = true

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -114,6 +114,14 @@ maccatalyst = "13.0"
 ios = "9.0"
 watchos = "2.0"
 
+[library.CoreAudioTypes]
+imports = []
+macos = "10.15"
+maccatalyst = "13.0"
+ios = "13.0"
+tvos = "13.0"
+watchos = "6.0"
+
 [library.CoreData]
 imports = ["Foundation"]
 # Temporary, since some structs and statics use these

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1816,6 +1816,10 @@ CoreAnimation_all = [
     "CoreAnimation_CATransition",
     "CoreAnimation_CAValueFunction",
 ]
+CoreAudioTypes = []
+CoreAudioTypes_all = [
+    "CoreAudioTypes",
+]
 CoreData = [
     "Foundation",
     "CoreData_NSAsynchronousFetchResult",
@@ -5318,6 +5322,7 @@ unstable-frameworks-macos-13 = [
     "BackgroundAssets_all",
     "BusinessChat_all",
     "CallKit_all",
+    "CoreAudioTypes_all",
     "DeviceCheck_all",
     "ExtensionKit_all",
     "FileProviderUI_all",

--- a/crates/icrate/src/CoreAudioTypes/fixes.rs
+++ b/crates/icrate/src/CoreAudioTypes/fixes.rs
@@ -1,0 +1,11 @@
+use crate::common::*;
+use crate::CoreAudioTypes::*;
+
+extern_enum!(
+    #[underlying(c_uint)]
+    pub enum __anonymous__ {
+        #[deprecated]
+        AVAudioSessionErrorInsufficientPriority =
+            AVAudioSessionErrorCodeInsufficientPriority as c_uint,
+    }
+);

--- a/crates/icrate/src/CoreAudioTypes/mod.rs
+++ b/crates/icrate/src/CoreAudioTypes/mod.rs
@@ -1,0 +1,7 @@
+#[path = "../generated/CoreAudioTypes/mod.rs"]
+mod generated;
+
+pub use self::generated::*;
+
+#[cfg_attr(feature = "apple", link(name = "CoreAudioTypes", kind = "framework"))]
+extern "C" {}

--- a/crates/icrate/src/CoreAudioTypes/mod.rs
+++ b/crates/icrate/src/CoreAudioTypes/mod.rs
@@ -1,7 +1,6 @@
+mod fixes;
 #[path = "../generated/CoreAudioTypes/mod.rs"]
 mod generated;
 
+pub use self::fixes::*;
 pub use self::generated::*;
-
-#[cfg_attr(feature = "apple", link(name = "CoreAudioTypes", kind = "framework"))]
-extern "C" {}

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -47,5 +47,6 @@ pub(crate) type FourCharCode = u32;
 pub(crate) type OSType = FourCharCode;
 pub(crate) type ResType = FourCharCode;
 pub(crate) type UTF32Char = u32; // Or maybe Rust's char?
+pub(crate) type OSStatus = i32;
 
 pub(crate) const INT64_MAX: i64 = i64::MAX;

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -80,6 +80,8 @@ pub mod CloudKit;
 pub mod Contacts;
 #[cfg(feature = "CoreAnimation")]
 pub mod CoreAnimation;
+#[cfg(feature = "CoreAudioTypes")]
+pub mod CoreAudioTypes;
 #[cfg(feature = "CoreData")]
 pub mod CoreData;
 #[cfg(feature = "CoreLocation")]

--- a/crates/icrate/tests/four_char_codes.rs
+++ b/crates/icrate/tests/four_char_codes.rs
@@ -1,0 +1,9 @@
+#![cfg(feature = "CoreAudioTypes")]
+
+use icrate::CoreAudioTypes::*;
+
+#[test]
+fn generated_four_char_code_is_correct() {
+    // 'lpcm' == 1819304813
+    assert_eq!(kAudioFormatLinearPCM, 1819304813);
+}


### PR DESCRIPTION
This PR adds support for the [`CoreAudioTypes` framework](https://developer.apple.com/documentation/coreaudiotypes?language=objc), as an initial, (somewhat) simple start to the road of _eventually_ adding `AVFoundation`.

As simple and small a library as it is (almost exclusively type/constant definitions and header-only, not even any linking), it did throw a couple of curveballs at me:

- I needed to support four character codes, as they were used in several of the enum definitions in here. I've opted to do this by pulling [this library](https://github.com/shurizzle/rust-four-char-code) in as a dependency of the header translator, and outputting the underlying `u32` into the generated code so it's completely silent to the `icrate` library itself. I'm not 100% convinced I've done this in the best way, so I'm very much open to discussion here!
- One of the exposed constans required a cast as part of it's definition, so I needed to add that as a fix manually. Feels like that _should_ be a solvable problem, but I'm not sure it actually is at this stage?

With regards to the generated code, [I appear to have added a large number of `deprecated` attributes](https://github.com/samuelsleight/icrate-generated/commit/bd5e14aadb3b6c5fe3167b3631f76a2846e81046) - I'm not sure if this is some issue with my SDK setup or whether the submodule just hasn't been updated since some relevant change! Happy to look into that if needed.

More than happy for discussions on any decisions I've made in here, given I've not added anything here before!