### PR TITLE
Refactor macro internals

### DIFF
--- a/crates/icrate/src/additions/Foundation/macros/ns_string.rs
+++ b/crates/icrate/src/additions/Foundation/macros/ns_string.rs
@@ -86,11 +86,17 @@ macro_rules! __ns_string {
 macro_rules! __ns_string_inner {
     ($inp:ident) => {{
         const X: &[u8] = $inp.as_bytes();
-        $crate::__ns_string_inner!(@inner X);
+        $crate::__ns_string_static!(X);
         // Return &'static NSString
         CFSTRING.as_nsstring()
     }};
-    (@inner $inp:ident) => {
+}
+
+#[doc(hidden)]
+#[cfg(all(feature = "apple", feature = "unstable-static-nsstring"))]
+#[macro_export]
+macro_rules! __ns_string_static {
+    ($inp:ident) => {
         // Note: We create both the ASCII + NUL and the UTF-16 + NUL versions
         // of the string, since we can't conditionally create a static.
         //

--- a/crates/icrate/src/macros.rs
+++ b/crates/icrate/src/macros.rs
@@ -70,14 +70,13 @@ macro_rules! extern_enum {
             ),* $(,)?
         }
     ) => {
-        extern_enum! {
-            @__inner
-            @($v)
-            @($ty)
-            @($(
+        extern_enum_inner! {
+            ($v)
+            ($ty)
+            $(
                 $(#[$field_m])*
                 $field = $value,
-            )*)
+            )*
         }
     };
     (
@@ -94,45 +93,42 @@ macro_rules! extern_enum {
         $(#[$m])*
         $v type $name = $ty;
 
-        extern_enum! {
-            @__inner
-            @($v)
-            @($name)
-            @($(
+        extern_enum_inner! {
+            ($v)
+            ($name)
+            $(
                 $(#[$field_m])*
                 $field = $value,
-            )*)
+            )*
         }
     };
+}
 
-    // tt-munch each field
+// tt-munch each enum field
+macro_rules! extern_enum_inner {
+    // Base case
     (
-        @__inner
-        @($v:vis)
-        @($ty:ty)
-        @()
-    ) => {
-        // Base case
-    };
-    (
-        @__inner
-        @($v:vis)
-        @($ty:ty)
-        @(
-            $(#[$field_m:meta])*
-            $field:ident = $value:expr,
+        ($v:vis)
+        ($ty:ty)
+    ) => {};
 
-            $($rest:tt)*
-        )
+    // Parse each field
+    (
+        ($v:vis)
+        ($ty:ty)
+
+        $(#[$field_m:meta])*
+        $field:ident = $value:expr,
+
+        $($rest:tt)*
     ) => {
         $(#[$field_m])*
         $v const $field: $ty = $value;
 
-        extern_enum! {
-            @__inner
-            @($v)
-            @($ty)
-            @($($rest)*)
+        extern_enum_inner! {
+            ($v)
+            ($ty)
+            $($rest)*
         }
     };
 }

--- a/crates/icrate/src/macros.rs
+++ b/crates/icrate/src/macros.rs
@@ -309,11 +309,11 @@ macro_rules! extern_static {
 macro_rules! extern_fn {
     (
         $(#[$m:meta])*
-        $v:vis unsafe fn $name:ident($($args:tt)*) $(-> $res:ty)?;
+        $v:vis unsafe fn $name:ident($($params:tt)*) $(-> $res:ty)?;
     ) => {
         $(#[$m])*
         extern "C" {
-            $v fn $name($($args)*) $(-> $res)?;
+            $v fn $name($($params)*) $(-> $res)?;
         }
     };
     (
@@ -336,7 +336,7 @@ macro_rules! extern_fn {
 macro_rules! inline_fn {
     (
         $(#[$m:meta])*
-        $v:vis unsafe fn $name:ident($($args:tt)*) $(-> $res:ty)? $body:block
+        $v:vis unsafe fn $name:ident($($params:tt)*) $(-> $res:ty)? $body:block
     ) => {
         // TODO
     };

--- a/crates/objc2/src/macros/__attribute_helpers.rs
+++ b/crates/objc2/src/macros/__attribute_helpers.rs
@@ -115,7 +115,7 @@ macro_rules! __extract_custom_attributes_inner {
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        compile_error!("must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`");
+        $crate::__macro_helpers::compile_error!("must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`");
     };
 
     // Base case
@@ -183,7 +183,7 @@ macro_rules! __extract_custom_attributes_inner {
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        compile_error!("cannot specify the `method`/`method_id` attribute twice");
+        $crate::__macro_helpers::compile_error!("cannot specify the `method`/`method_id` attribute twice");
     };
 
     // `method_id` attribute with retain semantics
@@ -254,7 +254,7 @@ macro_rules! __extract_custom_attributes_inner {
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        compile_error!("cannot specify the `method`/`method_id` attribute twice");
+        $crate::__macro_helpers::compile_error!("cannot specify the `method`/`method_id` attribute twice");
     };
 
     // `optional` attribute
@@ -298,7 +298,7 @@ macro_rules! __extract_custom_attributes_inner {
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        compile_error!("cannot specify the `optional` attribute twice");
+        $crate::__macro_helpers::compile_error!("cannot specify the `optional` attribute twice");
     };
 
     // Other attributes

--- a/crates/objc2/src/macros/__attribute_helpers.rs
+++ b/crates/objc2/src/macros/__attribute_helpers.rs
@@ -53,23 +53,28 @@ macro_rules! __extract_and_apply_cfg_attributes {
 /// This will ensure that there is one and only one of the method attributes
 /// present.
 ///
-/// This is implemented as a tt-muncher, taking the following arguments:
-/// - The attributes to parse.
-/// - The function name, for better UI if an error occurs.
-/// - The output macro that will be called.
-/// - Any extra arguments given to the output macro.
+/// This takes the following arguments:
+/// 1. The attributes to parse.
+///    ($($m:tt)*)
 ///
-/// And will call the output macro with the given arguments, along with the
-/// following extra arguments:
-/// - The `method` or `method_id` attribute.
-/// - The `optional` attribute, if any.
-/// - The rest of the attributes.
+/// 2. The output macro.
+///    ($out_macro:path)
+///
+/// Further arguments are passed on to the output macro, with the following
+/// arguments appended to it:
+/// 1. The `method` or `method_id` attribute.
+///    (#[$method_or_method_id:ident($($sel:tt)*)])
+///
+/// 2. The `optional` attribute, if any.
+///    ($(#[optional])?)
+///
+/// 3. The rest of the attributes.
+///    ($(#[$($m:tt)*])*)
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __extract_custom_attributes {
     {
         ($($m:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -80,7 +85,6 @@ macro_rules! __extract_custom_attributes {
             ()
             ()
             ()
-            ($name)
 
             ($out_macro)
             $($macro_args)*
@@ -99,14 +103,11 @@ macro_rules! __extract_custom_attributes_inner {
         ()
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        fn $name() {
-            compile_error!("must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`")
-        }
+        compile_error!("must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`");
     };
 
     // Base case
@@ -117,7 +118,6 @@ macro_rules! __extract_custom_attributes_inner {
         ($($m_method:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -142,7 +142,6 @@ macro_rules! __extract_custom_attributes_inner {
         ()
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -153,7 +152,6 @@ macro_rules! __extract_custom_attributes_inner {
             (#[method($($args)*)])
             ($($m_optional)*)
             ($($m_checked)*)
-            ($name)
 
             ($out_macro)
             $($macro_args)*
@@ -168,14 +166,11 @@ macro_rules! __extract_custom_attributes_inner {
         ($($m_method:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        fn $name() {
-            compile_error!("cannot specify the `method`/`method_id` attribute twice")
-        }
+        compile_error!("cannot specify the `method`/`method_id` attribute twice");
     };
 
     // `method_id` attribute
@@ -188,7 +183,6 @@ macro_rules! __extract_custom_attributes_inner {
         ()
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -199,7 +193,6 @@ macro_rules! __extract_custom_attributes_inner {
             (#[method_id($($args)*)])
             ($($m_optional)*)
             ($($m_checked)*)
-            ($name)
 
             ($out_macro)
             $($macro_args)*
@@ -214,14 +207,11 @@ macro_rules! __extract_custom_attributes_inner {
         ($($m_method:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        fn $name() {
-            compile_error!("cannot specify the `method`/`method_id` attribute twice")
-        }
+        compile_error!("cannot specify the `method`/`method_id` attribute twice");
     };
 
     // `optional` attribute
@@ -234,7 +224,6 @@ macro_rules! __extract_custom_attributes_inner {
         // If no existing `optional` attributes exist
         ()
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -245,7 +234,6 @@ macro_rules! __extract_custom_attributes_inner {
             // Add optional attribute
             (#[optional])
             ($($m_checked)*)
-            ($name)
 
             ($out_macro)
             $($macro_args)*
@@ -260,14 +248,11 @@ macro_rules! __extract_custom_attributes_inner {
         ($($m_method:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        fn $name() {
-            compile_error!("cannot specify the `optional` attribute twice")
-        }
+        compile_error!("cannot specify the `optional` attribute twice");
     };
 
     // Other attributes
@@ -279,7 +264,6 @@ macro_rules! __extract_custom_attributes_inner {
         ($($m_method:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
-        ($name:ident)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -294,7 +278,6 @@ macro_rules! __extract_custom_attributes_inner {
                 // been consuming the attributes from the front.
                 #[$($checked)*]
             )
-            ($name)
 
             ($out_macro)
             $($macro_args)*

--- a/crates/objc2/src/macros/__attribute_helpers.rs
+++ b/crates/objc2/src/macros/__attribute_helpers.rs
@@ -9,40 +9,40 @@
 macro_rules! __extract_and_apply_cfg_attributes {
     // Base case
     {
-        @() // No attributes left to process
-        @($($output:tt)*)
+        () // No attributes left to process
+        $($output:tt)*
     } => {
         $($output)*
     };
     // `cfg` attribute
     {
-        @(
+        (
             #[cfg $($args:tt)*]
             $($m_rest:tt)*
         )
-        @($($output:tt)*)
+        $($output:tt)*
     } => {
         // Apply the attribute and continue
         #[cfg $($args)*]
         {
             $crate::__extract_and_apply_cfg_attributes! {
-                @($($m_rest)*)
-                @($($output)*)
+                ($($m_rest)*)
+                $($output)*
             }
         }
     };
     // Other attributes
     {
-        @(
+        (
             #[$($m_ignored:tt)*]
             $($m_rest:tt)*
         )
-        @($($output:tt)*)
+        $($output:tt)*
     } => {
         // Ignore the attribute, and continue parsing the rest
         $crate::__extract_and_apply_cfg_attributes! {
-            @($($m_rest)*)
-            @($($output)*)
+            ($($m_rest)*)
+            $($output)*
         }
     };
 }

--- a/crates/objc2/src/macros/__method_msg_send.rs
+++ b/crates/objc2/src/macros/__method_msg_send.rs
@@ -157,44 +157,19 @@ macro_rules! __method_msg_send_id {
     // Selector with no arguments
     (
         ($receiver:expr)
-        ($(@__retain_semantics $retain_semantics:ident)? $sel:ident)
+        ($sel:ident)
         ()
 
         ()
         ()
-        // Possible to hit via. the MainThreadMarker branch
-        ($($already_parsed_retain_semantics:ident)?)
+        ($($retain_semantics:ident)?)
     ) => {
         $crate::__msg_send_id_helper! {
             @(send_message_id)
             @($receiver)
-            @($($retain_semantics)? $($already_parsed_retain_semantics)?)
+            @($($retain_semantics)?)
             @($sel)
             @()
-        }
-    };
-
-    // Parse retain semantics
-    //
-    // Note: While this is not public, it is still a breaking change to change
-    // this, since `icrate` relies on it.
-    (
-        ($receiver:expr)
-        (@__retain_semantics $retain_semantics:ident $($sel_rest:tt)*)
-        ($($args_rest:tt)*)
-
-        ($($sel_parsed:tt)*)
-        ($($arg_parsed:tt)*)
-        ()
-    ) => {
-        $crate::__method_msg_send_id! {
-            ($receiver)
-            ($($sel_rest)*)
-            ($($args_rest)*)
-
-            ($($sel_parsed)*)
-            ($($arg_parsed)*)
-            ($retain_semantics)
         }
     };
 

--- a/crates/objc2/src/macros/__method_msg_send.rs
+++ b/crates/objc2/src/macros/__method_msg_send.rs
@@ -15,10 +15,10 @@ macro_rules! __method_msg_send {
         ()
     ) => {
         $crate::__msg_send_helper! {
-            @(send_message)
-            @($receiver)
-            @($sel)
-            @()
+            ($receiver)
+            (send_message)
+            ($sel)
+            ()
         }
     };
 
@@ -95,10 +95,10 @@ macro_rules! __method_msg_send {
         ($($arg_parsed:tt)*)
     ) => {
         $crate::__msg_send_helper! {
-            @(send_message)
-            @($receiver)
-            @($($sel_parsed)*)
-            @($($arg_parsed)*)
+            ($receiver)
+            (send_message)
+            ($($sel_parsed)*)
+            ($($arg_parsed)*)
         }
     };
 
@@ -113,11 +113,11 @@ macro_rules! __method_msg_send {
         ($($arg_parsed:tt)*)
     ) => {
         $crate::__msg_send_helper! {
+            ($receiver)
             // Use error method
-            @(__send_message_error)
-            @($receiver)
-            @($($sel_parsed)* $sel :)
-            @($($arg_parsed)*)
+            (__send_message_error)
+            ($($sel_parsed)* $sel :)
+            ($($arg_parsed)*)
         }
     };
 
@@ -165,11 +165,11 @@ macro_rules! __method_msg_send_id {
         ($($retain_semantics:ident)?)
     ) => {
         $crate::__msg_send_id_helper! {
-            @(send_message_id)
-            @($receiver)
-            @($($retain_semantics)?)
-            @($sel)
-            @()
+            ($receiver)
+            ($($retain_semantics)?)
+            (send_message_id)
+            ($sel)
+            ()
         }
     };
 
@@ -253,11 +253,11 @@ macro_rules! __method_msg_send_id {
         ($($retain_semantics:ident)?)
     ) => {
         $crate::__msg_send_id_helper! {
-            @(send_message_id)
-            @($receiver)
-            @($($retain_semantics)?)
-            @($($sel_parsed)*)
-            @($($arg_parsed)*)
+            ($receiver)
+            ($($retain_semantics)?)
+            (send_message_id)
+            ($($sel_parsed)*)
+            ($($arg_parsed)*)
         }
     };
 
@@ -273,12 +273,12 @@ macro_rules! __method_msg_send_id {
         ($($retain_semantics:ident)?)
     ) => {
         $crate::__msg_send_id_helper! {
+            ($receiver)
+            ($($retain_semantics)?)
             // Use error method
-            @(send_message_id_error)
-            @($receiver)
-            @($($retain_semantics)?)
-            @($($sel_parsed)* $sel :)
-            @($($arg_parsed)*)
+            (send_message_id_error)
+            ($($sel_parsed)* $sel :)
+            ($($arg_parsed)*)
         }
     };
 

--- a/crates/objc2/src/macros/__method_msg_send.rs
+++ b/crates/objc2/src/macros/__method_msg_send.rs
@@ -30,7 +30,7 @@ macro_rules! __method_msg_send {
     (
         ($receiver:expr)
         ($($sel_rest:tt)*)
-        ($arg:ident: MainThreadMarker $(, $($args_rest:tt)*)?)
+        ($arg:ident: MainThreadMarker $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -39,7 +39,7 @@ macro_rules! __method_msg_send {
         $crate::__method_msg_send! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)*)
             ($($arg_parsed)*)
@@ -50,7 +50,7 @@ macro_rules! __method_msg_send {
     (
         ($receiver:expr)
         ($($sel:ident)? : $($sel_rest:tt)*)
-        ($arg:ident : $_arg_ty:ty $(, $($args_rest:tt)*)?)
+        ($arg:ident : $_arg_ty:ty $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -58,7 +58,7 @@ macro_rules! __method_msg_send {
         $crate::__method_msg_send! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)* $($sel)? :)
             ($($arg_parsed)* $arg,)
@@ -68,7 +68,7 @@ macro_rules! __method_msg_send {
     (
         ($receiver:expr)
         ($($sel:ident)? :: $($sel_rest:tt)*)
-        ($arg1:ident : $_arg_ty1:ty, $arg2:ident : $_arg_ty2:ty $(, $($args_rest:tt)*)?)
+        ($arg1:ident : $_arg_ty1:ty, $arg2:ident : $_arg_ty2:ty $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -76,7 +76,7 @@ macro_rules! __method_msg_send {
         $crate::__method_msg_send! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)* $($sel)? : :)
             ($($arg_parsed)* $arg1, $arg2,)
@@ -139,7 +139,7 @@ macro_rules! __method_msg_send {
     (
         ($receiver:expr)
         ($($sel_rest:tt)*)
-        ($($args_rest:tt)*)
+        ($($params_rest:tt)*)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -181,7 +181,7 @@ macro_rules! __method_msg_send_id {
     (
         ($receiver:expr)
         ($($sel_rest:tt)*)
-        ($arg:ident: MainThreadMarker $(, $($args_rest:tt)*)?)
+        ($arg:ident: MainThreadMarker $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -191,7 +191,7 @@ macro_rules! __method_msg_send_id {
         $crate::__method_msg_send_id! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)*)
             ($($arg_parsed)*)
@@ -203,7 +203,7 @@ macro_rules! __method_msg_send_id {
     (
         ($receiver:expr)
         ($($sel:ident)? : $($sel_rest:tt)*)
-        ($arg:ident : $_arg_ty:ty $(, $($args_rest:tt)*)?)
+        ($arg:ident : $_arg_ty:ty $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -212,7 +212,7 @@ macro_rules! __method_msg_send_id {
         $crate::__method_msg_send_id! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)* $($sel)? :)
             ($($arg_parsed)* $arg,)
@@ -223,7 +223,7 @@ macro_rules! __method_msg_send_id {
     (
         ($receiver:expr)
         ($($sel:ident)? :: $($sel_rest:tt)*)
-        ($arg1:ident : $_arg_ty1:ty, $arg2:ident : $_arg_ty2:ty $(, $($args_rest:tt)*)?)
+        ($arg1:ident : $_arg_ty1:ty, $arg2:ident : $_arg_ty2:ty $(, $($params_rest:tt)*)?)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)
@@ -232,7 +232,7 @@ macro_rules! __method_msg_send_id {
         $crate::__method_msg_send_id! {
             ($receiver)
             ($($sel_rest)*)
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
 
             ($($sel_parsed)* $($sel)? : :)
             ($($arg_parsed)* $arg1, $arg2,)
@@ -301,7 +301,7 @@ macro_rules! __method_msg_send_id {
     (
         ($receiver:expr)
         ($($sel_rest:tt)*)
-        ($($args_rest:tt)*)
+        ($($params_rest:tt)*)
 
         ($($sel_parsed:tt)*)
         ($($arg_parsed:tt)*)

--- a/crates/objc2/src/macros/__msg_send_parse.rs
+++ b/crates/objc2/src/macros/__msg_send_parse.rs
@@ -90,9 +90,9 @@ macro_rules! __msg_send_parse {
         $crate::__comma_between_args!(
             @($(
                 ", ",
-                stringify!($selector),
+                $crate::__macro_helpers::stringify!($selector),
                 ": ",
-                stringify!($argument),
+                $crate::__macro_helpers::stringify!($argument),
             )+)
             $($macro_args)*
         );
@@ -124,7 +124,7 @@ macro_rules! __comma_between_args {
         @($($args:tt)*)
         @($macro_name:literal)
     ) => {
-        #[deprecated = concat!(
+        #[deprecated = $crate::__macro_helpers::concat!(
             "using ", $macro_name, "! without a comma between arguments is ",
             "technically not valid macro syntax, and may break in a future ",
             "version of Rust. You should use the following instead:\n",
@@ -141,7 +141,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args! {
             @__output
-            @(stringify!(super($obj)), $($args)*)
+            @($crate::__macro_helpers::stringify!(super($obj)), $($args)*)
             @("msg_send")
         }
     };
@@ -152,7 +152,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args! {
             @__output
-            @(stringify!(super($obj, $superclass)), $($args)*)
+            @($crate::__macro_helpers::stringify!(super($obj, $superclass)), $($args)*)
             @("msg_send")
         }
     };
@@ -163,7 +163,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args! {
             @__output
-            @(stringify!($obj), $($args)*)
+            @($crate::__macro_helpers::stringify!($obj), $($args)*)
             @("msg_send")
         }
     };
@@ -176,7 +176,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args! {
             @__output
-            @(stringify!($obj), $($args)*)
+            @($crate::__macro_helpers::stringify!($obj), $($args)*)
             @("msg_send_id")
         }
     };

--- a/crates/objc2/src/macros/__rewrite_self_param.rs
+++ b/crates/objc2/src/macros/__rewrite_self_param.rs
@@ -5,23 +5,23 @@
 /// (builder_method:ident)
 /// (receiver:expr)
 /// (receiver_ty:ty)
-/// (args_prefix*)
-/// (args_rest*)
+/// (params_prefix*)
+/// (params_rest*)
 /// ```
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __rewrite_self_arg {
+macro_rules! __rewrite_self_param {
     {
-        ($($args:tt)*)
+        ($($params:tt)*)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        $crate::__rewrite_self_arg_inner! {
-            // Duplicate args out so that we can match on `self`, while still
-            // using it as a function argument
-            ($($args)*)
-            ($($args)*)
+        $crate::__rewrite_self_param_inner! {
+            // Duplicate params out so that we can match on `self`, while still
+            // using it as a function parameter
+            ($($params)*)
+            ($($params)*)
 
             ($out_macro)
             $($macro_args)*
@@ -31,11 +31,11 @@ macro_rules! __rewrite_self_arg {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __rewrite_self_arg_inner {
+macro_rules! __rewrite_self_param_inner {
     // Instance method
     {
-        (&self $($__args_rest:tt)*)
-        (&$self:ident $(, $($args_rest:tt)*)?)
+        (&self $($__params_rest:tt)*)
+        (&$self:ident $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -50,12 +50,12 @@ macro_rules! __rewrite_self_arg_inner {
                 &$self,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (&mut self $($__args_rest:tt)*)
-        (&mut $self:ident $(, $($args_rest:tt)*)?)
+        (&mut self $($__params_rest:tt)*)
+        (&mut $self:ident $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -70,12 +70,12 @@ macro_rules! __rewrite_self_arg_inner {
                 &mut $self,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (self: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($self:ident: $self_ty:ty $(, $($args_rest:tt)*)?)
+        (self: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($self:ident: $self_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -90,12 +90,12 @@ macro_rules! __rewrite_self_arg_inner {
                 $self: $self_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (mut self: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($mut:ident $self:ident: $self_ty:ty $(, $($args_rest:tt)*)?)
+        (mut self: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($mut:ident $self:ident: $self_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -110,7 +110,7 @@ macro_rules! __rewrite_self_arg_inner {
                 $mut $self: $self_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
 
@@ -118,8 +118,8 @@ macro_rules! __rewrite_self_arg_inner {
     // Workaround for arbitary self types being unstable
     // https://doc.rust-lang.org/nightly/unstable-book/language-features/arbitrary-self-types.html
     {
-        (mut this: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($mut:ident $this:ident: $this_ty:ty $(, $($args_rest:tt)*)?)
+        (mut this: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($mut:ident $this:ident: $this_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -134,12 +134,12 @@ macro_rules! __rewrite_self_arg_inner {
                 $mut $this: $this_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (this: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($this:ident: $this_ty:ty $(, $($args_rest:tt)*)?)
+        (this: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($this:ident: $this_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -154,12 +154,12 @@ macro_rules! __rewrite_self_arg_inner {
                 $this: $this_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (mut _this: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($mut:ident $this:ident: $this_ty:ty $(, $($args_rest:tt)*)?)
+        (mut _this: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($mut:ident $this:ident: $this_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -174,12 +174,12 @@ macro_rules! __rewrite_self_arg_inner {
                 $mut $this: $this_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
     {
-        (_this: $__self_ty:ty $(, $($__args_rest:tt)*)?)
-        ($this:ident: $this_ty:ty $(, $($args_rest:tt)*)?)
+        (_this: $__self_ty:ty $(, $($__params_rest:tt)*)?)
+        ($this:ident: $this_ty:ty $(, $($params_rest:tt)*)?)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -194,14 +194,14 @@ macro_rules! __rewrite_self_arg_inner {
                 $this: $this_ty,
                 _: $crate::runtime::Sel,
             )
-            ($($($args_rest)*)?)
+            ($($($params_rest)*)?)
         }
     };
 
     // Class method
     {
-        ($($__args:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params:tt)*)
+        ($($params_rest:tt)*)
 
         ($out_macro:path)
         $($macro_args:tt)*
@@ -216,7 +216,7 @@ macro_rules! __rewrite_self_arg_inner {
                 _: &$crate::runtime::AnyClass,
                 _: $crate::runtime::Sel,
             )
-            ($($args_rest)*)
+            ($($params_rest)*)
         }
     };
 }

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -819,7 +819,6 @@ macro_rules! __declare_class_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($out_macro)
             ($($macro_arg)*)
@@ -852,7 +851,6 @@ macro_rules! __declare_class_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($out_macro)
             ($($macro_arg)*)

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -779,30 +779,29 @@ macro_rules! __declare_class_register_impls {
         $($rest:tt)*
     ) => {
         $crate::__extract_and_apply_cfg_attributes! {
-            @($(#[$($m)*])*)
-            @(
-                // Implement protocol
-                #[allow(unused_mut)]
-                let mut __objc2_protocol_builder = $builder.__add_protocol_methods(
-                    <dyn $protocol as $crate::ProtocolType>::protocol()
-                );
+            ($(#[$($m)*])*)
 
-                // In case the user's function is marked `deprecated`
-                #[allow(deprecated)]
-                // In case the user did not specify any methods
-                #[allow(unused_unsafe)]
-                // SAFETY: Upheld by caller
-                unsafe {
-                    $crate::__declare_class_register_methods! {
-                        (__objc2_protocol_builder)
+            // Implement protocol
+            #[allow(unused_mut)]
+            let mut __objc2_protocol_builder = $builder.__add_protocol_methods(
+                <dyn $protocol as $crate::ProtocolType>::protocol()
+            );
 
-                        $($methods)*
-                    }
+            // In case the user's function is marked `deprecated`
+            #[allow(deprecated)]
+            // In case the user did not specify any methods
+            #[allow(unused_unsafe)]
+            // SAFETY: Upheld by caller
+            unsafe {
+                $crate::__declare_class_register_methods! {
+                    (__objc2_protocol_builder)
+
+                    $($methods)*
                 }
+            }
 
-                // Finished declaring protocol; get error message if any
-                __objc2_protocol_builder.__finish();
-            )
+            // Finished declaring protocol; get error message if any
+            __objc2_protocol_builder.__finish();
         }
 
         $crate::__declare_class_register_impls! {
@@ -823,21 +822,20 @@ macro_rules! __declare_class_register_impls {
         $($rest:tt)*
     ) => {
         $crate::__extract_and_apply_cfg_attributes! {
-            @($(#[$($m)*])*)
-            @(
-                // In case the user's function is marked `deprecated`
-                #[allow(deprecated)]
-                // In case the user did not specify any methods
-                #[allow(unused_unsafe)]
-                // SAFETY: Upheld by caller
-                unsafe {
-                    $crate::__declare_class_register_methods! {
-                        ($builder)
+            ($(#[$($m)*])*)
 
-                        $($methods)*
-                    }
+            // In case the user's function is marked `deprecated`
+            #[allow(deprecated)]
+            // In case the user did not specify any methods
+            #[allow(unused_unsafe)]
+            // SAFETY: Upheld by caller
+            unsafe {
+                $crate::__declare_class_register_methods! {
+                    ($builder)
+
+                    $($methods)*
                 }
-            )
+            }
         }
 
         $crate::__declare_class_register_impls! {
@@ -1127,7 +1125,7 @@ macro_rules! __declare_class_method_out_inner {
             <$crate::__macro_helpers::RetainSemantics<{
                 $crate::__macro_helpers::retain_semantics(
                     $crate::__sel_helper! {
-                        @()
+                        ()
                         $($sel)*
                     }
                 )
@@ -1200,20 +1198,19 @@ macro_rules! __declare_class_register_out {
         ($($m_checked:tt)*)
     } => {
         $crate::__extract_and_apply_cfg_attributes! {
-            @($($m_checked)*)
-            @(
-                $crate::__declare_class_invalid_selectors!(#[method($($sel)*)]);
-                $crate::__extern_methods_no_optional!($($m_optional)*);
+            ($($m_checked)*)
 
-                $builder.$builder_method(
-                    $crate::sel!($($sel)*),
-                    Self::$name as $crate::__fn_ptr! {
-                        ($($qualifiers)*)
-                        (_, _,)
-                        $($params_rest)*
-                    },
-                );
-            )
+            $crate::__declare_class_invalid_selectors!(#[method($($sel)*)]);
+            $crate::__extern_methods_no_optional!($($m_optional)*);
+
+            $builder.$builder_method(
+                $crate::sel!($($sel)*),
+                Self::$name as $crate::__fn_ptr! {
+                    ($($qualifiers)*)
+                    (_, _,)
+                    $($params_rest)*
+                },
+            );
         }
     };
 
@@ -1237,20 +1234,19 @@ macro_rules! __declare_class_register_out {
         ($($m_checked:tt)*)
     } => {
         $crate::__extract_and_apply_cfg_attributes! {
-            @($($m_checked)*)
-            @(
-                $crate::__declare_class_invalid_selectors!(#[method_id($($sel)*)]);
-                $crate::__extern_methods_no_optional!($($m_optional)*);
+            ($($m_checked)*)
 
-                $builder.$builder_method(
-                    $crate::sel!($($sel)*),
-                    Self::$name as $crate::__fn_ptr! {
-                        ($($qualifiers)*)
-                        (_, _,)
-                        $($params_rest)*
-                    },
-                );
-            )
+            $crate::__declare_class_invalid_selectors!(#[method_id($($sel)*)]);
+            $crate::__extern_methods_no_optional!($($m_optional)*);
+
+            $builder.$builder_method(
+                $crate::sel!($($sel)*),
+                Self::$name as $crate::__fn_ptr! {
+                    ($($qualifiers)*)
+                    (_, _,)
+                    $($params_rest)*
+                },
+            );
         }
     };
 }

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -1159,7 +1159,7 @@ macro_rules! __declare_class_method_out_inner {
     } => {
         $($m_checked)*
         $($qualifiers)* extern "C" fn $name() {
-            compile_error!("`#[method_id(...)]` must have a return type")
+            $crate::__macro_helpers::compile_error!("`#[method_id(...)]` must have a return type")
         }
     };
 }
@@ -1294,7 +1294,7 @@ macro_rules! __declare_class_register_out {
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
-        compile_error!("`#[optional]` is only supported in `extern_protocol!`")
+        $crate::__macro_helpers::compile_error!("`#[optional]` is only supported in `extern_protocol!`")
     };
 }
 
@@ -1302,31 +1302,31 @@ macro_rules! __declare_class_register_out {
 #[macro_export]
 macro_rules! __get_method_id_sel {
     (alloc) => {
-        compile_error!(concat!(
+        $crate::__macro_helpers::compile_error!($crate::__macro_helpers::concat!(
             "`#[method_id(alloc)]` is not supported. ",
             "Use `#[method(alloc)]` and do the memory management yourself",
         ))
     };
     (retain) => {
-        compile_error!(concat!(
+        $crate::__macro_helpers::compile_error!($crate::__macro_helpers::concat!(
             "`#[method_id(retain)]` is not supported. ",
             "Use `#[method(retain)]` and do the memory management yourself",
         ))
     };
     (release) => {
-        compile_error!(concat!(
+        $crate::__macro_helpers::compile_error!($crate::__macro_helpers::concat!(
             "`#[method_id(release)]` is not supported. ",
             "Use `#[method(release)]` and do the memory management yourself",
         ))
     };
     (autorelease) => {
-        compile_error!(concat!(
+        $crate::__macro_helpers::compile_error!($crate::__macro_helpers::concat!(
             "`#[method_id(autorelease)]` is not supported. ",
             "Use `#[method(autorelease)]` and do the memory management yourself",
         ))
     };
     (dealloc) => {
-        compile_error!(concat!(
+        $crate::__macro_helpers::compile_error!($crate::__macro_helpers::concat!(
             "`#[method_id(dealloc)]` is not supported. ",
             "Add an instance variable with a `Drop` impl to the class instead",
         ))

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -886,6 +886,7 @@ macro_rules! __declare_class_method_out {
         ($($args_rest:tt)*)
 
         ($($m_method:tt)*)
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
@@ -907,6 +908,7 @@ macro_rules! __declare_class_method_out {
             ($($args_prefix)*)
 
             ($($m_method)*)
+            ($($retain_semantics)*)
             ($($m_optional)*)
             ($($m_checked)*)
         }
@@ -1010,6 +1012,7 @@ macro_rules! __declare_class_method_out_inner {
         ($($args_prefix:tt)*)
 
         (#[method($($__sel:tt)*)])
+        ()
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
@@ -1041,6 +1044,7 @@ macro_rules! __declare_class_method_out_inner {
         ($($args_prefix:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        () // Specifying retain semantics is unsupported in declare_class! for now
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
@@ -1083,6 +1087,7 @@ macro_rules! __declare_class_method_out_inner {
         ($($args_prefix:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        ($($retain_semantics:tt)*)
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
@@ -1127,6 +1132,7 @@ macro_rules! __declare_class_register_out {
         ($($args_rest:tt)*)
 
         (#[method(dealloc)])
+        ()
         () // No optional
         ($($m_checked:tt)*)
     } => {
@@ -1153,6 +1159,7 @@ macro_rules! __declare_class_register_out {
         ($($args_rest:tt)*)
 
         (#[method($($sel:tt)*)])
+        ()
         () // No optional
         ($($m_checked:tt)*)
     } => {
@@ -1186,6 +1193,7 @@ macro_rules! __declare_class_register_out {
         ($($args_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        () // Retain semantics unsupported in declare_class!
         () // No optional
         ($($m_checked:tt)*)
     } => {
@@ -1219,6 +1227,7 @@ macro_rules! __declare_class_register_out {
         ($($args_rest:tt)*)
 
         ($($m_method:tt)*)
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -93,7 +93,7 @@
 ///
 /// If the `#[method_id(...)]` attribute is used, the return type must be
 /// `Option<Id<T>>` or `Id<T>`. Additionally, if the selector is in the
-/// "init"-family, the `self`/`this` argument must be `Allocated<Self>`.
+/// "init"-family, the `self`/`this` parameter must be `Allocated<Self>`.
 ///
 /// Putting other attributes on the method such as `cfg`, `allow`, `doc`,
 /// `deprecated` and so on is supported. However, note that `cfg_attr` may not
@@ -105,7 +105,7 @@
 /// can't mark them as `pub` for the same reason). Instead, use the
 /// [`extern_methods!`] macro to create a Rust interface to the methods.
 ///
-/// If the argument or return type is [`bool`], a conversion is performed to
+/// If the parameter or return type is [`bool`], a conversion is performed to
 /// make it behave similarly to the Objective-C `BOOL`. Use [`runtime::Bool`]
 /// if you want to control this manually.
 ///
@@ -801,27 +801,27 @@ macro_rules! __declare_class_register_methods {
 macro_rules! __declare_class_rewrite_methods {
     {
         ($out_macro:path)
-        ($($macro_arg:tt)*)
+        ($($macro_args:tt)*)
     } => {};
 
     // Unsafe variant
     {
         ($out_macro:path)
-        ($($macro_arg:tt)*)
+        ($($macro_args:tt)*)
 
         $(#[$($m:tt)*])*
-        unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($out_macro)
-            ($($macro_arg)*)
+            ($($macro_args)*)
             (unsafe)
             ($name)
             ($($ret)?)
@@ -830,7 +830,7 @@ macro_rules! __declare_class_rewrite_methods {
 
         $crate::__declare_class_rewrite_methods! {
             ($out_macro)
-            ($($macro_arg)*)
+            ($($macro_args)*)
 
             $($rest)*
         }
@@ -839,21 +839,21 @@ macro_rules! __declare_class_rewrite_methods {
     // Safe variant
     {
         ($out_macro:path)
-        ($($macro_arg:tt)*)
+        ($($macro_args:tt)*)
 
         $(#[$($m:tt)*])*
-        fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($out_macro)
-            ($($macro_arg)*)
+            ($($macro_args)*)
             ()
             ($name)
             ($($ret)?)
@@ -862,7 +862,7 @@ macro_rules! __declare_class_rewrite_methods {
 
         $crate::__declare_class_rewrite_methods! {
             ($out_macro)
-            ($($macro_arg)*)
+            ($($macro_args)*)
 
             $($rest)*
         }
@@ -882,16 +882,16 @@ macro_rules! __declare_class_method_out {
         ($builder_method:ident)
         ($receiver:expr)
         ($receiver_ty:ty)
-        ($($args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         ($($m_method:tt)*)
         ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
-        $crate::__declare_class_rewrite_args! {
-            ($($args_rest)*)
+        $crate::__declare_class_rewrite_params! {
+            ($($params_rest)*)
             ()
             ()
 
@@ -905,7 +905,7 @@ macro_rules! __declare_class_method_out {
             ($builder_method)
             ($receiver)
             ($receiver_ty)
-            ($($args_prefix)*)
+            ($($params_prefix)*)
 
             ($($m_method)*)
             ($($retain_semantics)*)
@@ -917,19 +917,19 @@ macro_rules! __declare_class_method_out {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __declare_class_rewrite_args {
+macro_rules! __declare_class_rewrite_params {
     // Convert _
     {
-        (_ : $param_ty:ty $(, $($rest_args:tt)*)?)
-        ($($args_converted:tt)*)
+        (_ : $param_ty:ty $(, $($params_rest:tt)*)?)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        $crate::__declare_class_rewrite_args! {
-            ($($($rest_args)*)?)
-            ($($args_converted)* _ : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
+        $crate::__declare_class_rewrite_params! {
+            ($($($params_rest)*)?)
+            ($($params_converted)* _ : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
             ($($body_prefix)*)
 
             ($out_macro)
@@ -938,16 +938,16 @@ macro_rules! __declare_class_rewrite_args {
     };
     // Convert mut
     {
-        (mut $param:ident : $param_ty:ty $(, $($rest_args:tt)*)?)
-        ($($args_converted:tt)*)
+        (mut $param:ident : $param_ty:ty $(, $($params_rest:tt)*)?)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        $crate::__declare_class_rewrite_args! {
-            ($($($rest_args)*)?)
-            ($($args_converted)* $param : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
+        $crate::__declare_class_rewrite_params! {
+            ($($($params_rest)*)?)
+            ($($params_converted)* $param : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
             (
                 $($body_prefix)*
                 let mut $param = <$param_ty as $crate::__macro_helpers::ConvertArgument>::__from_declared_param($param);
@@ -959,16 +959,16 @@ macro_rules! __declare_class_rewrite_args {
     };
     // Convert
     {
-        ($param:ident : $param_ty:ty $(, $($rest_args:tt)*)?)
-        ($($args_converted:tt)*)
+        ($param:ident : $param_ty:ty $(, $($params_rest:tt)*)?)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
 
         ($out_macro:path)
         $($macro_args:tt)*
     } => {
-        $crate::__declare_class_rewrite_args! {
-            ($($($rest_args)*)?)
-            ($($args_converted)* $param : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
+        $crate::__declare_class_rewrite_params! {
+            ($($($params_rest)*)?)
+            ($($params_converted)* $param : <$param_ty as $crate::__macro_helpers::ConvertArgument>::__Inner,)
             (
                 $($body_prefix)*
                 let $param = <$param_ty as $crate::__macro_helpers::ConvertArgument>::__from_declared_param($param);
@@ -981,7 +981,7 @@ macro_rules! __declare_class_rewrite_args {
     // Output result
     {
         ()
-        ($($args_converted:tt)*)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
 
         ($out_macro:path)
@@ -990,7 +990,7 @@ macro_rules! __declare_class_rewrite_args {
         $out_macro! {
             $($macro_args)*
 
-            ($($args_converted)*)
+            ($($params_converted)*)
             ($($body_prefix)*)
         }
     };
@@ -1009,20 +1009,20 @@ macro_rules! __declare_class_method_out_inner {
         ($__builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($args_prefix:tt)*)
+        ($($params_prefix:tt)*)
 
         (#[method($($__sel:tt)*)])
         ()
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
-        ($($args_converted:tt)*)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
     } => {
         $($m_checked)*
         $($qualifiers)* extern "C" fn $name(
-            $($args_prefix)*
-            $($args_converted)*
+            $($params_prefix)*
+            $($params_converted)*
         ) $(-> <$ret as $crate::__macro_helpers::ConvertReturn>::__Inner)? {
             $($body_prefix)*
             $crate::__convert_result! {
@@ -1041,20 +1041,20 @@ macro_rules! __declare_class_method_out_inner {
         ($__builder_method:ident)
         ($__receiver:expr)
         ($receiver_ty:ty)
-        ($($args_prefix:tt)*)
+        ($($params_prefix:tt)*)
 
         (#[method_id($($sel:tt)*)])
         () // Specifying retain semantics is unsupported in declare_class! for now
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
-        ($($args_converted:tt)*)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
     } => {
         $($m_checked)*
         $($qualifiers)* extern "C" fn $name(
-            $($args_prefix)*
-            $($args_converted)*
+            $($params_prefix)*
+            $($params_converted)*
         ) -> $crate::declare::__IdReturnValue {
             $($body_prefix)*
 
@@ -1084,14 +1084,14 @@ macro_rules! __declare_class_method_out_inner {
         ($__builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($args_prefix:tt)*)
+        ($($params_prefix:tt)*)
 
         (#[method_id($($sel:tt)*)])
         ($($retain_semantics:tt)*)
         ($($__m_optional:tt)*)
         ($($m_checked:tt)*)
 
-        ($($args_converted:tt)*)
+        ($($params_converted:tt)*)
         ($($body_prefix:tt)*)
     } => {
         $($m_checked)*
@@ -1128,8 +1128,8 @@ macro_rules! __declare_class_register_out {
         ($builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method(dealloc)])
         ()
@@ -1155,8 +1155,8 @@ macro_rules! __declare_class_register_out {
         ($builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method($($sel:tt)*)])
         ()
@@ -1171,7 +1171,7 @@ macro_rules! __declare_class_register_out {
                     Self::$name as $crate::__fn_ptr! {
                         ($($qualifiers)*)
                         (_, _,)
-                        $($args_rest)*
+                        $($params_rest)*
                     },
                 );
             )
@@ -1189,8 +1189,8 @@ macro_rules! __declare_class_register_out {
         ($builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
         () // Retain semantics unsupported in declare_class!
@@ -1205,7 +1205,7 @@ macro_rules! __declare_class_register_out {
                     Self::$name as $crate::__fn_ptr! {
                         ($($qualifiers)*)
                         (_, _,)
-                        $($args_rest)*
+                        $($params_rest)*
                     },
                 );
             )
@@ -1223,8 +1223,8 @@ macro_rules! __declare_class_register_out {
         ($builder_method:ident)
         ($__receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         ($($m_method:tt)*)
         ($($retain_semantics:tt)*)
@@ -1273,7 +1273,7 @@ macro_rules! __get_method_id_sel {
     };
 }
 
-/// Create function pointer type with inferred arguments.
+/// Create function pointer type with inferred parameters.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __fn_ptr {

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -389,7 +389,7 @@ macro_rules! declare_class {
             const NAME: &'static str = $name_const:expr;
         }
 
-        $($methods:tt)*
+        $($impls:tt)*
     } => {
         $crate::__emit_struct_and_ivars! {
             ($(#[$m])*)
@@ -403,7 +403,7 @@ macro_rules! declare_class {
             )
         }
 
-        $crate::__inner_declare_class! {
+        $crate::__declare_class_inner! {
             ($ivar_helper_module)
 
             unsafe impl ClassType for $for {
@@ -415,7 +415,7 @@ macro_rules! declare_class {
                 const NAME: &'static str = $name_const;
             }
 
-            $($methods)*
+            $($impls)*
         }
     };
 
@@ -435,7 +435,7 @@ macro_rules! declare_class {
             const NAME: &'static str = $name_const:expr;
         }
 
-        $($methods:tt)*
+        $($impls:tt)*
     } => {
         $crate::__emit_struct_and_ivars! {
             ($(#[$m])*)
@@ -449,7 +449,7 @@ macro_rules! declare_class {
             )
         }
 
-        $crate::__inner_declare_class! {
+        $crate::__declare_class_inner! {
             ()
 
             unsafe impl ClassType for $for {
@@ -461,7 +461,7 @@ macro_rules! declare_class {
                 const NAME: &'static str = $name_const;
             }
 
-            $($methods)*
+            $($impls)*
         }
     };
 
@@ -479,7 +479,7 @@ macro_rules! declare_class {
             const NAME: &'static str = $name_const:expr;
         }
 
-        $($methods:tt)*
+        $($impls:tt)*
     } => {
         $crate::__emit_struct_and_ivars! {
             ($(#[$m])*)
@@ -493,7 +493,7 @@ macro_rules! declare_class {
             )
         }
 
-        $crate::__inner_declare_class! {
+        $crate::__declare_class_inner! {
             ()
 
             unsafe impl ClassType for $for {
@@ -505,14 +505,14 @@ macro_rules! declare_class {
                 const NAME: &'static str = $name_const;
             }
 
-            $($methods)*
+            $($impls)*
         }
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __inner_declare_class {
+macro_rules! __declare_class_inner {
     {
         ($($ivar_helper_module:ident)?)
 
@@ -525,7 +525,7 @@ macro_rules! __inner_declare_class {
             const NAME: &'static str = $name_const:expr;
         }
 
-        $($methods:tt)*
+        $($impls:tt)*
     } => {
         $crate::__extern_class_impl_traits! {
             // SAFETY: Upheld by caller
@@ -608,9 +608,9 @@ macro_rules! __inner_declare_class {
                     }
 
                     // Implement protocols and methods
-                    $crate::__declare_class_register_methods! {
+                    $crate::__declare_class_register_impls! {
                         (__objc2_builder)
-                        $($methods)*
+                        $($impls)*
                     }
 
                     let _cls = __objc2_builder.register();
@@ -632,8 +632,8 @@ macro_rules! __inner_declare_class {
         }
 
         // Methods
-        $crate::__declare_class_methods! {
-            $($methods)*
+        $crate::__declare_class_output_impls! {
+            $($impls)*
         }
     };
 }
@@ -651,9 +651,10 @@ macro_rules! __select_name {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __declare_class_methods {
+macro_rules! __declare_class_output_impls {
     // Base-case
     () => {};
+
     // With protocol
     (
         $(#[$m:meta])*
@@ -677,10 +678,11 @@ macro_rules! __declare_class_methods {
             }
         }
 
-        $crate::__declare_class_methods!{
+        $crate::__declare_class_output_impls!{
             $($rest)*
         }
     };
+
     // Without protocol
     (
         $(#[$m:meta])*
@@ -700,7 +702,7 @@ macro_rules! __declare_class_methods {
             }
         }
 
-        $crate::__declare_class_methods! {
+        $crate::__declare_class_output_impls! {
             $($rest)*
         }
     };
@@ -708,7 +710,7 @@ macro_rules! __declare_class_methods {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __declare_class_register_methods {
+macro_rules! __declare_class_register_impls {
     // Base-case
     (
         ($builder:ident)
@@ -753,7 +755,7 @@ macro_rules! __declare_class_register_methods {
             )
         }
 
-        $crate::__declare_class_register_methods! {
+        $crate::__declare_class_register_impls! {
             ($builder)
             $($rest)*
         }
@@ -789,7 +791,7 @@ macro_rules! __declare_class_register_methods {
             )
         }
 
-        $crate::__declare_class_register_methods! {
+        $crate::__declare_class_register_impls! {
             ($builder)
             $($rest)*
         }

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -1178,7 +1178,6 @@ macro_rules! __convert_result {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __declare_class_register_out {
-    // #[method(...)]
     {
         ($builder:ident)
         ($($qualifiers:tt)*)
@@ -1192,51 +1191,15 @@ macro_rules! __declare_class_register_out {
         ($($__params_prefix:tt)*)
         ($($params_rest:tt)*)
 
-        (#[method($($sel:tt)*)])
-        ()
+        (#[$method_or_method_id:ident($($sel:tt)*)])
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
         $crate::__extract_and_apply_cfg_attributes! {
             ($($m_checked)*)
 
-            $crate::__declare_class_invalid_selectors!(#[method($($sel)*)]);
-            $crate::__extern_methods_no_optional!($($m_optional)*);
-
-            $builder.$builder_method(
-                $crate::sel!($($sel)*),
-                Self::$name as $crate::__fn_ptr! {
-                    ($($qualifiers)*)
-                    (_, _,)
-                    $($params_rest)*
-                },
-            );
-        }
-    };
-
-    // #[method_id(...)]
-    {
-        ($builder:ident)
-        ($($qualifiers:tt)*)
-        ($name:ident)
-        ($($__ret:ty)?)
-        ($__body:block)
-
-        ($builder_method:ident)
-        ($__receiver:expr)
-        ($__receiver_ty:ty)
-        ($($__params_prefix:tt)*)
-        ($($params_rest:tt)*)
-
-        (#[method_id($($sel:tt)*)])
-        () // Retain semantics unsupported in declare_class!
-        ($($m_optional:tt)*)
-        ($($m_checked:tt)*)
-    } => {
-        $crate::__extract_and_apply_cfg_attributes! {
-            ($($m_checked)*)
-
-            $crate::__declare_class_invalid_selectors!(#[method_id($($sel)*)]);
+            $crate::__declare_class_invalid_selectors!(#[$method_or_method_id($($sel)*)]);
             $crate::__extern_methods_no_optional!($($m_optional)*);
 
             $builder.$builder_method(

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -266,7 +266,7 @@ macro_rules! __impl_as_ref_borrow {
             fn as_mut($($self_mut:tt)*) $mut:block
         }
 
-        @()
+        ()
     } => {};
     {
         impl ($($t:tt)*) for $for:ty {
@@ -274,7 +274,7 @@ macro_rules! __impl_as_ref_borrow {
             fn as_mut($($self_mut:tt)*) $mut:block
         }
 
-        @($item:ty, $($tail:ty,)*)
+        ($item:ty, $($tail:ty,)*)
     } => {
         impl<$($t)*> $crate::__macro_helpers::AsRef<$item> for $for {
             #[inline]
@@ -308,7 +308,7 @@ macro_rules! __impl_as_ref_borrow {
                 fn as_mut($($self_mut)*) $mut
             }
 
-            @($($tail,)*)
+            ($($tail,)*)
         }
     };
     // TODO: Expose a generic variant of the macro.
@@ -504,7 +504,7 @@ macro_rules! __extern_class_impl_traits {
                 }
             }
 
-            @($superclass, $($inheritance_rest,)*)
+            ($superclass, $($inheritance_rest,)*)
         }
     };
 }

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -301,6 +301,7 @@ macro_rules! __extern_methods_method_out {
         ($($args_rest:tt)*)
 
         (#[method($($sel:tt)*)])
+        ()
         () // No `optional`
         ($($m_checked:tt)*)
     } => {
@@ -335,6 +336,7 @@ macro_rules! __extern_methods_method_out {
         ($($args_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        ($($retain_semantics:tt)*)
         () // No `optional`
         ($($m_checked:tt)*)
     } => {
@@ -352,7 +354,7 @@ macro_rules! __extern_methods_method_out {
 
                     ()
                     ()
-                    ()
+                    ($($retain_semantics)*)
                 }
             }
         }
@@ -370,6 +372,7 @@ macro_rules! __extern_methods_method_out {
         ($($args_rest:tt)*)
 
         ($($m_method:tt)*)
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -224,20 +224,20 @@ macro_rules! __extern_methods_rewrite_methods {
     // Unsafe variant
     {
         $(#[$($m:tt)*])*
-        $v:vis unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+        $v:vis unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)?
         // TODO: Handle where bounds better
         $(where $($where:ty : $bound:path),+ $(,)?)?;
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($crate::__extern_methods_method_out)
-            ($v unsafe fn $name($($args)*) $(-> $ret)?)
+            ($v unsafe fn $name($($params)*) $(-> $ret)?)
             ($($($where : $bound ,)+)?)
         }
 
@@ -249,20 +249,20 @@ macro_rules! __extern_methods_rewrite_methods {
     // Safe variant
     {
         $(#[$($m:tt)*])*
-        $v:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+        $v:vis fn $name:ident($($params:tt)*) $(-> $ret:ty)?
         // TODO: Handle where bounds better
         $(where $($where:ty : $bound:path),+ $(,)?)?;
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($crate::__extern_methods_method_out)
-            ($v fn $name($($args)*) $(-> $ret)?)
+            ($v fn $name($($params)*) $(-> $ret)?)
             ($($($where : $bound ,)+)?)
         }
 
@@ -297,8 +297,8 @@ macro_rules! __extern_methods_method_out {
         ($__builder_method:ident)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method($($sel:tt)*)])
         ()
@@ -315,7 +315,7 @@ macro_rules! __extern_methods_method_out {
                 $crate::__method_msg_send! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()
@@ -332,8 +332,8 @@ macro_rules! __extern_methods_method_out {
         ($__builder_method:ident)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
         ($($retain_semantics:tt)*)
@@ -350,7 +350,7 @@ macro_rules! __extern_methods_method_out {
                 $crate::__method_msg_send_id! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()
@@ -368,8 +368,8 @@ macro_rules! __extern_methods_method_out {
         ($__builder_method:ident)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         ($($m_method:tt)*)
         ($($retain_semantics:tt)*)

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -302,7 +302,7 @@ macro_rules! __extern_methods_method_out {
 
         (#[method($($sel:tt)*)])
         ()
-        () // No `optional`
+        ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
         $($m_checked)*
@@ -310,6 +310,8 @@ macro_rules! __extern_methods_method_out {
         where
             $($where : $bound,)*
         {
+            $crate::__extern_methods_no_optional!($($m_optional)*);
+
             #[allow(unused_unsafe)]
             unsafe {
                 $crate::__method_msg_send! {
@@ -337,7 +339,7 @@ macro_rules! __extern_methods_method_out {
 
         (#[method_id($($sel:tt)*)])
         ($($retain_semantics:tt)*)
-        () // No `optional`
+        ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
         $($m_checked)*
@@ -345,6 +347,8 @@ macro_rules! __extern_methods_method_out {
         where
             $($where : $bound,)*
         {
+            $crate::__extern_methods_no_optional!($($m_optional)*);
+
             #[allow(unused_unsafe)]
             unsafe {
                 $crate::__method_msg_send_id! {
@@ -359,26 +363,15 @@ macro_rules! __extern_methods_method_out {
             }
         }
     };
+}
 
-    // #[optional]
-    {
-        ($($function_start:tt)*)
-        ($($where:ty : $bound:path ,)*)
-
-        ($__builder_method:ident)
-        ($receiver:expr)
-        ($__receiver_ty:ty)
-        ($($__params_prefix:tt)*)
-        ($($params_rest:tt)*)
-
-        ($($m_method:tt)*)
-        ($($retain_semantics:tt)*)
-        ($($m_optional:tt)*)
-        ($($m_checked:tt)*)
-    } => {
-        $($m_checked)*
-        $($function_start)* {
-            $crate::__macro_helpers::compile_error!("`#[optional]` is only supported in `extern_protocol!`")
-        }
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __extern_methods_no_optional {
+    () => {};
+    (#[optional]) => {
+        $crate::__macro_helpers::compile_error!(
+            "`#[optional]` is only supported in `extern_protocol!`"
+        )
     };
 }

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -378,7 +378,7 @@ macro_rules! __extern_methods_method_out {
     } => {
         $($m_checked)*
         $($function_start)* {
-            compile_error!("`#[optional]` is only supported in `extern_protocol!`")
+            $crate::__macro_helpers::compile_error!("`#[optional]` is only supported in `extern_protocol!`")
         }
     };
 }

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -235,7 +235,6 @@ macro_rules! __extern_methods_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($crate::__extern_methods_method_out)
             ($v unsafe fn $name($($args)*) $(-> $ret)?)
@@ -261,7 +260,6 @@ macro_rules! __extern_methods_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($crate::__extern_methods_method_out)
             ($v fn $name($($args)*) $(-> $ret)?)

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -228,7 +228,6 @@ macro_rules! __extern_protocol_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($crate::__extern_protocol_method_out)
             ($v unsafe fn $name($($args)*) $(-> $ret)?)
@@ -254,7 +253,6 @@ macro_rules! __extern_protocol_rewrite_methods {
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
-            ($name)
 
             ($crate::__extern_protocol_method_out)
             ($v fn $name($($args)*) $(-> $ret)?)

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -217,20 +217,20 @@ macro_rules! __extern_protocol_rewrite_methods {
     // Unsafe variant
     {
         $(#[$($m:tt)*])*
-        $v:vis unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+        $v:vis unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)?
         // TODO: Handle where bounds better
         $(where $($where:ty : $bound:path),+ $(,)?)?;
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($crate::__extern_protocol_method_out)
-            ($v unsafe fn $name($($args)*) $(-> $ret)?)
+            ($v unsafe fn $name($($params)*) $(-> $ret)?)
             ($($($where : $bound ,)+)?)
         }
 
@@ -242,20 +242,20 @@ macro_rules! __extern_protocol_rewrite_methods {
     // Safe variant
     {
         $(#[$($m:tt)*])*
-        $v:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+        $v:vis fn $name:ident($($params:tt)*) $(-> $ret:ty)?
         // TODO: Handle where bounds better
         $(where $($where:ty : $bound:path),+ $(,)?)?;
 
         $($rest:tt)*
     } => {
-        $crate::__rewrite_self_arg! {
-            ($($args)*)
+        $crate::__rewrite_self_param! {
+            ($($params)*)
 
             ($crate::__extract_custom_attributes)
             ($(#[$($m)*])*)
 
             ($crate::__extern_protocol_method_out)
-            ($v fn $name($($args)*) $(-> $ret)?)
+            ($v fn $name($($params)*) $(-> $ret)?)
             ($($($where : $bound ,)+)?)
         }
 
@@ -276,8 +276,8 @@ macro_rules! __extern_protocol_method_out {
         (add_method)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method($($sel:tt)*)])
         ()
@@ -295,7 +295,7 @@ macro_rules! __extern_protocol_method_out {
                 $crate::__method_msg_send! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()
@@ -312,8 +312,8 @@ macro_rules! __extern_protocol_method_out {
         (add_method)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
         ($($retain_semantics:tt)*)
@@ -331,7 +331,7 @@ macro_rules! __extern_protocol_method_out {
                 $crate::__method_msg_send_id! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()
@@ -349,8 +349,8 @@ macro_rules! __extern_protocol_method_out {
         (add_class_method)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method($($sel:tt)*)])
         ()
@@ -368,7 +368,7 @@ macro_rules! __extern_protocol_method_out {
                 $crate::__method_msg_send! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()
@@ -385,8 +385,8 @@ macro_rules! __extern_protocol_method_out {
         (add_class_method)
         ($receiver:expr)
         ($__receiver_ty:ty)
-        ($($__args_prefix:tt)*)
-        ($($args_rest:tt)*)
+        ($($__params_prefix:tt)*)
+        ($($params_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
         ($($retain_semantics:tt)*)
@@ -404,7 +404,7 @@ macro_rules! __extern_protocol_method_out {
                 $crate::__method_msg_send_id! {
                     ($receiver)
                     ($($sel)*)
-                    ($($args_rest)*)
+                    ($($params_rest)*)
 
                     ()
                     ()

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -280,6 +280,7 @@ macro_rules! __extern_protocol_method_out {
         ($($args_rest:tt)*)
 
         (#[method($($sel:tt)*)])
+        ()
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
@@ -315,6 +316,7 @@ macro_rules! __extern_protocol_method_out {
         ($($args_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
@@ -333,7 +335,7 @@ macro_rules! __extern_protocol_method_out {
 
                     ()
                     ()
-                    ()
+                    ($($retain_semantics)*)
                 }
             }
         }
@@ -351,6 +353,7 @@ macro_rules! __extern_protocol_method_out {
         ($($args_rest:tt)*)
 
         (#[method($($sel:tt)*)])
+        ()
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
@@ -386,6 +389,7 @@ macro_rules! __extern_protocol_method_out {
         ($($args_rest:tt)*)
 
         (#[method_id($($sel:tt)*)])
+        ($($retain_semantics:tt)*)
         ($($m_optional:tt)*)
         ($($m_checked:tt)*)
     } => {
@@ -404,7 +408,7 @@ macro_rules! __extern_protocol_method_out {
 
                     ()
                     ()
-                    ()
+                    ($($retain_semantics)*)
                 }
             }
         }

--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -247,7 +247,7 @@ macro_rules! sel {
     ($($sel:tt)*) => {
         $crate::__sel_inner!(
             $crate::__sel_helper! {
-                @()
+                ()
                 $($sel)*
             },
             $crate::__hash_idents!($($sel)*)
@@ -263,37 +263,37 @@ macro_rules! sel {
 macro_rules! __sel_helper {
     // Base-case
     {
-        @($($parsed_sel:tt)*)
+        ($($parsed_sel:tt)*)
     } => ({
         $crate::__sel_data!($($parsed_sel)*)
     });
     // Single identifier
     {
-        @()
+        ()
         $ident:ident
     } => {
         $crate::__sel_helper! {
-            @($ident)
+            ($ident)
         }
     };
     // Parse identitifer + colon token
     {
-        @($($parsed_sel:tt)*)
+        ($($parsed_sel:tt)*)
         $($ident:ident)? : $($rest:tt)*
     } => {
         $crate::__sel_helper! {
-            @($($parsed_sel)* $($ident)? :)
+            ($($parsed_sel)* $($ident)? :)
             $($rest)*
         }
     };
     // Parse identitifer + path separator token
     {
-        @($($parsed_sel:tt)*)
+        ($($parsed_sel:tt)*)
         $($ident:ident)? :: $($rest:tt)*
     } => {
         $crate::__sel_helper! {
             // Notice space between these
-            @($($parsed_sel)* $($ident)? : :)
+            ($($parsed_sel)* $($ident)? : :)
             $($rest)*
         }
     };
@@ -989,38 +989,38 @@ macro_rules! __class_inner {
 macro_rules! msg_send {
     [super($obj:expr), $($selector_and_arguments:tt)+] => {
         $crate::__msg_send_parse! {
-            ($crate::__msg_send_helper)
-            @(__send_super_message_static_error)
-            @()
-            @()
-            @($($selector_and_arguments)+)
-            @(__send_super_message_static)
+            (__send_super_message_static_error)
+            ()
+            ()
+            ($($selector_and_arguments)+)
+            (__send_super_message_static)
 
-            @($obj)
+            ($crate::__msg_send_helper)
+            ($obj)
         }
     };
     [super($obj:expr, $superclass:expr), $($selector_and_arguments:tt)+] => {
         $crate::__msg_send_parse! {
-            ($crate::__msg_send_helper)
-            @(__send_super_message_error)
-            @()
-            @()
-            @($($selector_and_arguments)+)
-            @(send_super_message)
+            (__send_super_message_error)
+            ()
+            ()
+            ($($selector_and_arguments)+)
+            (send_super_message)
 
-            @($obj, $superclass)
+            ($crate::__msg_send_helper)
+            ($obj, $superclass)
         }
     };
     [$obj:expr, $($selector_and_arguments:tt)+] => {
         $crate::__msg_send_parse! {
-            ($crate::__msg_send_helper)
-            @(__send_message_error)
-            @()
-            @()
-            @($($selector_and_arguments)+)
-            @(send_message)
+            (__send_message_error)
+            ()
+            ()
+            ($($selector_and_arguments)+)
+            (send_message)
 
-            @($obj)
+            ($crate::__msg_send_helper)
+            ($obj)
         }
     };
 }
@@ -1029,10 +1029,10 @@ macro_rules! msg_send {
 #[macro_export]
 macro_rules! __msg_send_helper {
     {
-        @($fn:ident)
-        @($($fn_args:tt)+)
-        @($($selector:tt)*)
-        @($($argument:expr,)*)
+        ($($fn_args:tt)+)
+        ($fn:ident)
+        ($($selector:tt)*)
+        ($($argument:expr,)*)
     } => ({
         // Assign to intermediary variable for better UI, and to prevent
         // miscompilation on older Rust versions.
@@ -1244,15 +1244,15 @@ macro_rules! msg_send_id {
     });
     [$obj:expr, $($selector_and_arguments:tt)+] => {
         $crate::__msg_send_parse! {
-            ($crate::__msg_send_id_helper)
-            @(send_message_id_error)
-            @()
-            @()
-            @($($selector_and_arguments)+)
-            @(send_message_id)
+            (send_message_id_error)
+            ()
+            ()
+            ($($selector_and_arguments)+)
+            (send_message_id)
 
-            @($obj)
-            @()
+            ($crate::__msg_send_id_helper)
+            ($obj)
+            () // No retain semantics
         }
     };
 }
@@ -1262,55 +1262,55 @@ macro_rules! msg_send_id {
 #[macro_export]
 macro_rules! __msg_send_id_helper {
     {
-        @($fn:ident)
-        @($obj:expr)
-        @($($retain_semantics:ident)?)
-        @(retain)
-        @()
+        ($obj:expr)
+        ($($retain_semantics:ident)?)
+        ($fn:ident)
+        (retain)
+        ()
     } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, retain] is not supported. Use `Id::retain` instead"
         )
     }};
     {
-        @($fn:ident)
-        @($obj:expr)
-        @($($retain_semantics:ident)?)
-        @(release)
-        @()
+        ($obj:expr)
+        ($($retain_semantics:ident)?)
+        ($fn:ident)
+        (release)
+        ()
     } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, release] is not supported. Drop an `Id` instead"
         )
     }};
     {
-        @($fn:ident)
-        @($obj:expr)
-        @($($retain_semantics:ident)?)
-        @(autorelease)
-        @()
+        ($obj:expr)
+        ($($retain_semantics:ident)?)
+        ($fn:ident)
+        (autorelease)
+        ()
     } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, autorelease] is not supported. Use `Id::autorelease`"
         )
     }};
     {
-        @($fn:ident)
-        @($obj:expr)
-        @($($retain_semantics:ident)?)
-        @(dealloc)
-        @()
+        ($obj:expr)
+        ($($retain_semantics:ident)?)
+        ($fn:ident)
+        (dealloc)
+        ()
     } => {{
         $crate::__macro_helpers::compile_error!(
             "msg_send_id![obj, dealloc] is not supported. Drop an `Id` instead"
         )
     }};
     {
-        @($fn:ident)
-        @($obj:expr)
-        @($retain_semantics:ident)
-        @($($selector:tt)*)
-        @($($argument:expr,)*)
+        ($obj:expr)
+        ($retain_semantics:ident)
+        ($fn:ident)
+        ($($selector:tt)*)
+        ($($argument:expr,)*)
     } => ({
         <$crate::__macro_helpers::$retain_semantics as $crate::__macro_helpers::MsgSendId<_, _>>::$fn::<_, _>(
             $obj,
@@ -1319,11 +1319,11 @@ macro_rules! __msg_send_id_helper {
         )
     });
     {
-        @($fn:ident)
-        @($obj:expr)
-        @()
-        @($($selector:tt)*)
-        @($($argument:expr,)*)
+        ($obj:expr)
+        ()
+        ($fn:ident)
+        ($($selector:tt)*)
+        ($($argument:expr,)*)
     } => ({
         // Don't use `sel!`, otherwise we'd end up with defining this data twice.
         const __SELECTOR_DATA: &$crate::__macro_helpers::str = $crate::__sel_data!(

--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -2,7 +2,7 @@ mod __attribute_helpers;
 mod __field_helpers;
 mod __method_msg_send;
 mod __msg_send_parse;
-mod __rewrite_self_arg;
+mod __rewrite_self_param;
 mod declare_class;
 mod extern_class;
 mod extern_methods;

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
@@ -878,12 +878,6 @@ l_anon.[ID].21:
 	.quad	l_anon.[ID].16
 	.asciz	"\017\000\000\000\000\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -896,9 +890,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.quad	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -913,9 +907,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.quad	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -930,9 +924,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.quad	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -947,9 +941,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.quad	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -964,9 +958,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.quad	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -979,5 +973,11 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.quad	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-armv7.s
@@ -806,12 +806,6 @@ l_anon.[ID].21:
 	.long	l_anon.[ID].16
 	.asciz	"\017\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -824,9 +818,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.long	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -841,9 +835,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.long	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -858,9 +852,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.long	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -875,9 +869,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.long	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -892,9 +886,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.long	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -907,6 +901,12 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.long	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-armv7s.s
@@ -809,12 +809,6 @@ l_anon.[ID].21:
 	.long	l_anon.[ID].16
 	.asciz	"\017\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -827,9 +821,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.long	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -844,9 +838,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.long	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -861,9 +855,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.long	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -878,9 +872,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.long	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -895,9 +889,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.long	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -910,6 +904,12 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.long	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-old-x86.s
@@ -831,12 +831,6 @@ l_anon.[ID].21:
 	.long	l_anon.[ID].16
 	.asciz	"\017\000\000"
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -849,9 +843,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.long	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -866,9 +860,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.long	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -883,9 +877,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.long	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -900,9 +894,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.long	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -917,9 +911,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.long	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -932,6 +926,12 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.long	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_CLASS_REFERENCES_NSObject$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86.s
@@ -831,12 +831,6 @@ l_anon.[ID].21:
 	.long	l_anon.[ID].16
 	.asciz	"\017\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -849,9 +843,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.long	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -866,9 +860,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.long	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -883,9 +877,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.long	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -900,9 +894,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.long	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -917,9 +911,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.long	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -932,6 +926,12 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.long	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_CLASSLIST_REFERENCES_$_NSObject$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
@@ -645,12 +645,6 @@ l_anon.[ID].21:
 	.quad	l_anon.[ID].16
 	.asciz	"\017\000\000\000\000\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_d874ee9262978be2:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 L_OBJC_METH_VAR_NAME_d874ee9262978be2:
@@ -663,9 +657,9 @@ L_OBJC_SELECTOR_REFERENCES_d874ee9262978be2:
 	.quad	L_OBJC_METH_VAR_NAME_d874ee9262978be2
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
+	.globl	L_OBJC_IMAGE_INFO_d874ee9262978be2
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
+L_OBJC_IMAGE_INFO_d874ee9262978be2:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -680,9 +674,9 @@ L_OBJC_SELECTOR_REFERENCES_4539fd1dbda0cddc:
 	.quad	L_OBJC_METH_VAR_NAME_4539fd1dbda0cddc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
+	.globl	L_OBJC_IMAGE_INFO_4539fd1dbda0cddc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
+L_OBJC_IMAGE_INFO_4539fd1dbda0cddc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -697,9 +691,9 @@ L_OBJC_SELECTOR_REFERENCES_2b1b3a94e0ece2e5:
 	.quad	L_OBJC_METH_VAR_NAME_2b1b3a94e0ece2e5
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
+	.globl	L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_f7f521670860b0ce:
+L_OBJC_IMAGE_INFO_2b1b3a94e0ece2e5:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -714,9 +708,9 @@ L_OBJC_SELECTOR_REFERENCES_f7f521670860b0ce:
 	.quad	L_OBJC_METH_VAR_NAME_f7f521670860b0ce
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
+	.globl	L_OBJC_IMAGE_INFO_f7f521670860b0ce
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6addfcf634c6232f:
+L_OBJC_IMAGE_INFO_f7f521670860b0ce:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -731,9 +725,9 @@ L_OBJC_SELECTOR_REFERENCES_6addfcf634c6232f:
 	.quad	L_OBJC_METH_VAR_NAME_6addfcf634c6232f
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.globl	L_OBJC_IMAGE_INFO_6addfcf634c6232f
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+L_OBJC_IMAGE_INFO_6addfcf634c6232f:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -746,5 +740,11 @@ L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_4a8c690dbc9d8166:
 	.quad	L_OBJC_METH_VAR_NAME_4a8c690dbc9d8166
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_4a8c690dbc9d8166
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_4a8c690dbc9d8166:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
@@ -42,12 +42,6 @@ Lloh5:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -58,5 +52,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.quad	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7.s
@@ -41,12 +41,6 @@ LPC2_0:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -57,5 +51,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
@@ -47,12 +47,6 @@ LPC2_0:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -63,5 +57,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
@@ -56,12 +56,6 @@ L2$pb:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -72,5 +66,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
@@ -56,12 +56,6 @@ L2$pb:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -72,5 +66,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.long	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
@@ -39,12 +39,6 @@ _dyn_consume:
 l_anon.[ID].0:
 	.ascii	"MyProtocol"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_17aa92881c42487f:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_17aa92881c42487f
 L_OBJC_METH_VAR_NAME_17aa92881c42487f:
@@ -55,5 +49,11 @@ L_OBJC_METH_VAR_NAME_17aa92881c42487f:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_17aa92881c42487f:
 	.quad	L_OBJC_METH_VAR_NAME_17aa92881c42487f
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_17aa92881c42487f
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_17aa92881c42487f:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
@@ -91,12 +91,6 @@ l_anon.[ID].1:
 	.quad	l_anon.[ID].0
 	.asciz	";\000\000\000\000\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -109,9 +103,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.quad	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -126,9 +120,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.quad	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -143,9 +137,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.quad	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -160,9 +154,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.quad	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -175,5 +169,11 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.quad	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7.s
@@ -90,12 +90,6 @@ l_anon.[ID].1:
 	.long	l_anon.[ID].0
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -108,9 +102,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -125,9 +119,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -142,9 +136,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -159,9 +153,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -174,6 +168,12 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -93,12 +93,6 @@ l_anon.[ID].1:
 	.long	l_anon.[ID].0
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -111,9 +105,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -128,9 +122,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -145,9 +139,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -162,9 +156,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -177,6 +171,12 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
@@ -101,12 +101,6 @@ l_anon.[ID].1:
 	.long	l_anon.[ID].0
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -119,9 +113,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -136,9 +130,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -153,9 +147,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -170,9 +164,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -185,6 +179,12 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
@@ -101,12 +101,6 @@ l_anon.[ID].1:
 	.long	l_anon.[ID].0
 	.asciz	";\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -119,9 +113,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.long	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -136,9 +130,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.long	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -153,9 +147,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.long	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -170,9 +164,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.long	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -185,6 +179,12 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.long	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
@@ -70,12 +70,6 @@ l_anon.[ID].1:
 	.quad	l_anon.[ID].0
 	.asciz	";\000\000\000\000\000\000\000\016\000\000\000\005\000\000"
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ad1b815073641351:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_ad1b815073641351
 L_OBJC_METH_VAR_NAME_ad1b815073641351:
@@ -88,9 +82,9 @@ L_OBJC_SELECTOR_REFERENCES_ad1b815073641351:
 	.quad	L_OBJC_METH_VAR_NAME_ad1b815073641351
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
+	.globl	L_OBJC_IMAGE_INFO_ad1b815073641351
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_5ace898e385eba05:
+L_OBJC_IMAGE_INFO_ad1b815073641351:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -105,9 +99,9 @@ L_OBJC_SELECTOR_REFERENCES_5ace898e385eba05:
 	.quad	L_OBJC_METH_VAR_NAME_5ace898e385eba05
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
+	.globl	L_OBJC_IMAGE_INFO_5ace898e385eba05
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
+L_OBJC_IMAGE_INFO_5ace898e385eba05:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -122,9 +116,9 @@ L_OBJC_SELECTOR_REFERENCES_1f1c7bd8029c3138:
 	.quad	L_OBJC_METH_VAR_NAME_1f1c7bd8029c3138
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
+	.globl	L_OBJC_IMAGE_INFO_1f1c7bd8029c3138
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
+L_OBJC_IMAGE_INFO_1f1c7bd8029c3138:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -139,9 +133,9 @@ L_OBJC_SELECTOR_REFERENCES_eb5b4d2de37744da:
 	.quad	L_OBJC_METH_VAR_NAME_eb5b4d2de37744da
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.globl	L_OBJC_IMAGE_INFO_eb5b4d2de37744da
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+L_OBJC_IMAGE_INFO_eb5b4d2de37744da:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -154,5 +148,11 @@ L_OBJC_METH_VAR_NAME_c76827c00227cd8a:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_c76827c00227cd8a:
 	.quad	L_OBJC_METH_VAR_NAME_c76827c00227cd8a
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c76827c00227cd8a
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c76827c00227cd8a:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_ns_string/lib.rs
+++ b/crates/test-assembly/crates/test_ns_string/lib.rs
@@ -9,14 +9,14 @@ use icrate::Foundation::{ns_string, NSString};
 #[no_mangle]
 static EMPTY: &NSString = {
     const INPUT: &[u8] = b"";
-    icrate::__ns_string_inner!(@inner INPUT);
+    icrate::__ns_string_static!(INPUT);
     CFSTRING.as_nsstring_const()
 };
 #[cfg(all(feature = "apple", feature = "assembly-features"))]
 #[no_mangle]
 static XYZ: &NSString = {
     const INPUT: &[u8] = b"xyz";
-    icrate::__ns_string_inner!(@inner INPUT);
+    icrate::__ns_string_static!(INPUT);
     CFSTRING.as_nsstring_const()
 };
 

--- a/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
@@ -77,12 +77,6 @@ Lloh15:
 _use_in_loop:
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	3, 0x0
@@ -90,9 +84,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -102,9 +96,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -114,9 +108,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.quad	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -126,9 +120,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_ea6fbcf172f7f513:
 	.quad	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -138,9 +132,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_97e6a8c6ed5db063:
 	.quad	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -148,5 +142,11 @@ L_OBJC_IMAGE_INFO_bb5b616899716c0d:
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_bb5b616899716c0d:
 	.quad	_OBJC_CLASS_$_NSLock
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-armv7.s
@@ -79,12 +79,6 @@ LPC5_0:
 _use_in_loop:
 	bx	lr
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
@@ -92,9 +86,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -104,9 +98,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -116,9 +110,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -128,9 +122,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_ea6fbcf172f7f513:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -140,9 +134,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_97e6a8c6ed5db063:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -150,5 +144,11 @@ L_OBJC_IMAGE_INFO_bb5b616899716c0d:
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_bb5b616899716c0d:
 	.long	_OBJC_CLASS_$_NSLock
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
@@ -79,12 +79,6 @@ LPC5_0:
 _use_in_loop:
 	bx	lr
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
@@ -92,9 +86,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -104,9 +98,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -116,9 +110,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -128,9 +122,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_ea6fbcf172f7f513:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -140,9 +134,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_97e6a8c6ed5db063:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -150,5 +144,11 @@ L_OBJC_IMAGE_INFO_bb5b616899716c0d:
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_bb5b616899716c0d:
 	.long	_OBJC_CLASS_$_NSLock
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
@@ -91,12 +91,6 @@ _use_in_loop:
 	pop	ebp
 	ret
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_928cf03fcc497777
 L_OBJC_CLASS_NAME_928cf03fcc497777:
@@ -107,6 +101,12 @@ L_OBJC_CLASS_NAME_928cf03fcc497777:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_928cf03fcc497777:
 	.long	L_OBJC_CLASS_NAME_928cf03fcc497777
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_928cf03fcc497777_MODULE_INFO
@@ -121,12 +121,6 @@ L_OBJC_MODULES_928cf03fcc497777:
 	.long	L_OBJC_CLASS_NAME_928cf03fcc497777_MODULE_INFO
 	.space	4
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_2fe1990982915f07
 L_OBJC_CLASS_NAME_2fe1990982915f07:
@@ -137,6 +131,12 @@ L_OBJC_CLASS_NAME_2fe1990982915f07:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_2fe1990982915f07:
 	.long	L_OBJC_CLASS_NAME_2fe1990982915f07
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_2fe1990982915f07_MODULE_INFO
@@ -151,12 +151,6 @@ L_OBJC_MODULES_2fe1990982915f07:
 	.long	L_OBJC_CLASS_NAME_2fe1990982915f07_MODULE_INFO
 	.space	4
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_dfff3a06c0bf722b
 L_OBJC_CLASS_NAME_dfff3a06c0bf722b:
@@ -167,6 +161,12 @@ L_OBJC_CLASS_NAME_dfff3a06c0bf722b:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_dfff3a06c0bf722b:
 	.long	L_OBJC_CLASS_NAME_dfff3a06c0bf722b
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_dfff3a06c0bf722b_MODULE_INFO
@@ -181,12 +181,6 @@ L_OBJC_MODULES_dfff3a06c0bf722b:
 	.long	L_OBJC_CLASS_NAME_dfff3a06c0bf722b_MODULE_INFO
 	.space	4
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_ea6fbcf172f7f513
 L_OBJC_CLASS_NAME_ea6fbcf172f7f513:
@@ -197,6 +191,12 @@ L_OBJC_CLASS_NAME_ea6fbcf172f7f513:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_ea6fbcf172f7f513:
 	.long	L_OBJC_CLASS_NAME_ea6fbcf172f7f513
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_ea6fbcf172f7f513_MODULE_INFO
@@ -211,12 +211,6 @@ L_OBJC_MODULES_ea6fbcf172f7f513:
 	.long	L_OBJC_CLASS_NAME_ea6fbcf172f7f513_MODULE_INFO
 	.space	4
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_97e6a8c6ed5db063
 L_OBJC_CLASS_NAME_97e6a8c6ed5db063:
@@ -227,6 +221,12 @@ L_OBJC_CLASS_NAME_97e6a8c6ed5db063:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_97e6a8c6ed5db063:
 	.long	L_OBJC_CLASS_NAME_97e6a8c6ed5db063
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_97e6a8c6ed5db063_MODULE_INFO
@@ -241,12 +241,6 @@ L_OBJC_MODULES_97e6a8c6ed5db063:
 	.long	L_OBJC_CLASS_NAME_97e6a8c6ed5db063_MODULE_INFO
 	.space	4
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_bb5b616899716c0d
 L_OBJC_CLASS_NAME_bb5b616899716c0d:
@@ -257,6 +251,12 @@ L_OBJC_CLASS_NAME_bb5b616899716c0d:
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_bb5b616899716c0d:
 	.long	L_OBJC_CLASS_NAME_bb5b616899716c0d
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_CLASS_NAME_bb5b616899716c0d_MODULE_INFO

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
@@ -91,12 +91,6 @@ _use_in_loop:
 	pop	ebp
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	2, 0x0
@@ -104,9 +98,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -116,9 +110,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.long	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -128,9 +122,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.long	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -140,9 +134,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_ea6fbcf172f7f513:
 	.long	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -152,9 +146,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_97e6a8c6ed5db063:
 	.long	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -162,5 +156,11 @@ L_OBJC_IMAGE_INFO_bb5b616899716c0d:
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_bb5b616899716c0d:
 	.long	_OBJC_CLASS_$_NSLock
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
@@ -72,12 +72,6 @@ _use_in_loop:
 	pop	rbp
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_928cf03fcc497777:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777
 	.p2align	3, 0x0
@@ -85,9 +79,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_928cf03fcc497777:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
+	.globl	L_OBJC_IMAGE_INFO_928cf03fcc497777
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2fe1990982915f07:
+L_OBJC_IMAGE_INFO_928cf03fcc497777:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -97,9 +91,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_2fe1990982915f07:
 	.quad	_OBJC_CLASS_$_NSObject
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
+	.globl	L_OBJC_IMAGE_INFO_2fe1990982915f07
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
+L_OBJC_IMAGE_INFO_2fe1990982915f07:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -109,9 +103,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_dfff3a06c0bf722b:
 	.quad	_OBJC_CLASS_$_NSString
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
+	.globl	L_OBJC_IMAGE_INFO_dfff3a06c0bf722b
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
+L_OBJC_IMAGE_INFO_dfff3a06c0bf722b:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -121,9 +115,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_ea6fbcf172f7f513:
 	.quad	_OBJC_CLASS_$_NSData
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
+	.globl	L_OBJC_IMAGE_INFO_ea6fbcf172f7f513
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
+L_OBJC_IMAGE_INFO_ea6fbcf172f7f513:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -133,9 +127,9 @@ L_OBJC_CLASSLIST_REFERENCES_$_97e6a8c6ed5db063:
 	.quad	_OBJC_CLASS_$_NSException
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.globl	L_OBJC_IMAGE_INFO_97e6a8c6ed5db063
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+L_OBJC_IMAGE_INFO_97e6a8c6ed5db063:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__objc_classrefs,regular,no_dead_strip
@@ -143,5 +137,11 @@ L_OBJC_IMAGE_INFO_bb5b616899716c0d:
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_bb5b616899716c0d:
 	.quad	_OBJC_CLASS_$_NSLock
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_bb5b616899716c0d
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_bb5b616899716c0d:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
@@ -90,12 +90,6 @@ Lloh18:
 _use_in_loop:
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -108,9 +102,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.quad	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -125,9 +119,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.quad	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -142,9 +136,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.quad	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -159,9 +153,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.quad	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -176,9 +170,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.quad	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -191,5 +185,11 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.quad	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-armv7.s
@@ -91,12 +91,6 @@ LPC6_0:
 _use_in_loop:
 	bx	lr
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -109,9 +103,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.long	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -126,9 +120,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -143,9 +137,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.long	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -160,9 +154,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.long	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -177,9 +171,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.long	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -192,6 +186,12 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
@@ -91,12 +91,6 @@ LPC6_0:
 _use_in_loop:
 	bx	lr
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -109,9 +103,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.long	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -126,9 +120,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -143,9 +137,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.long	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -160,9 +154,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.long	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -177,9 +171,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.long	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -192,6 +186,12 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__DATA,__nl_symbol_ptr,non_lazy_symbol_pointers
 	.p2align	2, 0x0

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
@@ -105,12 +105,6 @@ _use_in_loop:
 	pop	ebp
 	ret
 
-	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__cstring,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -123,9 +117,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.long	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -140,9 +134,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -157,9 +151,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.long	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -174,9 +168,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.long	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -191,9 +185,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.long	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__OBJC,__image_info
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__cstring,cstring_literals
@@ -206,6 +200,12 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__OBJC,__image_info
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-x86.s
@@ -105,12 +105,6 @@ _use_in_loop:
 	pop	ebp
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -123,9 +117,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.long	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -140,9 +134,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.long	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -157,9 +151,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.long	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -174,9 +168,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.long	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -191,9 +185,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.long	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -206,6 +200,12 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.long	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__IMPORT,__pointers,non_lazy_symbol_pointers
 LL_OBJC_SELECTOR_REFERENCES_alloc$non_lazy_ptr:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
@@ -83,12 +83,6 @@ _use_in_loop:
 	pop	rbp
 	ret
 
-	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
-	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
-	.asciz	"\000\000\000\000@\000\000"
-
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0:
@@ -101,9 +95,9 @@ L_OBJC_SELECTOR_REFERENCES_2ff5c2d33acc98c0:
 	.quad	L_OBJC_METH_VAR_NAME_2ff5c2d33acc98c0
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
+	.globl	L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
+L_OBJC_IMAGE_INFO_2ff5c2d33acc98c0:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -118,9 +112,9 @@ L_OBJC_SELECTOR_REFERENCES_6e17eb9d3fa7fa83:
 	.quad	L_OBJC_METH_VAR_NAME_6e17eb9d3fa7fa83
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
+	.globl	L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_25911857653c680c:
+L_OBJC_IMAGE_INFO_6e17eb9d3fa7fa83:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -135,9 +129,9 @@ L_OBJC_SELECTOR_REFERENCES_25911857653c680c:
 	.quad	L_OBJC_METH_VAR_NAME_25911857653c680c
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
+	.globl	L_OBJC_IMAGE_INFO_25911857653c680c
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_baa3c09478169afc:
+L_OBJC_IMAGE_INFO_25911857653c680c:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -152,9 +146,9 @@ L_OBJC_SELECTOR_REFERENCES_baa3c09478169afc:
 	.quad	L_OBJC_METH_VAR_NAME_baa3c09478169afc
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
+	.globl	L_OBJC_IMAGE_INFO_baa3c09478169afc
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_acb291d82e56f534:
+L_OBJC_IMAGE_INFO_baa3c09478169afc:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -169,9 +163,9 @@ L_OBJC_SELECTOR_REFERENCES_acb291d82e56f534:
 	.quad	L_OBJC_METH_VAR_NAME_acb291d82e56f534
 
 	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
-	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.globl	L_OBJC_IMAGE_INFO_acb291d82e56f534
 	.p2align	2, 0x0
-L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+L_OBJC_IMAGE_INFO_acb291d82e56f534:
 	.asciz	"\000\000\000\000@\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -184,5 +178,11 @@ L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e:
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_c831c01ba82dcc2e:
 	.quad	L_OBJC_METH_VAR_NAME_c831c01ba82dcc2e
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+	.globl	L_OBJC_IMAGE_INFO_c831c01ba82dcc2e
+	.p2align	2, 0x0
+L_OBJC_IMAGE_INFO_c831c01ba82dcc2e:
+	.asciz	"\000\000\000\000@\000\000"
 
 .subsections_via_symbols

--- a/crates/test-ui/ui/declare_class_invalid_receiver.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_receiver.stderr
@@ -131,7 +131,7 @@ note: required by a bound in `ClassBuilder::add_method`
   |     where
   |         T: Message + ?Sized,
   |            ^^^^^^^ required by this bound in `ClassBuilder::add_method`
-  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `extern "C" fn(Box<CustomObject>, objc2::runtime::Sel) -> __IdReturnValue: MethodImplementation` is not satisfied
  --> ui/declare_class_invalid_receiver.rs
@@ -316,4 +316,4 @@ error[E0277]: the trait bound `RetainSemantics<3>: MessageRecieveId<&CustomObjec
   | |_^ the trait `MessageRecieveId<&CustomObject, Id<CustomObject>>` is not implemented for `RetainSemantics<3>`
   |
   = help: the trait `MessageRecieveId<Allocated<T>, Ret>` is implemented for `RetainSemantics<3>`
-  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_syntax.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_syntax.stderr
@@ -66,6 +66,255 @@ note: while trying to match `:`
   |         $param:ident : $param_ty:ty $(, $($rest:tt)*)?
   |                      ^
 
+error: no rules expected the token `(`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro
+  = note: this error originates in the macro `$crate::__declare_class_register_methods` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: no rules expected the token `(`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro
+  = note: this error originates in the macro `$crate::__declare_class_register_methods` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected identifier, found keyword `fn`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         fn fn test_fn_fn() {}
+  |            ^^ expected identifier, found keyword
+
+error: expected one of `(` or `<`, found `test_fn_fn`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         fn fn test_fn_fn() {}
+  |               ^^^^^^^^^^ expected one of `(` or `<`
+  |
+ ::: $WORKSPACE/crates/objc2/src/macros/declare_class.rs
+  |
+  |         $_associated_item:item
+  |         ---------------------- while parsing argument for this `item` macro fragment
+
+error: expected one of `->`, `where`, or `{`, found `<eof>`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         fn test_unfinished()
+  |                            ^ expected one of `->`, `where`, or `{`
+  |
+ ::: $WORKSPACE/crates/objc2/src/macros/declare_class.rs
+  |
+  |         $_associated_item:item
+  |         ---------------------- while parsing argument for this `item` macro fragment
+
+error: `#[method_id(alloc)]` is not supported. Use `#[method(alloc)]` and do the memory management yourself
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method_id(retain)]` is not supported. Use `#[method(retain)]` and do the memory management yourself
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method_id(release)]` is not supported. Use `#[method(release)]` and do the memory management yourself
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method_id(autorelease)]` is not supported. Use `#[method(autorelease)]` and do the memory management yourself
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method_id(dealloc)]` is not supported. Add an instance variable with a `Drop` impl to the class instead
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method(dealloc)]` is not supported. Implement `Drop` for the type instead
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: an inner attribute is not permitted in this context
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         #![doc = "inner_attribute"]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+  = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: expected an item keyword
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         #![doc = "inner_attribute"]
+  |                                   ^
+  |
+ ::: $WORKSPACE/crates/objc2/src/macros/declare_class.rs
+  |
+  |         $_associated_item:item
+  |         ---------------------- while parsing argument for this `item` macro fragment
+
+error: must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot specify the `method`/`method_id` attribute twice
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot specify the `method`/`method_id` attribute twice
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `#[method_id(...)]` must have a return type
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: no rules expected the token `(`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  |         fn test_pattern((a, b): (u32, i32)) {
+  |                         ^ no rules expected this token in macro call
+  |
+note: while trying to match `_`
+ --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
+  |
+  |         (_ : $param_ty:ty $(, $($params_rest:tt)*)?)
+  |          ^
+
+error: no rules expected the token `)`
+ --> ui/declare_class_invalid_syntax.rs
+  |
+  | / declare_class!(
+  | |     struct InvalidMethodDeclarations;
+  | |
+  | |     unsafe impl ClassType for InvalidMethodDeclarations {
+... |
+  | |     }
+  | | );
+  | |_^ no rules expected this token in macro call
+  |
+note: while trying to match `:`
+ --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
+  |
+  |         ($param:ident : $param_ty:ty $(, $($params_rest:tt)*)?)
+  |                       ^
+  = note: this error originates in the macro `$crate::__declare_class_method_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: no rules expected the token `pub`
  --> ui/declare_class_invalid_syntax.rs
   |
@@ -162,90 +411,6 @@ note: while trying to match meta-variable `$body:block`
   |         fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |                                                       ^^^^^^^^^^^
 
-error: `#[method_id(alloc)]` is not supported. Use `#[method(alloc)]` and do the memory management yourself
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method_id(retain)]` is not supported. Use `#[method(retain)]` and do the memory management yourself
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method_id(release)]` is not supported. Use `#[method(release)]` and do the memory management yourself
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method_id(autorelease)]` is not supported. Use `#[method(autorelease)]` and do the memory management yourself
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method_id(dealloc)]` is not supported. Add an instance variable with a `Drop` impl to the class instead
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method(dealloc)]` is not supported. Implement `Drop` for the type instead
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: no rules expected the token `!`
  --> ui/declare_class_invalid_syntax.rs
   |
@@ -264,11 +429,7 @@ error: no rules expected the token `type`
   |         type TypeAlias = Self;
   |         ^^^^ no rules expected this token in macro call
   |
-note: while trying to match `)`
- --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
-  |
-  |         ($($macro_args:tt)*)
-  |                            ^
+  = note: while trying to match end of macro
 
 error: no rules expected the token `const`
  --> ui/declare_class_invalid_syntax.rs
@@ -276,98 +437,7 @@ error: no rules expected the token `const`
   |         const CONSTANT: () = ();
   |         ^^^^^ no rules expected this token in macro call
   |
-note: while trying to match `)`
- --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
-  |
-  |         ($($macro_args:tt)*)
-  |                            ^
-
-error: must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: cannot specify the `method`/`method_id` attribute twice
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: cannot specify the `method`/`method_id` attribute twice
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__extract_custom_attributes_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `#[method_id(...)]` must have a return type
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^
-  |
-  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: no rules expected the token `(`
- --> ui/declare_class_invalid_syntax.rs
-  |
-  |         fn test_pattern((a, b): (u32, i32)) {
-  |                         ^ no rules expected this token in macro call
-  |
-note: while trying to match `_`
- --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
-  |
-  |         (_ : $param_ty:ty $(, $($params_rest:tt)*)?)
-  |          ^
-
-error: no rules expected the token `)`
- --> ui/declare_class_invalid_syntax.rs
-  |
-  | / declare_class!(
-  | |     struct InvalidMethodDeclarations;
-  | |
-  | |     unsafe impl ClassType for InvalidMethodDeclarations {
-... |
-  | |     }
-  | | );
-  | |_^ no rules expected this token in macro call
-  |
-note: while trying to match `:`
- --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
-  |
-  |         ($param:ident : $param_ty:ty $(, $($params_rest:tt)*)?)
-  |                       ^
-  = note: this error originates in the macro `$crate::__declare_class_method_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: while trying to match end of macro
 
 error: no rules expected the token `}`
  --> ui/declare_class_invalid_syntax.rs

--- a/crates/test-ui/ui/declare_class_invalid_syntax.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_syntax.stderr
@@ -75,7 +75,7 @@ error: no rules expected the token `pub`
 note: while trying to match `unsafe`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |         ^^^^^^
 
 error: no rules expected the token `const`
@@ -87,7 +87,7 @@ error: no rules expected the token `const`
 note: while trying to match `unsafe`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |         ^^^^^^
 
 error: no rules expected the token `async`
@@ -99,7 +99,7 @@ error: no rules expected the token `async`
 note: while trying to match `unsafe`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |         ^^^^^^
 
 error: no rules expected the token `extern`
@@ -111,7 +111,7 @@ error: no rules expected the token `extern`
 note: while trying to match `unsafe`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         unsafe fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         unsafe fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |         ^^^^^^
 
 error: no rules expected the token `test_fn_fn`
@@ -123,7 +123,7 @@ error: no rules expected the token `test_fn_fn`
 note: while trying to match `(`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |                       ^
 
 error: no rules expected the token `<`
@@ -135,7 +135,7 @@ error: no rules expected the token `<`
 note: while trying to match `(`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+  |         fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
   |                       ^
 
 error: no rules expected the token `;`
@@ -147,8 +147,8 @@ error: no rules expected the token `;`
 note: while trying to match meta-variable `$body:block`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
-  |                                                     ^^^^^^^^^^^
+  |         fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+  |                                                       ^^^^^^^^^^^
 
 error: unexpected end of macro invocation
  --> ui/declare_class_invalid_syntax.rs
@@ -159,8 +159,8 @@ error: unexpected end of macro invocation
 note: while trying to match meta-variable `$body:block`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
-  |                                                     ^^^^^^^^^^^
+  |         fn $name:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+  |                                                       ^^^^^^^^^^^
 
 error: `#[method_id(alloc)]` is not supported. Use `#[method(alloc)]` and do the memory management yourself
  --> ui/declare_class_invalid_syntax.rs
@@ -267,8 +267,8 @@ error: no rules expected the token `type`
 note: while trying to match `)`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         ($($macro_arg:tt)*)
-  |                           ^
+  |         ($($macro_args:tt)*)
+  |                            ^
 
 error: no rules expected the token `const`
  --> ui/declare_class_invalid_syntax.rs
@@ -279,8 +279,8 @@ error: no rules expected the token `const`
 note: while trying to match `)`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         ($($macro_arg:tt)*)
-  |                           ^
+  |         ($($macro_args:tt)*)
+  |                            ^
 
 error: must specify the desired selector using `#[method(...)]` or `#[method_id(...)]`
  --> ui/declare_class_invalid_syntax.rs
@@ -347,7 +347,7 @@ error: no rules expected the token `(`
 note: while trying to match `_`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         (_ : $param_ty:ty $(, $($rest_args:tt)*)?)
+  |         (_ : $param_ty:ty $(, $($params_rest:tt)*)?)
   |          ^
 
 error: no rules expected the token `)`
@@ -365,7 +365,7 @@ error: no rules expected the token `)`
 note: while trying to match `:`
  --> $WORKSPACE/crates/objc2/src/macros/declare_class.rs
   |
-  |         ($param:ident : $param_ty:ty $(, $($rest_args:tt)*)?)
+  |         ($param:ident : $param_ty:ty $(, $($params_rest:tt)*)?)
   |                       ^
   = note: this error originates in the macro `$crate::__declare_class_method_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -494,4 +494,4 @@ error[E0277]: the trait bound `RetainSemantics<2>: MessageRecieveId<&AnyClass, I
             <RetainSemantics<3> as MessageRecieveId<Allocated<T>, Ret>>
             <RetainSemantics<4> as MessageRecieveId<Receiver, Ret>>
             <RetainSemantics<5> as MessageRecieveId<Receiver, Ret>>
-  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_syntax.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_syntax.stderr
@@ -136,7 +136,7 @@ error: `#[method_id(alloc)]` is not supported. Use `#[method(alloc)]` and do the
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[method_id(retain)]` is not supported. Use `#[method(retain)]` and do the memory management yourself
  --> ui/declare_class_invalid_syntax.rs
@@ -150,7 +150,7 @@ error: `#[method_id(retain)]` is not supported. Use `#[method(retain)]` and do t
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[method_id(release)]` is not supported. Use `#[method(release)]` and do the memory management yourself
  --> ui/declare_class_invalid_syntax.rs
@@ -164,7 +164,7 @@ error: `#[method_id(release)]` is not supported. Use `#[method(release)]` and do
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[method_id(autorelease)]` is not supported. Use `#[method(autorelease)]` and do the memory management yourself
  --> ui/declare_class_invalid_syntax.rs
@@ -178,9 +178,9 @@ error: `#[method_id(autorelease)]` is not supported. Use `#[method(autorelease)]
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `#[method_id(dealloc)]` is not supported. Add an instance variable with a `Drop` impl to the class instead
+error: `#[method_id(dealloc)]` is not supported. Implement `Drop` for the type instead
  --> ui/declare_class_invalid_syntax.rs
   |
   | / declare_class!(
@@ -192,7 +192,7 @@ error: `#[method_id(dealloc)]` is not supported. Add an instance variable with a
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__get_method_id_sel` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[method(dealloc)]` is not supported. Implement `Drop` for the type instead
  --> ui/declare_class_invalid_syntax.rs
@@ -206,7 +206,7 @@ error: `#[method(dealloc)]` is not supported. Implement `Drop` for the type inst
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_invalid_selectors` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: an inner attribute is not permitted in this context
  --> ui/declare_class_invalid_syntax.rs

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -92,7 +92,7 @@ note: required by a bound in `ConvertArgument`
   | pub trait ConvertArgument: argument_private::Sealed {
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = note: this error originates in the macro `$crate::__declare_class_rewrite_args` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
  --> ui/declare_class_invalid_type.rs
@@ -124,4 +124,4 @@ note: required by a bound in `ConvertArgument`
   | pub trait ConvertArgument: argument_private::Sealed {
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = note: this error originates in the macro `$crate::__declare_class_rewrite_args` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_type2.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type2.stderr
@@ -24,4 +24,4 @@ error[E0277]: the trait bound `i32: MaybeOptionId` is not satisfied
             Id<T>
             Option<Id<T>>
   = note: required for `RetainSemantics<5>` to implement `MessageRecieveId<&CustomObject, i32>`
-  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_type.stderr
@@ -75,7 +75,7 @@ note: associated function defined here
   |
   |     unsafe fn send_message_id<A: MessageArguments, R: MaybeUnwrap<Input = U>>(
   |               ^^^^^^^^^^^^^^^
-  = note: this error originates in the macro `$crate::__rewrite_self_arg_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<(), Id<NSObject>>: Encode` is not satisfied
  --> ui/extern_methods_invalid_type.rs

--- a/crates/test-ui/ui/invalid_msg_send.stderr
+++ b/crates/test-ui/ui/invalid_msg_send.stderr
@@ -31,8 +31,8 @@ error: no rules expected the token `)`
 note: while trying to match `_`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($selector:ident: _ $(,)?)
-  |                            ^
+  |         ($selector:ident: _ $(,)?)
+  |                           ^
   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: no rules expected the token `)`
@@ -44,8 +44,8 @@ error: no rules expected the token `)`
 note: while trying to match `:`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($($selector:ident : $argument:expr)*)
-  |                             ^
+  |         ($($selector:ident : $argument:expr)*)
+  |                            ^
   = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier, found `:`
@@ -56,8 +56,8 @@ error: expected identifier, found `:`
   |
  ::: $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($selector:ident : $argument:expr $(, $($rest:tt)*)?)
-  |                             -------------- while parsing argument for this `expr` macro fragment
+  |         ($selector:ident : $argument:expr $(, $($rest:tt)*)?)
+  |                            -------------- while parsing argument for this `expr` macro fragment
 
 error: no rules expected the token `d`
  --> ui/invalid_msg_send.rs
@@ -68,8 +68,8 @@ error: no rules expected the token `d`
 note: while trying to match `:`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($selector:ident: _ $(,)?)
-  |                          ^
+  |         ($selector:ident: _ $(,)?)
+  |                         ^
 
 error: expected identifier, found `:`
  --> ui/invalid_msg_send.rs
@@ -79,8 +79,8 @@ error: expected identifier, found `:`
   |
  ::: $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($selector:ident : $argument:expr $(, $($rest:tt)*)?)
-  |                             -------------- while parsing argument for this `expr` macro fragment
+  |         ($selector:ident : $argument:expr $(, $($rest:tt)*)?)
+  |                            -------------- while parsing argument for this `expr` macro fragment
 
 error: no rules expected the token `,`
  --> ui/invalid_msg_send.rs
@@ -91,8 +91,8 @@ error: no rules expected the token `,`
 note: while trying to match `)`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($($selector:ident : $argument:expr)*)
-  |                                               ^
+  |         ($($selector:ident : $argument:expr)*)
+  |                                              ^
 
 error: no rules expected the token `b`
  --> ui/invalid_msg_send.rs
@@ -103,5 +103,5 @@ error: no rules expected the token `b`
 note: while trying to match `)`
  --> $WORKSPACE/crates/objc2/src/macros/__msg_send_parse.rs
   |
-  |         @($selector:ident: _ $(,)?)
-  |                                   ^
+  |         ($selector:ident: _ $(,)?)
+  |                                  ^

--- a/crates/test-ui/ui/msg_send_missing_comma.stderr
+++ b/crates/test-ui/ui/msg_send_missing_comma.stderr
@@ -19,7 +19,7 @@ error: use of deprecated function `main::__msg_send_missing_comma`: using msg_se
   |     let _: () = unsafe { msg_send![super(obj), a:obj b:obj] };
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the macro `$crate::__comma_between_args` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__comma_between_args_inner` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of deprecated function `main::__msg_send_missing_comma`: using msg_send! without a comma between arguments is technically not valid macro syntax, and may break in a future version of Rust. You should use the following instead:
        msg_send![super(obj, NSString::class()), a: obj, b: obj]
@@ -28,7 +28,7 @@ error: use of deprecated function `main::__msg_send_missing_comma`: using msg_se
    |     let _: () = unsafe { msg_send![super(obj, NSString::class()), a:obj b:obj] };
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__comma_between_args` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__comma_between_args_inner` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of deprecated function `main::__msg_send_missing_comma`: using msg_send! without a comma between arguments is technically not valid macro syntax, and may break in a future version of Rust. You should use the following instead:
        msg_send![obj, a: obj, b: obj]
@@ -37,7 +37,7 @@ error: use of deprecated function `main::__msg_send_missing_comma`: using msg_se
    |     let _: () = unsafe { msg_send![obj, a:obj b:obj] };
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__comma_between_args` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__comma_between_args_inner` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of deprecated function `main::__msg_send_missing_comma`: using msg_send! without a comma between arguments is technically not valid macro syntax, and may break in a future version of Rust. You should use the following instead:
        msg_send![obj, c: obj, d: obj]
@@ -46,7 +46,7 @@ error: use of deprecated function `main::__msg_send_missing_comma`: using msg_se
    |     unsafe { msg_send_bool![obj, c:obj d:obj] };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__comma_between_args` which comes from the expansion of the macro `msg_send_bool` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__comma_between_args_inner` which comes from the expansion of the macro `msg_send_bool` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of deprecated function `main::__msg_send_missing_comma`: using msg_send_id! without a comma between arguments is technically not valid macro syntax, and may break in a future version of Rust. You should use the following instead:
        msg_send_id![obj, e: obj, f: obj]
@@ -55,4 +55,4 @@ error: use of deprecated function `main::__msg_send_missing_comma`: using msg_se
    |     let _: Id<NSString> = unsafe { msg_send_id![obj, e:obj f:obj] };
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `$crate::__comma_between_args` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__comma_between_args_inner` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/ns_string_output_not_const.stderr
+++ b/crates/test-ui/ui/ns_string_output_not_const.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `CachedId::<NSString>::get::<[closure@$WORKSPACE/crates/icrate/src/generated/Foundation/../../additions/Foundation/macros/ns_string.rs:189:29: 189:31]>` in statics
+error[E0015]: cannot call non-const fn `CachedId::<NSString>::get::<[closure@$WORKSPACE/crates/icrate/src/generated/Foundation/../../additions/Foundation/macros/ns_string.rs:195:29: 195:31]>` in statics
  --> ui/ns_string_output_not_const.rs
   |
   |     static STRING: &NSString = ns_string!("abc");

--- a/crates/test-ui/ui/wrong_optional.stderr
+++ b/crates/test-ui/ui/wrong_optional.stderr
@@ -10,7 +10,7 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__extern_methods_method_out` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_no_optional` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[optional]` is only supported in `extern_protocol!`
  --> ui/wrong_optional.rs
@@ -24,7 +24,7 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__extern_methods_method_out` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_no_optional` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[optional]` is only supported in `extern_protocol!`
  --> ui/wrong_optional.rs
@@ -38,7 +38,7 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_no_optional` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[optional]` is only supported in `extern_protocol!`
  --> ui/wrong_optional.rs
@@ -52,4 +52,4 @@ error: `#[optional]` is only supported in `extern_protocol!`
   | | );
   | |_^
   |
-  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__extern_methods_no_optional` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
A general cleanup to make the macros more consistent with each other, and to prepare for https://github.com/madsmtm/objc2/issues/457 and similar rewrites of `declare_class!` internals