### PR TITLE
Use `impl` instead of ProtocolObject where possible

### DIFF
--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -1416,14 +1416,18 @@ impl Ty {
             Self::GenericParam { name } => write!(f, "{name}"),
             Self::AnyObject { protocols } => match &**protocols {
                 [] => write!(f, "AnyObject"),
-                [decl] => write!(f, "ProtocolObject<dyn {}>", decl.id.path()),
-                // TODO: Handle this better
-                [first, rest @ ..] => {
-                    write!(f, "AnyObject /* {}", first.id.path())?;
-                    for protocol in rest {
-                        write!(f, "+ {}", protocol.id.path())?;
+                protocols => {
+                    write!(f, "ProtocolObject<dyn ")?;
+
+                    let mut iter = protocols.iter();
+                    let protocol = iter.next().unwrap();
+                    write!(f, "{}", protocol.path())?;
+
+                    for protocol in iter {
+                        write!(f, " + {}", protocol.path())?;
                     }
-                    write!(f, " */")?;
+
+                    write!(f, ">")?;
                     Ok(())
                 }
             },

--- a/crates/header-translator/src/rust_type.rs
+++ b/crates/header-translator/src/rust_type.rs
@@ -1635,6 +1635,26 @@ impl Ty {
 
     pub(crate) fn fn_argument(&self) -> impl fmt::Display + '_ {
         FormatterFn(move |f| match self {
+            Inner::Id {
+                ty: IdType::AnyObject { protocols },
+                is_const: false,
+                lifetime: Lifetime::Unspecified | Lifetime::Strong,
+                nullability,
+            } if self.kind == TyKind::MethodArgument && !protocols.is_empty() => {
+                if *nullability != Nullability::NonNull {
+                    write!(f, "Option<")?;
+                }
+                write!(f, "&")?;
+                write!(f, "(impl ")?;
+                for protocol in protocols {
+                    write!(f, "{} + ", protocol.path())?;
+                }
+                write!(f, "Message)")?;
+                if *nullability != Nullability::NonNull {
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
             Self::Pointer {
                 nullability,
                 is_const: _,

--- a/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.rs
+++ b/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.rs
@@ -49,4 +49,10 @@ extern_methods!(
     }
 );
 
-fn main() {}
+fn main() {
+    let mtm = MainThreadMarker::new().unwrap();
+    let app = NSApplication::sharedApplication(mtm);
+
+    let delegate = CustomObject::new(mtm);
+    app.setDelegate(Some(&delegate));
+}

--- a/framework-crates/objc2-app-kit/examples/delegate.rs
+++ b/framework-crates/objc2-app-kit/examples/delegate.rs
@@ -76,8 +76,7 @@ fn main() {
 
     // configure the application delegate
     let delegate = AppDelegate::new(42, true, mtm);
-    let object = ProtocolObject::from_ref(&*delegate);
-    app.setDelegate(Some(object));
+    app.setDelegate(Some(&*delegate));
 
     // run the app
     app.run();

--- a/framework-crates/objc2-foundation/src/dictionary.rs
+++ b/framework-crates/objc2-foundation/src/dictionary.rs
@@ -381,7 +381,6 @@ impl<KeyType: Message, ObjectType: Message> NSMutableDictionary<KeyType, ObjectT
     where
         CopiedKey: Message + NSCopying + CopyingHelper<Result = KeyType>,
     {
-        let key = ProtocolObject::from_ref(key);
         // SAFETY: The key is copied, and then has the correct type `KeyType`.
         unsafe { self.setObject_forKey(object, key) };
     }

--- a/framework-crates/objc2-metal/examples/triangle.rs
+++ b/framework-crates/objc2-metal/examples/triangle.rs
@@ -163,8 +163,7 @@ declare_class!(
 
             // configure the metal view delegate
             unsafe {
-                let object = ProtocolObject::from_ref(self);
-                mtk_view.setDelegate(Some(object));
+                mtk_view.setDelegate(Some(self));
             }
 
             // configure the window
@@ -310,8 +309,7 @@ fn main() {
 
     // configure the application delegate
     let delegate = Delegate::new(mtm);
-    let object = ProtocolObject::from_ref(&*delegate);
-    app.setDelegate(Some(object));
+    app.setDelegate(Some(&*delegate));
 
     // run the app
     app.run();

--- a/framework-crates/objc2-web-kit/examples/browser.rs
+++ b/framework-crates/objc2-web-kit/examples/browser.rs
@@ -200,12 +200,10 @@ declare_class!(
 
             unsafe {
                 // handle input from text field (on <ENTER>, load URL from text field in web view)
-                let object = ProtocolObject::from_ref(self);
-                nav_url.setDelegate(Some(object));
+                nav_url.setDelegate(Some(self));
 
                 // handle nav events from web view (on finished navigating, update text area with current URL)
-                let object = ProtocolObject::from_ref(self);
-                web_view.setNavigationDelegate(Some(object));
+                web_view.setNavigationDelegate(Some(self));
             }
 
             // create the menu with a "quit" entry
@@ -311,8 +309,7 @@ fn main() {
 
     // configure the application delegate
     let delegate = Delegate::new(mtm);
-    let object = ProtocolObject::from_ref(&*delegate);
-    app.setDelegate(Some(object));
+    app.setDelegate(Some(&*delegate));
 
     // run the app
     app.run();


### PR DESCRIPTION
Builds upon https://github.com/madsmtm/objc2/pull/516.

We now use `&(impl MyProtocol + Message)` instead of `&ProtocolObject<dyn MyProtocol>` as parameters to functions, this allows users to pass in their objects to these functions much more easily.

I'm not sure it's worth the tradeoff in code size though (since now a lot of methods are generic where they don't really have to be), will have to think about.

Alternative to https://github.com/madsmtm/objc2/issues/686 (that one is still strictly cleaner, but probably also not really possible in current Rust (?)).