### PR TITLE
Fix `AuthenticationServices` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
       run: cargo test $ARGS $PUBLIC_CRATES -ptests
 
     - name: Test all frameworks
-      run: cargo test $ARGS $PUBLIC_CRATES -ptests --features=$INTERESTING_FEATURES,$LATEST_MACOS_FEATURE
+      run: cargo test $ARGS $PUBLIC_CRATES -ptests --features=$INTERESTING_FEATURES,unstable-frameworks-macos-12
 
   test-apple:
     # if: ${{ env.FULL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,12 @@ jobs:
         include:
         - name: macOS 64bit
           target: aarch64-apple-darwin
+          # Ideally this would use $LATEST_MACOS_FEATURE, but this causes clippy to
+          # use too much memory for the CI runner
           args: >-
             $PUBLIC_CRATES
             --features=$INTERESTING_FEATURES
-            --features=$LATEST_MACOS_FEATURE
+            --features=unstable-frameworks-macos-12
         - name: iOS 32bit
           target: armv7-apple-ios
           build-std: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ env:
   # compiling C code, even if just running a `check`/`clippy` build.
   INTERESTING_FEATURES: malloc,block,verify,unstable-private
   UNSTABLE_FEATURES: unstable-autoreleasesafe,unstable-c-unwind
+  LATEST_MACOS_FEATURE: unstable-frameworks-macos-13
   # Required when we want to use a different runtime than the default `apple`
   OTHER_RUNTIME: --no-default-features --features=std
   # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
@@ -97,7 +98,7 @@ jobs:
           args: >-
             $PUBLIC_CRATES
             --features=$INTERESTING_FEATURES
-            --features=unstable-frameworks-macos-12
+            --features=$LATEST_MACOS_FEATURE
         - name: iOS 32bit
           target: armv7-apple-ios
           build-std: true
@@ -180,7 +181,7 @@ jobs:
         cargo check
         $PUBLIC_CRATES
         --features=$INTERESTING_FEATURES
-        --features=unstable-frameworks-macos-12
+        --features=$LATEST_MACOS_FEATURE
 
   ui:
     name: Compiler UI
@@ -342,7 +343,7 @@ jobs:
       run: cargo test $ARGS $PUBLIC_CRATES -ptests
 
     - name: Test all frameworks
-      run: cargo test $ARGS $PUBLIC_CRATES -ptests --features=$INTERESTING_FEATURES,unstable-frameworks-macos-12
+      run: cargo test $ARGS $PUBLIC_CRATES -ptests --features=$INTERESTING_FEATURES,$LATEST_MACOS_FEATURE
 
   test-apple:
     # if: ${{ env.FULL }}

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -45,7 +45,7 @@ macos = "10.0"
 maccatalyst = "13.0"
 
 [library.AuthenticationServices]
-imports = ["Foundation"]
+imports = ["AppKit", "Foundation"]
 # Temporary, since some structs and statics use these
 extra-features = ["Foundation_NSURL"]
 macos = "10.15"

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1105,6 +1105,7 @@ AppKit_all = [
     "AppKit_NSWorkspaceOpenConfiguration",
 ]
 AuthenticationServices = [
+    "AppKit",
     "Foundation",
     "Foundation_NSURL",
 ]


### PR DESCRIPTION
This PR is a quick fix to add what appears to be a missing `AppKit` dependency to `AuthenticationServices`

To help with testing things, I hacked in the ability for `header-generator` to generate a feature that enables all `{library}_all` features, so I could trivially attempt to build the whole of `icrate`. Upon doing this, I discovered that `AuthenticationServices` failed to build with a missing import - everything else built successfully.

I am not entirely convinced this isn't a setup issue on my part, but I've pushed up this PR to at least start the discussion. FWIW, my build steps were simply:

```
cargo run --bin header-translator -- /Applications/Xcode_14.2.app/Contents/Developer/
cd crates/icrate
cargo build --features all_libraries
```
where `Xcode_14.2.app` is a direct download from apple, matching the version noted [here](https://github.com/samuelsleight/objc2/blob/master/crates/icrate/README.md), and the `all_libraries` feature is what it sounds like (and I'm happy to push up the implementation to this PR, if that would be useful