### PR TITLE
New versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,6 @@ Copy and fill out the following checklist into the release PR:
 - Local tests have been run (see `helper-scripts/test-local.fish`):
     - [ ] macOS 10.14.6 32bit
     - [ ] iOS 9.3.6, 1st generation iPad Mini
-- [ ] Any errors that emerge have been fixed in other PRs.
 
 Post merge:
 - [ ] A tag is created on the merge commit for each new version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "iai",
  "malloc_buf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0"
+version = "3.0.0"
 
 [[package]]
 name = "objc2-proc-macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "icrate"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "block2",
  "dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "block-sys",
  "objc2",

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
+## 0.3.0 - 2023-07-31
+
+### Fixed
+* Bumped version number to ensure that this crate can be compiled together
+  with code that depends on pre-releases of `0.2.0`.
+
+
 ## 0.2.0 - 2023-06-20
 
 ### Changed

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs and README.md
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -35,7 +35,7 @@ gnustep-2-0 = ["gnustep-1-9", "block-sys/gnustep-2-0", "objc2/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "block-sys/gnustep-2-1", "objc2/gnustep-2-1"]
 
 [dependencies]
-objc2 = { path = "../objc2", version = "0.4.0", default-features = false }
+objc2 = { path = "../objc2", version = "0.4.1", default-features = false }
 block-sys = { path = "../block-sys", version = "0.2.0", default-features = false }
 
 [package.metadata.docs.rs]

--- a/crates/block2/src/lib.rs
+++ b/crates/block2/src/lib.rs
@@ -83,7 +83,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/block2/0.3.0")]
 
 extern crate alloc;
 extern crate std;

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## icrate Unreleased - YYYY-MM-DD
 
+
+## icrate 0.0.4 - 2023-07-31
+
 ### Changed
 * **BREAKING**: Updated `block2` to `v0.3.0`.
 

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## icrate Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Updated `block2` to `v0.3.0`.
+
+### Fixed
+* Documentation on docs.rs.
+
 
 ## icrate 0.0.3 - 2023-06-20
 

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrate"
-version = "0.0.3" # Remember to update html_root_url in lib.rs
+version = "0.0.4" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 
 [dependencies]
 objc2 = { path = "../objc2", version = "0.4.1", default-features = false, optional = true }
-block2 = { path = "../block2", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../block2", version = "0.3.0", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 
 [dev-dependencies]

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://docs.rs/icrate/"
 license = "MIT"
 
 [dependencies]
-objc2 = { path = "../objc2", version = "0.4.0", default-features = false, optional = true }
+objc2 = { path = "../objc2", version = "0.4.1", default-features = false, optional = true }
 block2 = { path = "../block2", version = "0.2.0", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -21,7 +21,7 @@
 #![allow(clippy::identity_op)]
 #![allow(clippy::missing_safety_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/icrate/0.0.3")]
+#![doc(html_root_url = "https://docs.rs/icrate/0.0.4")]
 #![recursion_limit = "512"]
 
 #[cfg(feature = "alloc")]

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
+## 3.0.0 - 2023-07-31
+
+### Fixed
+* Bumped version number to ensure that this crate can be compiled together
+  with code that depends on pre-releases of `2.0.0`.
+
+
 ## 2.0.0 - 2023-06-20
 
 ### Added

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
-# Remember to update html_root_url in lib.rs and README.md
-version = "2.0.0"
+# Remember to update html_root_url in lib.rs
+version = "3.0.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -44,7 +44,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/2.0.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/3.0.0")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 
 #[cfg(doctest)]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   To better fit with Swift's naming scheme. The types are still available
   under the old names as deprecated aliases.
 
+### Fixed
+* Updated `encode` types to those from `objc2-encode v3.0.0`. Should allow
+  this crate can be compiled together with pre-release versions.
+
 
 ## 0.4.0 - 2023-06-20
 

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.4.1 - 2023-07-31
+
 ### Added
 * Allow using `MainThreadMarker` in `extern_methods!`.
 * Added the feature flag `"relax-void-encoding"`, which when enabled, allows
@@ -22,8 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   under the old names as deprecated aliases.
 
 ### Fixed
-* Updated `encode` types to those from `objc2-encode v3.0.0`. Should allow
-  this crate can be compiled together with pre-release versions.
+* **BREAKING**: Updated `encode` types to those from `objc2-encode v3.0.0`.
+
+  This is technically a breaking change, but it should allow this crate to be
+  compiled together with pre-release versions of it, meaning that in practice
+  strictly more code out there will compile because of this. Hence it was
+  deemed the better trade-off.
 
 
 ## 0.4.0 - 2023-06-20

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -99,7 +99,7 @@ unstable-compiler-rt = ["apple"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.1", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "2.0.0", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "3.0.0", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.4.0" # Remember to update html_root_url in lib.rs
+version = "0.4.1" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -166,7 +166,7 @@
 #![warn(clippy::cargo)]
 #![warn(clippy::ptr_as_ptr)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.4.1")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");


### PR DESCRIPTION
Mostly to deal with issues about pre-release versions still haunting me :/

Checklist:
- [x] The branch is named `new-versions`, such that the full CI will run.
- [x] Changelogs have only been modified under the `Unreleased` header.
- [x] Version numbers are bumped in the following order:
    - `objc2-encode`
    - `objc2`
    - `block2`
    - `icrate`
- Local tests have been run (see `helper-scripts/test-local.fish`):
    - [x] macOS 10.14.6 32bit
    - [x] iOS 9.3.6, 1st generation iPad Mini
- [x] Any errors that emerge have been fixed in other PRs.
  - Dropped this, it doesn't really make sense.

Post merge:
- [ ] A tag is created on the merge commit for each new version.
