### PR TITLE
Relax `ProtocolType` requirement on `ProtocolObject`

### DIFF
--- a/crates/icrate/src/fixes/Foundation/copying.rs
+++ b/crates/icrate/src/fixes/Foundation/copying.rs
@@ -22,7 +22,6 @@ extern_protocol!(
         #[optional]
         fn copy(&self) -> Id<Self::Immutable>
         where
-            Self: Sized,
             Self: CounterpartOrSelf;
 
         /// Returns a new instance that's a copy of the receiver.
@@ -37,7 +36,6 @@ extern_protocol!(
         #[method_id(copyWithZone:)]
         unsafe fn copyWithZone(&self, zone: *mut NSZone) -> Id<Self::Immutable>
         where
-            Self: Sized,
             Self: CounterpartOrSelf;
     }
 
@@ -65,7 +63,6 @@ extern_protocol!(
         #[optional]
         fn mutableCopy(&self) -> Id<Self::Mutable>
         where
-            Self: Sized,
             Self: CounterpartOrSelf;
 
         /// Returns a new instance that's a mutable copy of the receiver.
@@ -80,7 +77,6 @@ extern_protocol!(
         #[method_id(mutableCopyWithZone:)]
         unsafe fn mutableCopyWithZone(&self, zone: *mut NSZone) -> Id<Self::Mutable>
         where
-            Self: Sized,
             Self: CounterpartOrSelf;
     }
 

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `Allocated::set_ivars`, which sets the instance variables of an
   object, and returns the new `rc::PartialInit`.
 * Added the ability for `msg_send_id!` to call `super` methods.
+* Implement `Send` and `Sync` for `ProtocolObject` if the underlying protocol
+  implements it.
+* Added ability to create `Send` and `Sync` versions of
+  `ProtocolObject<dyn NSObjectProtocol>`.
 
 ### Changed
 * **BREAKING**: Changed how instance variables work in `declare_class!`.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -149,6 +149,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **BREAKING**: Make `rc::Allocated` allowed to be `NULL` internally, such
   that uses of `Option<Allocated<T>>` is now simply `Allocated<T>`.
 * `AnyObject::class` now returns a `'static` reference to the class.
+* Relaxed `ProtocolType` requirement on `ProtocolObject`.
 
 ### Deprecated
 * Soft deprecated using `msg_send!` without a comma between arguments (i.e.

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -184,7 +184,7 @@ macro_rules! __inner_extern_protocol {
         $(#[$impl_m])*
         unsafe impl<T> $name for $crate::runtime::ProtocolObject<T>
         where
-            T: ?$crate::__macro_helpers::Sized + $crate::ProtocolType + $name
+            T: ?$crate::__macro_helpers::Sized + $name
         {}
 
         // SAFETY: The specified name is ensured by caller to be a protocol,

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -204,6 +204,9 @@ macro_rules! __inner_extern_protocol {
         {
             const __INNER: () = ();
         }
+
+        // TODO: Should we also implement `ImplementedBy` for `Send + Sync`
+        // types, as is done for `NSObjectProtocol`?
     };
 }
 

--- a/crates/objc2/src/mutability.rs
+++ b/crates/objc2/src/mutability.rs
@@ -33,7 +33,7 @@
 use core::marker::PhantomData;
 
 use crate::runtime::{AnyObject, ProtocolObject};
-use crate::{ClassType, Message, ProtocolType};
+use crate::{ClassType, Message};
 
 mod private_mutability {
     pub trait Sealed {}
@@ -269,7 +269,7 @@ mod private_traits {
 }
 
 impl<T: ?Sized + ClassType> private_traits::Sealed for T {}
-impl<P: ?Sized + ProtocolType> private_traits::Sealed for ProtocolObject<P> {}
+impl<P: ?Sized> private_traits::Sealed for ProtocolObject<P> {}
 impl private_traits::Sealed for AnyObject {}
 
 /// Marker trait for classes where [`Id::clone`] is safe.
@@ -303,7 +303,7 @@ impl MutabilityIsIdCloneable for InteriorMutable {}
 impl MutabilityIsIdCloneable for MainThreadOnly {}
 
 unsafe impl<T: ?Sized + ClassType> IsIdCloneable for T where T::Mutability: MutabilityIsIdCloneable {}
-unsafe impl<P: ?Sized + ProtocolType + IsIdCloneable> IsIdCloneable for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + IsIdCloneable> IsIdCloneable for ProtocolObject<P> {}
 // SAFETY: Same as for root classes.
 unsafe impl IsIdCloneable for AnyObject {}
 
@@ -336,7 +336,7 @@ impl MutabilityIsRetainable for InteriorMutable {}
 impl MutabilityIsRetainable for MainThreadOnly {}
 
 unsafe impl<T: ?Sized + ClassType> IsRetainable for T where T::Mutability: MutabilityIsRetainable {}
-unsafe impl<P: ?Sized + ProtocolType + IsRetainable> IsRetainable for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + IsRetainable> IsRetainable for ProtocolObject<P> {}
 
 /// Marker trait for classes that can be allocated from any thread.
 ///
@@ -367,10 +367,7 @@ unsafe impl<T: ?Sized + ClassType> IsAllocableAnyThread for T where
     T::Mutability: MutabilityIsAllocableAnyThread
 {
 }
-unsafe impl<P: ?Sized + ProtocolType + IsAllocableAnyThread> IsAllocableAnyThread
-    for ProtocolObject<P>
-{
-}
+unsafe impl<P: ?Sized + IsAllocableAnyThread> IsAllocableAnyThread for ProtocolObject<P> {}
 
 /// Marker trait for classes that may feasibly be used behind a mutable
 /// reference.
@@ -401,7 +398,7 @@ unsafe impl<T: ?Sized + ClassType> IsAllowedMutable for T where
     T::Mutability: MutabilityIsAllowedMutable
 {
 }
-unsafe impl<P: ?Sized + ProtocolType + IsAllowedMutable> IsAllowedMutable for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + IsAllowedMutable> IsAllowedMutable for ProtocolObject<P> {}
 // SAFETY: Same as for root classes.
 unsafe impl IsAllowedMutable for AnyObject {}
 
@@ -430,7 +427,7 @@ impl MutabilityIsMutable for Mutable {}
 impl<IS: ?Sized> MutabilityIsMutable for MutableWithImmutableSuperclass<IS> {}
 
 unsafe impl<T: ?Sized + ClassType> IsMutable for T where T::Mutability: MutabilityIsMutable {}
-unsafe impl<P: ?Sized + ProtocolType + IsMutable> IsMutable for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + IsMutable> IsMutable for ProtocolObject<P> {}
 
 /// Marker trait for classes that are only available on the main thread.
 ///
@@ -455,7 +452,7 @@ unsafe impl<T: ?Sized + ClassType> IsMainThreadOnly for T where
     T::Mutability: MutabilityIsMainThreadOnly
 {
 }
-unsafe impl<P: ?Sized + ProtocolType + IsMainThreadOnly> IsMainThreadOnly for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + IsMainThreadOnly> IsMainThreadOnly for ProtocolObject<P> {}
 
 /// Marker trait for classes whose `hash` and `isEqual:` methods are stable.
 ///
@@ -489,7 +486,7 @@ impl<MS: ?Sized> MutabilityHashIsStable for ImmutableWithMutableSubclass<MS> {}
 impl<IS: ?Sized> MutabilityHashIsStable for MutableWithImmutableSuperclass<IS> {}
 
 unsafe impl<T: ?Sized + ClassType> HasStableHash for T where T::Mutability: MutabilityHashIsStable {}
-unsafe impl<P: ?Sized + ProtocolType + HasStableHash> HasStableHash for ProtocolObject<P> {}
+unsafe impl<P: ?Sized + HasStableHash> HasStableHash for ProtocolObject<P> {}
 
 /// Retrieve the immutable/mutable counterpart class, and fall back to `Self`
 /// if not applicable.
@@ -589,7 +586,7 @@ where
     type Mutable = <T::Mutability as private_counterpart::MutabilityCounterpartOrSelf<T>>::Mutable;
 }
 
-unsafe impl<P: ?Sized + ProtocolType> CounterpartOrSelf for ProtocolObject<P> {
+unsafe impl<P: ?Sized> CounterpartOrSelf for ProtocolObject<P> {
     // SAFETY: The only place where this would differ from `Self` is for
     // classes with `MutableWithImmutableSuperclass<IS>`.
     //

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -7,6 +7,8 @@ use crate::runtime::{AnyClass, AnyObject, ProtocolObject};
 use crate::{extern_methods, msg_send, msg_send_id, Message};
 use crate::{ClassType, ProtocolType};
 
+use super::ImplementedBy;
+
 /// The root class of most Objective-C class hierarchies.
 ///
 /// This represents the [`NSObject` class][cls]. The name "NSObject" also
@@ -162,6 +164,33 @@ crate::__inner_extern_protocol!(
     (dyn NSObjectProtocol)
     ("NSObject")
 );
+
+// SAFETY: Anything that implements `NSObjectProtocol` and is `Send` is valid
+// to convert to `ProtocolObject<dyn NSObjectProtocol + Send>`.
+unsafe impl<T> ImplementedBy<T> for dyn NSObjectProtocol + Send
+where
+    T: ?Sized + Message + NSObjectProtocol + Send,
+{
+    const __INNER: () = ();
+}
+
+// SAFETY: Anything that implements `NSObjectProtocol` and is `Sync` is valid
+// to convert to `ProtocolObject<dyn NSObjectProtocol + Sync>`.
+unsafe impl<T> ImplementedBy<T> for dyn NSObjectProtocol + Sync
+where
+    T: ?Sized + Message + NSObjectProtocol + Sync,
+{
+    const __INNER: () = ();
+}
+
+// SAFETY: Anything that implements `NSObjectProtocol` and is `Send + Sync` is
+// valid to convert to `ProtocolObject<dyn NSObjectProtocol + Send + Sync>`.
+unsafe impl<T> ImplementedBy<T> for dyn NSObjectProtocol + Send + Sync
+where
+    T: ?Sized + Message + NSObjectProtocol + Send + Sync,
+{
+    const __INNER: () = ();
+}
 
 unsafe impl NSObjectProtocol for NSObject {}
 

--- a/crates/test-ui/ui/protocol_object_only_protocols.rs
+++ b/crates/test-ui/ui/protocol_object_only_protocols.rs
@@ -1,0 +1,27 @@
+//! Ensure that `ProtocolObject` cannot be incorrectly constructed.
+use icrate::Foundation::NSCopying;
+use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
+
+trait Foo {
+    fn foo(&self) {}
+}
+
+impl<T: ?Sized> Foo for T {}
+
+fn main() {
+    let obj = NSObject::new();
+    let _: &ProtocolObject<NSObject> = ProtocolObject::from_ref(&*obj);
+    let _: &ProtocolObject<dyn Send> = ProtocolObject::from_ref(&*obj);
+    let _: &ProtocolObject<dyn Foo> = ProtocolObject::from_ref(&*obj);
+
+    // `NSObject` is neither `Send` nor `Sync`.
+    let _: &ProtocolObject<dyn NSObjectProtocol + Send> = ProtocolObject::from_ref(&*obj);
+    let _: &ProtocolObject<dyn NSObjectProtocol + Sync> = ProtocolObject::from_ref(&*obj);
+    let _: &ProtocolObject<dyn NSObjectProtocol + Send + Sync> = ProtocolObject::from_ref(&*obj);
+
+    // `NSObject` is not `NSCopying`.
+    let _: &ProtocolObject<dyn NSCopying> = ProtocolObject::from_ref(&*obj);
+
+    // `dyn NSCopying + Send` does not implement `ImplementedBy` (yet).
+    let _: &ProtocolObject<dyn NSCopying + Send> = ProtocolObject::from_ref(&*obj);
+}

--- a/crates/test-ui/ui/protocol_object_only_protocols.stderr
+++ b/crates/test-ui/ui/protocol_object_only_protocols.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `NSObject: ImplementedBy<NSObject>` is not satisfi
   |
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
@@ -35,13 +35,13 @@ error[E0277]: the trait bound `dyn Send: ImplementedBy<NSObject>` is not satisfi
   |
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
@@ -62,13 +62,13 @@ error[E0277]: the trait bound `dyn Foo: ImplementedBy<NSObject>` is not satisfie
   |
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
@@ -79,24 +79,52 @@ note: required by a bound in `ProtocolObject::<P>::from_ref`
   |         P: ImplementedBy<T>,
   |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
 
-error[E0277]: the trait bound `dyn NSObjectProtocol + Send: ImplementedBy<NSObject>` is not satisfied
+error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
  --> ui/protocol_object_only_protocols.rs
   |
   |     let _: &ProtocolObject<dyn NSObjectProtocol + Send> = ProtocolObject::from_ref(&*obj);
-  |                                                           ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Send`
+  |                                                           ------------------------ ^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |                                                           |
   |                                                           required by a bound introduced by this call
   |
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
+  = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
+note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: ?Sized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+ --> $RUST/core/src/cell.rs
+  |
+  | pub struct UnsafeCell<T: ?Sized> {
+  |            ^^^^^^^^^^
+note: required because it appears within the type `objc_object`
+ --> $WORKSPACE/crates/objc-sys/src/object.rs
+  |
+  | pub struct objc_object {
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `AnyObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
+  |
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
+note: required because it appears within the type `NSObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
+  |
+  | pub struct NSObject {
+  |            ^^^^^^^^
+  = note: required for `dyn NSObjectProtocol + Send` to implement `ImplementedBy<NSObject>`
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
   |
@@ -106,24 +134,41 @@ note: required by a bound in `ProtocolObject::<P>::from_ref`
   |         P: ImplementedBy<T>,
   |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
 
-error[E0277]: the trait bound `dyn NSObjectProtocol + Sync: ImplementedBy<NSObject>` is not satisfied
+error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
  --> ui/protocol_object_only_protocols.rs
   |
   |     let _: &ProtocolObject<dyn NSObjectProtocol + Sync> = ProtocolObject::from_ref(&*obj);
-  |                                                           ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Sync`
+  |                                                           ------------------------ ^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |                                                           |
   |                                                           required by a bound introduced by this call
   |
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
+note: required because it appears within the type `objc_object`
+ --> $WORKSPACE/crates/objc-sys/src/object.rs
+  |
+  | pub struct objc_object {
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `AnyObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
+  |
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
+note: required because it appears within the type `NSObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
+  |
+  | pub struct NSObject {
+  |            ^^^^^^^^
+  = note: required for `dyn NSObjectProtocol + Sync` to implement `ImplementedBy<NSObject>`
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
   |
@@ -133,24 +178,96 @@ note: required by a bound in `ProtocolObject::<P>::from_ref`
   |         P: ImplementedBy<T>,
   |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
 
-error[E0277]: the trait bound `dyn NSObjectProtocol + Send + Sync: ImplementedBy<NSObject>` is not satisfied
+error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
  --> ui/protocol_object_only_protocols.rs
   |
   |     let _: &ProtocolObject<dyn NSObjectProtocol + Send + Sync> = ProtocolObject::from_ref(&*obj);
-  |                                                                  ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Send + Sync`
+  |                                                                  ------------------------ ^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |                                                                  |
   |                                                                  required by a bound introduced by this call
   |
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
+note: required because it appears within the type `objc_object`
+ --> $WORKSPACE/crates/objc-sys/src/object.rs
+  |
+  | pub struct objc_object {
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `AnyObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
+  |
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
+note: required because it appears within the type `NSObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
+  |
+  | pub struct NSObject {
+  |            ^^^^^^^^
+  = note: required for `dyn NSObjectProtocol + Send + Sync` to implement `ImplementedBy<NSObject>`
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSObjectProtocol + Send + Sync> = ProtocolObject::from_ref(&*obj);
+  |                                                                  ------------------------ ^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
+  |                                                                  |
+  |                                                                  required by a bound introduced by this call
+  |
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+          and $N others
+  = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
+note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
+ --> $RUST/core/src/marker.rs
+  |
+  | pub struct PhantomData<T: ?Sized>;
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+ --> $RUST/core/src/cell.rs
+  |
+  | pub struct UnsafeCell<T: ?Sized> {
+  |            ^^^^^^^^^^
+note: required because it appears within the type `objc_object`
+ --> $WORKSPACE/crates/objc-sys/src/object.rs
+  |
+  | pub struct objc_object {
+  |            ^^^^^^^^^^^
+note: required because it appears within the type `AnyObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/mod.rs
+  |
+  | pub struct AnyObject(ffi::objc_object);
+  |            ^^^^^^^^^
+note: required because it appears within the type `NSObject`
+ --> $WORKSPACE/crates/objc2/src/runtime/nsobject.rs
+  |
+  | pub struct NSObject {
+  |            ^^^^^^^^
+  = note: required for `dyn NSObjectProtocol + Send + Sync` to implement `ImplementedBy<NSObject>`
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
   |
@@ -198,13 +315,13 @@ error[E0277]: the trait bound `dyn NSCopying + Send: ImplementedBy<NSObject>` is
   |
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSObjectProtocol + 'static)
+            (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Sync + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSAccessibilityColor + 'static)
             (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
             (dyn NSAccessibilityElementProtocol + 'static)
             (dyn NSAccessibilityGroup + 'static)
-            (dyn NSAccessibilityButton + 'static)
-            (dyn NSAccessibilitySwitch + 'static)
-            (dyn NSAccessibilityRadioButton + 'static)
           and $N others
 note: required by a bound in `ProtocolObject::<P>::from_ref`
  --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs

--- a/crates/test-ui/ui/protocol_object_only_protocols.stderr
+++ b/crates/test-ui/ui/protocol_object_only_protocols.stderr
@@ -1,0 +1,216 @@
+error[E0277]: the trait bound `NSObject: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<NSObject> = ProtocolObject::from_ref(&*obj);
+  |                                        ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `NSObject`
+  |                                        |
+  |                                        required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn Send: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn Send> = ProtocolObject::from_ref(&*obj);
+  |                                        ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn Send`
+  |                                        |
+  |                                        required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn Foo: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn Foo> = ProtocolObject::from_ref(&*obj);
+  |                                       ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn Foo`
+  |                                       |
+  |                                       required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn NSObjectProtocol + Send: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSObjectProtocol + Send> = ProtocolObject::from_ref(&*obj);
+  |                                                           ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Send`
+  |                                                           |
+  |                                                           required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn NSObjectProtocol + Sync: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSObjectProtocol + Sync> = ProtocolObject::from_ref(&*obj);
+  |                                                           ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Sync`
+  |                                                           |
+  |                                                           required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn NSObjectProtocol + Send + Sync: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSObjectProtocol + Send + Sync> = ProtocolObject::from_ref(&*obj);
+  |                                                                  ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSObjectProtocol + Send + Sync`
+  |                                                                  |
+  |                                                                  required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `NSObject: NSCopying` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSCopying> = ProtocolObject::from_ref(&*obj);
+  |                                             ------------------------ ^^^^^ the trait `NSCopying` is not implemented for `NSObject`
+  |                                             |
+  |                                             required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `NSCopying`:
+            ProtocolObject<T>
+            __RcTestObject
+            NSCollectionLayoutSection
+            NSCollectionLayoutGroupCustomItem
+            NSArray<ObjectType>
+            NSMutableArray<ObjectType>
+            NSDictionary<KeyType, ObjectType>
+            NSSet<ObjectType>
+          and $N others
+  = note: required for `dyn NSCopying` to implement `ImplementedBy<NSObject>`
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`
+
+error[E0277]: the trait bound `dyn NSCopying + Send: ImplementedBy<NSObject>` is not satisfied
+ --> ui/protocol_object_only_protocols.rs
+  |
+  |     let _: &ProtocolObject<dyn NSCopying + Send> = ProtocolObject::from_ref(&*obj);
+  |                                                    ------------------------ ^^^^^ the trait `ImplementedBy<NSObject>` is not implemented for `dyn NSCopying + Send`
+  |                                                    |
+  |                                                    required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `ImplementedBy<T>`:
+            (dyn NSObjectProtocol + 'static)
+            (dyn NSAccessibilityColor + 'static)
+            (dyn NSAccessibilityCustomRotorItemSearchDelegate + 'static)
+            (dyn NSAccessibilityElementProtocol + 'static)
+            (dyn NSAccessibilityGroup + 'static)
+            (dyn NSAccessibilityButton + 'static)
+            (dyn NSAccessibilitySwitch + 'static)
+            (dyn NSAccessibilityRadioButton + 'static)
+          and $N others
+note: required by a bound in `ProtocolObject::<P>::from_ref`
+ --> $WORKSPACE/crates/objc2/src/runtime/protocol_object.rs
+  |
+  |     pub fn from_ref<T: ?Sized + Message>(obj: &T) -> &Self
+  |            -------- required by a bound in this associated function
+  |     where
+  |         P: ImplementedBy<T>,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `ProtocolObject::<P>::from_ref`


### PR DESCRIPTION
Relax the `ProtocolType` requirement on `ProtocolObject`, which means we can now have protocol objects with auto traits, such as `ProtocolObject<dyn NSObjectProtocol + Send>`.

Protocols objects with multiple protocols are not yet possible.

Construction of these is still difficult, we'd have to somehow do `impl ImplementedBy<T: Any + Combination + Of + Traits> for dyn Any + Combination + Of + Traits`. But I suspect construction of these will be exceedingly rare anyhow, and at least it's better that you can _use_ them, if `icrate` constructs them for you.

TODO:
- [x] Add changelog and documentation
- [x] Add tests for new functionality
- [x] Add UI tests for things that would be unsound
