### PR TITLE
Remove `NSCopying`/`NSMutableCopying` workarounds in header translator

### DIFF
--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -186,12 +186,10 @@ enum IdType {
 }
 
 impl IdType {
-    #[allow(dead_code)]
     fn _id(&self) -> Option<&ItemIdentifier> {
         match self {
             Self::Class { id, .. } => Some(id),
             Self::AnyObject { protocols } => match &**protocols {
-                [id] if id.name == "NSCopying" || id.name == "NSMutableCopying" => None,
                 [id] => Some(id),
                 _ => None,
             },
@@ -370,9 +368,6 @@ impl fmt::Display for IdType {
             Self::AnyObject { protocols } => match &**protocols {
                 [] => write!(f, "AnyObject"),
                 [id] if id.is_nsobject() => write!(f, "NSObject"),
-                [id] if id.name == "NSCopying" || id.name == "NSMutableCopying" => {
-                    write!(f, "AnyObject")
-                }
                 [id] => write!(f, "ProtocolObject<dyn {}>", id.path()),
                 // TODO: Handle this better
                 _ => write!(f, "TodoProtocols"),

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1680,13 +1680,7 @@ impl fmt::Display for Stmt {
 
                 write!(f, "    pub unsafe trait {}", id.name)?;
                 if !protocols.is_empty() {
-                    for (i, protocol) in protocols
-                        .iter()
-                        .filter(|protocol| {
-                            protocol.name != "NSCopying" && protocol.name != "NSMutableCopying"
-                        })
-                        .enumerate()
-                    {
+                    for (i, protocol) in protocols.iter().enumerate() {
                         if i == 0 {
                             write!(f, ": ")?;
                         } else {

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -71,6 +71,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `NSTextAttachmentCellProtocol` and `NSFileProviderItemProtocol`.
 * **BREAKING**: Generic types no longer strictly require `Message` (although
   most of their trait implementations still require that).
+* **BREAKING**: Removed a workaround that made the `NSCopying` and
+  `NSMutableCopying` protocols not act as regular protocols (many methods used
+  `AnyObject` instead of the correct `ProtocolObject<dyn NSCopying>`).
 
 
 ## icrate 0.0.4 - 2023-07-31


### PR DESCRIPTION
I think this has been possible since https://github.com/madsmtm/objc2/pull/419, I just forgot to remove these workarounds.