### PR TITLE
Fix main thread requirements on protocols

### DIFF
--- a/crates/header-translator/src/cache.rs
+++ b/crates/header-translator/src/cache.rs
@@ -13,23 +13,44 @@ use crate::Mutability;
 #[derive(Debug, PartialEq, Clone)]
 pub struct Cache<'a> {
     config: &'a Config,
-    mainthreadonly_classes: BTreeSet<ItemIdentifier>,
+    mainthreadonly_items: BTreeSet<ItemIdentifier>,
 }
 
 impl<'a> Cache<'a> {
     pub fn new(output: &Output, config: &'a Config) -> Self {
-        let mut mainthreadonly_classes = BTreeSet::new();
+        let mut mainthreadonly_items = BTreeSet::new();
 
         for library in output.libraries.values() {
             for file in library.files.values() {
                 for stmt in file.stmts.iter() {
-                    if let Stmt::ClassDecl {
-                        id,
-                        mutability: Mutability::MainThreadOnly,
-                        ..
-                    } = stmt
-                    {
-                        mainthreadonly_classes.insert(id.clone());
+                    match stmt {
+                        Stmt::ClassDecl {
+                            id,
+                            mutability: Mutability::MainThreadOnly,
+                            ..
+                        } => {
+                            mainthreadonly_items.insert(id.clone());
+                        }
+                        Stmt::ProtocolDecl {
+                            id,
+                            required_mainthreadonly: true,
+                            ..
+                        } => {
+                            mainthreadonly_items.insert(id.clone());
+                        }
+                        Stmt::ProtocolDecl {
+                            id,
+                            required_mainthreadonly: false,
+                            protocols,
+                            ..
+                        } => {
+                            for protocol in protocols {
+                                if mainthreadonly_items.contains(protocol) {
+                                    let _ = mainthreadonly_items.insert(id.clone());
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -37,7 +58,7 @@ impl<'a> Cache<'a> {
 
         Self {
             config,
-            mainthreadonly_classes,
+            mainthreadonly_items,
         }
     }
 
@@ -100,7 +121,7 @@ impl<'a> Cache<'a> {
                     for method in methods.iter_mut() {
                         let mut result_type_contains_mainthreadonly: bool = false;
                         method.result_type.visit_required_types(&mut |id| {
-                            if self.mainthreadonly_classes.contains(id) {
+                            if self.mainthreadonly_items.contains(id) {
                                 result_type_contains_mainthreadonly = true;
                             }
                         });
@@ -111,13 +132,13 @@ impl<'a> Cache<'a> {
                             // include optional arguments like `Option<&NSView>` or
                             // `&NSArray<NSView>`.
                             argument.visit_toplevel_types(&mut |id| {
-                                if self.mainthreadonly_classes.contains(id) {
+                                if self.mainthreadonly_items.contains(id) {
                                     any_argument_contains_mainthreadonly = true;
                                 }
                             });
                         }
 
-                        if self.mainthreadonly_classes.contains(id) {
+                        if self.mainthreadonly_items.contains(id) {
                             if method.is_class {
                                 // Assume the method needs main thread if it's
                                 // declared on a main thread only class.

--- a/crates/header-translator/src/config.rs
+++ b/crates/header-translator/src/config.rs
@@ -146,6 +146,9 @@ pub struct ProtocolData {
     #[serde(default)]
     pub skipped: bool,
     #[serde(default)]
+    #[serde(rename = "requires-mainthreadonly")]
+    pub requires_mainthreadonly: Option<bool>,
+    #[serde(default)]
     pub methods: HashMap<String, MethodData>,
 }
 

--- a/crates/header-translator/src/data/AppKit.rs
+++ b/crates/header-translator/src/data/AppKit.rs
@@ -30,6 +30,13 @@ data! {
         // `run` cannot be safe, the user must ensure there is no re-entrancy.
     }
 
+    class NSController: MainThreadOnly {}
+    class NSObjectController: MainThreadOnly {}
+    class NSArrayController: MainThreadOnly {}
+    class NSDictionaryController: MainThreadOnly {}
+    class NSTreeController: MainThreadOnly {}
+    class NSUserDefaultsController: MainThreadOnly {}
+
     // Documentation says:
     // > Color objects are immutable and thread-safe
     //
@@ -37,6 +44,8 @@ data! {
     class NSColor: Immutable {
         unsafe -clear;
     }
+
+    class NSColorPicker: MainThreadOnly {}
 
     class NSControl {
         unsafe -isEnabled;
@@ -80,6 +89,8 @@ data! {
     class NSEvent: Immutable {
 
     }
+
+    class NSFontManager: MainThreadOnly {}
 
     // Documented Thread-Unsafe, but:
     // > One thread can create an NSImage object, draw to the image buffer,

--- a/crates/header-translator/src/data/Automator.rs
+++ b/crates/header-translator/src/data/Automator.rs
@@ -1,2 +1,3 @@
 data! {
+    class AMWorkflowController: MainThreadOnly {}
 }

--- a/crates/header-translator/src/data/OSAKit.rs
+++ b/crates/header-translator/src/data/OSAKit.rs
@@ -1,2 +1,3 @@
 data! {
+    class OSAScriptController: MainThreadOnly {}
 }

--- a/crates/header-translator/src/id.rs
+++ b/crates/header-translator/src/id.rs
@@ -1,4 +1,6 @@
+use core::cmp::Ordering;
 use core::fmt;
+use core::hash;
 
 use clang::Entity;
 
@@ -20,7 +22,7 @@ impl ToOptionString for Option<String> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone)]
 pub struct ItemIdentifier<N = String> {
     /// Names in Objective-C are global, so this is always enough to uniquely
     /// identify the item.
@@ -29,6 +31,32 @@ pub struct ItemIdentifier<N = String> {
     pub name: N,
     pub library: String,
     pub file_name: Option<String>,
+}
+
+impl<N: PartialEq> PartialEq for ItemIdentifier<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl<N: Eq> Eq for ItemIdentifier<N> {}
+
+impl<N: hash::Hash> hash::Hash for ItemIdentifier<N> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl<N: Ord> PartialOrd for ItemIdentifier<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<N: Ord> Ord for ItemIdentifier<N> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
 }
 
 impl<N: ToOptionString> ItemIdentifier<N> {

--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -700,8 +700,7 @@ impl fmt::Display for Method {
             let param = handle_reserved(&crate::to_snake_case(param));
             write!(f, "{param}: {arg_ty}, ")?;
         }
-        // FIXME: Skipping main thread only on protocols for now
-        if self.mainthreadonly && !self.is_protocol {
+        if self.mainthreadonly {
             write!(f, "mtm: MainThreadMarker")?;
         }
         write!(f, ")")?;

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -852,6 +852,20 @@ skipped = true
 [class.NSCollectionViewDiffableDataSource.methods.initWithCollectionView_itemProvider]
 skipped = true
 
+# Requires `MainThreadOnly`, which I'm not sure is a good idea here?
+[class.NSCollectionViewDiffableDataSource]
+skipped-protocols = ["NSCollectionViewDataSource"]
+[class.NSManagedObjectContext]
+skipped-protocols = ["NSEditor", "NSEditorRegistration"]
+
+# Most methods on these require MainThreadMarker anyhow
+[protocol.NSDraggingInfo]
+requires-mainthreadonly = true
+[protocol.NSBrowserDelegate]
+requires-mainthreadonly = true
+[protocol.NSSplitViewDelegate]
+requires-mainthreadonly = true
+
 # Both protocols and classes
 [protocol.NSTextAttachmentCell]
 renamed = "NSTextAttachmentCellProtocol"
@@ -1614,7 +1628,7 @@ skipped-protocols = ["NSCopying", "NSMutableCopying"]
 skipped-protocols = ["NSCopying", "NSMutableCopying"]
 
 # Uses `NS_SWIFT_UI_ACTOR` on a static, which is hard to support.
-# 
+#
 # Will have to be a method that takes `MainThreadMarker`.
 [static.NSApp]
 skipped = true

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -67,6 +67,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `NSSet` creation methods, fixing a long-standing soundess issue.
 * Fixed the protocol names of `NSAccessibilityElementProtocol`,
   `NSTextAttachmentCellProtocol` and `NSFileProviderItemProtocol`.
+* **BREAKING**: Generic types no longer strictly require `Message` (although
+  most of their trait implementations still require that).
 
 
 ## icrate 0.0.4 - 2023-07-31

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -31,9 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `MTLAccelerationStructureCommandEncoder` now take a nullable scratch buffer:
   - `refitAccelerationStructure_descriptor_destination_scratchBuffer_scratchBufferOffset`
   - `refitAccelerationStructure_descriptor_destination_scratchBuffer_scratchBufferOffset_options`
-* **BREAKING**: Marked UI-related types as `MainThreadOnly`. This means that
-  they can now only be constructed on the main thread, meaning you have to
-  aquire a `MainThreadMarker` first.
+* **BREAKING**: Marked UI-related classes as `MainThreadOnly`, and UI-related
+  protocols as `IsMainThreadOnly`.
+
+  This means that they can now only be constructed, retrieved and used on the
+  main thread, meaning you usually have to aquire a `MainThreadMarker` first.
 
   ```rust
   // Before

--- a/crates/icrate/src/additions/Foundation/array.rs
+++ b/crates/icrate/src/additions/Foundation/array.rs
@@ -391,7 +391,7 @@ __impl_iter! {
 pub struct IterMut<'a, T: Message>(iter::IterMut<'a, NSArray<T>>);
 
 __impl_iter! {
-    impl<'a, T: IsMutable> Iterator<Item = &'a mut T> for IterMut<'a, T> { ... }
+    impl<'a, T: Message + IsMutable> Iterator<Item = &'a mut T> for IterMut<'a, T> { ... }
 }
 
 /// An iterator that retains the items of a `NSArray`.
@@ -399,7 +399,7 @@ __impl_iter! {
 pub struct IterRetained<'a, T: Message>(iter::IterRetained<'a, NSArray<T>>);
 
 __impl_iter! {
-    impl<'a, T: IsIdCloneable> Iterator<Item = Id<T>> for IterRetained<'a, T> { ... }
+    impl<'a, T: Message + IsIdCloneable> Iterator<Item = Id<T>> for IterRetained<'a, T> { ... }
 }
 
 /// A consuming iterator over the items of a `NSArray`.
@@ -420,16 +420,16 @@ __impl_into_iter! {
         type IntoIter = Iter<'_, T>;
     }
 
-    impl<T: IsMutable> IntoIterator for &mut NSArray<T> {
+    impl<T: Message + IsMutable> IntoIterator for &mut NSArray<T> {
         type IntoIter = IterMut<'_, T>;
     }
 
     #[cfg(feature = "Foundation_NSMutableArray")]
-    impl<T: IsMutable> IntoIterator for &mut NSMutableArray<T> {
+    impl<T: Message + IsMutable> IntoIterator for &mut NSMutableArray<T> {
         type IntoIter = IterMut<'_, T>;
     }
 
-    impl<T: IsIdCloneable> IntoIterator for Id<NSArray<T>> {
+    impl<T: Message + IsIdCloneable> IntoIterator for Id<NSArray<T>> {
         type IntoIter = IntoIter<T>;
     }
 
@@ -456,14 +456,14 @@ impl<T: Message> Index<usize> for NSMutableArray<T> {
     }
 }
 
-impl<T: IsMutable> IndexMut<usize> for NSArray<T> {
+impl<T: Message + IsMutable> IndexMut<usize> for NSArray<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index).unwrap()
     }
 }
 
 #[cfg(feature = "Foundation_NSMutableArray")]
-impl<T: IsMutable> IndexMut<usize> for NSMutableArray<T> {
+impl<T: Message + IsMutable> IndexMut<usize> for NSMutableArray<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index).unwrap()
     }
@@ -484,7 +484,7 @@ impl<T: Message> Extend<Id<T>> for NSMutableArray<T> {
 }
 
 #[cfg(feature = "Foundation_NSMutableArray")]
-impl<'a, T: IsRetainable> Extend<&'a T> for NSMutableArray<T> {
+impl<'a, T: Message + IsRetainable> Extend<&'a T> for NSMutableArray<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         // SAFETY: Because of the `T: IsRetainable` bound, it is safe for the
         // array to retain the object here.
@@ -493,7 +493,7 @@ impl<'a, T: IsRetainable> Extend<&'a T> for NSMutableArray<T> {
     }
 }
 
-impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSArray<T> {
+impl<'a, T: Message + IsRetainable + 'a> IdFromIterator<&'a T> for NSArray<T> {
     fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
         let vec = Vec::from_iter(iter);
         Self::from_slice(&vec)
@@ -508,7 +508,7 @@ impl<T: Message> IdFromIterator<Id<T>> for NSArray<T> {
 }
 
 #[cfg(feature = "Foundation_NSMutableArray")]
-impl<'a, T: IsRetainable + 'a> IdFromIterator<&'a T> for NSMutableArray<T> {
+impl<'a, T: Message + IsRetainable + 'a> IdFromIterator<&'a T> for NSMutableArray<T> {
     fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
         let vec = Vec::from_iter(iter);
         Self::from_slice(&vec)

--- a/crates/icrate/src/additions/Foundation/dictionary.rs
+++ b/crates/icrate/src/additions/Foundation/dictionary.rs
@@ -516,7 +516,7 @@ mod iter_helpers {
     );
 
     __impl_iter! {
-        impl<'a, K: IsIdCloneable, V: Message> Iterator<Item = Id<K>> for KeysRetained<'a, K, V> { ... }
+        impl<'a, K: Message + IsIdCloneable, V: Message> Iterator<Item = Id<K>> for KeysRetained<'a, K, V> { ... }
     }
 
     /// An iterator over the values of a `NSDictionary`.
@@ -536,7 +536,7 @@ mod iter_helpers {
     );
 
     __impl_iter! {
-        impl<'a, K: Message, V: IsMutable> Iterator<Item = &'a mut V> for ValuesMut<'a, K, V> { ... }
+        impl<'a, K: Message, V: Message + IsMutable> Iterator<Item = &'a mut V> for ValuesMut<'a, K, V> { ... }
     }
 
     /// A iterator that retains the values of a `NSDictionary`.
@@ -546,7 +546,7 @@ mod iter_helpers {
     );
 
     __impl_iter! {
-        impl<'a, K: Message, V: IsIdCloneable> Iterator<Item = Id<V>> for ValuesRetained<'a, K, V> { ... }
+        impl<'a, K: Message, V: Message + IsIdCloneable> Iterator<Item = Id<V>> for ValuesRetained<'a, K, V> { ... }
     }
 
     /// A consuming iterator over the values of a `NSDictionary`.
@@ -580,14 +580,16 @@ impl<'a, K: Message + Eq + Hash, V: Message> Index<&'a K> for NSMutableDictionar
     }
 }
 
-impl<'a, K: Message + Eq + Hash, V: IsMutable> IndexMut<&'a K> for NSDictionary<K, V> {
+impl<'a, K: Message + Eq + Hash, V: Message + IsMutable> IndexMut<&'a K> for NSDictionary<K, V> {
     fn index_mut<'s>(&'s mut self, index: &'a K) -> &'s mut V {
         self.get_mut(index).unwrap()
     }
 }
 
 #[cfg(feature = "Foundation_NSMutableDictionary")]
-impl<'a, K: Message + Eq + Hash, V: IsMutable> IndexMut<&'a K> for NSMutableDictionary<K, V> {
+impl<'a, K: Message + Eq + Hash, V: Message + IsMutable> IndexMut<&'a K>
+    for NSMutableDictionary<K, V>
+{
     fn index_mut<'s>(&'s mut self, index: &'a K) -> &'s mut V {
         self.get_mut(index).unwrap()
     }

--- a/crates/icrate/src/additions/Foundation/enumerator.rs
+++ b/crates/icrate/src/additions/Foundation/enumerator.rs
@@ -1,7 +1,5 @@
 //! Utilities for the `NSEnumerator` class.
 #![cfg(feature = "Foundation_NSEnumerator")]
-use objc2::mutability::{IsIdCloneable, IsMutable};
-
 use super::iter;
 use crate::common::*;
 use crate::Foundation::NSEnumerator;

--- a/crates/icrate/src/additions/Foundation/iter.rs
+++ b/crates/icrate/src/additions/Foundation/iter.rs
@@ -428,7 +428,7 @@ impl<C: FastEnumerationHelper> IntoIter<C> {
         }
     }
 
-    pub(crate) fn new_mutable<T: IsMutable + ClassType<Super = C>>(collection: Id<T>) -> Self
+    pub(crate) fn new_mutable<T: ClassType<Super = C> + IsMutable>(collection: Id<T>) -> Self
     where
         C: IsIdCloneable,
     {
@@ -648,7 +648,7 @@ where
         }
     }
 
-    pub(crate) unsafe fn new_mutable<T: IsMutable + ClassType<Super = C>>(
+    pub(crate) unsafe fn new_mutable<T: ClassType<Super = C> + IsMutable>(
         collection: Id<T>,
         enumerator: Id<E>,
     ) -> Self
@@ -696,9 +696,9 @@ where
 #[doc(hidden)]
 macro_rules! __impl_iter {
     (
-        impl<$($lifetime:lifetime, )? $t1:ident: $bound1:ident $(, $t2:ident: $bound2:ident)?> Iterator<Item = $item:ty> for $for:ty { ... }
+        impl<$($lifetime:lifetime, )? $t1:ident: $bound1:ident $(+ $bound1_b:ident)? $(, $t2:ident: $bound2:ident $(+ $bound2_b:ident)?)?> Iterator<Item = $item:ty> for $for:ty { ... }
     ) => {
-        impl<$($lifetime, )? $t1: $bound1 $(, $t2: $bound2)?> Iterator for $for {
+        impl<$($lifetime, )? $t1: $bound1 $(+ $bound1_b)? $(, $t2: $bound2 $(+ $bound2_b)?)?> Iterator for $for {
             type Item = $item;
 
             #[inline]
@@ -743,14 +743,14 @@ macro_rules! __impl_into_iter {
     };
     (
         $(#[$m:meta])*
-        impl<T: IsMutable> IntoIterator for &mut $ty:ident<T> {
+        impl<T: Message + IsMutable> IntoIterator for &mut $ty:ident<T> {
             type IntoIter = $iter_mut:ident<'_, T>;
         }
 
         $($rest:tt)*
     ) => {
         $(#[$m])*
-        impl<'a, T: IsMutable> IntoIterator for &'a mut $ty<T> {
+        impl<'a, T: Message + IsMutable> IntoIterator for &'a mut $ty<T> {
             type Item = &'a mut T;
             type IntoIter = $iter_mut<'a, T>;
 
@@ -766,14 +766,14 @@ macro_rules! __impl_into_iter {
     };
     (
         $(#[$m:meta])*
-        impl<T: IsIdCloneable> IntoIterator for Id<$ty:ident<T>> {
+        impl<T: Message + IsIdCloneable> IntoIterator for Id<$ty:ident<T>> {
             type IntoIter = $into_iter:ident<T>;
         }
 
         $($rest:tt)*
     ) => {
         $(#[$m])*
-        impl<T: IsIdCloneable> objc2::rc::IdIntoIterator for $ty<T> {
+        impl<T: Message + IsIdCloneable> objc2::rc::IdIntoIterator for $ty<T> {
             type Item = Id<T>;
             type IntoIter = $into_iter<T>;
 

--- a/crates/icrate/src/additions/Foundation/set.rs
+++ b/crates/icrate/src/additions/Foundation/set.rs
@@ -501,7 +501,7 @@ __impl_iter! {
 pub struct IterRetained<'a, T: Message>(iter::IterRetained<'a, NSSet<T>>);
 
 __impl_iter! {
-    impl<'a, T: IsIdCloneable> Iterator<Item = Id<T>> for IterRetained<'a, T> { ... }
+    impl<'a, T: Message + IsIdCloneable> Iterator<Item = Id<T>> for IterRetained<'a, T> { ... }
 }
 
 /// A consuming iterator over the items of a `NSSet`.
@@ -522,7 +522,7 @@ __impl_into_iter! {
         type IntoIter = Iter<'_, T>;
     }
 
-    impl<T: IsIdCloneable> IntoIterator for Id<NSSet<T>> {
+    impl<T: Message + IsIdCloneable> IntoIterator for Id<NSSet<T>> {
         type IntoIter = IntoIter<T>;
     }
 
@@ -549,7 +549,7 @@ impl<T: Message + Eq + Hash + HasStableHash> Extend<Id<T>> for NSMutableSet<T> {
 }
 
 #[cfg(feature = "Foundation_NSMutableSet")]
-impl<'a, T: IsRetainable + Eq + Hash + HasStableHash> Extend<&'a T> for NSMutableSet<T> {
+impl<'a, T: Message + Eq + Hash + HasStableHash + IsRetainable> Extend<&'a T> for NSMutableSet<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |item| {
             self.insert(item);
@@ -557,7 +557,9 @@ impl<'a, T: IsRetainable + Eq + Hash + HasStableHash> Extend<&'a T> for NSMutabl
     }
 }
 
-impl<'a, T: IsRetainable + Eq + Hash + HasStableHash + 'a> IdFromIterator<&'a T> for NSSet<T> {
+impl<'a, T: Message + Eq + Hash + HasStableHash + IsRetainable + 'a> IdFromIterator<&'a T>
+    for NSSet<T>
+{
     fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {
         let vec = Vec::from_iter(iter);
         Self::from_slice(&vec)
@@ -572,7 +574,7 @@ impl<T: Message + Eq + Hash + HasStableHash> IdFromIterator<Id<T>> for NSSet<T> 
 }
 
 #[cfg(feature = "Foundation_NSMutableSet")]
-impl<'a, T: IsRetainable + Eq + Hash + HasStableHash + 'a> IdFromIterator<&'a T>
+impl<'a, T: Message + Eq + Hash + HasStableHash + IsRetainable + 'a> IdFromIterator<&'a T>
     for NSMutableSet<T>
 {
     fn id_from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Id<Self> {

--- a/crates/icrate/src/additions/Foundation/util.rs
+++ b/crates/icrate/src/additions/Foundation/util.rs
@@ -68,7 +68,7 @@ pub(crate) fn id_ptr_cast_const<T: ?Sized>(objects: *const Id<T>) -> *mut NonNul
 #[inline]
 pub(crate) unsafe fn collection_retain_id<T>(obj: &T) -> Id<T>
 where
-    T: IsIdCloneable,
+    T: Message + IsIdCloneable,
 {
     // SAFETY: We're allowed to access `&Id<T>` from `&self` in collections,
     // and since `T: IsIdCloneable`, we can convert that to `Id<T>`.

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -14,8 +14,8 @@ pub(crate) use std::os::raw::{
 pub(crate) use objc2::ffi::{NSInteger, NSIntegerMax, NSUInteger, NSUIntegerMax, IMP};
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::mutability::{
-    Immutable, ImmutableWithMutableSubclass, InteriorMutable, IsIdCloneable, MainThreadOnly,
-    Mutable, MutableWithImmutableSuperclass,
+    Immutable, ImmutableWithMutableSubclass, InteriorMutable, IsIdCloneable, IsMainThreadOnly,
+    MainThreadOnly, Mutable, MutableWithImmutableSuperclass,
 };
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::rc::{Allocated, DefaultId, Id};

--- a/crates/icrate/src/fixes/AppKit/mod.rs
+++ b/crates/icrate/src/fixes/AppKit/mod.rs
@@ -43,14 +43,14 @@ extern_class!(
 __inner_extern_class!(
     #[cfg(feature = "AppKit_NSLayoutAnchor")]
     #[derive(Debug, PartialEq, Eq, Hash)]
-    pub struct NSLayoutAnchor<AnchorType: Message = AnyObject> {
+    pub struct NSLayoutAnchor<AnchorType: ?Sized = AnyObject> {
         __superclass: NSObject,
         _inner0: PhantomData<*mut AnchorType>,
         notunwindsafe: PhantomData<&'static mut ()>,
     }
 
     #[cfg(feature = "AppKit_NSLayoutAnchor")]
-    unsafe impl<AnchorType: Message> ClassType for NSLayoutAnchor<AnchorType> {
+    unsafe impl<AnchorType: ?Sized + Message> ClassType for NSLayoutAnchor<AnchorType> {
         type Super = NSObject;
         type Mutability = InteriorMutable;
 

--- a/crates/icrate/src/fixes/Foundation/copy.rs
+++ b/crates/icrate/src/fixes/Foundation/copy.rs
@@ -4,7 +4,7 @@ use crate::common::*;
 use crate::Foundation::{self, NSCopying, NSMutableCopying};
 
 #[cfg(feature = "Foundation_NSArray")]
-impl<T: IsIdCloneable> ToOwned for Foundation::NSArray<T> {
+impl<T: Message + IsIdCloneable> ToOwned for Foundation::NSArray<T> {
     type Owned = Id<Self>;
     fn to_owned(&self) -> Self::Owned {
         self.copy()
@@ -12,7 +12,7 @@ impl<T: IsIdCloneable> ToOwned for Foundation::NSArray<T> {
 }
 
 #[cfg(feature = "Foundation_NSMutableArray")]
-impl<T: IsIdCloneable> ToOwned for Foundation::NSMutableArray<T> {
+impl<T: Message + IsIdCloneable> ToOwned for Foundation::NSMutableArray<T> {
     type Owned = Id<Self>;
     fn to_owned(&self) -> Self::Owned {
         self.mutableCopy()
@@ -44,7 +44,7 @@ impl ToOwned for Foundation::NSException {
 }
 
 #[cfg(feature = "Foundation_NSSet")]
-impl<T: IsIdCloneable> ToOwned for Foundation::NSSet<T> {
+impl<T: Message + IsIdCloneable> ToOwned for Foundation::NSSet<T> {
     type Owned = Id<Self>;
     fn to_owned(&self) -> Self::Owned {
         self.copy()
@@ -52,7 +52,7 @@ impl<T: IsIdCloneable> ToOwned for Foundation::NSSet<T> {
 }
 
 #[cfg(feature = "Foundation_NSMutableSet")]
-impl<T: IsIdCloneable> ToOwned for Foundation::NSMutableSet<T> {
+impl<T: Message + IsIdCloneable> ToOwned for Foundation::NSMutableSet<T> {
     type Owned = Id<Self>;
     fn to_owned(&self) -> Self::Owned {
         self.mutableCopy()

--- a/crates/icrate/src/fixes/Foundation/debug.rs
+++ b/crates/icrate/src/fixes/Foundation/debug.rs
@@ -53,6 +53,14 @@ impl<K: fmt::Debug + Message, V: fmt::Debug + Message> fmt::Debug
     }
 }
 
+#[cfg(feature = "Foundation_NSCountedSet")]
+impl<T: fmt::Debug + Message> fmt::Debug for Foundation::NSCountedSet<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
 #[cfg(feature = "Foundation_NSMutableSet")]
 impl<T: fmt::Debug + Message> fmt::Debug for Foundation::NSMutableSet<T> {
     #[inline]

--- a/crates/icrate/src/fixes/Foundation/generics.rs
+++ b/crates/icrate/src/fixes/Foundation/generics.rs
@@ -18,7 +18,7 @@ impl<T: ?Sized> UnwindSafe for UnsafeIgnoreAutoTraits<T> {}
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSArray")]
-    pub struct NSArray<ObjectType: Message = AnyObject> {
+    pub struct NSArray<ObjectType: ?Sized = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         /// `NSArray` and `NSMutableArray` have `Id`-like storage.
@@ -84,7 +84,7 @@ __inner_extern_class!(
     }
 
     #[cfg(feature = "Foundation_NSArray")]
-    unsafe impl<ObjectType: Message> ClassType for NSArray<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSArray<ObjectType> {
         type Super = NSObject;
         type Mutability = ImmutableWithMutableSubclass<NSMutableArray<ObjectType>>;
 
@@ -101,13 +101,13 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSArray")]
-    pub struct NSMutableArray<ObjectType: Message = AnyObject> {
+    pub struct NSMutableArray<ObjectType: ?Sized = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSArray<ObjectType>,
     }
 
     #[cfg(feature = "Foundation_NSArray")]
-    unsafe impl<ObjectType: Message> ClassType for NSMutableArray<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSMutableArray<ObjectType> {
         #[inherits(NSObject)]
         type Super = NSArray<ObjectType>;
         type Mutability = MutableWithImmutableSuperclass<NSArray<ObjectType>>;
@@ -125,7 +125,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSDictionary")]
-    pub struct NSDictionary<KeyType: Message = AnyObject, ObjectType: Message = AnyObject> {
+    pub struct NSDictionary<KeyType: ?Sized = AnyObject, ObjectType: ?Sized = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the dictionary was implemented with:
@@ -134,7 +134,9 @@ __inner_extern_class!(
     }
 
     #[cfg(feature = "Foundation_NSDictionary")]
-    unsafe impl<KeyType: Message, ObjectType: Message> ClassType for NSDictionary<KeyType, ObjectType> {
+    unsafe impl<KeyType: ?Sized + Message, ObjectType: ?Sized + Message> ClassType
+        for NSDictionary<KeyType, ObjectType>
+    {
         type Super = NSObject;
         type Mutability = ImmutableWithMutableSubclass<NSMutableDictionary<KeyType, ObjectType>>;
 
@@ -151,13 +153,13 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSDictionary")]
-    pub struct NSMutableDictionary<KeyType: Message = AnyObject, ObjectType: Message = AnyObject> {
+    pub struct NSMutableDictionary<KeyType: ?Sized = AnyObject, ObjectType: ?Sized = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSDictionary<KeyType, ObjectType>,
     }
 
     #[cfg(feature = "Foundation_NSDictionary")]
-    unsafe impl<KeyType: Message, ObjectType: Message> ClassType
+    unsafe impl<KeyType: ?Sized + Message, ObjectType: ?Sized + Message> ClassType
         for NSMutableDictionary<KeyType, ObjectType>
     {
         #[inherits(NSObject)]
@@ -177,7 +179,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSSet")]
-    pub struct NSSet<ObjectType: Message = AnyObject> {
+    pub struct NSSet<ObjectType: ?Sized = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the set was implemented as `NSArray<ObjectType>`.
@@ -185,7 +187,7 @@ __inner_extern_class!(
     }
 
     #[cfg(feature = "Foundation_NSSet")]
-    unsafe impl<ObjectType: Message> ClassType for NSSet<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSSet<ObjectType> {
         type Super = NSObject;
         type Mutability = ImmutableWithMutableSubclass<NSMutableSet<ObjectType>>;
 
@@ -202,13 +204,13 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSSet")]
-    pub struct NSMutableSet<ObjectType: Message = AnyObject> {
+    pub struct NSMutableSet<ObjectType: ?Sized = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSSet<ObjectType>,
     }
 
     #[cfg(feature = "Foundation_NSSet")]
-    unsafe impl<ObjectType: Message> ClassType for NSMutableSet<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSMutableSet<ObjectType> {
         #[inherits(NSObject)]
         type Super = NSSet<ObjectType>;
         type Mutability = MutableWithImmutableSuperclass<NSSet<ObjectType>>;
@@ -224,15 +226,15 @@ __inner_extern_class!(
 );
 
 __inner_extern_class!(
-    #[derive(Debug, PartialEq, Eq, Hash)]
+    #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSCountedSet")]
-    pub struct NSCountedSet<ObjectType: Message = AnyObject> {
+    pub struct NSCountedSet<ObjectType: ?Sized = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSMutableSet<ObjectType>,
     }
 
     #[cfg(feature = "Foundation_NSCountedSet")]
-    unsafe impl<ObjectType: Message> ClassType for NSCountedSet<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSCountedSet<ObjectType> {
         #[inherits(NSSet<ObjectType>, NSObject)]
         type Super = NSMutableSet<ObjectType>;
         type Mutability = Mutable;
@@ -250,7 +252,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    pub struct NSOrderedSet<ObjectType: Message = AnyObject> {
+    pub struct NSOrderedSet<ObjectType: ?Sized = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Same as if the set was implemented with `NSArray<ObjectType>`.
@@ -258,7 +260,7 @@ __inner_extern_class!(
     }
 
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    unsafe impl<ObjectType: Message> ClassType for NSOrderedSet<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSOrderedSet<ObjectType> {
         type Super = NSObject;
         type Mutability = ImmutableWithMutableSubclass<NSMutableOrderedSet<ObjectType>>;
 
@@ -275,13 +277,13 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    pub struct NSMutableOrderedSet<ObjectType: Message = AnyObject> {
+    pub struct NSMutableOrderedSet<ObjectType: ?Sized = AnyObject> {
         // Inherit auto traits from superclass.
         __superclass: NSOrderedSet<ObjectType>,
     }
 
     #[cfg(feature = "Foundation_NSOrderedSet")]
-    unsafe impl<ObjectType: Message> ClassType for NSMutableOrderedSet<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSMutableOrderedSet<ObjectType> {
         #[inherits(NSObject)]
         type Super = NSOrderedSet<ObjectType>;
         type Mutability = MutableWithImmutableSuperclass<NSOrderedSet<ObjectType>>;
@@ -299,7 +301,7 @@ __inner_extern_class!(
 __inner_extern_class!(
     #[derive(Debug, PartialEq, Eq, Hash)]
     #[cfg(feature = "Foundation_NSEnumerator")]
-    pub struct NSEnumerator<ObjectType: Message = AnyObject> {
+    pub struct NSEnumerator<ObjectType: ?Sized = AnyObject> {
         // SAFETY: Auto traits specified below.
         __superclass: UnsafeIgnoreAutoTraits<NSObject>,
         // Enumerators are basically the same as if we were storing
@@ -315,7 +317,7 @@ __inner_extern_class!(
     }
 
     #[cfg(feature = "Foundation_NSEnumerator")]
-    unsafe impl<ObjectType: Message> ClassType for NSEnumerator<ObjectType> {
+    unsafe impl<ObjectType: ?Sized + Message> ClassType for NSEnumerator<ObjectType> {
         type Super = NSObject;
         type Mutability = Mutable;
 

--- a/crates/icrate/tests/copying.rs
+++ b/crates/icrate/tests/copying.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "Foundation")]
+#![cfg(feature = "Foundation_NSString")]
+use icrate::Foundation::{NSCopying, NSMutableCopying, NSString};
+use objc2::{rc::Id, runtime::ProtocolObject};
+
+#[test]
+fn copy() {
+    let obj = NSString::new();
+    let protocol_object: &ProtocolObject<dyn NSCopying> = ProtocolObject::from_ref(&*obj);
+    let _: Id<ProtocolObject<dyn NSCopying>> = protocol_object.copy();
+}
+
+#[test]
+fn copy_mutable() {
+    let obj = NSString::new();
+    let protocol_object: &ProtocolObject<dyn NSMutableCopying> = ProtocolObject::from_ref(&*obj);
+    let _: Id<ProtocolObject<dyn NSMutableCopying>> = protocol_object.mutableCopy();
+}

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -18,6 +18,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * **BREAKING**: `AnyClass::verify_sel` now take more well-defined types
   `EncodeArguments` and  `EncodeReturn`.
+* **BREAKING**: Changed how the `mutability` traits work; these no longer have
+  `ClassType` as a super trait, allowing them to work for `ProtocolObject` as
+  well.
+
+  This effectively means you can now `copy` a `ProtocolObject<dyn NSCopying>`.
+* **BREAKING**: Allow implementing `DefaultId` for any type, not just those
+  who are `IsAllocableAnyThread`.
 
 ### Deprecated
 * Soft deprecated using `msg_send!` without a comma between arguments (i.e.

--- a/crates/objc2/src/declare/mod.rs
+++ b/crates/objc2/src/declare/mod.rs
@@ -167,17 +167,17 @@ pub trait MethodImplementation: private::Sealed + Sized {
 }
 
 macro_rules! method_decl_impl {
-    (@<$($l:lifetime),*> T: $t_bound:ident, $r:ident, $f:ty, $($t:ident),*) => {
+    (@<$($l:lifetime),*> T: $t_bound:ident $(+ $t_bound2:ident)?, $r:ident, $f:ty, $($t:ident),*) => {
         impl<$($l,)* T, $r, $($t),*> private::Sealed for $f
         where
-            T: ?Sized + $t_bound,
+            T: ?Sized + $t_bound $(+ $t_bound2)?,
             $r: EncodeReturn,
             $($t: EncodeArgument,)*
         {}
 
         impl<$($l,)* T, $r, $($t),*> MethodImplementation for $f
         where
-            T: ?Sized + $t_bound,
+            T: ?Sized + $t_bound $(+ $t_bound2)?,
             $r: EncodeReturn,
             $($t: EncodeArgument,)*
         {
@@ -244,11 +244,11 @@ macro_rules! method_decl_impl {
     };
     (# $abi:literal; $($t:ident),*) => {
         method_decl_impl!(@<'a> T: Message, R, extern $abi fn(&'a T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(@<'a> T: IsMutable, R, extern $abi fn(&'a mut T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(@<'a> T: Message + IsMutable, R, extern $abi fn(&'a mut T, Sel $(, $t)*) -> R, $($t),*);
         method_decl_impl!(@<> T: Message, R, unsafe extern $abi fn(*const T, Sel $(, $t)*) -> R, $($t),*);
         method_decl_impl!(@<> T: Message, R, unsafe extern $abi fn(*mut T, Sel $(, $t)*) -> R, $($t),*);
         method_decl_impl!(@<'a> T: Message, R, unsafe extern $abi fn(&'a T, Sel $(, $t)*) -> R, $($t),*);
-        method_decl_impl!(@<'a> T: IsMutable, R, unsafe extern $abi fn(&'a mut T, Sel $(, $t)*) -> R, $($t),*);
+        method_decl_impl!(@<'a> T: Message + IsMutable, R, unsafe extern $abi fn(&'a mut T, Sel $(, $t)*) -> R, $($t),*);
 
         method_decl_impl!(@<'a> AnyObject, R, extern $abi fn(&'a mut AnyObject, Sel $(, $t)*) -> R, $($t),*);
         method_decl_impl!(@<'a> AnyObject, R, unsafe extern $abi fn(&'a mut AnyObject, Sel $(, $t)*) -> R, $($t),*);

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -321,13 +321,13 @@ macro_rules! __impl_as_ref_borrow {
 macro_rules! __inner_extern_class {
     (
         $(#[$m:meta])*
-        $v:vis struct $name:ident<$($t_struct:ident $(: $b_struct:ident $(= $default:ty)?)?),* $(,)?> {
+        $v:vis struct $name:ident<$($t_struct:ident $(: $(?$b_sized_struct:ident)? $($b_struct:ident)? $(= $default:ty)?)?),* $(,)?> {
             $superclass_field:ident: $superclass_field_ty:ty,
             $($fields:tt)*
         }
 
         $(#[$impl_m:meta])*
-        unsafe impl<$($t_for:ident $(: $b_for:ident)?),* $(,)?> ClassType for $for:ty {
+        unsafe impl<$($t_for:ident $(: $(?$b_sized_for:ident +)? $b_for:ident)?),* $(,)?> ClassType for $for:ty {
             $(#[inherits($($inheritance_rest:ty),+ $(,)?)])?
             type Super = $superclass:ty;
             type Mutability = $mutability:ty;
@@ -341,7 +341,7 @@ macro_rules! __inner_extern_class {
         $crate::__emit_struct! {
             ($(#[$m])*)
             ($v)
-            ($name<$($t_struct $(: $b_struct $(= $default)?)?),*>)
+            ($name<$($t_struct $(: $(?$b_sized_struct)? $($b_struct)? $(= $default)?)?),*>)
             (
                 $superclass_field: $superclass_field_ty,
                 $($fields)*
@@ -350,7 +350,7 @@ macro_rules! __inner_extern_class {
 
         $crate::__extern_class_impl_traits! {
             $(#[$impl_m])*
-            unsafe impl ($($t_for $(: $b_for)?),*) for $for {
+            unsafe impl ($($t_for $(: $(?$b_sized_for +)? $b_for)?),*) for $for {
                 INHERITS = [$superclass, $($($inheritance_rest,)+)? $crate::runtime::AnyObject];
 
                 fn as_super(&$as_super_self) $as_super
@@ -359,7 +359,7 @@ macro_rules! __inner_extern_class {
         }
 
         $(#[$impl_m])*
-        unsafe impl<$($t_for $(: $b_for)?),*> ClassType for $for {
+        unsafe impl<$($t_for $(: $(?$b_sized_for +)? $b_for)?),*> ClassType for $for {
             type Super = $superclass;
             type Mutability = $mutability;
             const NAME: &'static $crate::__macro_helpers::str = $crate::__select_name!($name; $($name_const)?);

--- a/crates/objc2/src/message/mod.rs
+++ b/crates/objc2/src/message/mod.rs
@@ -448,8 +448,8 @@ unsafe impl<'a, T: ?Sized + Message> MessageReceiver for &'a Id<T> {
     }
 }
 
-impl<'a, T: ?Sized + IsMutable> private::Sealed for &'a mut Id<T> {}
-unsafe impl<'a, T: ?Sized + IsMutable> MessageReceiver for &'a mut Id<T> {
+impl<'a, T: ?Sized + Message + IsMutable> private::Sealed for &'a mut Id<T> {}
+unsafe impl<'a, T: ?Sized + Message + IsMutable> MessageReceiver for &'a mut Id<T> {
     type __Inner = T;
 
     #[inline]

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -761,8 +761,7 @@ mod private {
     }
 
     /// Helper struct for avoiding a gnarly ICE in `rustdoc` when generating
-    /// documentation for `icrate` iterator helpers (in particular, it fails
-    /// in generating auto trait implementations).
+    /// documentation for auto traits for `Id<T>` where `T: !ClassType`.
     ///
     /// See related issues:
     /// - <https://github.com/rust-lang/rust/issues/91380>
@@ -821,6 +820,12 @@ impl<T: ?Sized + RefUnwindSafe> RefUnwindSafe for Id<T> {}
 
 // TODO: Relax this bound
 impl<T: ?Sized + RefUnwindSafe + UnwindSafe> UnwindSafe for Id<T> {}
+
+#[cfg(doc)]
+#[allow(unused)]
+struct TestDocIdWithNonClassType {
+    id: Id<crate::runtime::AnyObject>,
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -621,7 +621,7 @@ where
 }
 
 // TODO: Add ?Sized bound
-impl<T: IsIdCloneable> Clone for Id<T> {
+impl<T: Message + IsIdCloneable> Clone for Id<T> {
     /// Makes a clone of the shared object.
     ///
     /// This increases the object's reference count.
@@ -815,12 +815,12 @@ where
 //
 // See https://doc.rust-lang.org/1.54.0/src/alloc/boxed.rs.html#1652-1675
 // and the `Arc` implementation.
-impl<T: ?Sized + Message> Unpin for Id<T> {}
+impl<T: ?Sized> Unpin for Id<T> {}
 
-impl<T: ?Sized + Message + RefUnwindSafe> RefUnwindSafe for Id<T> {}
+impl<T: ?Sized + RefUnwindSafe> RefUnwindSafe for Id<T> {}
 
 // TODO: Relax this bound
-impl<T: ?Sized + Message + RefUnwindSafe + UnwindSafe> UnwindSafe for Id<T> {}
+impl<T: ?Sized + RefUnwindSafe + UnwindSafe> UnwindSafe for Id<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/objc2/src/rc/id_traits.rs
+++ b/crates/objc2/src/rc/id_traits.rs
@@ -1,11 +1,10 @@
 //! Helper traits for Id.
 
 use super::Id;
-use crate::mutability::{IsAllocableAnyThread, IsMutable};
+use crate::mutability::IsMutable;
 
 /// Helper trait to implement [`Default`] on [`Id`].
-// TODO: Maybe make this `unsafe` and provide a default implementation?
-pub trait DefaultId: IsAllocableAnyThread {
+pub trait DefaultId {
     /// The default [`Id`] for a type.
     ///
     /// On most objects the implementation would be sending a message to the

--- a/crates/objc2/src/rc/weak_id.rs
+++ b/crates/objc2/src/rc/weak_id.rs
@@ -116,7 +116,7 @@ impl<T: ?Sized> Drop for WeakId<T> {
 }
 
 // TODO: Add ?Sized
-impl<T: IsRetainable> Clone for WeakId<T> {
+impl<T: Message + IsRetainable> Clone for WeakId<T> {
     /// Make a clone of the weak pointer that points to the same object.
     #[doc(alias = "objc_copyWeak")]
     fn clone(&self) -> Self {
@@ -130,7 +130,7 @@ impl<T: IsRetainable> Clone for WeakId<T> {
 }
 
 // TODO: Add ?Sized
-impl<T: IsRetainable> Default for WeakId<T> {
+impl<T: Message + IsRetainable> Default for WeakId<T> {
     /// Constructs a new weak pointer that doesn't reference any object.
     ///
     /// Calling [`Self::load`] on the return value always gives [`None`].
@@ -151,35 +151,35 @@ impl<T: ?Sized> fmt::Debug for WeakId<T> {
 }
 
 // Same as `std::sync::Weak<T>`.
-unsafe impl<T: Sync + Send + ?Sized + IsIdCloneable> Sync for WeakId<T> {}
+unsafe impl<T: ?Sized + Sync + Send + IsIdCloneable> Sync for WeakId<T> {}
 
 // Same as `std::sync::Weak<T>`.
-unsafe impl<T: Sync + Send + ?Sized + IsIdCloneable> Send for WeakId<T> {}
+unsafe impl<T: ?Sized + Sync + Send + IsIdCloneable> Send for WeakId<T> {}
 
 // Same as `std::sync::Weak<T>`.
-impl<T: ?Sized + Message> Unpin for WeakId<T> {}
+impl<T: ?Sized> Unpin for WeakId<T> {}
 
 // Same as `std::sync::Weak<T>`.
-impl<T: RefUnwindSafe + ?Sized + IsIdCloneable> RefUnwindSafe for WeakId<T> {}
+impl<T: ?Sized + RefUnwindSafe + IsIdCloneable> RefUnwindSafe for WeakId<T> {}
 
 // Same as `std::sync::Weak<T>`.
-impl<T: RefUnwindSafe + ?Sized + IsIdCloneable> UnwindSafe for WeakId<T> {}
+impl<T: ?Sized + RefUnwindSafe + IsIdCloneable> UnwindSafe for WeakId<T> {}
 
-impl<T: IsRetainable> From<&T> for WeakId<T> {
+impl<T: Message + IsRetainable> From<&T> for WeakId<T> {
     #[inline]
     fn from(obj: &T) -> Self {
         WeakId::new(obj)
     }
 }
 
-impl<T: IsIdCloneable> From<&Id<T>> for WeakId<T> {
+impl<T: Message + IsIdCloneable> From<&Id<T>> for WeakId<T> {
     #[inline]
     fn from(obj: &Id<T>) -> Self {
         WeakId::from_id(obj)
     }
 }
 
-impl<T: IsIdCloneable> From<Id<T>> for WeakId<T> {
+impl<T: Message + IsIdCloneable> From<Id<T>> for WeakId<T> {
     #[inline]
     fn from(obj: Id<T>) -> Self {
         WeakId::from_id(&obj)

--- a/crates/test-ui/Cargo.toml
+++ b/crates/test-ui/Cargo.toml
@@ -16,12 +16,15 @@ default = [
     "icrate/Foundation",
     "icrate/Foundation_NSString",
     "icrate/Foundation_NSMutableString",
+    "icrate/Foundation_NSNotification",
     "icrate/Foundation_NSThread",
     "icrate/Foundation_NSError",
     "icrate/Foundation_NSArray",
     "icrate/Foundation_NSMutableArray",
     "icrate/Foundation_NSValue",
     "icrate/Foundation_NSSet",
+    "icrate/AppKit",
+    "icrate/AppKit_NSApplication",
     "objc2/unstable-msg-send-always-comma",
 ]
 std = ["block2/std", "objc2/std", "icrate/std"]

--- a/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.rs
+++ b/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.rs
@@ -1,0 +1,43 @@
+//! Test that implementing `NSApplicationDelegate` and similar requires
+//! a `MainThreadOnly` class.
+use icrate::AppKit::{NSApplication, NSApplicationDelegate};
+use icrate::Foundation::{MainThreadMarker, NSNotification, NSObject, NSObjectProtocol};
+use objc2::rc::Id;
+use objc2::runtime::ProtocolObject;
+use objc2::{declare_class, extern_methods, mutability, ClassType};
+
+declare_class!(
+    struct CustomObject;
+
+    unsafe impl ClassType for CustomObject {
+        type Super = NSObject;
+        type Mutability = mutability::InteriorMutable; // Not `MainThreadOnly`
+        const NAME: &'static str = "CustomObject";
+    }
+
+    unsafe impl NSObjectProtocol for CustomObject {}
+
+    unsafe impl NSApplicationDelegate for CustomObject {
+        #[method(applicationDidFinishLaunching:)]
+        unsafe fn application_did_finish_launching(&self, _notification: &NSNotification) {
+            // Unclear for the user how to get a main thread marker if `self` is not `MainThreadOnly`
+            let _mtm = MainThreadMarker::new().unwrap();
+        }
+    }
+);
+
+extern_methods!(
+    unsafe impl CustomObject {
+        #[method_id(new)]
+        fn new(mtm: MainThreadMarker) -> Id<Self>;
+    }
+);
+
+fn main() {
+    let mtm = MainThreadMarker::new().unwrap();
+    let app = NSApplication::sharedApplication(mtm);
+
+    let delegate = CustomObject::new(mtm);
+    let delegate = ProtocolObject::from_ref(&*delegate);
+    app.setDelegate(Some(delegate));
+}

--- a/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.stderr
+++ b/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsMainThreadOnly` is not satisfied
+ --> ui/declare_class_delegate_not_mainthreadonly.rs
+  |
+  |     unsafe impl NSApplicationDelegate for CustomObject {
+  |                                           ^^^^^^^^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `InteriorMutable`
+  |
+  = help: the trait `mutability::MutabilityIsMainThreadOnly` is implemented for `MainThreadOnly`
+  = note: required for `CustomObject` to implement `IsMainThreadOnly`
+note: required by a bound in `NSApplicationDelegate`
+ --> $WORKSPACE/crates/icrate/src/generated/AppKit/NSApplication.rs
+  |
+  | / extern_protocol!(
+  | |     pub unsafe trait NSApplicationDelegate: NSObjectProtocol + IsMainThreadOnly {
+  | |                      --------------------- required by a bound in this trait
+  | |         #[cfg(feature = "AppKit_NSApplication")]
+  | |         #[optional]
+... |
+  | |     unsafe impl ProtocolType for dyn NSApplicationDelegate {}
+  | | );
+  | |_^ required by this bound in `NSApplicationDelegate`
+  = note: this error originates in the macro `extern_protocol` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_mut_self_not_mutable.stderr
+++ b/crates/test-ui/ui/declare_class_mut_self_not_mutable.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityIsMutable` is not satisfied
+error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsMutable` is not satisfied
  --> ui/declare_class_mut_self_not_mutable.rs
   |
   | / declare_class!(
@@ -10,10 +10,10 @@ error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityI
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::private::MutabilityIsMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsMutable` is not implemented for `InteriorMutable`
   |   required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsMutable`:
+  = help: the following other types implement trait `mutability::MutabilityIsMutable`:
             Mutable
             MutableWithImmutableSuperclass<IS>
   = note: required for `CustomObject` to implement `IsMutable`
@@ -28,7 +28,7 @@ note: required by a bound in `ClassBuilder::add_method`
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilder::add_method`
   = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityIsMutable` is not satisfied
+error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsMutable` is not satisfied
  --> ui/declare_class_mut_self_not_mutable.rs
   |
   | / declare_class!(
@@ -40,10 +40,10 @@ error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityI
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::private::MutabilityIsMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsMutable` is not implemented for `InteriorMutable`
   |   required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsMutable`:
+  = help: the following other types implement trait `mutability::MutabilityIsMutable`:
             Mutable
             MutableWithImmutableSuperclass<IS>
   = note: required for `CustomObject` to implement `IsMutable`
@@ -58,7 +58,7 @@ note: required by a bound in `ClassBuilder::add_method`
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilder::add_method`
   = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityIsMutable` is not satisfied
+error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsMutable` is not satisfied
  --> ui/declare_class_mut_self_not_mutable.rs
   |
   | / declare_class!(
@@ -70,10 +70,10 @@ error[E0277]: the trait bound `InteriorMutable: mutability::private::MutabilityI
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::private::MutabilityIsMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsMutable` is not implemented for `InteriorMutable`
   |   required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsMutable`:
+  = help: the following other types implement trait `mutability::MutabilityIsMutable`:
             Mutable
             MutableWithImmutableSuperclass<IS>
   = note: required for `CustomObject` to implement `IsMutable`

--- a/crates/test-ui/ui/implement_protocol_missing_super.rs
+++ b/crates/test-ui/ui/implement_protocol_missing_super.rs
@@ -1,0 +1,19 @@
+//! Test that implementing traits like `NSApplicationDelegate` requires super
+//! protocols like `NSObjectProtocol` to also be implemented.
+use icrate::AppKit::NSApplicationDelegate;
+use icrate::Foundation::NSObject;
+use objc2::{declare_class, mutability, ClassType};
+
+declare_class!(
+    struct CustomObject;
+
+    unsafe impl ClassType for CustomObject {
+        type Super = NSObject;
+        type Mutability = mutability::MainThreadOnly;
+        const NAME: &'static str = "CustomObject";
+    }
+
+    unsafe impl NSApplicationDelegate for CustomObject {}
+);
+
+fn main() {}

--- a/crates/test-ui/ui/implement_protocol_missing_super.stderr
+++ b/crates/test-ui/ui/implement_protocol_missing_super.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `CustomObject: NSObjectProtocol` is not satisfied
+ --> ui/implement_protocol_missing_super.rs
+  |
+  |     unsafe impl NSApplicationDelegate for CustomObject {}
+  |                                           ^^^^^^^^^^^^ the trait `NSObjectProtocol` is not implemented for `CustomObject`
+  |
+  = help: the following other types implement trait `NSObjectProtocol`:
+            ProtocolObject<T>
+            NSObject
+            __NSProxy
+            NSApplication
+            NSCollectionView
+            NSCollectionLayoutSection
+            NSCollectionLayoutGroupCustomItem
+            NSControl
+          and $N others
+note: required by a bound in `NSApplicationDelegate`
+ --> $WORKSPACE/crates/icrate/src/generated/AppKit/NSApplication.rs
+  |
+  | / extern_protocol!(
+  | |     pub unsafe trait NSApplicationDelegate: NSObjectProtocol + IsMainThreadOnly {
+  | |                      --------------------- required by a bound in this trait
+  | |         #[cfg(feature = "AppKit_NSApplication")]
+  | |         #[optional]
+... |
+  | |     unsafe impl ProtocolType for dyn NSApplicationDelegate {}
+  | | );
+  | |_^ required by this bound in `NSApplicationDelegate`
+  = note: this error originates in the macro `extern_protocol` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/main_thread_only_not_allocable.stderr
+++ b/crates/test-ui/ui/main_thread_only_not_allocable.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `MainThreadOnly: mutability::private::MutabilityIsAllocableAnyThread` is not satisfied
+error[E0277]: the trait bound `MainThreadOnly: mutability::MutabilityIsAllocableAnyThread` is not satisfied
  --> ui/main_thread_only_not_allocable.rs
   |
   |     let _ = MyMainThreadOnlyClass::alloc();
-  |             ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::private::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`
+  |             ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsAllocableAnyThread`:
+  = help: the following other types implement trait `mutability::MutabilityIsAllocableAnyThread`:
             Root
             Immutable
             Mutable

--- a/crates/test-ui/ui/mainthreadmarker_from_nsobject.rs
+++ b/crates/test-ui/ui/mainthreadmarker_from_nsobject.rs
@@ -1,0 +1,6 @@
+use icrate::Foundation::{MainThreadMarker, NSObject};
+
+fn main() {
+    let obj = NSObject::new();
+    let mtm = MainThreadMarker::from(&*obj);
+}

--- a/crates/test-ui/ui/mainthreadmarker_from_nsobject.stderr
+++ b/crates/test-ui/ui/mainthreadmarker_from_nsobject.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `Root: mutability::MutabilityIsMainThreadOnly` is not satisfied
+ --> ui/mainthreadmarker_from_nsobject.rs
+  |
+  |     let mtm = MainThreadMarker::from(&*obj);
+  |               ---------------------- ^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `Root`
+  |               |
+  |               required by a bound introduced by this call
+  |
+  = help: the trait `mutability::MutabilityIsMainThreadOnly` is implemented for `MainThreadOnly`
+  = note: required for `NSObject` to implement `IsMainThreadOnly`
+  = note: required for `MainThreadMarker` to implement `From<&NSObject>`

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -38,11 +38,11 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
             Exception
             ProtocolObject<P>
             AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
+            __RcTestObject
+            NSObject
+            __NSProxy
+            NSApplication
+            NSCollectionView
           and $N others
 note: required by a bound in `__send_message_error`
  --> $WORKSPACE/crates/objc2/src/message/mod.rs

--- a/crates/test-ui/ui/mutability_traits_unimplementable.rs
+++ b/crates/test-ui/ui/mutability_traits_unimplementable.rs
@@ -1,6 +1,4 @@
-//! Check that the `mutability` traits are not implementable manually.
-//!
-//! Since they are not `unsafe`, it would be a soundness hole if you could.
+//! Check that `mutability` traits are not implementable manually.
 use objc2::runtime::NSObject;
 use objc2::{declare_class, mutability, ClassType};
 
@@ -14,6 +12,6 @@ declare_class!(
     }
 );
 
-impl mutability::IsMutable for CustomObject {}
+unsafe impl mutability::IsMutable for CustomObject {}
 
 fn main() {}

--- a/crates/test-ui/ui/mutability_traits_unimplementable.stderr
+++ b/crates/test-ui/ui/mutability_traits_unimplementable.stderr
@@ -6,4 +6,4 @@ error[E0119]: conflicting implementations of trait `IsMutable` for type `CustomO
   |
   = note: conflicting implementation in crate `objc2`:
           - impl<T> IsMutable for T
-            where T: ClassType, <T as ClassType>::Mutability: mutability::private::MutabilityIsMutable, T: ?Sized;
+            where T: ClassType, <T as ClassType>::Mutability: mutability::MutabilityIsMutable, T: ?Sized;

--- a/crates/test-ui/ui/mutability_traits_unimplementable.stderr
+++ b/crates/test-ui/ui/mutability_traits_unimplementable.stderr
@@ -1,8 +1,8 @@
 error[E0119]: conflicting implementations of trait `IsMutable` for type `CustomObject`
  --> ui/mutability_traits_unimplementable.rs
   |
-  | impl mutability::IsMutable for CustomObject {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | unsafe impl mutability::IsMutable for CustomObject {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: conflicting implementation in crate `objc2`:
           - impl<T> IsMutable for T

--- a/crates/test-ui/ui/mutability_traits_unimplementable2.rs
+++ b/crates/test-ui/ui/mutability_traits_unimplementable2.rs
@@ -1,0 +1,8 @@
+//! Check that `mutability` traits are not implementable manually.
+use objc2::mutability;
+
+struct CustomStruct;
+
+unsafe impl mutability::IsMutable for CustomStruct {}
+
+fn main() {}

--- a/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
+++ b/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `CustomStruct: ClassType` is not satisfied
+ --> ui/mutability_traits_unimplementable2.rs
+  |
+  | unsafe impl mutability::IsMutable for CustomStruct {}
+  |                                       ^^^^^^^^^^^^ the trait `ClassType` is not implemented for `CustomStruct`
+  |
+  = help: the following other types implement trait `ClassType`:
+            __RcTestObject
+            NSObject
+            __NSProxy
+  = note: required for `CustomStruct` to implement `mutability::private_traits::Sealed`
+note: required by a bound in `IsMutable`
+ --> $WORKSPACE/crates/objc2/src/mutability.rs
+  |
+  | pub unsafe trait IsMutable: private_traits::Sealed {}
+  |                             ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `IsMutable`
+  = note: `IsMutable` is a "sealed trait", because to implement it you also need to implement `objc2::mutability::private_traits::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it

--- a/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
+++ b/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
@@ -27,13 +27,13 @@ note: the trait `IsIdCloneable` must be implemented
   | pub trait IsIdCloneable: ClassType {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Mutable: mutability::private::MutabilityIsRetainable` is not satisfied
+error[E0277]: the trait bound `Mutable: mutability::MutabilityIsRetainable` is not satisfied
  --> ui/mutable_id_not_clone_not_retain.rs
   |
   |     let _ = obj.retain();
-  |                 ^^^^^^ the trait `mutability::private::MutabilityIsRetainable` is not implemented for `Mutable`
+  |                 ^^^^^^ the trait `mutability::MutabilityIsRetainable` is not implemented for `Mutable`
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsRetainable`:
+  = help: the following other types implement trait `mutability::MutabilityIsRetainable`:
             Immutable
             InteriorMutable
             MainThreadOnly

--- a/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
+++ b/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
@@ -24,8 +24,8 @@ error[E0599]: the method `clone` exists for struct `Id<NSMutableObject>`, but it
 note: the trait `IsIdCloneable` must be implemented
  --> $WORKSPACE/crates/objc2/src/mutability.rs
   |
-  | pub trait IsIdCloneable: ClassType {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | pub unsafe trait IsIdCloneable: private_traits::Sealed {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Mutable: mutability::MutabilityIsRetainable` is not satisfied
  --> ui/mutable_id_not_clone_not_retain.rs

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -25,7 +25,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -65,7 +65,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -100,7 +100,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -151,7 +151,7 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -186,12 +186,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSMutableArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -231,12 +231,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSMutableArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_sync`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -271,12 +271,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSMutableArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs
@@ -327,12 +327,12 @@ note: required because it appears within the type `PhantomData<Id<NSObject>>`
 note: required because it appears within the type `NSArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^
 note: required because it appears within the type `NSMutableArray<NSObject>`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
   |
-  |     pub struct NSMutableArray<ObjectType: Message = AnyObject> {
+  |     pub struct NSMutableArray<ObjectType: ?Sized = AnyObject> {
   |                ^^^^^^^^^^^^^^
 note: required by a bound in `needs_send`
  --> ui/nsarray_bound_not_send_sync.rs

--- a/crates/test-ui/ui/nsarray_not_message.rs
+++ b/crates/test-ui/ui/nsarray_not_message.rs
@@ -1,0 +1,8 @@
+//! Test output of creating `NSArray` from a non-`Message` type.
+use icrate::Foundation::{NSArray, NSObject};
+use objc2::rc::Id;
+
+fn main() {
+    let _: Id<NSArray<i32>> = NSArray::new();
+    let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
+}

--- a/crates/test-ui/ui/nsarray_not_message.stderr
+++ b/crates/test-ui/ui/nsarray_not_message.stderr
@@ -8,11 +8,11 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
             Exception
             ProtocolObject<P>
             AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
+            __RcTestObject
+            NSObject
+            __NSProxy
+            NSApplication
+            NSCollectionView
           and $N others
 note: required by a bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/NSArray.rs
@@ -38,14 +38,14 @@ error[E0277]: the trait bound `Id<NSObject>: ClassType` is not satisfied
   |                                        required by a bound introduced by this call
   |
   = help: the following other types implement trait `ClassType`:
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-            NSMutableSet<ObjectType>
-            NSEnumerator<ObjectType>
-            NSAppleEventDescriptor
+            __RcTestObject
+            NSObject
+            __NSProxy
+            NSApplication
+            NSCollectionView
+            NSCollectionLayoutSection
+            NSCollectionLayoutGroupCustomItem
+            NSControl
           and $N others
   = note: required for `Id<NSObject>` to implement `IsRetainable`
 note: required by a bound in `icrate::Foundation::array::<impl NSArray<T>>::from_slice`

--- a/crates/test-ui/ui/nsarray_not_message.stderr
+++ b/crates/test-ui/ui/nsarray_not_message.stderr
@@ -1,0 +1,178 @@
+error[E0277]: the trait bound `i32: Message` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<i32>> = NSArray::new();
+  |            ^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            ProtocolObject<P>
+            AnyObject
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+note: required by a bound in `NSArray`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
+  |
+  | / __inner_extern_class!(
+  | |     #[derive(PartialEq, Eq, Hash)]
+  | |     #[cfg(feature = "Foundation_NSArray")]
+  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  | |                ------- required by a bound in this struct
+... |
+  | |     }
+  | | );
+  | |_^ required by this bound in `NSArray`
+  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Id<NSObject>: Message` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `Id<NSObject>`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            ProtocolObject<P>
+            AnyObject
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+note: required by a bound in `NSArray`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
+  |
+  | / __inner_extern_class!(
+  | |     #[derive(PartialEq, Eq, Hash)]
+  | |     #[cfg(feature = "Foundation_NSArray")]
+  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  | |                ------- required by a bound in this struct
+... |
+  | |     }
+  | | );
+  | |_^ required by this bound in `NSArray`
+  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `i32: Message` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<i32>> = NSArray::new();
+  |                               ^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            ProtocolObject<P>
+            AnyObject
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+note: required by a bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/NSArray.rs
+  |
+  | / extern_methods!(
+  | |     /// Methods declared on superclass `NSObject`
+  | |     #[cfg(feature = "Foundation_NSArray")]
+  | |     unsafe impl<ObjectType: Message> NSArray<ObjectType> {
+  | |         #[method_id(@__retain_semantics New new)]
+  | |         pub fn new() -> Id<Self>;
+  | |                --- required by a bound in this associated function
+  | |     }
+  | | );
+  | |_^ required by this bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
+  = note: this error originates in the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `i32: Message` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<i32>> = NSArray::new();
+  |                               ^^^^^^^ the trait `Message` is not implemented for `i32`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            ProtocolObject<P>
+            AnyObject
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+note: required by a bound in `NSArray`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
+  |
+  | / __inner_extern_class!(
+  | |     #[derive(PartialEq, Eq, Hash)]
+  | |     #[cfg(feature = "Foundation_NSArray")]
+  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  | |                ------- required by a bound in this struct
+... |
+  | |     }
+  | | );
+  | |_^ required by this bound in `NSArray`
+  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Id<NSObject>: ClassType` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
+  |                                        ------------------- ^^^^^^^^^^^^^^^^^^^ the trait `ClassType` is not implemented for `Id<NSObject>`
+  |                                        |
+  |                                        required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ClassType`:
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+            NSMutableSet<ObjectType>
+            NSEnumerator<ObjectType>
+            NSAppleEventDescriptor
+          and $N others
+  = note: required for `Id<NSObject>` to implement `IsRetainable`
+note: required by a bound in `icrate::Foundation::array::<impl NSArray<T>>::from_slice`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../additions/Foundation/array.rs
+  |
+  |     pub fn from_slice(slice: &[&T]) -> Id<Self>
+  |            ---------- required by a bound in this associated function
+  |     where
+  |         T: IsRetainable,
+  |            ^^^^^^^^^^^^ required by this bound in `icrate::Foundation::array::<impl NSArray<T>>::from_slice`
+
+error[E0277]: the trait bound `Id<NSObject>: Message` is not satisfied
+ --> ui/nsarray_not_message.rs
+  |
+  |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
+  |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `Id<NSObject>`
+  |
+  = help: the following other types implement trait `Message`:
+            Exception
+            ProtocolObject<P>
+            AnyObject
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSMutableDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+note: required by a bound in `NSArray`
+ --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
+  |
+  | / __inner_extern_class!(
+  | |     #[derive(PartialEq, Eq, Hash)]
+  | |     #[cfg(feature = "Foundation_NSArray")]
+  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
+  | |                ------- required by a bound in this struct
+... |
+  | |     }
+  | | );
+  | |_^ required by this bound in `NSArray`
+  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/nsarray_not_message.stderr
+++ b/crates/test-ui/ui/nsarray_not_message.stderr
@@ -2,66 +2,6 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
  --> ui/nsarray_not_message.rs
   |
   |     let _: Id<NSArray<i32>> = NSArray::new();
-  |            ^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
-  |
-  = help: the following other types implement trait `Message`:
-            Exception
-            ProtocolObject<P>
-            AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-          and $N others
-note: required by a bound in `NSArray`
- --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
-  |
-  | / __inner_extern_class!(
-  | |     #[derive(PartialEq, Eq, Hash)]
-  | |     #[cfg(feature = "Foundation_NSArray")]
-  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
-  | |                ------- required by a bound in this struct
-... |
-  | |     }
-  | | );
-  | |_^ required by this bound in `NSArray`
-  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `Id<NSObject>: Message` is not satisfied
- --> ui/nsarray_not_message.rs
-  |
-  |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `Id<NSObject>`
-  |
-  = help: the following other types implement trait `Message`:
-            Exception
-            ProtocolObject<P>
-            AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-          and $N others
-note: required by a bound in `NSArray`
- --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
-  |
-  | / __inner_extern_class!(
-  | |     #[derive(PartialEq, Eq, Hash)]
-  | |     #[cfg(feature = "Foundation_NSArray")]
-  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
-  | |                ------- required by a bound in this struct
-... |
-  | |     }
-  | | );
-  | |_^ required by this bound in `NSArray`
-  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `i32: Message` is not satisfied
- --> ui/nsarray_not_message.rs
-  |
-  |     let _: Id<NSArray<i32>> = NSArray::new();
   |                               ^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
   |
   = help: the following other types implement trait `Message`:
@@ -88,36 +28,6 @@ note: required by a bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>:
   | | );
   | |_^ required by this bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
   = note: this error originates in the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `i32: Message` is not satisfied
- --> ui/nsarray_not_message.rs
-  |
-  |     let _: Id<NSArray<i32>> = NSArray::new();
-  |                               ^^^^^^^ the trait `Message` is not implemented for `i32`
-  |
-  = help: the following other types implement trait `Message`:
-            Exception
-            ProtocolObject<P>
-            AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-          and $N others
-note: required by a bound in `NSArray`
- --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
-  |
-  | / __inner_extern_class!(
-  | |     #[derive(PartialEq, Eq, Hash)]
-  | |     #[cfg(feature = "Foundation_NSArray")]
-  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
-  | |                ------- required by a bound in this struct
-... |
-  | |     }
-  | | );
-  | |_^ required by this bound in `NSArray`
-  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Id<NSObject>: ClassType` is not satisfied
  --> ui/nsarray_not_message.rs
@@ -146,33 +56,3 @@ note: required by a bound in `icrate::Foundation::array::<impl NSArray<T>>::from
   |     where
   |         T: IsRetainable,
   |            ^^^^^^^^^^^^ required by this bound in `icrate::Foundation::array::<impl NSArray<T>>::from_slice`
-
-error[E0277]: the trait bound `Id<NSObject>: Message` is not satisfied
- --> ui/nsarray_not_message.rs
-  |
-  |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
-  |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `Id<NSObject>`
-  |
-  = help: the following other types implement trait `Message`:
-            Exception
-            ProtocolObject<P>
-            AnyObject
-            NSArray<ObjectType>
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-          and $N others
-note: required by a bound in `NSArray`
- --> $WORKSPACE/crates/icrate/src/generated/Foundation/../../fixes/Foundation/generics.rs
-  |
-  | / __inner_extern_class!(
-  | |     #[derive(PartialEq, Eq, Hash)]
-  | |     #[cfg(feature = "Foundation_NSArray")]
-  | |     pub struct NSArray<ObjectType: Message = AnyObject> {
-  | |                ------- required by a bound in this struct
-... |
-  | |     }
-  | | );
-  | |_^ required by this bound in `NSArray`
-  = note: this error originates in the macro `__inner_extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/nsobject_not_mutable.stderr
+++ b/crates/test-ui/ui/nsobject_not_mutable.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `Root: mutability::private::MutabilityIsMutable` is not satisfied
+error[E0277]: the trait bound `Root: mutability::MutabilityIsMutable` is not satisfied
  --> ui/nsobject_not_mutable.rs
   |
   |     let mut_ptr = Id::as_mut_ptr(&mut obj);
-  |                   -------------- ^^^^^^^^ the trait `mutability::private::MutabilityIsMutable` is not implemented for `Root`
+  |                   -------------- ^^^^^^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`
   |                   |
   |                   required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsMutable`:
+  = help: the following other types implement trait `mutability::MutabilityIsMutable`:
             Mutable
             MutableWithImmutableSuperclass<IS>
   = note: required for `NSObject` to implement `IsMutable`
@@ -19,15 +19,15 @@ note: required by a bound in `Id::<T>::as_mut_ptr`
   |         T: IsMutable,
   |            ^^^^^^^^^ required by this bound in `Id::<T>::as_mut_ptr`
 
-error[E0277]: the trait bound `Root: mutability::private::MutabilityIsMutable` is not satisfied
+error[E0277]: the trait bound `Root: mutability::MutabilityIsMutable` is not satisfied
  --> ui/nsobject_not_mutable.rs
   |
   |         let mut_ref = Id::autorelease_mut(obj, pool);
-  |                       ------------------- ^^^ the trait `mutability::private::MutabilityIsMutable` is not implemented for `Root`
+  |                       ------------------- ^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`
   |                       |
   |                       required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityIsMutable`:
+  = help: the following other types implement trait `mutability::MutabilityIsMutable`:
             Mutable
             MutableWithImmutableSuperclass<IS>
   = note: required for `NSObject` to implement `IsMutable`

--- a/crates/test-ui/ui/nsset_from_nsobject.stderr
+++ b/crates/test-ui/ui/nsset_from_nsobject.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `Root: mutability::private::MutabilityHashIsStable` is not satisfied
+error[E0277]: the trait bound `Root: mutability::MutabilityHashIsStable` is not satisfied
  --> ui/nsset_from_nsobject.rs
   |
   |     let _ = NSSet::from_vec(vec![NSObject::new()]);
-  |             --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::private::MutabilityHashIsStable` is not implemented for `Root`
+  |             --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityHashIsStable` is not implemented for `Root`
   |             |
   |             required by a bound introduced by this call
   |
-  = help: the following other types implement trait `mutability::private::MutabilityHashIsStable`:
+  = help: the following other types implement trait `mutability::MutabilityHashIsStable`:
             Immutable
             Mutable
             ImmutableWithMutableSubclass<MS>


### PR DESCRIPTION
In https://github.com/madsmtm/objc2/pull/359 I implemented marking classes as `MainThreadOnly`, but a glaring omission there is that protocols were not yet marked in a similar way.

This PR rectifies that by changing how the `mutability` traits work, allowing implementing them for `ProtocolObject<P>` as well, which means we can now add "requirements" to protocols, such as `trait MyProtocol: IsMainThreadOnly`, or `trait MyProtocol: IsRetainable`.

We're still missing `IsRetainable` bounds on pretty much everything in `AppKit` (and others) before we can make protocol overriding safe, but now at least the capability of adding those attributes is there.