### PR TITLE
Update to Xcode 14.3, and update rustc nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,9 @@ jobs:
     - fmt
     - lint
 
+    env:
+      TEST_OVERWRITE: 1
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -247,10 +250,9 @@ jobs:
     - name: Run all assembly tests
       if: ${{ env.FULL }}
       run: ./helper-scripts/run-assembly-tests.sh
-      env:
-        TEST_OVERWRITE: 1
 
     - name: Check diff
+      if: ${{ always() }}
       run: git diff --exit-code
 
   header-translator:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,14 +234,6 @@ jobs:
         override: true
         components: rust-src
 
-    - name: Install remaining targets
-      run: >-
-        rustup target add
-        x86_64-apple-darwin
-        aarch64-apple-darwin
-        x86_64-unknown-linux-gnu
-        i686-unknown-linux-gnu
-
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
@@ -249,7 +241,7 @@ jobs:
         key: cargo-${{ github.job }}-${{ matrix.name }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Run macOS x86_64 assembly tests
-      run: cargo run --bin=test-assembly -- --target=x86_64-apple-darwin
+      run: cargo run --bin=test-assembly -- -Z build-std --target=x86_64-apple-darwin
 
     - name: Run all assembly tests
       if: ${{ env.FULL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ env:
     --package=objc2-encode
     --package=objc2-proc-macros
   # The current nightly Rust version that our CI uses
-  CURRENT_NIGHTLY: nightly-2023-05-25
+  CURRENT_NIGHTLY: nightly-2023-08-27
   # Various features that we'd usually want to test with
   #
   # Note: The `exception` feature is not enabled here, since it requires

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,8 @@ jobs:
       run: cargo doc --no-deps --document-private-items ${{ matrix.args }}
 
     - name: cargo clippy
-      run: cargo clippy --all-targets ${{ matrix.args }}
+      # Temporarily allow diverging_sub_expression until we figure out how to silence them in declare_class!
+      run: cargo clippy --all-targets ${{ matrix.args }} -- --allow=clippy::diverging_sub_expression
 
   msrv:
     name: Check MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,13 +262,13 @@ jobs:
 
   header-translator:
     name: Verify header translator output
-    runs-on: macos-12
+    runs-on: macos-13
     needs:
     - fmt
     - lint
 
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "basic-toml"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
  "serde",
 ]
@@ -60,27 +60,27 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -92,11 +92,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -191,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -212,15 +213,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
 dependencies = [
  "arbitrary",
  "cc",
@@ -239,12 +240,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "malloc_buf"
@@ -300,9 +298,9 @@ version = "0.1.1"
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "overload"
@@ -312,15 +310,15 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "proc-macro2"
@@ -333,18 +331,30 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -353,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc-demangle"
@@ -365,33 +375,33 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -400,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -420,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "static_assertions"
@@ -432,9 +442,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -600,18 +610,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -688,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.80"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
+checksum = "6df60d81823ed9c520ee897489573da4b1d79ffbe006b8134f46de1a1aa03555"
 dependencies = [
  "basic-toml",
  "glob",
@@ -703,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "valuable"

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -80,8 +80,8 @@ tvos = "13.0"
 [library.BusinessChat]
 imports = ["AppKit", "Foundation"]
 macos = "10.14"
-maccatalyst = "13.0" # Unsure
-ios = "11.0" # Unsure
+maccatalyst = "13.0"               # Unsure
+ios = "11.0"                       # Unsure
 
 [library.CallKit]
 imports = ["Foundation"]
@@ -98,9 +98,7 @@ ios = "11.4"
 
 [library.CloudKit]
 imports = ["CoreLocation", "Foundation"]
-extra-features = [
-    "CloudKit_CKShare",
-]
+extra-features = ["CloudKit_CKShare"]
 macos = "10.10"
 maccatalyst = "13.0"
 ios = "8.0"
@@ -126,11 +124,9 @@ watchos = "2.0"
 
 [library.CoreLocation]
 imports = ["Contacts", "Foundation"]
-extra-features = [
-    "CoreLocation_CLPlacemark",
-]
+extra-features = ["CoreLocation_CLPlacemark"]
 # macos = "10.6"
-macos = "10.11" # Temporarily raised since `CoreLocation` imports `Contacts`
+macos = "10.11"      # Temporarily raised since `CoreLocation` imports `Contacts`
 maccatalyst = "13.0"
 ios = "2.0"
 tvos = "9.0"
@@ -154,9 +150,7 @@ watchos = "9.0"
 
 [library.EventKit]
 imports = ["AppKit", "CoreLocation", "Foundation", "MapKit"]
-extra-features = [
-    "EventKit_EKEvent",
-]
+extra-features = ["EventKit_EKEvent"]
 macos = "10.8"
 maccatalyst = "13.0"
 ios = "4.0"
@@ -237,9 +231,7 @@ tvos = "9.0"
 
 [library.GameKit]
 imports = ["AppKit", "Foundation"]
-extra-features = [
-    "AppKit_NSViewController",
-]
+extra-features = ["AppKit_NSViewController"]
 macos = "10.8"
 maccatalyst = "13.0"
 ios = "3.0"
@@ -273,9 +265,7 @@ watchos = "9.0"
 
 [library.LocalAuthenticationEmbeddedUI]
 imports = ["AppKit", "Foundation", "LocalAuthentication"]
-extra-features = [
-    "AppKit_NSWindow",
-]
+extra-features = ["AppKit_NSWindow"]
 macos = "12.0"
 maccatalyst = "16.0"
 ios = "16.0"
@@ -389,9 +379,7 @@ watchos = "6.2"
 
 [library.UniformTypeIdentifiers]
 imports = ["Foundation"]
-extra-features = [
-    "UniformTypeIdentifiers_UTType",
-]
+extra-features = ["UniformTypeIdentifiers_UTType"]
 macos = "11.0"
 maccatalyst = "14.0"
 ios = "14.0"
@@ -1229,6 +1217,10 @@ skipped = true
 skipped = true
 [class.MPAdTimeRange.methods.setTimeRange]
 skipped = true
+# Uses LocalAuthentication framework
+[protocol.ASAuthorizationWebBrowserExternallyAuthenticatableRequest.methods]
+authenticatedContext = { skipped = true }
+setAuthenticatedContext = { skipped = true }
 
 # Uses a pointer to SEL, which doesn't implement Encode yet
 [protocol.NSMenuDelegate.methods]

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Moved the `ns_string!` macro to `icrate::Foundation::ns_string`. The old
   location in the crate root is deprecated.
+* Use SDK from Xcode 14.3.1 (previously Xcode 14.2).
+* **BREAKING**: The following two methods on `MTLAccelerationStructureCommandEncoder` now take a nullable scratch buffer:
+  - `refitAccelerationStructure_descriptor_destination_scratchBuffer_scratchBufferOffset`
+  - `refitAccelerationStructure_descriptor_destination_scratchBuffer_scratchBufferOffset_options`
 
 
 ## icrate 0.0.4 - 2023-07-31

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1172,6 +1172,8 @@ AuthenticationServices_ASAuthorizationSingleSignOnProvider = []
 AuthenticationServices_ASAuthorizationSingleSignOnRequest = [
     "AuthenticationServices_ASAuthorizationOpenIDRequest",
 ]
+AuthenticationServices_ASAuthorizationWebBrowserPlatformPublicKeyCredential = []
+AuthenticationServices_ASAuthorizationWebBrowserPublicKeyCredentialManager = []
 AuthenticationServices_ASCredentialIdentityStore = []
 AuthenticationServices_ASCredentialIdentityStoreState = []
 AuthenticationServices_ASCredentialProviderExtensionContext = [
@@ -1225,6 +1227,8 @@ AuthenticationServices_all = [
     "AuthenticationServices_ASAuthorizationSingleSignOnCredential",
     "AuthenticationServices_ASAuthorizationSingleSignOnProvider",
     "AuthenticationServices_ASAuthorizationSingleSignOnRequest",
+    "AuthenticationServices_ASAuthorizationWebBrowserPlatformPublicKeyCredential",
+    "AuthenticationServices_ASAuthorizationWebBrowserPublicKeyCredentialManager",
     "AuthenticationServices_ASCredentialIdentityStore",
     "AuthenticationServices_ASCredentialIdentityStoreState",
     "AuthenticationServices_ASCredentialProviderExtensionContext",

--- a/crates/icrate/README.md
+++ b/crates/icrate/README.md
@@ -14,7 +14,7 @@ more details.
 
 ## Supported versions
 
-These bindings are automatically generated from the SDKs in Xcode 14.2 (will
+These bindings are automatically generated from the SDKs in Xcode 14.3.1 (will
 be periodically updated).
 
 Currently supports:

--- a/crates/icrate/src/Foundation/additions/string.rs
+++ b/crates/icrate/src/Foundation/additions/string.rs
@@ -192,7 +192,7 @@ impl Ord for NSString {
 impl PartialOrd for NSMutableString {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        PartialOrd::partial_cmp(&**self, &**other)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/icrate/src/lib.rs
+++ b/crates/icrate/src/lib.rs
@@ -149,7 +149,7 @@ pub mod UserNotifications;
 #[cfg(feature = "WebKit")]
 pub mod WebKit;
 
-/// Deprecated alias of [`Foundation::ns_string`][crate::Foundation::ns_string].
+/// Deprecated alias of [`Foundation::ns_string`].
 #[macro_export]
 #[deprecated = "use icrate::Foundation::ns_string instead"]
 #[cfg(feature = "Foundation_NSString")]

--- a/crates/icrate/tests/exception.rs
+++ b/crates/icrate/tests/exception.rs
@@ -46,7 +46,7 @@ fn unwrap() {
     )
     .unwrap();
 
-    let _: () = Err(exc).unwrap();
+    panic!("{exc:?}");
 }
 
 // Further tests in `tests::exception`

--- a/crates/icrate/tests/mutable_data.rs
+++ b/crates/icrate/tests/mutable_data.rs
@@ -81,7 +81,12 @@ fn test_as_ref_borrow() {
     fn impls_borrow<T: AsRef<U> + Borrow<U> + ?Sized, U: ?Sized>(_: &T) {}
     fn impls_borrow_mut<T: AsMut<U> + BorrowMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
 
-    let mut obj = NSMutableData::new();
+    // TODO: For some reason `new` doesn't work on GNUStep in release mode?
+    let mut obj = if cfg!(feature = "gnustep-1-8") {
+        NSMutableData::with_bytes(&[])
+    } else {
+        NSMutableData::new()
+    };
     impls_borrow::<Id<NSMutableData>, NSMutableData>(&obj);
     impls_borrow_mut::<Id<NSMutableData>, NSMutableData>(&mut obj);
 

--- a/crates/objc2/src/message/mod.rs
+++ b/crates/objc2/src/message/mod.rs
@@ -482,7 +482,7 @@ unsafe impl<'a> MessageReceiver for &'a AnyClass {
 /// Types that may be used as the arguments of an Objective-C message.
 ///
 /// This is implemented for tuples of up to 16 arguments, where each argument
-/// implements [`Encode`][crate::Encode] (or can be converted from one).
+/// implements [`Encode`] (or can be converted from one).
 ///
 ///
 /// # Safety

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -231,6 +231,8 @@ impl<T: ?Sized + Message> Id<T> {
     /// This is an associated method, and must be called as
     /// `Id::as_mut_ptr(obj)`.
     #[inline]
+    #[allow(unknown_lints)] // New lint below
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn as_mut_ptr(this: &mut Self) -> *mut T
     where
         T: IsMutable,

--- a/crates/test-assembly/Cargo.toml
+++ b/crates/test-assembly/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-cargo_metadata = "0.15.2"
+cargo_metadata = "0.17"
 rustc-demangle = "0.1"
 regex = "1.6"
 lazy_static = "1.4.0"

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
@@ -789,7 +789,7 @@ l_anon.[ID].3:
 	.p2align	3, 0x0
 l_anon.[ID].4:
 	.quad	l_anon.[ID].3
-	.asciz	"t\000\000\000\000\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 l_anon.[ID].5:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-armv7.s
@@ -717,7 +717,7 @@ l_anon.[ID].3:
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].3
-	.asciz	"t\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 L_anon.[ID].5:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-armv7s.s
@@ -720,7 +720,7 @@ l_anon.[ID].3:
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].3
-	.asciz	"t\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 L_anon.[ID].5:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-old-x86.s
@@ -33,11 +33,11 @@ L1$pb:
 	add	esp, 16
 	test	eax, eax
 	je	LBB1_4
-	mov	dword ptr [ebp - 40], eax
+	mov	dword ptr [ebp - 36], eax
 	sub	esp, 8
 	lea	eax, [esi + l_anon.[ID].6-L1$pb]
 	lea	ecx, [esi + L_anon.[ID].5-L1$pb]
-	lea	ebx, [ebp - 40]
+	lea	ebx, [ebp - 36]
 	push	eax
 	push	0
 	push	1
@@ -152,7 +152,7 @@ L1$pb:
 	push	eax
 	call	SYM(objc2::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 	add	esp, 20
-	push	dword ptr [ebp - 40]
+	push	dword ptr [ebp - 36]
 	call	SYM(objc2::declare::ClassBuilder::register::GENERATED_ID, 0)
 	add	esp, 60
 	pop	esi
@@ -170,19 +170,19 @@ LBB1_3:
 	call	SYM(core::panicking::panic::GENERATED_ID, 0)
 LBB1_4:
 	lea	eax, [esi + l_anon.[ID].21-L1$pb]
-	mov	dword ptr [ebp - 48], eax
-	lea	eax, [esi + SYM(<&str as core[CRATE_ID]::fmt::Display>::fmt, 0)-L1$pb]
 	mov	dword ptr [ebp - 44], eax
-	lea	eax, [esi + l_anon.[ID].20-L1$pb]
+	lea	eax, [esi + SYM(<&str as core[CRATE_ID]::fmt::Display>::fmt, 0)-L1$pb]
 	mov	dword ptr [ebp - 40], eax
-	mov	dword ptr [ebp - 36], 2
-	mov	dword ptr [ebp - 24], 0
-	lea	eax, [ebp - 48]
-	mov	dword ptr [ebp - 32], eax
-	mov	dword ptr [ebp - 28], 1
+	lea	eax, [esi + l_anon.[ID].20-L1$pb]
+	mov	dword ptr [ebp - 36], eax
+	mov	dword ptr [ebp - 32], 2
+	mov	dword ptr [ebp - 20], 0
+	lea	eax, [ebp - 44]
+	mov	dword ptr [ebp - 28], eax
+	mov	dword ptr [ebp - 24], 1
 	sub	esp, 8
 	lea	eax, [esi + l_anon.[ID].10-L1$pb]
-	lea	ecx, [ebp - 40]
+	lea	ecx, [ebp - 36]
 	push	eax
 	push	ecx
 	call	SYM(core::panicking::panic_fmt::GENERATED_ID, 0)
@@ -435,10 +435,10 @@ L8$pb:
 LBB8_2:
 	mov	eax, dword ptr [ebx + LL_OBJC_CLASS_REFERENCES_NSObject$non_lazy_ptr-L8$pb]
 	mov	eax, dword ptr [eax]
-	mov	dword ptr [ebp - 24], edi
-	mov	dword ptr [ebp - 20], eax
+	mov	dword ptr [ebp - 20], edi
+	mov	dword ptr [ebp - 16], eax
 	sub	esp, 8
-	lea	eax, [ebp - 24]
+	lea	eax, [ebp - 20]
 	push	esi
 	push	eax
 	call	_objc_msgSendSuper
@@ -742,7 +742,7 @@ l_anon.[ID].3:
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].3
-	.asciz	"t\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 L_anon.[ID].5:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86.s
@@ -33,11 +33,11 @@ L1$pb:
 	add	esp, 16
 	test	eax, eax
 	je	LBB1_4
-	mov	dword ptr [ebp - 40], eax
+	mov	dword ptr [ebp - 36], eax
 	sub	esp, 8
 	lea	eax, [esi + l_anon.[ID].6-L1$pb]
 	lea	ecx, [esi + L_anon.[ID].5-L1$pb]
-	lea	ebx, [ebp - 40]
+	lea	ebx, [ebp - 36]
 	push	eax
 	push	0
 	push	1
@@ -152,7 +152,7 @@ L1$pb:
 	push	eax
 	call	SYM(objc2::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 	add	esp, 20
-	push	dword ptr [ebp - 40]
+	push	dword ptr [ebp - 36]
 	call	SYM(objc2::declare::ClassBuilder::register::GENERATED_ID, 0)
 	add	esp, 60
 	pop	esi
@@ -170,19 +170,19 @@ LBB1_3:
 	call	SYM(core::panicking::panic::GENERATED_ID, 0)
 LBB1_4:
 	lea	eax, [esi + l_anon.[ID].21-L1$pb]
-	mov	dword ptr [ebp - 48], eax
-	lea	eax, [esi + SYM(<&str as core[CRATE_ID]::fmt::Display>::fmt, 0)-L1$pb]
 	mov	dword ptr [ebp - 44], eax
-	lea	eax, [esi + l_anon.[ID].20-L1$pb]
+	lea	eax, [esi + SYM(<&str as core[CRATE_ID]::fmt::Display>::fmt, 0)-L1$pb]
 	mov	dword ptr [ebp - 40], eax
-	mov	dword ptr [ebp - 36], 2
-	mov	dword ptr [ebp - 24], 0
-	lea	eax, [ebp - 48]
-	mov	dword ptr [ebp - 32], eax
-	mov	dword ptr [ebp - 28], 1
+	lea	eax, [esi + l_anon.[ID].20-L1$pb]
+	mov	dword ptr [ebp - 36], eax
+	mov	dword ptr [ebp - 32], 2
+	mov	dword ptr [ebp - 20], 0
+	lea	eax, [ebp - 44]
+	mov	dword ptr [ebp - 28], eax
+	mov	dword ptr [ebp - 24], 1
 	sub	esp, 8
 	lea	eax, [esi + l_anon.[ID].10-L1$pb]
-	lea	ecx, [ebp - 40]
+	lea	ecx, [ebp - 36]
 	push	eax
 	push	ecx
 	call	SYM(core::panicking::panic_fmt::GENERATED_ID, 0)
@@ -435,10 +435,10 @@ L8$pb:
 LBB8_2:
 	mov	eax, dword ptr [ebx + LL_OBJC_CLASSLIST_REFERENCES_$_NSObject$non_lazy_ptr-L8$pb]
 	mov	eax, dword ptr [eax]
-	mov	dword ptr [ebp - 24], edi
-	mov	dword ptr [ebp - 20], eax
+	mov	dword ptr [ebp - 20], edi
+	mov	dword ptr [ebp - 16], eax
 	sub	esp, 8
-	lea	eax, [ebp - 24]
+	lea	eax, [ebp - 20]
 	push	esi
 	push	eax
 	call	_objc_msgSendSuper
@@ -742,7 +742,7 @@ l_anon.[ID].3:
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].3
-	.asciz	"t\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 L_anon.[ID].5:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
@@ -556,7 +556,7 @@ l_anon.[ID].3:
 	.p2align	3, 0x0
 l_anon.[ID].4:
 	.quad	l_anon.[ID].3
-	.asciz	"L\000\000\000\000\000\000\000\225\000\000\0002\000\000"
+	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__literal4,4byte_literals
 L_anon.[ID].5:

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-aarch64.s
@@ -313,12 +313,12 @@ Lloh81:
 	.globl	_use_in_loop
 	.p2align	2
 _use_in_loop:
+	cbz	x0, LBB6_6
 	stp	x24, x23, [sp, #-64]!
 	stp	x22, x21, [sp, #16]
 	stp	x20, x19, [sp, #32]
 	stp	x29, x30, [sp, #48]
 	add	x29, sp, #48
-	cbz	x0, LBB6_5
 	mov	x19, x0
 	adrp	x23, SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)@PAGE
 Lloh82:
@@ -350,6 +350,7 @@ LBB6_5:
 	ldp	x20, x19, [sp, #32]
 	ldp	x22, x21, [sp, #16]
 	ldp	x24, x23, [sp], #64
+LBB6_6:
 	ret
 	.loh AdrpAdd	Lloh86, Lloh87
 	.loh AdrpAdd	Lloh84, Lloh85

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7.s
@@ -255,11 +255,12 @@ LPC5_6:
 	.p2align	2
 	.code	32
 _use_in_loop:
+	cmp	r0, #0
+	bxeq	lr
+LBB6_1:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
 	push	{r8}
-	cmp	r0, #0
-	beq	LBB6_5
 	movw	r5, :lower16:(SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)-(LPC6_0+8))
 	mov	r4, r0
 	movt	r5, :upper16:(SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)-(LPC6_0+8))
@@ -288,7 +289,8 @@ LBB6_3:
 	b	LBB6_2
 LBB6_5:
 	pop	{r8}
-	pop	{r4, r5, r6, r7, pc}
+	pop	{r4, r5, r6, r7, lr}
+	bx	lr
 
 	.section	__TEXT,__const
 l_anon.[ID].0:

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7s.s
@@ -4,16 +4,16 @@
 	.p2align	2
 	.code	32
 _get_class:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r0, :lower16:(__MergedGlobals-(LPC0_0+8))
 	movt	r0, :upper16:(__MergedGlobals-(LPC0_0+8))
 LPC0_0:
 	add	r0, pc, r0
 	ldr	r0, [r0]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB0_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r0, :lower16:(__MergedGlobals-(LPC0_1+8))
 	movt	r0, :upper16:(__MergedGlobals-(LPC0_1+8))
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC0_2+8))
@@ -27,22 +27,23 @@ LPC0_2:
 LPC0_3:
 	add	r2, pc, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_get_same_class
 	.p2align	2
 	.code	32
 _get_same_class:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r3, :lower16:(__MergedGlobals-(LPC1_0+8))
 	movt	r3, :upper16:(__MergedGlobals-(LPC1_0+8))
 LPC1_0:
 	add	r3, pc, r3
 	ldr	r0, [r3, #4]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB1_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC1_1+8))
 	add	r0, r3, #4
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC1_1+8))
@@ -53,22 +54,23 @@ LPC1_1:
 LPC1_2:
 	add	r2, pc, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_get_different_class
 	.p2align	2
 	.code	32
 _get_different_class:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r3, :lower16:(__MergedGlobals-(LPC2_0+8))
 	movt	r3, :upper16:(__MergedGlobals-(LPC2_0+8))
 LPC2_0:
 	add	r3, pc, r3
 	ldr	r0, [r3, #8]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB2_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r1, :lower16:(l_anon.[ID].4-(LPC2_1+8))
 	add	r0, r3, #8
 	movt	r1, :upper16:(l_anon.[ID].4-(LPC2_1+8))
@@ -79,22 +81,23 @@ LPC2_1:
 LPC2_2:
 	add	r2, pc, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_unused_class
 	.p2align	2
 	.code	32
 _unused_class:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r0, :lower16:(SYM(test_dynamic_class[CRATE_ID]::unused_class::CACHED_CLASS, 0)-(LPC3_0+8))
 	movt	r0, :upper16:(SYM(test_dynamic_class[CRATE_ID]::unused_class::CACHED_CLASS, 0)-(LPC3_0+8))
 LPC3_0:
 	add	r0, pc, r0
 	ldr	r0, [r0]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB3_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r0, :lower16:(SYM(test_dynamic_class[CRATE_ID]::unused_class::CACHED_CLASS, 0)-(LPC3_1+8))
 	movt	r0, :upper16:(SYM(test_dynamic_class[CRATE_ID]::unused_class::CACHED_CLASS, 0)-(LPC3_1+8))
 	movw	r1, :lower16:(l_anon.[ID].6-(LPC3_2+8))
@@ -108,7 +111,8 @@ LPC3_2:
 LPC3_3:
 	add	r2, pc, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_use_fns
 	.p2align	2
@@ -267,11 +271,12 @@ LPC5_6:
 	.p2align	2
 	.code	32
 _use_in_loop:
+	cmp	r0, #0
+	bxeq	lr
+LBB6_1:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
 	push	{r8}
-	cmp	r0, #0
-	beq	LBB6_5
 	movw	r5, :lower16:(SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)-(LPC6_0+8))
 	mov	r4, r0
 	movt	r5, :upper16:(SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)-(LPC6_0+8))
@@ -300,7 +305,8 @@ LBB6_3:
 	b	LBB6_2
 LBB6_5:
 	pop	{r8}
-	pop	{r4, r5, r6, r7, pc}
+	pop	{r4, r5, r6, r7, lr}
+	bx	lr
 
 	.section	__TEXT,__const
 l_anon.[ID].0:

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86_64.s
@@ -179,14 +179,14 @@ LBB5_3:
 	.globl	_use_in_loop
 	.p2align	4, 0x90
 _use_in_loop:
+	test	rdi, rdi
+	je	LBB6_6
 	push	rbp
 	mov	rbp, rsp
 	push	r15
 	push	r14
 	push	r12
 	push	rbx
-	test	rdi, rdi
-	je	LBB6_5
 	mov	rbx, rdi
 	lea	r14, [rip + SYM(test_dynamic_class[CRATE_ID]::use_in_loop::CACHED_CLASS, 0)]
 	lea	r15, [rip + l_anon.[ID].10]
@@ -211,6 +211,7 @@ LBB6_5:
 	pop	r14
 	pop	r15
 	pop	rbp
+LBB6_6:
 	ret
 
 	.section	__TEXT,__const

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-aarch64.s
@@ -316,11 +316,11 @@ Lloh71:
 	.globl	_use_in_loop
 	.p2align	2
 _use_in_loop:
+	cbz	x0, LBB7_6
 	stp	x22, x21, [sp, #-48]!
 	stp	x20, x19, [sp, #16]
 	stp	x29, x30, [sp, #32]
 	add	x29, sp, #32
-	cbz	x0, LBB7_5
 	mov	x19, x0
 	adrp	x22, SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)@PAGE
 Lloh72:
@@ -346,6 +346,7 @@ LBB7_5:
 	ldp	x29, x30, [sp, #32]
 	ldp	x20, x19, [sp, #16]
 	ldp	x22, x21, [sp], #48
+LBB7_6:
 	ret
 	.loh AdrpAdd	Lloh74, Lloh75
 	.loh AdrpAdd	Lloh72, Lloh73

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7.s
@@ -262,11 +262,11 @@ LPC6_4:
 	.p2align	2
 	.code	32
 _use_in_loop:
+	cmp	r0, #0
+	bxeq	lr
+LBB7_1:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
-	cmp	r0, #0
-	popeq	{r4, r5, r6, r7, pc}
-LBB7_1:
 	movw	r5, :lower16:(SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)-(LPC7_0+8))
 	mov	r4, r0
 	movt	r5, :upper16:(SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)-(LPC7_0+8))
@@ -289,7 +289,8 @@ LBB7_3:
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	b	LBB7_2
 LBB7_5:
-	pop	{r4, r5, r6, r7, pc}
+	pop	{r4, r5, r6, r7, lr}
+	bx	lr
 
 	.section	__TEXT,__const
 l_anon.[ID].0:

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7s.s
@@ -4,16 +4,16 @@
 	.p2align	2
 	.code	32
 _get_sel:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r0, :lower16:(__MergedGlobals-(LPC0_0+8))
 	movt	r0, :upper16:(__MergedGlobals-(LPC0_0+8))
 LPC0_0:
 	add	r0, pc, r0
 	ldr	r0, [r0]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB0_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r0, :lower16:(__MergedGlobals-(LPC0_1+8))
 	movt	r0, :upper16:(__MergedGlobals-(LPC0_1+8))
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC0_2+8))
@@ -23,29 +23,31 @@ LPC0_1:
 LPC0_2:
 	add	r1, pc, r1
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_get_same_sel
 	.p2align	2
 	.code	32
 _get_same_sel:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r2, :lower16:(__MergedGlobals-(LPC1_0+8))
 	movt	r2, :upper16:(__MergedGlobals-(LPC1_0+8))
 LPC1_0:
 	add	r2, pc, r2
 	ldr	r0, [r2, #4]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB1_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC1_1+8))
 	add	r0, r2, #4
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC1_1+8))
 LPC1_1:
 	add	r1, pc, r1
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_get_common_twice
 	.p2align	2
@@ -98,38 +100,39 @@ LPC2_4:
 	.p2align	2
 	.code	32
 _get_different_sel:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r2, :lower16:(__MergedGlobals-(LPC3_0+8))
 	movt	r2, :upper16:(__MergedGlobals-(LPC3_0+8))
 LPC3_0:
 	add	r2, pc, r2
 	ldr	r0, [r2, #8]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB3_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r1, :lower16:(L_anon.[ID].2-(LPC3_1+8))
 	add	r0, r2, #8
 	movt	r1, :upper16:(L_anon.[ID].2-(LPC3_1+8))
 LPC3_1:
 	add	r1, pc, r1
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_unused_sel
 	.p2align	2
 	.code	32
 _unused_sel:
-	push	{r7, lr}
-	mov	r7, sp
 	movw	r0, :lower16:(SYM(test_dynamic_sel[CRATE_ID]::unused_sel::CACHED_SEL, 0)-(LPC4_0+8))
 	movt	r0, :upper16:(SYM(test_dynamic_sel[CRATE_ID]::unused_sel::CACHED_SEL, 0)-(LPC4_0+8))
 LPC4_0:
 	add	r0, pc, r0
 	ldr	r0, [r0]
 	cmp	r0, #0
-	popne	{r7, pc}
+	bxne	lr
 LBB4_1:
+	push	{r7, lr}
+	mov	r7, sp
 	movw	r0, :lower16:(SYM(test_dynamic_sel[CRATE_ID]::unused_sel::CACHED_SEL, 0)-(LPC4_1+8))
 	movt	r0, :upper16:(SYM(test_dynamic_sel[CRATE_ID]::unused_sel::CACHED_SEL, 0)-(LPC4_1+8))
 	movw	r1, :lower16:(l_anon.[ID].3-(LPC4_2+8))
@@ -139,7 +142,8 @@ LPC4_1:
 LPC4_2:
 	add	r1, pc, r1
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	pop	{r7, pc}
+	pop	{r7, lr}
+	bx	lr
 
 	.globl	_use_fns
 	.p2align	2
@@ -274,10 +278,11 @@ LPC6_4:
 	.p2align	2
 	.code	32
 _use_in_loop:
+	cmp	r0, #0
+	bxeq	lr
+LBB7_1:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
-	cmp	r0, #0
-	beq	LBB7_5
 	movw	r5, :lower16:(SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)-(LPC7_0+8))
 	mov	r4, r0
 	movt	r5, :upper16:(SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)-(LPC7_0+8))
@@ -300,7 +305,8 @@ LBB7_3:
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	b	LBB7_2
 LBB7_5:
-	pop	{r4, r5, r6, r7, pc}
+	pop	{r4, r5, r6, r7, lr}
+	bx	lr
 
 	.section	__TEXT,__const
 l_anon.[ID].0:

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86_64.s
@@ -204,14 +204,14 @@ LBB6_3:
 	.globl	_use_in_loop
 	.p2align	4, 0x90
 _use_in_loop:
+	test	rdi, rdi
+	je	LBB7_6
 	push	rbp
 	mov	rbp, rsp
 	push	r15
 	push	r14
 	push	rbx
 	push	rax
-	test	rdi, rdi
-	je	LBB7_5
 	mov	rbx, rdi
 	lea	r14, [rip + SYM(test_dynamic_sel[CRATE_ID]::use_in_loop::CACHED_SEL, 0)]
 	lea	r15, [rip + l_anon.[ID].5]
@@ -234,6 +234,7 @@ LBB7_5:
 	pop	r14
 	pop	r15
 	pop	rbp
+LBB7_6:
 	ret
 
 	.section	__TEXT,__const

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
@@ -125,34 +125,34 @@ _iter:
 L3$pb:
 	pop	eax
 	mov	ebx, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 48], 0
-	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 44], 0
 	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 128], ebx
-	lea	edi, [ebp - 60]
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 124], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 56], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 124], ebx
+	lea	edi, [ebp - 56]
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
+	mov	dword ptr [ebp - 20], 0
 	mov	esi, dword ptr [eax + LSYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L3$pb]
 	lea	eax, [eax + l_anon.[ID].0-L3$pb]
 	mov	dword ptr [ebp - 16], eax
@@ -163,28 +163,28 @@ L3$pb:
 LBB3_4:
 	sub	esp, 12
 	push	16
-	lea	ecx, [ebp - 124]
+	lea	ecx, [ebp - 120]
 	push	ecx
 	push	edi
 	push	eax
 	push	ebx
 	call	_objc_msgSend
 	add	esp, 32
-	mov	dword ptr [ebp - 24], eax
+	mov	dword ptr [ebp - 20], eax
 	xor	ecx, ecx
 	test	eax, eax
 	je	LBB3_5
 LBB3_6:
-	mov	eax, dword ptr [ebp - 56]
+	mov	eax, dword ptr [ebp - 52]
 	lea	edx, [ecx + 1]
-	mov	dword ptr [ebp - 28], edx
+	mov	dword ptr [ebp - 24], edx
 	sub	esp, 12
 	push	dword ptr [eax + 4*ecx]
 	call	_use_obj
 	add	esp, 16
-	mov	ebx, dword ptr [ebp - 128]
-	mov	ecx, dword ptr [ebp - 28]
-	mov	eax, dword ptr [ebp - 24]
+	mov	ebx, dword ptr [ebp - 124]
+	mov	ecx, dword ptr [ebp - 24]
+	mov	eax, dword ptr [ebp - 20]
 LBB3_1:
 	cmp	ecx, eax
 	jb	LBB3_6
@@ -218,34 +218,34 @@ _iter_noop:
 L4$pb:
 	pop	eax
 	mov	ebx, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 48], 0
-	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 44], 0
 	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 128], ebx
-	lea	edi, [ebp - 60]
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 124], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 56], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 124], ebx
+	lea	edi, [ebp - 56]
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
+	mov	dword ptr [ebp - 20], 0
 	mov	esi, dword ptr [eax + LSYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L4$pb]
 	lea	eax, [eax + l_anon.[ID].0-L4$pb]
 	mov	dword ptr [ebp - 16], eax
@@ -255,7 +255,7 @@ L4$pb:
 	.p2align	4, 0x90
 LBB4_6:
 	inc	ecx
-	mov	dword ptr [ebp - 28], ecx
+	mov	dword ptr [ebp - 24], ecx
 LBB4_1:
 	cmp	ecx, eax
 	jb	LBB4_6
@@ -265,18 +265,18 @@ LBB4_1:
 LBB4_4:
 	sub	esp, 12
 	push	16
-	lea	ecx, [ebp - 124]
+	lea	ecx, [ebp - 120]
 	push	ecx
 	push	edi
 	push	eax
 	push	ebx
 	call	_objc_msgSend
 	add	esp, 32
-	mov	dword ptr [ebp - 24], eax
+	mov	dword ptr [ebp - 20], eax
 	test	eax, eax
 	je	LBB4_7
 	xor	ecx, ecx
-	mov	ebx, dword ptr [ebp - 128]
+	mov	ebx, dword ptr [ebp - 124]
 	jmp	LBB4_6
 LBB4_3:
 	sub	esp, 8
@@ -306,34 +306,34 @@ _iter_retained:
 L5$pb:
 	pop	eax
 	mov	esi, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 48], 0
-	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 40], 0
+	mov	dword ptr [ebp - 44], 0
 	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 128], esi
-	lea	ebx, [ebp - 60]
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 124], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 56], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 36], 0
 	mov	dword ptr [ebp - 28], 0
+	mov	dword ptr [ebp - 124], esi
+	lea	ebx, [ebp - 56]
+	mov	dword ptr [ebp - 116], 0
+	mov	dword ptr [ebp - 120], 0
+	mov	dword ptr [ebp - 108], 0
+	mov	dword ptr [ebp - 112], 0
+	mov	dword ptr [ebp - 100], 0
+	mov	dword ptr [ebp - 104], 0
+	mov	dword ptr [ebp - 92], 0
+	mov	dword ptr [ebp - 96], 0
+	mov	dword ptr [ebp - 84], 0
+	mov	dword ptr [ebp - 88], 0
+	mov	dword ptr [ebp - 76], 0
+	mov	dword ptr [ebp - 80], 0
+	mov	dword ptr [ebp - 68], 0
+	mov	dword ptr [ebp - 72], 0
+	mov	dword ptr [ebp - 60], 0
+	mov	dword ptr [ebp - 64], 0
+	mov	dword ptr [ebp - 52], 0
+	mov	dword ptr [ebp - 56], 0
+	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
+	mov	dword ptr [ebp - 20], 0
 	mov	edi, dword ptr [eax + LSYM(icrate::Foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L5$pb]
 	lea	eax, [eax + l_anon.[ID].0-L5$pb]
 	mov	dword ptr [ebp - 16], eax
@@ -344,21 +344,21 @@ L5$pb:
 LBB5_4:
 	sub	esp, 12
 	push	16
-	lea	ecx, [ebp - 124]
+	lea	ecx, [ebp - 120]
 	push	ecx
 	push	ebx
 	push	eax
 	push	esi
 	call	_objc_msgSend
 	add	esp, 32
-	mov	dword ptr [ebp - 24], eax
+	mov	dword ptr [ebp - 20], eax
 	xor	ecx, ecx
 	test	eax, eax
 	je	LBB5_5
 LBB5_6:
-	mov	eax, dword ptr [ebp - 56]
+	mov	eax, dword ptr [ebp - 52]
 	lea	edx, [ecx + 1]
-	mov	dword ptr [ebp - 28], edx
+	mov	dword ptr [ebp - 24], edx
 	sub	esp, 12
 	push	dword ptr [eax + 4*ecx]
 	call	_objc_retain
@@ -371,9 +371,9 @@ LBB5_6:
 	push	esi
 	call	_objc_release
 	add	esp, 16
-	mov	esi, dword ptr [ebp - 128]
-	mov	ecx, dword ptr [ebp - 28]
-	mov	eax, dword ptr [ebp - 24]
+	mov	esi, dword ptr [ebp - 124]
+	mov	ecx, dword ptr [ebp - 24]
+	mov	eax, dword ptr [ebp - 20]
 LBB5_1:
 	cmp	ecx, eax
 	jb	LBB5_6

--- a/crates/test-assembly/crates/test_ns_string/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/apple-aarch64.s
@@ -41,8 +41,15 @@ _XYZ:
 	.quad	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0):
 	.space	1
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0):
+	.space	2
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0)
@@ -54,8 +61,15 @@ SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0):
 	.space	8
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0):
 	.asciz	"xyz"
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0):
+	.asciz	"x\000y\000z\000\000"
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)

--- a/crates/test-assembly/crates/test_ns_string/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/apple-armv7.s
@@ -42,8 +42,15 @@ _XYZ:
 	.long	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0):
 	.space	1
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0):
+	.space	2
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0)
@@ -55,8 +62,15 @@ SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0):
 	.space	4
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0):
 	.asciz	"xyz"
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0):
+	.asciz	"x\000y\000z\000\000"
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)

--- a/crates/test-assembly/crates/test_ns_string/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/apple-armv7s.s
@@ -42,8 +42,15 @@ _XYZ:
 	.long	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0):
 	.space	1
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0):
+	.space	2
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0)
@@ -55,8 +62,15 @@ SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0):
 	.space	4
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0):
 	.asciz	"xyz"
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0):
+	.asciz	"x\000y\000z\000\000"
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)

--- a/crates/test-assembly/crates/test_ns_string/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/apple-x86.s
@@ -48,8 +48,15 @@ _XYZ:
 	.long	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0):
 	.space	1
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0):
+	.space	2
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0)
@@ -61,8 +68,15 @@ SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0):
 	.space	4
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0):
 	.asciz	"xyz"
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0):
+	.asciz	"x\000y\000z\000\000"
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)

--- a/crates/test-assembly/crates/test_ns_string/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/apple-x86_64.s
@@ -39,8 +39,15 @@ _XYZ:
 	.quad	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::EMPTY::ASCII, 0):
 	.space	1
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::EMPTY::UTF16, 0):
+	.space	2
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0)
@@ -52,8 +59,15 @@ SYM(test_ns_string[CRATE_ID]::EMPTY::CFSTRING, 0):
 	.space	8
 
 	.section	__TEXT,__cstring,cstring_literals
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0)
 SYM(test_ns_string[CRATE_ID]::XYZ::ASCII, 0):
 	.asciz	"xyz"
+
+	.section	__TEXT,__ustring
+	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0)
+	.p2align	1, 0x0
+SYM(test_ns_string[CRATE_ID]::XYZ::UTF16, 0):
+	.asciz	"x\000y\000z\000\000"
 
 	.section	__DATA,__cfstring
 	.globl	SYM(test_ns_string[CRATE_ID]::XYZ::CFSTRING, 0)

--- a/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_ns_string/expected/gnustep-x86_64.s
@@ -5,19 +5,18 @@
 	.p2align	4, 0x90
 	.type	get_ascii,@function
 get_ascii:
-	push	rax
 	mov	rax, qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_ascii::CACHED_NSSTRING, 0).0]
 	test	rax, rax
 	je	.LBB0_1
-	pop	rcx
 	ret
 .LBB0_1:
+	push	rax
 	lea	rdi, [rip + .Lanon.[ID].0]
 	mov	esi, 3
 	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::<impl icrate::Foundation::generated::__NSString::NSString>::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_ascii::CACHED_NSSTRING, 0).0], rcx
-	pop	rcx
+	add	rsp, 8
 	ret
 .Lfunc_end0:
 	.size	get_ascii, .Lfunc_end0-get_ascii
@@ -27,19 +26,18 @@ get_ascii:
 	.p2align	4, 0x90
 	.type	get_utf16,@function
 get_utf16:
-	push	rax
 	mov	rax, qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_utf16::CACHED_NSSTRING, 0).0]
 	test	rax, rax
 	je	.LBB1_1
-	pop	rcx
 	ret
 .LBB1_1:
+	push	rax
 	lea	rdi, [rip + .Lanon.[ID].1]
 	mov	esi, 5
 	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::<impl icrate::Foundation::generated::__NSString::NSString>::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_utf16::CACHED_NSSTRING, 0).0], rcx
-	pop	rcx
+	add	rsp, 8
 	ret
 .Lfunc_end1:
 	.size	get_utf16, .Lfunc_end1-get_utf16
@@ -49,19 +47,18 @@ get_utf16:
 	.p2align	4, 0x90
 	.type	get_with_nul,@function
 get_with_nul:
-	push	rax
 	mov	rax, qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_with_nul::CACHED_NSSTRING, 0).0]
 	test	rax, rax
 	je	.LBB2_1
-	pop	rcx
 	ret
 .LBB2_1:
+	push	rax
 	lea	rdi, [rip + .Lanon.[ID].2]
 	mov	esi, 6
 	call	qword ptr [rip + SYM(icrate::Foundation::additions::string::<impl icrate::Foundation::generated::__NSString::NSString>::from_str::GENERATED_ID, 0)@GOTPCREL]
 	mov	rcx, rax
 	xchg	qword ptr [rip + SYM(test_ns_string[CRATE_ID]::get_with_nul::CACHED_NSSTRING, 0).0], rcx
-	pop	rcx
+	add	rsp, 8
 	ret
 .Lfunc_end2:
 	.size	get_with_nul, .Lfunc_end2-get_with_nul

--- a/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86_64.s
@@ -48,14 +48,13 @@ null_nonnull:
 	mov	r14, rsi
 	mov	r15, rdi
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rcx, rax
 	test	rbx, rbx
 	je	.LBB1_2
 	mov	r12, qword ptr [rbx]
 	mov	rdi, r15
 	mov	rsi, r14
 	mov	rdx, rbx
-	call	rcx
+	call	rax
 	mov	r14, rax
 	mov	rdi, qword ptr [rbx]
 	call	qword ptr [rip + objc_retain@GOTPCREL]
@@ -77,7 +76,7 @@ null_nonnull:
 	pop	r12
 	pop	r14
 	pop	r15
-	jmp	rcx
+	jmp	rax
 .Lfunc_end1:
 	.size	null_nonnull, .Lfunc_end1-null_nonnull
 
@@ -132,14 +131,13 @@ null_null:
 	mov	r14, rsi
 	mov	r12, rdi
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rcx, rax
 	test	rbx, rbx
 	je	.LBB3_4
 	mov	r15, qword ptr [rbx]
 	mov	rdi, r12
 	mov	rsi, r14
 	mov	rdx, rbx
-	call	rcx
+	call	rax
 	mov	r14, rax
 	mov	rdi, qword ptr [rbx]
 	call	qword ptr [rip + objc_retain@GOTPCREL]
@@ -164,7 +162,7 @@ null_null:
 	pop	r12
 	pop	r14
 	pop	r15
-	jmp	rcx
+	jmp	rax
 .Lfunc_end3:
 	.size	null_null, .Lfunc_end3-null_null
 

--- a/crates/test-assembly/src/lib.rs
+++ b/crates/test-assembly/src/lib.rs
@@ -87,7 +87,9 @@ pub fn read_assembly<P: AsRef<Path>>(path: P, package_path: &Path) -> io::Result
 
     // HACK: Make location data the same no matter which platform generated
     // the data.
-    let s = s.replace(".asciz\t\"}", ".asciz\t\"t");
+    let s = s.replace(".asciz\t\"}\\000", ".asciz\t\"p\\000");
+    let s = s.replace(".asciz\t\"L\\000", ".asciz\t\"p\\000");
+    let s = s.replace(".asciz\t\"t\\000", ".asciz\t\"p\\000");
 
     // HACK: Replace Objective-C image info for simulator targets
     let s = s.replace(
@@ -102,6 +104,7 @@ pub fn read_assembly<P: AsRef<Path>>(path: P, package_path: &Path) -> io::Result
     let s = strip_lines(&s, ".file");
     // Added in nightly-2022-07-21
     let s = strip_lines(&s, ".no_dead_strip");
+    let s = strip_lines(&s, ".ident\t\"rustc ");
     // We remove the __LLVM,__bitcode and __LLVM,__cmdline sections because
     // they're uninteresting for out use-case.
     //

--- a/crates/test-ui/ui/add_method_no_bool.stderr
+++ b/crates/test-ui/ui/add_method_no_bool.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
   |             required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel, bool)` to implement `MethodImplementation`
 note: required by a bound in `ClassBuilder::add_method`
@@ -35,14 +35,14 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
   |             required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `bool` to implement `EncodeReturn`
   = note: required for `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel) -> bool` to implement `MethodImplementation`

--- a/crates/test-ui/ui/array_iter_invalid.stderr
+++ b/crates/test-ui/ui/array_iter_invalid.stderr
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `&mut Id<NSMutableArray<NSString>>: IntoIterator` 
   |
   = note: `IntoIterator` is implemented for `&objc2::rc::Id<icrate::Foundation::NSMutableArray<icrate::Foundation::NSString>>`, but not for `&mut objc2::rc::Id<icrate::Foundation::NSMutableArray<icrate::Foundation::NSString>>`
 help: consider removing the leading `&`-reference
-   |
+  |
 16 -     for s in &mut arr {
 16 +     for s in arr {
    |

--- a/crates/test-ui/ui/array_iter_invalid.stderr
+++ b/crates/test-ui/ui/array_iter_invalid.stderr
@@ -18,9 +18,9 @@ error[E0277]: the trait bound `&mut Id<NSArray<NSMutableString>>: IntoIterator` 
   |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSMutableString>>`
   |
   = help: the following other types implement trait `IntoIterator`:
+            Id<T>
             &'a Id<T>
             &'a mut Id<T>
-            Id<T>
   = note: `IntoIterator` is implemented for `&objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSMutableString>>`, but not for `&mut objc2::rc::Id<icrate::Foundation::NSArray<icrate::Foundation::NSMutableString>>`
 
 error[E0277]: the trait bound `&mut Id<NSMutableArray<NSString>>: IntoIterator` is not satisfied
@@ -43,6 +43,6 @@ error[E0277]: the trait bound `Id<NSArray<NSMutableString>>: IntoIterator` is no
   |              ^^^ the trait `IntoIterator` is not implemented for `Id<NSArray<NSMutableString>>`
   |
   = help: the following other types implement trait `IntoIterator`:
+            Id<T>
             &'a Id<T>
             &'a mut Id<T>
-            Id<T>

--- a/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
+++ b/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
@@ -5,6 +5,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
   = help: within `AutoreleasePool<'_>`, the trait `Sync` is not implemented for `*mut c_void`
+  = note: consider using `std::sync::Arc<*mut c_void>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Pool`
  --> $WORKSPACE/crates/objc2/src/rc/autorelease.rs
   |
@@ -34,6 +35,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
   = help: within `objc2::rc::autorelease::Pool`, the trait `Sync` is not implemented for `*mut c_void`
+  = note: consider using `std::sync::Arc<*mut c_void>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `Pool`
  --> $WORKSPACE/crates/objc2/src/rc/autorelease.rs
   |

--- a/crates/test-ui/ui/declare_add_bad_method.stderr
+++ b/crates/test-ui/ui/declare_add_bad_method.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `fn(_, _): MethodImplementation` is not satisfied
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -34,14 +34,14 @@ error[E0277]: the trait bound `fn(_, _): MethodImplementation` is not satisfied
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -61,14 +61,14 @@ error[E0277]: the trait bound `fn(_, _) -> _: MethodImplementation` is not satis
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -88,14 +88,14 @@ error[E0277]: the trait bound `fn(_, _) -> _: MethodImplementation` is not satis
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -115,14 +115,14 @@ error[E0277]: the trait bound `fn(_, _, _): MethodImplementation` is not satisfi
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs

--- a/crates/test-ui/ui/declare_class_invalid_receiver.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_receiver.stderr
@@ -14,14 +14,14 @@ error[E0277]: the trait bound `extern "C" fn(Box<CustomObject>, objc2::runtime::
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -49,14 +49,14 @@ error[E0277]: the trait bound `extern "C" fn(Id<CustomObject>, objc2::runtime::S
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -84,14 +84,14 @@ error[E0277]: the trait bound `extern "C" fn(CustomObject, objc2::runtime::Sel):
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -116,13 +116,13 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
   | |_^ the trait `Message` is not implemented for `AnyClass`
   |
   = help: the following other types implement trait `Message`:
-            AnyObject
             CustomObject
             Exception
-            NSObject
             ProtocolObject<P>
-            __NSProxy
+            AnyObject
             __RcTestObject
+            NSObject
+            __NSProxy
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
   |
@@ -149,14 +149,14 @@ error[E0277]: the trait bound `extern "C" fn(Box<CustomObject>, objc2::runtime::
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -184,14 +184,14 @@ error[E0277]: the trait bound `extern "C" fn(Id<CustomObject>, objc2::runtime::S
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -219,14 +219,14 @@ error[E0277]: the trait bound `extern "C" fn(CustomObject, objc2::runtime::Sel) 
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs
@@ -241,95 +241,67 @@ note: required by a bound in `ClassBuilder::add_method`
 error[E0277]: the trait bound `Box<CustomObject>: MessageReceiver` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
   |
-  | / declare_class!(
-  | |     struct CustomObject;
-  | |
-  | |     unsafe impl ClassType for CustomObject {
-... |
-  | |     }
-  | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
+  |         fn test_box_id(self: Box<Self>) -> Id<Self> {
+  |                              ^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
   |
   = help: the following other types implement trait `MessageReceiver`:
-            &'a AnyClass
-            &'a Id<T>
-            &'a T
-            &'a mut Id<T>
-            &'a mut T
+            NonNull<T>
+            ManuallyDrop<Id<T>>
             *const AnyClass
             *const T
             *mut T
+            &'a T
+            &'a mut T
+            &'a Id<T>
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<Box<CustomObject>, Id<CustomObject>>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<CustomObject>: MessageReceiver` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
   |
-  | / declare_class!(
-  | |     struct CustomObject;
-  | |
-  | |     unsafe impl ClassType for CustomObject {
-... |
-  | |     }
-  | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Id<CustomObject>`
+  |         fn test_id_self_id(this: Id<Self>) -> Id<Self> {
+  |                                  ^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<CustomObject>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             &'a Id<T>
             &'a mut Id<T>
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<Id<CustomObject>, Id<CustomObject>>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `CustomObject: MessageReceiver` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
   |
-  | / declare_class!(
-  | |     struct CustomObject;
-  | |
-  | |     unsafe impl ClassType for CustomObject {
-... |
-  | |     }
-  | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `CustomObject`
+  |         fn test_self_id(this: Self) -> Id<Self> {
+  |                               ^^^^ the trait `MessageReceiver` is not implemented for `CustomObject`
   |
   = help: the following other types implement trait `MessageReceiver`:
-            &'a AnyClass
-            &'a Id<T>
-            &'a T
-            &'a mut Id<T>
-            &'a mut T
+            NonNull<T>
+            ManuallyDrop<Id<T>>
             *const AnyClass
             *const T
             *mut T
+            &'a T
+            &'a mut T
+            &'a Id<T>
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<CustomObject, Id<CustomObject>>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Allocated<CustomObject>: MessageReceiver` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
   |
-  | / declare_class!(
-  | |     struct CustomObject;
-  | |
-  | |     unsafe impl ClassType for CustomObject {
-... |
-  | |     }
-  | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Allocated<CustomObject>`
+  |         fn test_alloc(this: Allocated<Self>) -> Id<Self> {
+  |                             ^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Allocated<CustomObject>`
   |
   = help: the following other types implement trait `MessageReceiver`:
-            &'a AnyClass
-            &'a Id<T>
-            &'a T
-            &'a mut Id<T>
-            &'a mut T
+            NonNull<T>
+            ManuallyDrop<Id<T>>
             *const AnyClass
             *const T
             *mut T
+            &'a T
+            &'a mut T
+            &'a Id<T>
           and $N others
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<Allocated<CustomObject>, Id<CustomObject>>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `RetainSemantics<3>: MessageRecieveId<&CustomObject, Id<CustomObject>>` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
@@ -344,4 +316,4 @@ error[E0277]: the trait bound `RetainSemantics<3>: MessageRecieveId<&CustomObjec
   | |_^ the trait `MessageRecieveId<&CustomObject, Id<CustomObject>>` is not implemented for `RetainSemantics<3>`
   |
   = help: the trait `MessageRecieveId<Allocated<T>, Ret>` is implemented for `RetainSemantics<3>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_syntax.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_syntax.stderr
@@ -494,4 +494,4 @@ error[E0277]: the trait bound `RetainSemantics<2>: MessageRecieveId<&AnyClass, I
             <RetainSemantics<3> as MessageRecieveId<Allocated<T>, Ret>>
             <RetainSemantics<4> as MessageRecieveId<Receiver, Ret>>
             <RetainSemantics<5> as MessageRecieveId<Receiver, Ret>>
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `Id<CustomObject>: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `Id<CustomObject>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Id<CustomObject>` to implement `EncodeReturn`
   = note: required for `Id<CustomObject>` to implement `__unstable::convert_private::Sealed`
@@ -27,6 +27,7 @@ note: required by a bound in `EncodeConvertReturn`
   |
   | pub trait EncodeConvertReturn: convert_private::Sealed {
   |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvertReturn`
+  = note: `EncodeConvertReturn` is a "sealed trait", because to implement it you also need to implement `objc2::encode::__unstable::convert_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
@@ -42,14 +43,14 @@ error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `Vec<()>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Vec<()>` to implement `EncodeReturn`
   = note: required for `Vec<()>` to implement `__unstable::convert_private::Sealed`
@@ -58,6 +59,7 @@ note: required by a bound in `EncodeConvertReturn`
   |
   | pub trait EncodeConvertReturn: convert_private::Sealed {
   |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EncodeConvertReturn`
+  = note: `EncodeConvertReturn` is a "sealed trait", because to implement it you also need to implement `objc2::encode::__unstable::convert_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
@@ -73,14 +75,14 @@ error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `Box<u32>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Box<u32>` to implement `EncodeConvertArgument`
   = note: this error originates in the macro `$crate::__declare_class_rewrite_args` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -98,14 +100,14 @@ error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `CustomObject`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `CustomObject` to implement `EncodeConvertArgument`
   = note: this error originates in the macro `$crate::__declare_class_rewrite_args` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_type2.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type2.stderr
@@ -1,19 +1,12 @@
 error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Id<CustomObject>`
  --> ui/declare_class_invalid_type2.rs
   |
-  | / declare_class!(
-  | |     struct CustomObject;
-  | |
-  | |     unsafe impl ClassType for CustomObject {
-... |
-  | |     }
-  | | );
-  | |_^ expected `Id<CustomObject>`, found `Id<NSObject>`
+  |         fn test_init_not_same_generics(this: Allocated<Self>) -> Id<NSObject> {
+  |                                              ^^^^^^^^^^^^^^^ expected `Id<CustomObject>`, found `Id<NSObject>`
   |
   = note: expected struct `Id<CustomObject>`
              found struct `Id<NSObject>`
   = note: required for `RetainSemantics<3>` to implement `MessageRecieveId<Allocated<CustomObject>, Id<NSObject>>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: MaybeOptionId` is not satisfied
  --> ui/declare_class_invalid_type2.rs
@@ -31,4 +24,4 @@ error[E0277]: the trait bound `i32: MaybeOptionId` is not satisfied
             Id<T>
             Option<Id<T>>
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<&CustomObject, i32>`
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_type3.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type3.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `()`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `objc2::declare::IvarEncode<()>` to implement `InnerIvarType`
 note: required by a bound in `objc2::declare::IvarType::Type`

--- a/crates/test-ui/ui/extern_class_root.stderr
+++ b/crates/test-ui/ui/extern_class_root.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `MyObject: ClassType` is not satisfied
   |
   = help: the following other types implement trait `ClassType`:
             MyRootClass
+            __RcTestObject
             NSObject
             __NSProxy
-            __RcTestObject
   = note: this error originates in the macro `$crate::__inner_extern_class` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_type.stderr
@@ -10,14 +10,14 @@ error[E0277]: the trait bound `Id<MyObject>: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `Id<MyObject>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Id<MyObject>` to implement `EncodeReturn`
   = note: required for `Id<MyObject>` to implement `EncodeConvertReturn`
@@ -43,10 +43,10 @@ error[E0277]: the trait bound `i32: MaybeUnwrap` is not satisfied
   | |_^ the trait `MaybeUnwrap` is not implemented for `i32`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -89,14 +89,14 @@ error[E0277]: the trait bound `Result<(), Id<NSObject>>: Encode` is not satisfie
   | |_^ the trait `Encode` is not implemented for `Result<(), Id<NSObject>>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Result<(), Id<NSObject>>` to implement `EncodeReturn`
   = note: required for `Result<(), Id<NSObject>>` to implement `EncodeConvertReturn`
@@ -122,10 +122,10 @@ error[E0277]: the trait bound `Result<Id<MyObject>, Id<NSObject>>: MaybeUnwrap` 
   | |_^ the trait `MaybeUnwrap` is not implemented for `Result<Id<MyObject>, Id<NSObject>>`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -145,14 +145,14 @@ error[E0277]: the trait bound `MainThreadMarker: Encode` is not satisfied
   | |_^ the trait `Encode` is not implemented for `MainThreadMarker`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `MainThreadMarker` to implement `EncodeReturn`
   = note: required for `MainThreadMarker` to implement `EncodeConvertReturn`

--- a/crates/test-ui/ui/fn_ptr_reference_method.stderr
+++ b/crates/test-ui/ui/fn_ptr_reference_method.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `for<'a> extern "C" fn(_, _, &'a NSObject): Method
   |                 required by a bound introduced by this call
   |
   = help: the following other types implement trait `MethodImplementation`:
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F) -> R
-            extern "C" fn(&'a AnyClass, objc2::runtime::Sel, A, B, C, D, E, F, G) -> R
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B) -> __IdReturnValue
+            unsafe extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
+            extern "C" fn(Allocated<T>, objc2::runtime::Sel, A, B, C) -> __IdReturnValue
           and $N others
 note: required by a bound in `ClassBuilder::add_method`
  --> $WORKSPACE/crates/objc2/src/declare/mod.rs

--- a/crates/test-ui/ui/global_block_not_encode.stderr
+++ b/crates/test-ui/ui/global_block_not_encode.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `Box<i32>: objc2::encode::Encode` is not satisfied
   | |_^ the trait `objc2::encode::Encode` is not implemented for `Box<i32>`
   |
   = help: the following other types implement trait `objc2::encode::Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `(Box<i32>,)` to implement `BlockArguments`
   = note: required for `GlobalBlock<(Box<i32>,)>` to implement `Sync`

--- a/crates/test-ui/ui/main_thread_only_not_allocable.stderr
+++ b/crates/test-ui/ui/main_thread_only_not_allocable.stderr
@@ -2,15 +2,15 @@ error[E0277]: the trait bound `MainThreadOnly: mutability::private::MutabilityIs
  --> ui/main_thread_only_not_allocable.rs
   |
   |     let _ = MyMainThreadOnlyClass::alloc();
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::private::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`
+  |             ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::private::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`
   |
   = help: the following other types implement trait `mutability::private::MutabilityIsAllocableAnyThread`:
-            Immutable
-            ImmutableWithMutableSubclass<MS>
-            InteriorMutable
-            Mutable
-            MutableWithImmutableSuperclass<IS>
             Root
+            Immutable
+            Mutable
+            ImmutableWithMutableSubclass<MS>
+            MutableWithImmutableSuperclass<IS>
+            InteriorMutable
   = note: required for `MyMainThreadOnlyClass` to implement `IsAllocableAnyThread`
 note: required by a bound in `objc2::ClassType::alloc`
  --> $WORKSPACE/crates/objc2/src/class_type.rs

--- a/crates/test-ui/ui/mainthreadmarker_not_send_sync.stderr
+++ b/crates/test-ui/ui/mainthreadmarker_not_send_sync.stderr
@@ -5,6 +5,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
   |                  ^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
   |
   = help: within `MainThreadMarker`, the trait `Sync` is not implemented for `*mut ()`
+  = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
  --> $RUST/core/src/marker.rs
   |
@@ -28,6 +29,7 @@ error[E0277]: `*mut ()` cannot be sent between threads safely
   |                  ^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
   |
   = help: within `MainThreadMarker`, the trait `Send` is not implemented for `*mut ()`
+  = note: consider using `std::sync::Arc<*mut ()>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `PhantomData<*mut ()>`
  --> $RUST/core/src/marker.rs
   |

--- a/crates/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -5,10 +5,10 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
   |                                  ^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -26,12 +26,12 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
   |                                    required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
-            AnyObject
             Exception
-            NSObject
             ProtocolObject<P>
-            __NSProxy
+            AnyObject
             __RcTestObject
+            NSObject
+            __NSProxy
   = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
 
 error[E0277]: the trait bound `AnyClass: Message` is not satisfied
@@ -44,12 +44,12 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
   |                                            required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
-            AnyObject
             Exception
-            NSObject
             ProtocolObject<P>
-            __NSProxy
+            AnyObject
             __RcTestObject
+            NSObject
+            __NSProxy
   = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
 
 error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -80,12 +80,12 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
   |                                           required by a bound introduced by this call
   |
   = help: the following other types implement trait `Message`:
-            AnyObject
             Exception
-            NSObject
             ProtocolObject<P>
-            __NSProxy
+            AnyObject
             __RcTestObject
+            NSObject
+            __NSProxy
   = note: required for `RetainSemantics<2>` to implement `MsgSendId<&AnyClass, Allocated<AnyClass>>`
 
 error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == Allocated<_>`
@@ -125,10 +125,10 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -173,10 +173,10 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -191,10 +191,10 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `&AnyObject`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Allocated<T>
             Id<T>
-            Option<Allocated<T>>
+            Allocated<T>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |
@@ -209,8 +209,8 @@ error[E0277]: the trait bound `Option<&AnyObject>: MaybeUnwrap` is not satisfied
   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `Option<&AnyObject>`
   |
   = help: the following other types implement trait `MaybeUnwrap`:
-            Option<Allocated<T>>
             Option<Id<T>>
+            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/mod.rs
   |

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -17,11 +17,6 @@ error[E0308]: mismatched types
   = note: expected enum `Result<i32, _>`
              found enum `Result<(), Id<_>>`
   = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: try wrapping the expression in `Err`
-  --> $WORKSPACE/crates/objc2/src/macros/mod.rs
-   |
-   |         Err(result)
-   |         ++++      +
 
 error[E0308]: mismatched types
  --> ui/msg_send_invalid_error.rs
@@ -40,14 +35,14 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
   |                                           ^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
   |
   = help: the following other types implement trait `Message`:
-            AnyObject
             Exception
-            NSAppleEventDescriptor
+            ProtocolObject<P>
+            AnyObject
             NSArray<ObjectType>
+            NSMutableArray<ObjectType>
             NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
             NSEnumerator<ObjectType>
-            NSError
-            NSHashTable<ObjectType>
           and $N others
 note: required by a bound in `__send_message_error`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs

--- a/crates/test-ui/ui/msg_send_not_encode.stderr
+++ b/crates/test-ui/ui/msg_send_not_encode.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
   |                          ^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Vec<u8>` to implement `EncodeReturn`
   = note: required for `Vec<u8>` to implement `EncodeConvertReturn`
@@ -36,14 +36,14 @@ error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
   |                     required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Vec<u8>` to implement `EncodeConvertArgument`
   = note: required for `(Vec<u8>,)` to implement `MessageArguments`
@@ -67,14 +67,14 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
   |                     required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `()` to implement `EncodeConvertArgument`
   = note: required for `((),)` to implement `MessageArguments`

--- a/crates/test-ui/ui/msg_send_only_message.stderr
+++ b/crates/test-ui/ui/msg_send_only_message.stderr
@@ -8,12 +8,12 @@ error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
   |              required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
-            &'a AnyClass
-            &'a Id<T>
-            &'a T
-            &'a mut Id<T>
-            &'a mut T
+            NonNull<T>
+            ManuallyDrop<Id<T>>
             *const AnyClass
             *const T
             *mut T
+            &'a T
+            &'a mut T
+            &'a Id<T>
           and $N others

--- a/crates/test-ui/ui/msg_send_super_not_classtype.stderr
+++ b/crates/test-ui/ui/msg_send_super_not_classtype.stderr
@@ -8,9 +8,9 @@ error[E0277]: the trait bound `AnyObject: ClassType` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
+            __RcTestObject
             NSObject
             __NSProxy
-            __RcTestObject
 note: required by a bound in `__send_super_message_static`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs
   |
@@ -30,9 +30,9 @@ error[E0277]: the trait bound `AnyObject: ClassType` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
+            __RcTestObject
             NSObject
             __NSProxy
-            __RcTestObject
 note: required by a bound in `__send_super_message_static`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs
   |

--- a/crates/test-ui/ui/not_encode.stderr
+++ b/crates/test-ui/ui/not_encode.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `Vec<u32>: Encode` is not satisfied
   |                 ^^^^^^^^ the trait `Encode` is not implemented for `Vec<u32>`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
@@ -27,14 +27,14 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
   |                 ^^ the trait `Encode` is not implemented for `()`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
@@ -49,14 +49,14 @@ error[E0277]: the trait bound `(): RefEncode` is not satisfied
   |                 ^^^ the trait `RefEncode` is not implemented for `()`
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `&()` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -72,14 +72,14 @@ error[E0277]: the trait bound `(): RefEncode` is not satisfied
   |                 ^^^^^^^^^ the trait `RefEncode` is not implemented for `()`
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `*const ()` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -126,14 +126,14 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `()`
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `((), i32)` to implement `BlockArguments`
   = note: required for `block2::Block<((), i32), ()>` to implement `RefEncode`
@@ -151,14 +151,14 @@ error[E0277]: the trait bound `fn() -> &'static (): Encode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `fn() -> &'static ()`
   |
   = help: the following other types implement trait `Encode`:
+            unsafe extern "C" fn() -> Ret
             extern "C" fn() -> Ret
+            unsafe extern "C" fn(A) -> Ret
             extern "C" fn(A) -> Ret
+            unsafe extern "C" fn(A, ...) -> Ret
             extern "C" fn(A, ...) -> Ret
+            unsafe extern "C" fn(A, B) -> Ret
             extern "C" fn(A, B) -> Ret
-            extern "C" fn(A, B, ...) -> Ret
-            extern "C" fn(A, B, C) -> Ret
-            extern "C" fn(A, B, C, ...) -> Ret
-            extern "C" fn(A, B, C, D) -> Ret
           and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
@@ -173,14 +173,14 @@ error[E0277]: the trait bound `fn(()): Encode` is not satisfied
   |                 ^^^^^^ the trait `Encode` is not implemented for `fn(())`
   |
   = help: the following other types implement trait `Encode`:
+            unsafe extern "C" fn() -> Ret
             extern "C" fn() -> Ret
+            unsafe extern "C" fn(A) -> Ret
             extern "C" fn(A) -> Ret
+            unsafe extern "C" fn(A, ...) -> Ret
             extern "C" fn(A, ...) -> Ret
+            unsafe extern "C" fn(A, B) -> Ret
             extern "C" fn(A, B) -> Ret
-            extern "C" fn(A, B, ...) -> Ret
-            extern "C" fn(A, B, C) -> Ret
-            extern "C" fn(A, B, C, ...) -> Ret
-            extern "C" fn(A, B, C, D) -> Ret
           and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
@@ -195,14 +195,14 @@ error[E0277]: the trait bound `fn(i32, ()): Encode` is not satisfied
   |                 ^^^^^^^^^^^ the trait `Encode` is not implemented for `fn(i32, ())`
   |
   = help: the following other types implement trait `Encode`:
+            unsafe extern "C" fn() -> Ret
             extern "C" fn() -> Ret
+            unsafe extern "C" fn(A) -> Ret
             extern "C" fn(A) -> Ret
+            unsafe extern "C" fn(A, ...) -> Ret
             extern "C" fn(A, ...) -> Ret
+            unsafe extern "C" fn(A, B) -> Ret
             extern "C" fn(A, B) -> Ret
-            extern "C" fn(A, B, ...) -> Ret
-            extern "C" fn(A, B, C) -> Ret
-            extern "C" fn(A, B, C, ...) -> Ret
-            extern "C" fn(A, B, C, D) -> Ret
           and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
@@ -235,14 +235,14 @@ error[E0277]: the trait bound `UnsafeCell<&u8>: OptionEncode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `UnsafeCell<&u8>`
   |
   = help: the following other types implement trait `OptionEncode`:
-            &'a T
-            &'a mut T
-            NonNull<T>
             NonNull<c_void>
-            NonZeroI16
-            NonZeroI32
-            NonZeroI64
-            NonZeroI8
+            NonNull<T>
+            objc2::runtime::Sel
+            NonZeroU8
+            NonZeroU16
+            NonZeroU32
+            NonZeroU64
+            NonZeroUsize
           and $N others
   = note: required for `Option<UnsafeCell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -258,14 +258,14 @@ error[E0277]: the trait bound `Cell<&u8>: OptionEncode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `Cell<&u8>`
   |
   = help: the following other types implement trait `OptionEncode`:
-            &'a T
-            &'a mut T
-            NonNull<T>
             NonNull<c_void>
-            NonZeroI16
-            NonZeroI32
-            NonZeroI64
-            NonZeroI8
+            NonNull<T>
+            objc2::runtime::Sel
+            NonZeroU8
+            NonZeroU16
+            NonZeroU32
+            NonZeroU64
+            NonZeroUsize
           and $N others
   = note: required for `Option<Cell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`

--- a/crates/test-ui/ui/not_encode.stderr
+++ b/crates/test-ui/ui/not_encode.stderr
@@ -223,7 +223,7 @@ note: required by a bound in `is_encode`
   | fn is_encode<T: Encode>() {}
   |                 ^^^^^^ required by this bound in `is_encode`
 help: consider removing the leading `&`-reference
-   |
+  |
 25 -     is_encode::<&Sel>();
 25 +     is_encode::<Sel>();
    |

--- a/crates/test-ui/ui/not_writeback.stderr
+++ b/crates/test-ui/ui/not_writeback.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
   |                                         ^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `&mut Id<NSObject>` to implement `Encode`
   = note: required for `&mut Id<NSObject>` to implement `EncodeReturn`
@@ -37,14 +37,14 @@ error[E0277]: the trait bound `Id<NSObject>: Encode` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AtomicI16
-            AtomicI32
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `Id<NSObject>` to implement `EncodeConvertArgument`
   = note: required for `(Id<NSObject>,)` to implement `MessageArguments`
@@ -68,14 +68,14 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `&Id<NSObject>` to implement `Encode`
   = note: required for `&Id<NSObject>` to implement `EncodeConvertArgument`
@@ -100,14 +100,14 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `&Id<NSObject>` to implement `Encode`
   = note: 1 redundant requirement hidden
@@ -134,14 +134,14 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `*mut Id<NSObject>` to implement `Encode`
   = note: required for `*mut Id<NSObject>` to implement `EncodeConvertArgument`
@@ -166,14 +166,14 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `RefEncode`:
-            &'a T
-            &'a mut T
-            *const T
-            *const c_void
-            *mut T
-            *mut c_void
-            AnyClass
-            AnyObject
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
           and $N others
   = note: required for `&mut Id<NSObject>` to implement `RefEncode`
   = note: required for `&mut &mut Id<NSObject>` to implement `Encode`

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -5,6 +5,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
   = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = note: consider using `std::sync::Arc<*const NSObject>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -39,6 +40,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                  ^^^^^^^^^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
   = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = note: consider using `std::sync::Arc<UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -78,6 +80,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
   = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = note: consider using `std::sync::Arc<*const NSObject>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -112,6 +115,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                  ^^^^^^^^^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
   = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = note: consider using `std::sync::Arc<*const UnsafeCell<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -162,6 +166,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
   = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = note: consider using `std::sync::Arc<*const NSObject>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -201,6 +206,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
   = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = note: consider using `std::sync::Arc<UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -245,6 +251,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
   = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = note: consider using `std::sync::Arc<*const NSObject>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -284,6 +291,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
   = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = note: consider using `std::sync::Arc<*const UnsafeCell<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs

--- a/crates/test-ui/ui/nsstring_as_str_use_after_release.stderr
+++ b/crates/test-ui/ui/nsstring_as_str_use_after_release.stderr
@@ -4,7 +4,7 @@ error[E0505]: cannot move out of `ns_string` because it is borrowed
   |         let ns_string = NSString::new();
   |             --------- binding `ns_string` declared here
   |         let s = ns_string.as_str(pool);
-  |                 ---------------------- borrow of `ns_string` occurs here
+  |                 --------- borrow of `ns_string` occurs here
   |         drop(ns_string);
   |              ^^^^^^^^^ move out of `ns_string` occurs here
   |         println!("{}", s);

--- a/crates/test-ui/ui/object_not_send_sync.stderr
+++ b/crates/test-ui/ui/object_not_send_sync.stderr
@@ -5,6 +5,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                  ^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
   = help: within `AnyObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = note: consider using `std::sync::Arc<UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -28,6 +29,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                  ^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
   = help: within `AnyObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = note: consider using `std::sync::Arc<*const UnsafeCell<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -62,6 +64,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                  ^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
   = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = note: consider using `std::sync::Arc<UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -90,6 +93,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                  ^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
   = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = note: consider using `std::sync::Arc<*const UnsafeCell<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -129,6 +133,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                  ^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
   = help: within `NSValue`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = note: consider using `std::sync::Arc<UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -162,6 +167,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                  ^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
   = help: within `NSValue`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = note: consider using `std::sync::Arc<*const UnsafeCell<()>>`; for more information visit <https://doc.rust-lang.org/book/ch16-03-shared-state.html>
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs

--- a/helper-scripts/run-assembly-tests.sh
+++ b/helper-scripts/run-assembly-tests.sh
@@ -4,30 +4,29 @@
 
 set -euxo pipefail
 
-ARGS="run --features=run --bin=test-assembly --  -Zbuild-std --target"
-
-# Add `+nightly` when using `-Zbuild-std` if the user's `cargo` is not a
-# `nightly` by default
+# Add `+nightly` if the user's `cargo` is not a `nightly` already
 if grep -q nightly <<< $(cargo --version); then
     NIGHTLY=""
 else
     NIGHTLY="+nightly"
 fi
 
+RUN="cargo $NIGHTLY run --bin=test-assembly --  -Zbuild-std -Zbuild-std --target"
+
 echo "Apple"
-cargo $NIGHTLY $ARGS x86_64-apple-darwin
-cargo $NIGHTLY $ARGS aarch64-apple-darwin
-cargo $NIGHTLY $ARGS armv7s-apple-ios
-cargo $NIGHTLY $ARGS armv7-apple-ios
-cargo $NIGHTLY $ARGS i386-apple-ios
+$RUN x86_64-apple-darwin
+$RUN aarch64-apple-darwin
+$RUN armv7s-apple-ios
+$RUN armv7-apple-ios
+$RUN i386-apple-ios
 
 echo "Old Apple"
-cargo $NIGHTLY $ARGS i686-apple-darwin
+$RUN i686-apple-darwin
 
 echo "GNUStep"
-cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
-cargo $NIGHTLY $ARGS i686-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
+$RUN x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
+$RUN i686-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
 
 echo "Old GNUStep"
-cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7
-cargo $NIGHTLY $ARGS i686-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7
+$RUN x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7
+$RUN i686-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7

--- a/helper-scripts/run-assembly-tests.sh
+++ b/helper-scripts/run-assembly-tests.sh
@@ -4,30 +4,30 @@
 
 set -euxo pipefail
 
-export ARGS="run --features=run --bin=test-assembly -- --target"
+ARGS="run --features=run --bin=test-assembly --  -Zbuild-std --target"
 
 # Add `+nightly` when using `-Zbuild-std` if the user's `cargo` is not a
 # `nightly` by default
 if grep -q nightly <<< $(cargo --version); then
-    export NIGHTLY=""
+    NIGHTLY=""
 else
-    export NIGHTLY="+nightly"
+    NIGHTLY="+nightly"
 fi
 
 echo "Apple"
 cargo $NIGHTLY $ARGS x86_64-apple-darwin
-cargo $NIGHTLY $ARGS aarch64-apple-darwin -Zbuild-std
-cargo $NIGHTLY $ARGS armv7s-apple-ios -Zbuild-std
-cargo $NIGHTLY $ARGS armv7-apple-ios -Zbuild-std
-cargo $NIGHTLY $ARGS i386-apple-ios -Zbuild-std
+cargo $NIGHTLY $ARGS aarch64-apple-darwin
+cargo $NIGHTLY $ARGS armv7s-apple-ios
+cargo $NIGHTLY $ARGS armv7-apple-ios
+cargo $NIGHTLY $ARGS i386-apple-ios
 
 echo "Old Apple"
-cargo $NIGHTLY $ARGS i686-apple-darwin -Zbuild-std
+cargo $NIGHTLY $ARGS i686-apple-darwin
 
 echo "GNUStep"
-cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu -Zbuild-std --no-default-features --features=std,gnustep-2-1
-cargo $NIGHTLY $ARGS i686-unknown-linux-gnu -Zbuild-std --no-default-features --features=std,gnustep-2-1
+cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
+cargo $NIGHTLY $ARGS i686-unknown-linux-gnu --no-default-features --features=std,gnustep-2-1
 
 echo "Old GNUStep"
-cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu -Zbuild-std --no-default-features --features=std,gnustep-1-7
-cargo $NIGHTLY $ARGS i686-unknown-linux-gnu -Zbuild-std --no-default-features --features=std,gnustep-1-7
+cargo $NIGHTLY $ARGS x86_64-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7
+cargo $NIGHTLY $ARGS i686-unknown-linux-gnu --no-default-features --features=std,gnustep-1-7


### PR DESCRIPTION
A change in `rustc` dead code elimination causes the `UTF16` in `ns_string!` to appear in the assembly output; tracking that in https://github.com/madsmtm/objc2/issues/258.

UI tests triage: Have mostly improved, the changed ordering for "help: the following other types implement trait ..." are nice, except for `MethodImplementation`, that one is still mostly gibberish.
Also, spans inside `declare_class!` have now been fixed, such that the erring function is reported, which is _really_ nice!