### PR TITLE
Update proc-macro dep so it compiles on nightly again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -16,7 +16,7 @@ apple-sdk = { version = "0.4.0", default-features = false }
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
 tracing-tree = { git = "https://github.com/madsmtm/tracing-tree.git" }
-proc-macro2 = "1.0.49"
+proc-macro2 = "1.0.66"
 syn = { version = "2.0", features = ["parsing"] }
 heck = "0.4"
 semver = { version = "1.0", features = ["serde"] }


### PR DESCRIPTION
Not sure which particular proc-macro release fixed this but from their changelog I can see that some releases did have some changes around nightly features.

Edit: https://github.com/dtolnay/proc-macro2/releases/tag/1.0.60 probably fixed this.