### PR TITLE
Fix protocol names

### DIFF
--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -65,6 +65,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to use in such hashing collections.
 * **BREAKING**: Added `HasStableHash` requirement on `NSDictionary` and
   `NSSet` creation methods, fixing a long-standing soundess issue.
+* Fixed the protocol names of `NSAccessibilityElementProtocol`,
+  `NSTextAttachmentCellProtocol` and `NSFileProviderItemProtocol`.
 
 
 ## icrate 0.0.4 - 2023-07-31

--- a/crates/icrate/examples/browser.rs
+++ b/crates/icrate/examples/browser.rs
@@ -73,6 +73,8 @@ declare_class!(
         }
     }
 
+    unsafe impl NSObjectProtocol for Delegate {}
+
     unsafe impl NSApplicationDelegate for Delegate {
         #[method(applicationDidFinishLaunching:)]
         #[allow(non_snake_case)]
@@ -292,8 +294,6 @@ impl Delegate {
         unsafe { msg_send_id![mtm.alloc(), init] }
     }
 }
-
-unsafe impl NSObjectProtocol for Delegate {}
 
 fn main() {
     let mtm = MainThreadMarker::new().unwrap();

--- a/crates/icrate/examples/delegate.rs
+++ b/crates/icrate/examples/delegate.rs
@@ -50,6 +50,8 @@ declare_class!(
         }
     }
 
+    unsafe impl NSObjectProtocol for AppDelegate {}
+
     unsafe impl NSApplicationDelegate for AppDelegate {
         #[method(applicationDidFinishLaunching:)]
         fn did_finish_launching(&self, notification: &NSNotification) {
@@ -64,8 +66,6 @@ declare_class!(
         }
     }
 );
-
-unsafe impl NSObjectProtocol for AppDelegate {}
 
 impl AppDelegate {
     pub fn new(ivar: u8, another_ivar: bool, mtm: MainThreadMarker) -> Id<Self> {

--- a/crates/icrate/examples/metal.rs
+++ b/crates/icrate/examples/metal.rs
@@ -31,21 +31,21 @@ use objc2::{
 #[rustfmt::skip]
 const SHADERS: &str = r#"
     #include <metal_stdlib>
-        
+
     struct SceneProperties {
         float time;
-    };        
-    
+    };
+
     struct VertexInput {
         metal::packed_float3 position;
         metal::packed_float3 color;
     };
-    
+
     struct VertexOutput {
         metal::float4 position [[position]];
         metal::float4 color;
     };
-    
+
     vertex VertexOutput vertex_main(
         device const SceneProperties& properties [[buffer(0)]],
         device const VertexInput* vertices [[buffer(1)]],
@@ -64,7 +64,7 @@ const SHADERS: &str = r#"
         out.color = metal::float4(in.color, 1);
         return out;
     }
-    
+
     fragment metal::float4 fragment_main(VertexOutput in [[stage_in]]) {
         return in.color;
     }
@@ -154,6 +154,8 @@ declare_class!(
             })
         }
     }
+
+    unsafe impl NSObjectProtocol for Delegate {}
 
     // define the delegate methods for the `NSApplicationDelegate` protocol
     unsafe impl NSApplicationDelegate for Delegate {
@@ -355,8 +357,6 @@ declare_class!(
         }
     }
 );
-
-unsafe impl NSObjectProtocol for Delegate {}
 
 impl Delegate {
     pub fn new(mtm: MainThreadMarker) -> Id<Self> {

--- a/crates/icrate/src/fixes/Foundation/copying.rs
+++ b/crates/icrate/src/fixes/Foundation/copying.rs
@@ -41,9 +41,7 @@ extern_protocol!(
             Self: CounterpartOrSelf;
     }
 
-    unsafe impl ProtocolType for dyn NSCopying {
-        const NAME: &'static str = "NSCopying";
-    }
+    unsafe impl ProtocolType for dyn NSCopying {}
 );
 
 // FIXME: Remove this hack which makes NSMutableDictionary tests work
@@ -86,7 +84,5 @@ extern_protocol!(
             Self: CounterpartOrSelf;
     }
 
-    unsafe impl ProtocolType for dyn NSMutableCopying {
-        const NAME: &'static str = "NSMutableCopying";
-    }
+    unsafe impl ProtocolType for dyn NSMutableCopying {}
 );

--- a/crates/icrate/tests/renamed_protocols.rs
+++ b/crates/icrate/tests/renamed_protocols.rs
@@ -1,0 +1,9 @@
+#![cfg(feature = "AppKit")]
+use icrate::AppKit::NSAccessibilityElementProtocol;
+use objc2::ProtocolType;
+
+#[test]
+fn accessibility_element_protocol() {
+    let actual: &str = <dyn NSAccessibilityElementProtocol>::NAME;
+    assert_eq!(actual, "NSAccessibilityElement");
+}

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * Fixed the name of the protocol that `NSObjectProtocol` references.
 
+### Removed
+* **BREAKING**: Removed `ProtocolType` implementation for `NSObject`.
+  Use the more precise `NSObjectProtocol` trait instead!
+
 
 ## 0.4.1 - 2023-07-31
 

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ];
   ```
 
+### Fixed
+* Fixed the name of the protocol that `NSObjectProtocol` references.
+
 
 ## 0.4.1 - 2023-07-31
 

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -259,6 +259,8 @@
 /// #       }
 ///     }
 ///
+///     unsafe impl NSObjectProtocol for MyCustomObject {}
+///
 ///     # #[cfg(available_in_icrate)]
 ///     unsafe impl NSCopying for MyCustomObject {
 ///         #[method_id(copyWithZone:)]
@@ -273,9 +275,6 @@
 ///         // `verify` feature enabled.
 ///     }
 /// );
-///
-/// // TODO: Allow moving this inside `declare_class!`
-/// unsafe impl NSObjectProtocol for MyCustomObject {}
 ///
 /// impl MyCustomObject {
 ///     pub fn new(foo: u8) -> Id<Self> {

--- a/crates/objc2/src/protocol_type.rs
+++ b/crates/objc2/src/protocol_type.rs
@@ -23,10 +23,10 @@ use crate::runtime::AnyProtocol;
 ///
 /// ```
 /// use objc2::ProtocolType;
-/// use objc2::runtime::NSObject;
-/// // Get a protocol object representing `NSObject`
-/// let protocol = NSObject::protocol().expect("NSObject to have a protocol");
-/// assert_eq!(NSObject::NAME, protocol.name());
+/// use objc2::runtime::NSObjectProtocol;
+/// // Get a protocol object representing the `NSObject` protocol
+/// let protocol = <dyn NSObjectProtocol>::protocol().expect("NSObject to have a protocol");
+/// assert_eq!(<dyn NSObjectProtocol>::NAME, protocol.name());
 /// ```
 ///
 /// Use the [`extern_protocol!`] macro to implement this trait for a type.

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -165,7 +165,7 @@ crate::__inner_extern_protocol!(
     ()
     (NSObjectProtocol)
     (dyn NSObjectProtocol)
-    ("NSCopying")
+    ("NSObject")
 );
 
 unsafe impl NSObjectProtocol for NSObject {}
@@ -371,5 +371,11 @@ mod tests {
         let ptr2 = Id::as_ptr(&obj2);
 
         assert_eq!(ptr1, ptr2);
+    }
+
+    #[test]
+    fn conforms_to_nsobjectprotocol() {
+        let protocol = <dyn NSObjectProtocol>::protocol().unwrap();
+        assert!(NSObject::class().conforms_to(protocol));
     }
 }

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -3,7 +3,7 @@ use core::hash;
 
 use crate::mutability::Root;
 use crate::rc::{DefaultId, Id};
-use crate::runtime::{AnyClass, AnyObject, AnyProtocol, ImplementedBy, ProtocolObject};
+use crate::runtime::{AnyClass, AnyObject, ProtocolObject};
 use crate::{extern_methods, msg_send, msg_send_id, Message};
 use crate::{ClassType, ProtocolType};
 
@@ -170,26 +170,6 @@ crate::__inner_extern_protocol!(
 
 unsafe impl NSObjectProtocol for NSObject {}
 
-unsafe impl ProtocolType for NSObject {
-    const NAME: &'static str = "NSObject";
-
-    fn protocol() -> Option<&'static AnyProtocol> {
-        Some(
-            AnyProtocol::get(<Self as ProtocolType>::NAME)
-                .expect("could not find NSObject protocol"),
-        )
-    }
-
-    const __INNER: () = ();
-}
-
-unsafe impl<T> ImplementedBy<T> for NSObject
-where
-    T: ?Sized + Message + NSObjectProtocol,
-{
-    const __INNER: () = ();
-}
-
 extern_methods!(
     unsafe impl NSObject {
         /// Create a new empty `NSObject`.
@@ -234,7 +214,7 @@ impl fmt::Debug for NSObject {
     #[doc(alias = "description")]
     #[doc(alias = "debugDescription")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let obj: &ProtocolObject<NSObject> = ProtocolObject::from_ref(self);
+        let obj: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(self);
         obj.fmt(f)
     }
 }

--- a/crates/objc2/src/runtime/nsproxy.rs
+++ b/crates/objc2/src/runtime/nsproxy.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::hash;
 
 use crate::mutability::Root;
-use crate::runtime::{AnyClass, AnyObject, NSObject, NSObjectProtocol, ProtocolObject};
+use crate::runtime::{AnyClass, AnyObject, NSObjectProtocol, ProtocolObject};
 use crate::ClassType;
 
 crate::__emit_struct! {
@@ -97,7 +97,7 @@ impl fmt::Debug for NSProxy {
     #[doc(alias = "description")]
     #[doc(alias = "debugDescription")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let obj: &ProtocolObject<NSObject> = ProtocolObject::from_ref(self);
+        let obj: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(self);
         obj.fmt(f)
     }
 }

--- a/crates/objc2/src/runtime/protocol_object.rs
+++ b/crates/objc2/src/runtime/protocol_object.rs
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn impl_traits() {
         assert_impl_all!(NSObject: NSObjectProtocol);
-        assert_impl_all!(ProtocolObject<NSObject>: NSObjectProtocol);
+        assert_impl_all!(ProtocolObject<dyn NSObjectProtocol>: NSObjectProtocol);
         assert_not_impl_any!(ProtocolObject<dyn Foo>: NSObjectProtocol);
         assert_impl_all!(ProtocolObject<dyn Bar>: NSObjectProtocol);
         assert_impl_all!(ProtocolObject<dyn FooBar>: NSObjectProtocol);
@@ -280,7 +280,7 @@ mod tests {
         assert_impl_all!(DummyClass: NSObjectProtocol);
 
         assert_not_impl_any!(NSObject: Foo);
-        assert_not_impl_any!(ProtocolObject<NSObject>: Foo);
+        assert_not_impl_any!(ProtocolObject<dyn NSObjectProtocol>: Foo);
         assert_impl_all!(ProtocolObject<dyn Foo>: Foo);
         assert_not_impl_any!(ProtocolObject<dyn Bar>: Foo);
         assert_impl_all!(ProtocolObject<dyn FooBar>: Foo);
@@ -288,7 +288,7 @@ mod tests {
         assert_impl_all!(DummyClass: Foo);
 
         assert_not_impl_any!(NSObject: Bar);
-        assert_not_impl_any!(ProtocolObject<NSObject>: Bar);
+        assert_not_impl_any!(ProtocolObject<dyn NSObjectProtocol>: Bar);
         assert_not_impl_any!(ProtocolObject<dyn Foo>: Bar);
         assert_impl_all!(ProtocolObject<dyn Bar>: Bar);
         assert_impl_all!(ProtocolObject<dyn FooBar>: Bar);
@@ -296,7 +296,7 @@ mod tests {
         assert_impl_all!(DummyClass: Bar);
 
         assert_not_impl_any!(NSObject: FooBar);
-        assert_not_impl_any!(ProtocolObject<NSObject>: FooBar);
+        assert_not_impl_any!(ProtocolObject<dyn NSObjectProtocol>: FooBar);
         assert_not_impl_any!(ProtocolObject<dyn Foo>: FooBar);
         assert_not_impl_any!(ProtocolObject<dyn Bar>: FooBar);
         assert_impl_all!(ProtocolObject<dyn FooBar>: FooBar);
@@ -304,7 +304,7 @@ mod tests {
         assert_impl_all!(DummyClass: FooBar);
 
         assert_not_impl_any!(NSObject: FooFooBar);
-        assert_not_impl_any!(ProtocolObject<NSObject>: FooFooBar);
+        assert_not_impl_any!(ProtocolObject<dyn NSObjectProtocol>: FooFooBar);
         assert_not_impl_any!(ProtocolObject<dyn Foo>: FooFooBar);
         assert_not_impl_any!(ProtocolObject<dyn Bar>: FooFooBar);
         assert_not_impl_any!(ProtocolObject<dyn FooBar>: FooFooBar);
@@ -326,10 +326,10 @@ mod tests {
         let foo: &ProtocolObject<dyn Foo> = ProtocolObject::from_ref(&*obj);
         let _foo: &ProtocolObject<dyn Foo> = ProtocolObject::from_ref(foo);
 
-        let _nsobject: &ProtocolObject<NSObject> = ProtocolObject::from_ref(foobar);
-        let _nsobject: &ProtocolObject<NSObject> = ProtocolObject::from_ref(bar);
-        let nsobject: &ProtocolObject<NSObject> = ProtocolObject::from_ref(&*obj);
-        let _nsobject: &ProtocolObject<NSObject> = ProtocolObject::from_ref(nsobject);
+        let _nsobject: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(foobar);
+        let _nsobject: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(bar);
+        let nsobject: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(&*obj);
+        let _nsobject: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(nsobject);
 
         let _foobar: &mut ProtocolObject<dyn FooBar> = ProtocolObject::from_mut(&mut *obj);
         let _foobar: Id<ProtocolObject<dyn FooBar>> = ProtocolObject::from_id(obj);

--- a/crates/objc2/src/runtime/protocol_object.rs
+++ b/crates/objc2/src/runtime/protocol_object.rs
@@ -253,7 +253,14 @@ mod tests {
             type Mutability = Mutable;
             const NAME: &'static str = "ProtocolTestsDummyClass";
         }
+
+        unsafe impl NSObjectProtocol for DummyClass {}
     );
+
+    unsafe impl Foo for DummyClass {}
+    unsafe impl Bar for DummyClass {}
+    unsafe impl FooBar for DummyClass {}
+    // unsafe impl FooFooBar for DummyClass {}
 
     extern_methods!(
         unsafe impl DummyClass {
@@ -261,12 +268,6 @@ mod tests {
             fn new() -> Id<Self>;
         }
     );
-
-    unsafe impl NSObjectProtocol for DummyClass {}
-    unsafe impl Foo for DummyClass {}
-    unsafe impl Bar for DummyClass {}
-    unsafe impl FooBar for DummyClass {}
-    // unsafe impl FooFooBar for DummyClass {}
 
     #[test]
     fn impl_traits() {

--- a/crates/tests/src/test_object.rs
+++ b/crates/tests/src/test_object.rs
@@ -326,6 +326,6 @@ fn test_protocol() {
     #[cfg(feature = "Foundation_all")]
     assert_eq!(MyTestObject::h().as_i32(), 8);
 
-    // Check that transforming to `NSObject` works
-    let _obj: &ProtocolObject<NSObject> = ProtocolObject::from_ref(&*proto);
+    // Check that transforming to `NSObjectProtocol` works
+    let _obj: &ProtocolObject<dyn NSObjectProtocol> = ProtocolObject::from_ref(&*proto);
 }


### PR DESCRIPTION
Fix protocol names of renamed protocols `NSObjectProtocol`, `NSAccessibilityElementProtocol`, `NSTextAttachmentCellProtocol` and `NSFileProviderItemProtocol`.

This also fixes the issue with declaring conformance to the `NSObjectProtocol` in `declare_class!`, so that's really nice!