### PR TITLE
Allow `c_void` pointers as return and argument types in more cases (behind a feature flag)

### DIFF
--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Allow using `MainThreadMarker` in `extern_methods!`.
+* Added the feature flag `"relax-void-encoding"`, which when enabled, allows
+  using `*mut c_void` in a few places where you would otherwise have to
+  specify the encoding precisely.
 
 ### Changed
 * Renamed `runtime` types:

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -35,6 +35,13 @@ catch-all = ["exception"]
 # Enable all verification steps when debug assertions are enabled.
 verify = ["malloc"]
 
+# Allow `*const c_void` and `*mut c_void` to be used as arguments and return
+# types where other pointers were expected.
+#
+# This may be useful for CoreFoundation types, or for migrating code from objc
+# to objc2.
+relax-void-encoding = []
+
 # Expose features that require linking to `libc::free`.
 #
 # This is not enabled by default because most users won't need it, and it


### PR DESCRIPTION
Will help with https://github.com/servo/core-foundation-rs/pull/628, since a lot of CoreFoundation types are used there as just `*mut c_void`, and it would be really cumbersome and error-prone to have to change all of these to custom type aliases with a proper `Encode` implementation.