### PR TITLE
Change `Allocated<T>` in preparation for arbitrary self types

### DIFF
--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -686,7 +686,7 @@ impl fmt::Display for Method {
 
         // Receiver
         if let MemoryManagement::IdInit = self.memory_management {
-            write!(f, "this: Option<Allocated<Self>>, ")?;
+            write!(f, "this: Allocated<Self>, ")?;
         } else if self.is_class {
             // Insert nothing; a class method is assumed
         } else if self.mutating {

--- a/crates/icrate/src/additions/Foundation/data.rs
+++ b/crates/icrate/src/additions/Foundation/data.rs
@@ -267,7 +267,7 @@ impl IdFromIterator<u8> for NSMutableData {
 }
 
 #[cfg(feature = "block")]
-unsafe fn with_vec<T: Message>(obj: Option<Allocated<T>>, bytes: Vec<u8>) -> Id<T> {
+unsafe fn with_vec<T: Message>(obj: Allocated<T>, bytes: Vec<u8>) -> Id<T> {
     use core::mem::ManuallyDrop;
 
     use block2::{Block, ConcreteBlock};

--- a/crates/icrate/src/additions/Foundation/string.rs
+++ b/crates/icrate/src/additions/Foundation/string.rs
@@ -144,7 +144,7 @@ impl NSMutableString {
     }
 }
 
-unsafe fn init_with_str<T: Message>(obj: Option<Allocated<T>>, string: &str) -> Id<T> {
+unsafe fn init_with_str<T: Message>(obj: Allocated<T>, string: &str) -> Id<T> {
     let bytes: *const c_void = string.as_ptr().cast();
     // We use `msg_send_id` instead of the generated method from `icrate`,
     // since that assumes the encoding is `usize`, whereas GNUStep assumes

--- a/crates/icrate/src/additions/Foundation/thread.rs
+++ b/crates/icrate/src/additions/Foundation/thread.rs
@@ -157,7 +157,7 @@ impl MainThreadMarker {
     /// let obj: Id<SomeClass> = unsafe { msg_send_id![obj, init] };
     /// ```
     #[inline]
-    pub fn alloc<T: ClassType>(self) -> Option<Allocated<T>> {
+    pub fn alloc<T: ClassType>(self) -> Allocated<T> {
         // SAFETY: Same as `ClassType::alloc`, with the addition that since we
         // take `self: MainThreadMarker`, the `IsAllocableAnyThread` bound is
         // not required.

--- a/crates/icrate/src/additions/Metal/private.rs
+++ b/crates/icrate/src/additions/Metal/private.rs
@@ -27,7 +27,7 @@ extern_methods!(
         #[cfg(feature = "Metal_MTLDevice")]
         #[method_id(initWithVertexData:fragmentData:serializedVertexDescriptor:device:options:flags:)]
         pub unsafe fn initWithVertexData(
-            this: Option<Allocated<Self>>,
+            this: Allocated<Self>,
             vertex_data: *mut c_void,
             fragment_data: *mut c_void,
             vertex_desc: *mut c_void,

--- a/crates/icrate/src/fixes/Foundation/NSUUID.rs
+++ b/crates/icrate/src/fixes/Foundation/NSUUID.rs
@@ -19,10 +19,7 @@ unsafe impl RefEncode for UuidBytes {
 extern_methods!(
     unsafe impl Foundation::NSUUID {
         #[method_id(initWithUUIDBytes:)]
-        pub(crate) fn initWithUUIDBytes(
-            this: Option<Allocated<Self>>,
-            bytes: &UuidBytes,
-        ) -> Id<Self>;
+        pub(crate) fn initWithUUIDBytes(this: Allocated<Self>, bytes: &UuidBytes) -> Id<Self>;
 
         #[method(getUUIDBytes:)]
         pub(crate) fn getUUIDBytes(&self, bytes: &mut UuidBytes);

--- a/crates/icrate/tests/mutable_array.rs
+++ b/crates/icrate/tests/mutable_array.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "Foundation_NSMutableArray")]
-use objc2::rc::{__RcTestObject, __ThreadTestData, autoreleasepool};
+use objc2::rc::{__RcTestObject, __ThreadTestData, autoreleasepool, Allocated};
 use objc2::{msg_send, ClassType};
 
 #[cfg(feature = "Foundation_NSNumber")]
@@ -123,7 +123,8 @@ fn test_threaded() {
 
         s.spawn(|| {
             let array = <NSMutableArray<NSObject>>::alloc();
-            assert!(array.is_some());
+            let ptr = Allocated::as_ptr(&array);
+            assert!(!ptr.is_null());
         });
     });
 }

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `CounterpartOrSelf`.
 * Added new `encode` traits `EncodeReturn`, `EncodeArgument` and
   `EncodeArguments`.
+* Added methods `as_ptr` and `as_mut_ptr` to `Allocated`.
 
 ### Changed
 * **BREAKING**: `AnyClass::verify_sel` now take more well-defined types
@@ -47,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   a method.
 * **BREAKING**: Renamed the associated types `Ret` and `Args` on
   `MethodImplementation` to `Return` and `Arguments`.
+* **BREAKING**: Make `rc::Allocated` allowed to be `NULL` internally, such
+  that uses of `Option<Allocated<T>>` is now simply `Allocated<T>`.
 
 ### Deprecated
 * Soft deprecated using `msg_send!` without a comma between arguments (i.e.

--- a/crates/objc2/src/__macro_helpers/declare_class.rs
+++ b/crates/objc2/src/__macro_helpers/declare_class.rs
@@ -46,7 +46,7 @@ where
 }
 
 // Explicitly left unimplemented for now!
-// impl MessageRecieveId<impl MessageReceiver, Option<Allocated<T>>> for Alloc {}
+// impl MessageRecieveId<impl MessageReceiver, Allocated<T>> for Alloc {}
 
 // Note: `MethodImplementation` allows for `Allocated` as the receiver, so we
 // restrict it here to only be when the selector is `init`.
@@ -56,7 +56,7 @@ where
 impl<Ret, T> MessageRecieveId<Allocated<T>, Ret> for Init
 where
     T: Message,
-    Ret: MaybeOptionId<Input = Id<T>>,
+    Ret: MaybeOptionId<Input = Option<Id<T>>>,
 {
     #[inline]
     fn into_return(obj: Ret) -> IdReturnValue {

--- a/crates/objc2/src/__macro_helpers/method_family.rs
+++ b/crates/objc2/src/__macro_helpers/method_family.rs
@@ -13,8 +13,8 @@
 ///     retainable object pointer type - we ensure this by making
 ///     `message_send_id` return `Id`.
 ///   - `init`: The method must be an instance method and must return an
-///     Objective-C pointer type - We ensure this by taking
-///     `Option<Allocated<T>>`, which means it can't be a class method!
+///     Objective-C pointer type - We ensure this by taking `Allocated<T>`,
+///     which means it can't be a class method!
 ///
 /// <https://clang.llvm.org/docs/AutomaticReferenceCounting.html#retainable-object-pointers-as-operands-and-arguments>
 // TODO: Use an enum instead of u8 here when stable

--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -97,7 +97,7 @@
 ///         #[method_id(initWithVal:)]
 ///         // Arbitary self types are not stable, but we can work around it
 ///         // with the special name `this`.
-///         pub fn init(this: Option<Allocated<Self>>, val: usize) -> Id<Self>;
+///         pub fn init(this: Allocated<Self>, val: usize) -> Id<Self>;
 ///     }
 ///
 ///     /// Instance accessor methods.
@@ -150,7 +150,7 @@
 ///         unsafe { msg_send_id![Self::class(), new] }
 ///     }
 ///
-///     pub fn init(this: Option<Allocated<Self>>, val: usize) -> Id<Self> {
+///     pub fn init(this: Allocated<Self>, val: usize) -> Id<Self> {
 ///         unsafe { msg_send_id![this, initWithVal: val] }
 ///     }
 /// }

--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -1081,12 +1081,11 @@ macro_rules! msg_send_bool {
 ///   return type is a generic `Id<T>` or `Option<Id<T>>`.
 ///
 /// - The `alloc` family: The receiver must be `&AnyClass`, and the return
-///   type is a generic `Allocated<T>` or `Option<Allocated<T>>`.
+///   type is a generic `Allocated<T>`.
 ///
-/// - The `init` family: The receiver must be `Option<Allocated<T>>` as
-///   returned from `alloc`. The receiver is consumed, and a the
-///   now-initialized `Id<T>` or `Option<Id<T>>` (with the same `T`) is
-///   returned.
+/// - The `init` family: The receiver must be `Allocated<T>` as returned from
+///   `alloc`. The receiver is consumed, and a the now-initialized `Id<T>` or
+///   `Option<Id<T>>` (with the same `T`) is returned.
 ///
 /// - The `copy` family: The receiver may be anything that implements
 ///   [`MessageReceiver`] and the return type is a generic `Id<T>` or
@@ -1276,7 +1275,7 @@ macro_rules! __msg_send_id_helper {
         ($($selector:tt)*)
         ($($argument:expr,)*)
     } => ({
-        <$crate::__macro_helpers::$retain_semantics as $crate::__macro_helpers::MsgSendId<_, _>>::$fn::<_, _>(
+        <$crate::__macro_helpers::$retain_semantics as $crate::__macro_helpers::MsgSendId<_, _>>::$fn(
             $obj,
             $crate::sel!($($selector)*),
             ($($argument,)*),
@@ -1296,7 +1295,7 @@ macro_rules! __msg_send_id_helper {
         let result;
         result = <$crate::__macro_helpers::RetainSemantics<{
             $crate::__macro_helpers::retain_semantics(__SELECTOR_DATA)
-        }> as $crate::__macro_helpers::MsgSendId<_, _>>::$fn::<_, _>(
+        }> as $crate::__macro_helpers::MsgSendId<_, _>>::$fn(
             $obj,
             $crate::__sel_inner!(
                 __SELECTOR_DATA,

--- a/crates/objc2/src/rc/allocated.rs
+++ b/crates/objc2/src/rc/allocated.rs
@@ -1,28 +1,37 @@
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop};
-use core::ptr::NonNull;
+use core::mem::ManuallyDrop;
 
-use crate::runtime::objc_release_fast;
+use crate::mutability::IsMutable;
+use crate::runtime::{objc_release_fast, AnyObject};
 use crate::Message;
 
-/// A marker type that can be used to indicate that the object has been
-/// allocated but not initialized.
+/// An Objective-C object that has been allocated, but not initialized.
 ///
-/// The reason we use `Allocated<T>` / `Option<Allocated<T>>` instead of
-/// `*mut T` is:
-/// - To allow releasing allocated objects, e.g. in the face of panics.
-/// - To safely know the object is valid (albeit uninitialized).
-//
-// Note that there is no way to get something mutable out of `Allocated`
-// unless you're defining the object.
-//
-// For example, `+[NSMutableString alloc]` is allowed to return a non-unique
-// object as an optimization, and then only figure out afterwards whether it
-// needs to allocate, or if it can store an `NSString` internally.
-// Similarly, while e.g. `+[NSData alloc]` may return a unique object,
-// calling `-[NSData init]` afterwards could return a shared empty `NSData`
-// instance.
+/// Objective-C splits the allocation and initialization steps up into two, so
+/// we need to track it in the type-system whether something has been
+/// intialized or not.
+///
+/// Note that allocation in Objective-C can fail, e.g. in Out Of Memory
+/// situations! This is handled by `objc2` automatically, but if you really
+/// need to, you can check for this explicitly by inspecting the pointer
+/// returned from [`as_ptr`].
+///
+/// Note also that this represents that the _current_ class's instance
+/// variables are not yet initialized; but subclass instance variables may
+/// have been so.
+///
+/// See [Apple's documentation on Object Allocation][object-allocation] for a
+/// few more details.
+///
+/// [`as_ptr`]: Self::as_ptr
+/// [object-allocation]: https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/ObjectAllocation/ObjectAllocation.html
+///
+///
+/// # Memory layout
+///
+/// This is guaranteed to have the same size and alignment as a pointer to the
+/// object, `*const T`. The pointer may be NULL.
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct Allocated<T: ?Sized> {
@@ -31,42 +40,88 @@ pub struct Allocated<T: ?Sized> {
     /// We don't use `Id` here, since that has different auto-trait impls, and
     /// requires in it's safety contract that the object is initialized (which
     /// makes it difficult to ensure correctness if such things are split
-    /// across different files).
+    /// across different files). Additionally, we want to have fine control
+    /// over NULL-ness.
     ///
-    /// Variance is same as `Id`.
-    ptr: NonNull<T>,
+    /// Covariance is correct, same as `Id`.
+    ptr: *const T, // Intentially not `NonNull`!
     /// Necessary for dropck, as with `Id`.
     p: PhantomData<T>,
+    /// Necessary for restricting auto traits.
+    p_auto_traits: PhantomData<AnyObject>,
 }
 
 // We _could_ probably implement auto traits `Send` and `Sync` here, but to be
-// safe, we won't.
-
-// Explicitly don't implement `Deref`, `Message` nor `RefEncode`!
+// safe, we won't for now.
+//
+// Explicitly don't implement `Deref`, `Message` nor `RefEncode`, though!
 
 impl<T: ?Sized + Message> Allocated<T> {
     /// # Safety
     ///
     /// The caller must ensure the given object has +1 retain count, and that
     /// the object behind the pointer has been allocated (but not yet
-    /// initialized).
+    /// initialized), or that the pointer is NULL.
     #[inline]
-    pub(crate) unsafe fn new(ptr: *mut T) -> Option<Self> {
-        NonNull::new(ptr).map(|ptr| Self {
+    pub(crate) unsafe fn new(ptr: *mut T) -> Self {
+        Self {
             ptr,
             p: PhantomData,
-        })
+            p_auto_traits: PhantomData,
+        }
+    }
+
+    /// Returns a raw pointer to the object.
+    ///
+    /// The pointer is valid for at least as long as the `Allocated` is held.
+    ///
+    /// See [`Allocated::as_mut_ptr`] for the mutable equivalent.
+    ///
+    /// This is an associated method, and must be called as
+    /// `Allocated::as_ptr(obj)`.
+    #[inline]
+    pub fn as_ptr(this: &Self) -> *const T {
+        this.ptr
+    }
+
+    /// Returns a raw mutable pointer to the object.
+    ///
+    /// The pointer is valid for at least as long as the `Allocated` is held.
+    ///
+    /// See [`Allocated::as_ptr`] for the immutable equivalent.
+    ///
+    /// This is an associated method, and must be called as
+    /// `Allocated::as_mut_ptr(obj)`.
+    ///
+    ///
+    /// # Note about mutable references
+    ///
+    /// In general, you're not allowed to create a mutable reference from
+    /// `Allocated`, unless you're defining the object and know that to be
+    /// safe.
+    ///
+    /// For example, `+[NSMutableString alloc]` is allowed to return a
+    /// non-unique object as an optimization, and then only figure out
+    /// afterwards whether it needs to allocate, or if it can store an
+    /// `NSString` internally.
+    ///
+    /// Similarly, while e.g. `+[NSData alloc]` may return a unique object,
+    /// calling `-[NSData init]` afterwards could return a shared empty
+    /// `NSData` instance.
+    #[inline]
+    #[allow(unknown_lints)] // New lint below
+    #[allow(clippy::needless_pass_by_ref_mut)]
+    pub fn as_mut_ptr(this: &mut Self) -> *mut T
+    where
+        T: IsMutable,
+    {
+        this.ptr as *mut T
     }
 
     #[inline]
-    pub(crate) fn option_into_ptr(this: Option<Self>) -> *mut T {
-        let ptr = this.map(|this| ManuallyDrop::new(this).ptr);
-
-        // Difficult to write this in an ergonomic way with `?Sized`, so we
-        // hack it with transmute.
-        //
-        // SAFETY: `Option<NonNull<T>>` has the same size as `*mut T`.
-        unsafe { mem::transmute::<Option<NonNull<T>>, *mut T>(ptr) }
+    pub(crate) fn into_ptr(this: Self) -> *mut T {
+        let this = ManuallyDrop::new(this);
+        this.ptr as *mut T
     }
 }
 
@@ -77,13 +132,43 @@ impl<T: ?Sized> Drop for Allocated<T> {
         // destructors are written to take into account that the object may
         // not have been initialized.
         //
+        // This is also safe in the case where the object is NULL,
+        // since `objc_release` allows NULL pointers.
+        //
         // Rest is same as `Id`'s `Drop`.
-        unsafe { objc_release_fast(self.ptr.as_ptr().cast()) };
+        unsafe { objc_release_fast(self.ptr as *mut _) };
     }
 }
 
 impl<T: ?Sized> fmt::Pointer for Allocated<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Pointer::fmt(&self.ptr.as_ptr(), f)
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::panic::{RefUnwindSafe, UnwindSafe};
+
+    use static_assertions::assert_not_impl_any;
+
+    use super::*;
+    use crate::runtime::NSObject;
+
+    #[test]
+    fn auto_traits() {
+        assert_not_impl_any!(Allocated<()>: Send, Sync, UnwindSafe, RefUnwindSafe, Unpin);
+    }
+
+    #[repr(C)]
+    struct MyObject<'a> {
+        inner: NSObject,
+        p: PhantomData<&'a str>,
+    }
+
+    /// Test that `Allocated<T>` is covariant over `T`.
+    #[allow(unused)]
+    fn assert_variance<'b>(obj: Allocated<MyObject<'static>>) -> Allocated<MyObject<'b>> {
+        obj
     }
 }

--- a/crates/objc2/src/runtime/message_receiver.rs
+++ b/crates/objc2/src/runtime/message_receiver.rs
@@ -482,9 +482,11 @@ unsafe impl<'a> MessageReceiver for &'a AnyClass {
 
 #[cfg(test)]
 mod tests {
+    use core::ptr;
+
     use super::*;
     use crate::mutability;
-    use crate::rc::Id;
+    use crate::rc::{Allocated, Id};
     use crate::runtime::NSObject;
     use crate::test_utils;
     use crate::{declare_class, msg_send, msg_send_id, ClassType};
@@ -568,7 +570,8 @@ mod tests {
         assert!(result.is_none());
 
         // This result should not be relied on
-        let result: Option<Id<NSObject>> = unsafe { msg_send_id![None, init] };
+        let obj = unsafe { Allocated::new(ptr::null_mut()) };
+        let result: Option<Id<NSObject>> = unsafe { msg_send_id![obj, init] };
         assert!(result.is_none());
     }
 

--- a/crates/objc2/src/top_level_traits.rs
+++ b/crates/objc2/src/top_level_traits.rs
@@ -287,7 +287,7 @@ pub unsafe trait ClassType: Message {
     // but `ClassType` is more often already in scope, allowing easier access
     // to `T::alloc()`.
     #[inline]
-    fn alloc() -> Option<Allocated<Self>>
+    fn alloc() -> Allocated<Self>
     where
         Self: IsAllocableAnyThread,
     {

--- a/crates/objc2/tests/track_caller.rs
+++ b/crates/objc2/tests/track_caller.rs
@@ -152,9 +152,14 @@ pub fn test_id_unwrap(checker: &PanicChecker) {
         let _obj: Id<__RcTestObject> = unsafe { msg_send_id![cls, newReturningNull] };
     });
 
-    let msg = "failed allocating with +[__RcTestObject allocReturningNull]";
-    checker.assert_panics(msg, line!() + 1, || {
-        let _obj: Allocated<__RcTestObject> = unsafe { msg_send_id![cls, allocReturningNull] };
+    let msg = if cfg!(debug_assertions) {
+        "messsaging init to nil"
+    } else {
+        "failed allocating object"
+    };
+    checker.assert_panics(msg, line!() + 2, || {
+        let obj: Allocated<__RcTestObject> = unsafe { msg_send_id![cls, allocReturningNull] };
+        let _obj: Id<__RcTestObject> = unsafe { msg_send_id![obj, init] };
     });
 
     let msg = "failed initializing object with -initReturningNull";

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-aarch64.s
@@ -93,9 +93,9 @@ Lloh7:
 	ret
 	.loh AdrpAdd	Lloh6, Lloh7
 
-	.globl	_error_alloc
+	.globl	_error_init
 	.p2align	2
-_error_alloc:
+_error_init:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -122,9 +122,9 @@ Lloh9:
 	ret
 	.loh AdrpAdd	Lloh8, Lloh9
 
-	.globl	_error_init
+	.globl	_error_copy
 	.p2align	2
-_error_init:
+_error_copy:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -151,15 +151,19 @@ Lloh11:
 	ret
 	.loh AdrpAdd	Lloh10, Lloh11
 
-	.globl	_error_copy
+	.globl	_error_autoreleased
 	.p2align	2
-_error_copy:
+_error_autoreleased:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
 	str	xzr, [sp, #8]
 	add	x2, sp, #8
 	bl	_objc_msgSend
+	; InlineAsm Start
+	mov	x29, x29
+	; InlineAsm End
+	bl	_objc_retainAutoreleasedReturnValue
 	cbz	x0, LBB6_2
 	mov	x1, x0
 	mov	x0, #0
@@ -179,39 +183,6 @@ Lloh13:
 	add	sp, sp, #32
 	ret
 	.loh AdrpAdd	Lloh12, Lloh13
-
-	.globl	_error_autoreleased
-	.p2align	2
-_error_autoreleased:
-	sub	sp, sp, #32
-	stp	x29, x30, [sp, #16]
-	add	x29, sp, #16
-	str	xzr, [sp, #8]
-	add	x2, sp, #8
-	bl	_objc_msgSend
-	; InlineAsm Start
-	mov	x29, x29
-	; InlineAsm End
-	bl	_objc_retainAutoreleasedReturnValue
-	cbz	x0, LBB7_2
-	mov	x1, x0
-	mov	x0, #0
-	ldp	x29, x30, [sp, #16]
-	add	sp, sp, #32
-	ret
-LBB7_2:
-	ldr	x0, [sp, #8]
-Lloh14:
-	adrp	x1, l_anon.[ID].8@PAGE
-Lloh15:
-	add	x1, x1, l_anon.[ID].8@PAGEOFF
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	x1, x0
-	mov	w0, #1
-	ldp	x29, x30, [sp, #16]
-	add	sp, sp, #32
-	ret
-	.loh AdrpAdd	Lloh14, Lloh15
 
 	.section	__TEXT,__const
 l_anon.[ID].0:
@@ -237,21 +208,16 @@ l_anon.[ID].4:
 	.p2align	3, 0x0
 l_anon.[ID].5:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\026\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].6:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\033\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].7:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\036\000\000\000\005\000\000"
-
-	.p2align	3, 0x0
-l_anon.[ID].8:
-	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000#\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000 \000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7.s
@@ -94,10 +94,10 @@ LPC3_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_alloc
+	.globl	_error_init
 	.p2align	2
 	.code	32
-_error_alloc:
+_error_init:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	sub	sp, sp, #4
@@ -124,10 +124,10 @@ LPC4_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_init
+	.globl	_error_copy
 	.p2align	2
 	.code	32
-_error_init:
+_error_copy:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	sub	sp, sp, #4
@@ -154,36 +154,6 @@ LPC5_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_copy
-	.p2align	2
-	.code	32
-_error_copy:
-	push	{r4, r7, lr}
-	add	r7, sp, #4
-	sub	sp, sp, #4
-	mov	r4, #0
-	mov	r2, sp
-	str	r4, [sp]
-	bl	_objc_msgSend
-	mov	r1, r0
-	cmp	r0, #0
-	beq	LBB6_2
-	mov	r0, r4
-	sub	sp, r7, #4
-	pop	{r4, r7, pc}
-LBB6_2:
-	ldr	r0, [sp]
-	movw	r1, :lower16:(l_anon.[ID].7-(LPC6_0+8))
-	movt	r1, :upper16:(l_anon.[ID].7-(LPC6_0+8))
-LPC6_0:
-	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	r1, r0
-	mov	r4, #1
-	mov	r0, r4
-	sub	sp, r7, #4
-	pop	{r4, r7, pc}
-
 	.globl	_error_autoreleased
 	.p2align	2
 	.code	32
@@ -201,15 +171,15 @@ _error_autoreleased:
 	bl	_objc_retainAutoreleasedReturnValue
 	mov	r1, r0
 	cmp	r0, #0
-	beq	LBB7_2
+	beq	LBB6_2
 	mov	r0, r4
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
-LBB7_2:
+LBB6_2:
 	ldr	r0, [sp]
-	movw	r1, :lower16:(l_anon.[ID].8-(LPC7_0+8))
-	movt	r1, :upper16:(l_anon.[ID].8-(LPC7_0+8))
-LPC7_0:
+	movw	r1, :lower16:(l_anon.[ID].7-(LPC6_0+8))
+	movt	r1, :upper16:(l_anon.[ID].7-(LPC6_0+8))
+LPC6_0:
 	add	r1, pc, r1
 	bl	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
@@ -242,21 +212,16 @@ l_anon.[ID].4:
 	.p2align	2, 0x0
 l_anon.[ID].5:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\026\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].6:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\033\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].7:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\036\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].8:
-	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000#\000\000\000\005\000\000"
+	.asciz	"6\000\000\000 \000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-armv7s.s
@@ -94,10 +94,10 @@ LPC3_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_alloc
+	.globl	_error_init
 	.p2align	2
 	.code	32
-_error_alloc:
+_error_init:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	sub	sp, sp, #4
@@ -124,10 +124,10 @@ LPC4_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_init
+	.globl	_error_copy
 	.p2align	2
 	.code	32
-_error_init:
+_error_copy:
 	push	{r4, r7, lr}
 	add	r7, sp, #4
 	sub	sp, sp, #4
@@ -154,36 +154,6 @@ LPC5_0:
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
 
-	.globl	_error_copy
-	.p2align	2
-	.code	32
-_error_copy:
-	push	{r4, r7, lr}
-	add	r7, sp, #4
-	sub	sp, sp, #4
-	mov	r4, #0
-	mov	r2, sp
-	str	r4, [sp]
-	bl	_objc_msgSend
-	mov	r1, r0
-	cmp	r0, #0
-	beq	LBB6_2
-	mov	r0, r4
-	sub	sp, r7, #4
-	pop	{r4, r7, pc}
-LBB6_2:
-	movw	r1, :lower16:(l_anon.[ID].7-(LPC6_0+8))
-	movt	r1, :upper16:(l_anon.[ID].7-(LPC6_0+8))
-	ldr	r0, [sp]
-LPC6_0:
-	add	r1, pc, r1
-	bl	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	r1, r0
-	mov	r4, #1
-	mov	r0, r4
-	sub	sp, r7, #4
-	pop	{r4, r7, pc}
-
 	.globl	_error_autoreleased
 	.p2align	2
 	.code	32
@@ -201,15 +171,15 @@ _error_autoreleased:
 	bl	_objc_retainAutoreleasedReturnValue
 	mov	r1, r0
 	cmp	r0, #0
-	beq	LBB7_2
+	beq	LBB6_2
 	mov	r0, r4
 	sub	sp, r7, #4
 	pop	{r4, r7, pc}
-LBB7_2:
-	movw	r1, :lower16:(l_anon.[ID].8-(LPC7_0+8))
-	movt	r1, :upper16:(l_anon.[ID].8-(LPC7_0+8))
+LBB6_2:
+	movw	r1, :lower16:(l_anon.[ID].7-(LPC6_0+8))
+	movt	r1, :upper16:(l_anon.[ID].7-(LPC6_0+8))
 	ldr	r0, [sp]
-LPC7_0:
+LPC6_0:
 	add	r1, pc, r1
 	bl	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	r1, r0
@@ -242,21 +212,16 @@ l_anon.[ID].4:
 	.p2align	2, 0x0
 l_anon.[ID].5:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\026\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].6:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\033\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].7:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\036\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].8:
-	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000#\000\000\000\005\000\000"
+	.asciz	"6\000\000\000 \000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86.s
@@ -129,9 +129,9 @@ LBB3_2:
 	pop	ebp
 	ret
 
-	.globl	_error_alloc
+	.globl	_error_init
 	.p2align	4, 0x90
-_error_alloc:
+_error_init:
 	push	ebp
 	mov	ebp, esp
 	push	esi
@@ -168,9 +168,9 @@ LBB4_2:
 	pop	ebp
 	ret
 
-	.globl	_error_init
+	.globl	_error_copy
 	.p2align	4, 0x90
-_error_init:
+_error_copy:
 	push	ebp
 	mov	ebp, esp
 	push	esi
@@ -207,45 +207,6 @@ LBB5_2:
 	pop	ebp
 	ret
 
-	.globl	_error_copy
-	.p2align	4, 0x90
-_error_copy:
-	push	ebp
-	mov	ebp, esp
-	push	esi
-	push	eax
-	call	L6$pb
-L6$pb:
-	pop	esi
-	mov	eax, dword ptr [ebp + 8]
-	mov	ecx, dword ptr [ebp + 12]
-	mov	dword ptr [ebp - 8], 0
-	sub	esp, 4
-	lea	edx, [ebp - 8]
-	push	edx
-	push	ecx
-	push	eax
-	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB6_2
-	mov	edx, eax
-	xor	eax, eax
-	add	esp, 4
-	pop	esi
-	pop	ebp
-	ret
-LBB6_2:
-	mov	ecx, dword ptr [ebp - 8]
-	lea	edx, [esi + l_anon.[ID].7-L6$pb]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	edx, eax
-	mov	eax, 1
-	add	esp, 4
-	pop	esi
-	pop	ebp
-	ret
-
 	.globl	_error_autoreleased
 	.p2align	4, 0x90
 _error_autoreleased:
@@ -253,8 +214,8 @@ _error_autoreleased:
 	mov	ebp, esp
 	push	esi
 	push	eax
-	call	L7$pb
-L7$pb:
+	call	L6$pb
+L6$pb:
 	pop	esi
 	mov	eax, dword ptr [ebp + 8]
 	mov	ecx, dword ptr [ebp + 12]
@@ -276,16 +237,16 @@ L7$pb:
 	call	_objc_retainAutoreleasedReturnValue
 	add	esp, 16
 	test	eax, eax
-	je	LBB7_2
+	je	LBB6_2
 	mov	edx, eax
 	xor	eax, eax
 	add	esp, 4
 	pop	esi
 	pop	ebp
 	ret
-LBB7_2:
+LBB6_2:
 	mov	ecx, dword ptr [ebp - 8]
-	lea	edx, [esi + l_anon.[ID].8-L7$pb]
+	lea	edx, [esi + l_anon.[ID].7-L6$pb]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
@@ -318,21 +279,16 @@ l_anon.[ID].4:
 	.p2align	2, 0x0
 l_anon.[ID].5:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\026\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].6:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\033\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].7:
 	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000\036\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].8:
-	.long	l_anon.[ID].2
-	.asciz	"6\000\000\000#\000\000\000\005\000\000"
+	.asciz	"6\000\000\000 \000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/apple-x86_64.s
@@ -83,9 +83,9 @@ LBB3_2:
 	pop	rbp
 	ret
 
-	.globl	_error_alloc
+	.globl	_error_init
 	.p2align	4, 0x90
-_error_alloc:
+_error_init:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -109,9 +109,9 @@ LBB4_2:
 	pop	rbp
 	ret
 
-	.globl	_error_init
+	.globl	_error_copy
 	.p2align	4, 0x90
-_error_init:
+_error_copy:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -128,32 +128,6 @@ _error_init:
 LBB5_2:
 	mov	rdi, qword ptr [rbp - 8]
 	lea	rsi, [rip + l_anon.[ID].6]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	rdx, rax
-	mov	eax, 1
-	add	rsp, 16
-	pop	rbp
-	ret
-
-	.globl	_error_copy
-	.p2align	4, 0x90
-_error_copy:
-	push	rbp
-	mov	rbp, rsp
-	sub	rsp, 16
-	mov	qword ptr [rbp - 8], 0
-	lea	rdx, [rbp - 8]
-	call	_objc_msgSend
-	test	rax, rax
-	je	LBB6_2
-	mov	rdx, rax
-	xor	eax, eax
-	add	rsp, 16
-	pop	rbp
-	ret
-LBB6_2:
-	mov	rdi, qword ptr [rbp - 8]
-	lea	rsi, [rip + l_anon.[ID].7]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
@@ -178,15 +152,15 @@ _error_autoreleased:
 
 	## InlineAsm End
 	test	rax, rax
-	je	LBB7_2
+	je	LBB6_2
 	mov	rdx, rax
 	xor	eax, eax
 	add	rsp, 16
 	pop	rbp
 	ret
-LBB7_2:
+LBB6_2:
 	mov	rdi, qword ptr [rbp - 8]
-	lea	rsi, [rip + l_anon.[ID].8]
+	lea	rsi, [rip + l_anon.[ID].7]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
@@ -218,21 +192,16 @@ l_anon.[ID].4:
 	.p2align	3, 0x0
 l_anon.[ID].5:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\026\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].6:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\033\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].7:
 	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\036\000\000\000\005\000\000"
-
-	.p2align	3, 0x0
-l_anon.[ID].8:
-	.quad	l_anon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000#\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000 \000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86.s
@@ -165,54 +165,6 @@ error_new:
 .Lfunc_end3:
 	.size	error_new, .Lfunc_end3-error_new
 
-	.section	.text.error_alloc,"ax",@progbits
-	.globl	error_alloc
-	.p2align	4, 0x90
-	.type	error_alloc,@function
-error_alloc:
-	push	ebx
-	push	edi
-	push	esi
-	sub	esp, 16
-	mov	esi, dword ptr [esp + 32]
-	mov	edi, dword ptr [esp + 36]
-	call	.L4$pb
-.L4$pb:
-	pop	ebx
-	mov	dword ptr [esp + 12], 0
-.Ltmp4:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp4-.L4$pb)
-	sub	esp, 8
-	push	edi
-	push	esi
-	call	objc_msg_lookup@PLT
-	add	esp, 12
-	lea	ecx, [esp + 16]
-	push	ecx
-	push	edi
-	push	esi
-	call	eax
-	add	esp, 16
-	test	eax, eax
-	je	.LBB4_2
-	mov	edx, eax
-	xor	eax, eax
-.LBB4_3:
-	add	esp, 16
-	pop	esi
-	pop	edi
-	pop	ebx
-	ret
-.LBB4_2:
-	mov	ecx, dword ptr [esp + 12]
-	lea	edx, [ebx + .Lanon.[ID].5@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	edx, eax
-	mov	eax, 1
-	jmp	.LBB4_3
-.Lfunc_end4:
-	.size	error_alloc, .Lfunc_end4-error_alloc
-
 	.section	.text.error_init,"ax",@progbits
 	.globl	error_init
 	.p2align	4, 0x90
@@ -223,14 +175,14 @@ error_init:
 	push	esi
 	sub	esp, 16
 	mov	esi, dword ptr [esp + 32]
-	call	.L5$pb
-.L5$pb:
+	call	.L4$pb
+.L4$pb:
 	pop	ebx
 	mov	dword ptr [esp + 12], 0
-.Ltmp5:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp5-.L5$pb)
+.Ltmp4:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp4-.L4$pb)
 	test	esi, esi
-	je	.LBB5_1
+	je	.LBB4_1
 	mov	edi, dword ptr [esp + 36]
 	sub	esp, 8
 	push	edi
@@ -244,34 +196,82 @@ error_init:
 	call	eax
 	add	esp, 16
 	test	eax, eax
-	je	.LBB5_4
+	je	.LBB4_4
 	mov	edx, eax
 	xor	eax, eax
-.LBB5_6:
+.LBB4_6:
 	add	esp, 16
 	pop	esi
 	pop	edi
 	pop	ebx
 	ret
-.LBB5_1:
+.LBB4_1:
 	xor	ecx, ecx
-	jmp	.LBB5_5
-.LBB5_4:
+	jmp	.LBB4_5
+.LBB4_4:
 	mov	ecx, dword ptr [esp + 12]
-.LBB5_5:
-	lea	edx, [ebx + .Lanon.[ID].6@GOTOFF]
+.LBB4_5:
+	lea	edx, [ebx + .Lanon.[ID].5@GOTOFF]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	edx, eax
 	mov	eax, 1
-	jmp	.LBB5_6
-.Lfunc_end5:
-	.size	error_init, .Lfunc_end5-error_init
+	jmp	.LBB4_6
+.Lfunc_end4:
+	.size	error_init, .Lfunc_end4-error_init
 
 	.section	.text.error_copy,"ax",@progbits
 	.globl	error_copy
 	.p2align	4, 0x90
 	.type	error_copy,@function
 error_copy:
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 16
+	mov	esi, dword ptr [esp + 32]
+	mov	edi, dword ptr [esp + 36]
+	call	.L5$pb
+.L5$pb:
+	pop	ebx
+	mov	dword ptr [esp + 12], 0
+.Ltmp5:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp5-.L5$pb)
+	sub	esp, 8
+	push	edi
+	push	esi
+	call	objc_msg_lookup@PLT
+	add	esp, 12
+	lea	ecx, [esp + 16]
+	push	ecx
+	push	edi
+	push	esi
+	call	eax
+	add	esp, 16
+	test	eax, eax
+	je	.LBB5_2
+	mov	edx, eax
+	xor	eax, eax
+.LBB5_3:
+	add	esp, 16
+	pop	esi
+	pop	edi
+	pop	ebx
+	ret
+.LBB5_2:
+	mov	ecx, dword ptr [esp + 12]
+	lea	edx, [ebx + .Lanon.[ID].6@GOTOFF]
+	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
+	mov	edx, eax
+	mov	eax, 1
+	jmp	.LBB5_3
+.Lfunc_end5:
+	.size	error_copy, .Lfunc_end5-error_copy
+
+	.section	.text.error_autoreleased,"ax",@progbits
+	.globl	error_autoreleased
+	.p2align	4, 0x90
+	.type	error_autoreleased,@function
+error_autoreleased:
 	push	ebx
 	push	edi
 	push	esi
@@ -294,6 +294,9 @@ error_copy:
 	push	edi
 	push	esi
 	call	eax
+	add	esp, 4
+	push	eax
+	call	objc_retainAutoreleasedReturnValue@PLT
 	add	esp, 16
 	test	eax, eax
 	je	.LBB6_2
@@ -313,58 +316,7 @@ error_copy:
 	mov	eax, 1
 	jmp	.LBB6_3
 .Lfunc_end6:
-	.size	error_copy, .Lfunc_end6-error_copy
-
-	.section	.text.error_autoreleased,"ax",@progbits
-	.globl	error_autoreleased
-	.p2align	4, 0x90
-	.type	error_autoreleased,@function
-error_autoreleased:
-	push	ebx
-	push	edi
-	push	esi
-	sub	esp, 16
-	mov	esi, dword ptr [esp + 32]
-	mov	edi, dword ptr [esp + 36]
-	call	.L7$pb
-.L7$pb:
-	pop	ebx
-	mov	dword ptr [esp + 12], 0
-.Ltmp7:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp7-.L7$pb)
-	sub	esp, 8
-	push	edi
-	push	esi
-	call	objc_msg_lookup@PLT
-	add	esp, 12
-	lea	ecx, [esp + 16]
-	push	ecx
-	push	edi
-	push	esi
-	call	eax
-	add	esp, 4
-	push	eax
-	call	objc_retainAutoreleasedReturnValue@PLT
-	add	esp, 16
-	test	eax, eax
-	je	.LBB7_2
-	mov	edx, eax
-	xor	eax, eax
-.LBB7_3:
-	add	esp, 16
-	pop	esi
-	pop	edi
-	pop	ebx
-	ret
-.LBB7_2:
-	mov	ecx, dword ptr [esp + 12]
-	lea	edx, [ebx + .Lanon.[ID].8@GOTOFF]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	edx, eax
-	mov	eax, 1
-	jmp	.LBB7_3
-.Lfunc_end7:
-	.size	error_autoreleased, .Lfunc_end7-error_autoreleased
+	.size	error_autoreleased, .Lfunc_end6-error_autoreleased
 
 	.type	.Lanon.[ID].0,@object
 	.section	.rodata..Lanon.[ID].0,"a",@progbits
@@ -405,7 +357,7 @@ error_autoreleased:
 	.p2align	2, 0x0
 .Lanon.[ID].5:
 	.long	.Lanon.[ID].2
-	.asciz	"6\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\026\000\000\000\005\000\000"
 	.size	.Lanon.[ID].5, 16
 
 	.type	.Lanon.[ID].6,@object
@@ -413,7 +365,7 @@ error_autoreleased:
 	.p2align	2, 0x0
 .Lanon.[ID].6:
 	.long	.Lanon.[ID].2
-	.asciz	"6\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\033\000\000\000\005\000\000"
 	.size	.Lanon.[ID].6, 16
 
 	.type	.Lanon.[ID].7,@object
@@ -421,15 +373,7 @@ error_autoreleased:
 	.p2align	2, 0x0
 .Lanon.[ID].7:
 	.long	.Lanon.[ID].2
-	.asciz	"6\000\000\000\036\000\000\000\005\000\000"
+	.asciz	"6\000\000\000 \000\000\000\005\000\000"
 	.size	.Lanon.[ID].7, 16
-
-	.type	.Lanon.[ID].8,@object
-	.section	.data.rel.ro..Lanon.[ID].8,"aw",@progbits
-	.p2align	2, 0x0
-.Lanon.[ID].8:
-	.long	.Lanon.[ID].2
-	.asciz	"6\000\000\000#\000\000\000\005\000\000"
-	.size	.Lanon.[ID].8, 16
 
 	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
@@ -111,43 +111,6 @@ error_new:
 .Lfunc_end3:
 	.size	error_new, .Lfunc_end3-error_new
 
-	.section	.text.error_alloc,"ax",@progbits
-	.globl	error_alloc
-	.p2align	4, 0x90
-	.type	error_alloc,@function
-error_alloc:
-	push	r14
-	push	rbx
-	push	rax
-	mov	rbx, rsi
-	mov	r14, rdi
-	mov	qword ptr [rsp], 0
-	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rdx, rsp
-	mov	rdi, r14
-	mov	rsi, rbx
-	call	rax
-	test	rax, rax
-	je	.LBB4_2
-	mov	rdx, rax
-	xor	eax, eax
-	add	rsp, 8
-	pop	rbx
-	pop	r14
-	ret
-.LBB4_2:
-	mov	rdi, qword ptr [rsp]
-	lea	rsi, [rip + .Lanon.[ID].5]
-	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
-	mov	rdx, rax
-	mov	eax, 1
-	add	rsp, 8
-	pop	rbx
-	pop	r14
-	ret
-.Lfunc_end4:
-	.size	error_alloc, .Lfunc_end4-error_alloc
-
 	.section	.text.error_init,"ax",@progbits
 	.globl	error_init
 	.p2align	4, 0x90
@@ -158,7 +121,7 @@ error_init:
 	push	rax
 	mov	qword ptr [rsp], 0
 	test	rdi, rdi
-	je	.LBB5_1
+	je	.LBB4_1
 	mov	rbx, rsi
 	mov	r14, rdi
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
@@ -167,20 +130,20 @@ error_init:
 	mov	rsi, rbx
 	call	rax
 	test	rax, rax
-	je	.LBB5_4
+	je	.LBB4_4
 	mov	rdx, rax
 	xor	eax, eax
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB5_1:
+.LBB4_1:
 	xor	edi, edi
-	jmp	.LBB5_5
-.LBB5_4:
+	jmp	.LBB4_5
+.LBB4_4:
 	mov	rdi, qword ptr [rsp]
-.LBB5_5:
-	lea	rsi, [rip + .Lanon.[ID].6]
+.LBB4_5:
+	lea	rsi, [rip + .Lanon.[ID].5]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
@@ -188,8 +151,8 @@ error_init:
 	pop	rbx
 	pop	r14
 	ret
-.Lfunc_end5:
-	.size	error_init, .Lfunc_end5-error_init
+.Lfunc_end4:
+	.size	error_init, .Lfunc_end4-error_init
 
 	.section	.text.error_copy,"ax",@progbits
 	.globl	error_copy
@@ -208,16 +171,16 @@ error_copy:
 	mov	rsi, rbx
 	call	rax
 	test	rax, rax
-	je	.LBB6_2
+	je	.LBB5_2
 	mov	rdx, rax
 	xor	eax, eax
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB6_2:
+.LBB5_2:
 	mov	rdi, qword ptr [rsp]
-	lea	rsi, [rip + .Lanon.[ID].7]
+	lea	rsi, [rip + .Lanon.[ID].6]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
@@ -225,8 +188,8 @@ error_copy:
 	pop	rbx
 	pop	r14
 	ret
-.Lfunc_end6:
-	.size	error_copy, .Lfunc_end6-error_copy
+.Lfunc_end5:
+	.size	error_copy, .Lfunc_end5-error_copy
 
 	.section	.text.error_autoreleased,"ax",@progbits
 	.globl	error_autoreleased
@@ -247,16 +210,16 @@ error_autoreleased:
 	mov	rdi, rax
 	call	qword ptr [rip + objc_retainAutoreleasedReturnValue@GOTPCREL]
 	test	rax, rax
-	je	.LBB7_2
+	je	.LBB6_2
 	mov	rdx, rax
 	xor	eax, eax
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB7_2:
+.LBB6_2:
 	mov	rdi, qword ptr [rsp]
-	lea	rsi, [rip + .Lanon.[ID].8]
+	lea	rsi, [rip + .Lanon.[ID].7]
 	call	SYM(objc2[CRATE_ID]::__macro_helpers::msg_send_id::encountered_error::<objc2[CRATE_ID]::runtime::AnyObject>, 0)
 	mov	rdx, rax
 	mov	eax, 1
@@ -264,8 +227,8 @@ error_autoreleased:
 	pop	rbx
 	pop	r14
 	ret
-.Lfunc_end7:
-	.size	error_autoreleased, .Lfunc_end7-error_autoreleased
+.Lfunc_end6:
+	.size	error_autoreleased, .Lfunc_end6-error_autoreleased
 
 	.type	.Lanon.[ID].0,@object
 	.section	.rodata..Lanon.[ID].0,"a",@progbits
@@ -306,7 +269,7 @@ error_autoreleased:
 	.p2align	3, 0x0
 .Lanon.[ID].5:
 	.quad	.Lanon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\024\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\026\000\000\000\005\000\000"
 	.size	.Lanon.[ID].5, 24
 
 	.type	.Lanon.[ID].6,@object
@@ -314,7 +277,7 @@ error_autoreleased:
 	.p2align	3, 0x0
 .Lanon.[ID].6:
 	.quad	.Lanon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\031\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000\033\000\000\000\005\000\000"
 	.size	.Lanon.[ID].6, 24
 
 	.type	.Lanon.[ID].7,@object
@@ -322,15 +285,7 @@ error_autoreleased:
 	.p2align	3, 0x0
 .Lanon.[ID].7:
 	.quad	.Lanon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000\036\000\000\000\005\000\000"
+	.asciz	"6\000\000\000\000\000\000\000 \000\000\000\005\000\000"
 	.size	.Lanon.[ID].7, 24
-
-	.type	.Lanon.[ID].8,@object
-	.section	.data.rel.ro..Lanon.[ID].8,"aw",@progbits
-	.p2align	3, 0x0
-.Lanon.[ID].8:
-	.quad	.Lanon.[ID].2
-	.asciz	"6\000\000\000\000\000\000\000#\000\000\000\005\000\000"
-	.size	.Lanon.[ID].8, 24
 
 	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_msg_send_error/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_error/lib.rs
@@ -1,5 +1,5 @@
 //! Test that error parameters are handled correctly.
-use objc2::__macro_helpers::{Alloc, CopyOrMutCopy, Init, MsgSend, MsgSendId, New, Other};
+use objc2::__macro_helpers::{CopyOrMutCopy, Init, MsgSend, MsgSendId, New, Other};
 use objc2::rc::{Allocated, Id};
 use objc2::runtime::{AnyClass, AnyObject, Sel};
 
@@ -15,13 +15,10 @@ unsafe fn error_new(cls: &AnyClass, sel: Sel) -> Result<Id<AnyObject>> {
     New::send_message_id_error(cls, sel, ())
 }
 
-#[no_mangle]
-unsafe fn error_alloc(cls: &AnyClass, sel: Sel) -> Result<Allocated<AnyObject>> {
-    Alloc::send_message_id_error(cls, sel, ())
-}
+// Note: Erroring allocation methods are intentionally not supported
 
 #[no_mangle]
-unsafe fn error_init(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Result<Id<AnyObject>> {
+unsafe fn error_init(obj: Allocated<AnyObject>, sel: Sel) -> Result<Id<AnyObject>> {
     Init::send_message_id_error(obj, sel, ())
 }
 

--- a/crates/test-assembly/crates/test_msg_send_id/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/apple-aarch64.s
@@ -32,29 +32,6 @@ Lloh1:
 _handle_alloc:
 	b	_objc_msgSend
 
-	.globl	_handle_alloc_fallible
-	.p2align	2
-_handle_alloc_fallible:
-	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
-	add	x29, sp, #16
-	mov	x19, x1
-	mov	x20, x0
-	bl	_objc_msgSend
-	cbz	x0, LBB3_2
-	ldp	x29, x30, [sp, #16]
-	ldp	x20, x19, [sp], #32
-	ret
-LBB3_2:
-Lloh2:
-	adrp	x2, l_anon.[ID].2@PAGE
-Lloh3:
-	add	x2, x2, l_anon.[ID].2@PAGEOFF
-	mov	x0, x20
-	mov	x1, x19
-	bl	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh2, Lloh3
-
 	.globl	_handle_init
 	.p2align	2
 _handle_init:
@@ -69,19 +46,19 @@ _handle_init_fallible:
 	mov	x19, x1
 	mov	x20, x0
 	bl	_objc_msgSend
-	cbz	x0, LBB5_2
+	cbz	x0, LBB4_2
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	ret
-LBB5_2:
-Lloh4:
-	adrp	x2, l_anon.[ID].3@PAGE
-Lloh5:
-	add	x2, x2, l_anon.[ID].3@PAGEOFF
+LBB4_2:
+Lloh2:
+	adrp	x2, l_anon.[ID].2@PAGE
+Lloh3:
+	add	x2, x2, l_anon.[ID].2@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
 	bl	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh4, Lloh5
+	.loh AdrpAdd	Lloh2, Lloh3
 
 	.globl	_handle_alloc_init
 	.p2align	2
@@ -130,16 +107,16 @@ _handle_copy_fallible:
 	stp	x29, x30, [sp, #-16]!
 	mov	x29, sp
 	bl	_objc_msgSend
-	cbz	x0, LBB10_2
+	cbz	x0, LBB9_2
 	ldp	x29, x30, [sp], #16
 	ret
-LBB10_2:
-Lloh6:
-	adrp	x0, l_anon.[ID].4@PAGE
-Lloh7:
-	add	x0, x0, l_anon.[ID].4@PAGEOFF
+LBB9_2:
+Lloh4:
+	adrp	x0, l_anon.[ID].3@PAGE
+Lloh5:
+	add	x0, x0, l_anon.[ID].3@PAGEOFF
 	bl	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh6, Lloh7
+	.loh AdrpAdd	Lloh4, Lloh5
 
 	.globl	_handle_autoreleased
 	.p2align	2
@@ -166,19 +143,19 @@ _handle_autoreleased_fallible:
 	mov	x29, x29
 	; InlineAsm End
 	bl	_objc_retainAutoreleasedReturnValue
-	cbz	x0, LBB12_2
+	cbz	x0, LBB11_2
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	ret
-LBB12_2:
-Lloh8:
-	adrp	x2, l_anon.[ID].5@PAGE
-Lloh9:
-	add	x2, x2, l_anon.[ID].5@PAGEOFF
+LBB11_2:
+Lloh6:
+	adrp	x2, l_anon.[ID].4@PAGE
+Lloh7:
+	add	x2, x2, l_anon.[ID].4@PAGEOFF
 	mov	x0, x20
 	mov	x1, x19
 	bl	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh8, Lloh9
+	.loh AdrpAdd	Lloh6, Lloh7
 
 	.globl	_handle_with_out_param
 	.p2align	2
@@ -217,21 +194,16 @@ l_anon.[ID].1:
 	.p2align	3, 0x0
 l_anon.[ID].2:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000\034\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].3:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\0008\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].4:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000>\000\000\000\005\000\000"
-
-	.p2align	3, 0x0
-l_anon.[ID].5:
-	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000H\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000B\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_id/expected/apple-armv7.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/apple-armv7.s
@@ -33,27 +33,6 @@ LPC1_0:
 _handle_alloc:
 	b	_objc_msgSend
 
-	.globl	_handle_alloc_fallible
-	.p2align	2
-	.code	32
-_handle_alloc_fallible:
-	push	{r4, r5, r7, lr}
-	add	r7, sp, #8
-	mov	r4, r1
-	mov	r5, r0
-	bl	_objc_msgSend
-	cmp	r0, #0
-	popne	{r4, r5, r7, pc}
-LBB3_1:
-	movw	r2, :lower16:(l_anon.[ID].2-(LPC3_0+8))
-	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].2-(LPC3_0+8))
-	mov	r1, r4
-LPC3_0:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-
 	.globl	_handle_init
 	.p2align	2
 	.code	32
@@ -71,12 +50,12 @@ _handle_init_fallible:
 	bl	_objc_msgSend
 	cmp	r0, #0
 	popne	{r4, r5, r7, pc}
-LBB5_1:
-	movw	r2, :lower16:(l_anon.[ID].3-(LPC5_0+8))
+LBB4_1:
+	movw	r2, :lower16:(l_anon.[ID].2-(LPC4_0+8))
 	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].3-(LPC5_0+8))
+	movt	r2, :upper16:(l_anon.[ID].2-(LPC4_0+8))
 	mov	r1, r4
-LPC5_0:
+LPC4_0:
 	add	r2, pc, r2
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -131,10 +110,10 @@ _handle_copy_fallible:
 	bl	_objc_msgSend
 	cmp	r0, #0
 	popne	{r7, pc}
-LBB10_1:
-	movw	r0, :lower16:(l_anon.[ID].4-(LPC10_0+8))
-	movt	r0, :upper16:(l_anon.[ID].4-(LPC10_0+8))
-LPC10_0:
+LBB9_1:
+	movw	r0, :lower16:(l_anon.[ID].3-(LPC9_0+8))
+	movt	r0, :upper16:(l_anon.[ID].3-(LPC9_0+8))
+LPC9_0:
 	add	r0, pc, r0
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -167,12 +146,12 @@ _handle_autoreleased_fallible:
 	bl	_objc_retainAutoreleasedReturnValue
 	cmp	r0, #0
 	popne	{r4, r5, r7, pc}
-LBB12_1:
-	movw	r2, :lower16:(l_anon.[ID].5-(LPC12_0+8))
+LBB11_1:
+	movw	r2, :lower16:(l_anon.[ID].4-(LPC11_0+8))
 	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].5-(LPC12_0+8))
+	movt	r2, :upper16:(l_anon.[ID].4-(LPC11_0+8))
 	mov	r1, r4
-LPC12_0:
+LPC11_0:
 	add	r2, pc, r2
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -211,21 +190,16 @@ l_anon.[ID].1:
 	.p2align	2, 0x0
 l_anon.[ID].2:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\034\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].3:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\0008\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000>\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].5:
-	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000H\000\000\000\005\000\000"
+	.asciz	"3\000\000\000B\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_id/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/apple-armv7s.s
@@ -39,27 +39,6 @@ _handle_alloc:
 	bl	_objc_msgSend
 	pop	{r7, pc}
 
-	.globl	_handle_alloc_fallible
-	.p2align	2
-	.code	32
-_handle_alloc_fallible:
-	push	{r4, r5, r7, lr}
-	add	r7, sp, #8
-	mov	r4, r1
-	mov	r5, r0
-	bl	_objc_msgSend
-	cmp	r0, #0
-	popne	{r4, r5, r7, pc}
-LBB3_1:
-	movw	r2, :lower16:(l_anon.[ID].2-(LPC3_0+8))
-	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].2-(LPC3_0+8))
-	mov	r1, r4
-LPC3_0:
-	add	r2, pc, r2
-	mov	lr, pc
-	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-
 	.globl	_handle_init
 	.p2align	2
 	.code	32
@@ -80,12 +59,12 @@ _handle_init_fallible:
 	bl	_objc_msgSend
 	cmp	r0, #0
 	popne	{r4, r5, r7, pc}
-LBB5_1:
-	movw	r2, :lower16:(l_anon.[ID].3-(LPC5_0+8))
+LBB4_1:
+	movw	r2, :lower16:(l_anon.[ID].2-(LPC4_0+8))
 	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].3-(LPC5_0+8))
+	movt	r2, :upper16:(l_anon.[ID].2-(LPC4_0+8))
 	mov	r1, r4
-LPC5_0:
+LPC4_0:
 	add	r2, pc, r2
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -143,10 +122,10 @@ _handle_copy_fallible:
 	bl	_objc_msgSend
 	cmp	r0, #0
 	popne	{r7, pc}
-LBB10_1:
-	movw	r0, :lower16:(l_anon.[ID].4-(LPC10_0+8))
-	movt	r0, :upper16:(l_anon.[ID].4-(LPC10_0+8))
-LPC10_0:
+LBB9_1:
+	movw	r0, :lower16:(l_anon.[ID].3-(LPC9_0+8))
+	movt	r0, :upper16:(l_anon.[ID].3-(LPC9_0+8))
+LPC9_0:
 	add	r0, pc, r0
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -179,12 +158,12 @@ _handle_autoreleased_fallible:
 	bl	_objc_retainAutoreleasedReturnValue
 	cmp	r0, #0
 	popne	{r4, r5, r7, pc}
-LBB12_1:
-	movw	r2, :lower16:(l_anon.[ID].5-(LPC12_0+8))
+LBB11_1:
+	movw	r2, :lower16:(l_anon.[ID].4-(LPC11_0+8))
 	mov	r0, r5
-	movt	r2, :upper16:(l_anon.[ID].5-(LPC12_0+8))
+	movt	r2, :upper16:(l_anon.[ID].4-(LPC11_0+8))
 	mov	r1, r4
-LPC12_0:
+LPC11_0:
 	add	r2, pc, r2
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -223,21 +202,16 @@ l_anon.[ID].1:
 	.p2align	2, 0x0
 l_anon.[ID].2:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\034\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].3:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\0008\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000>\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].5:
-	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000H\000\000\000\005\000\000"
+	.asciz	"3\000\000\000B\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_id/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/apple-x86.s
@@ -51,41 +51,6 @@ _handle_alloc:
 	pop	ebp
 	jmp	_objc_msgSend
 
-	.globl	_handle_alloc_fallible
-	.p2align	4, 0x90
-_handle_alloc_fallible:
-	push	ebp
-	mov	ebp, esp
-	push	ebx
-	push	edi
-	push	esi
-	sub	esp, 12
-	call	L3$pb
-L3$pb:
-	pop	ebx
-	mov	edi, dword ptr [ebp + 12]
-	mov	esi, dword ptr [ebp + 8]
-	sub	esp, 8
-	push	edi
-	push	esi
-	call	_objc_msgSend
-	add	esp, 16
-	test	eax, eax
-	je	LBB3_2
-	add	esp, 12
-	pop	esi
-	pop	edi
-	pop	ebx
-	pop	ebp
-	ret
-LBB3_2:
-	sub	esp, 4
-	lea	eax, [ebx + l_anon.[ID].2-L3$pb]
-	push	eax
-	push	edi
-	push	esi
-	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-
 	.globl	_handle_init
 	.p2align	4, 0x90
 _handle_init:
@@ -103,8 +68,8 @@ _handle_init_fallible:
 	push	edi
 	push	esi
 	sub	esp, 12
-	call	L5$pb
-L5$pb:
+	call	L4$pb
+L4$pb:
 	pop	ebx
 	mov	edi, dword ptr [ebp + 12]
 	mov	esi, dword ptr [ebp + 8]
@@ -114,16 +79,16 @@ L5$pb:
 	call	_objc_msgSend
 	add	esp, 16
 	test	eax, eax
-	je	LBB5_2
+	je	LBB4_2
 	add	esp, 12
 	pop	esi
 	pop	edi
 	pop	ebx
 	pop	ebp
 	ret
-LBB5_2:
+LBB4_2:
 	sub	esp, 4
-	lea	eax, [ebx + l_anon.[ID].3-L5$pb]
+	lea	eax, [ebx + l_anon.[ID].2-L4$pb]
 	push	eax
 	push	edi
 	push	esi
@@ -205,8 +170,8 @@ _handle_copy_fallible:
 	mov	ebp, esp
 	push	esi
 	sub	esp, 20
-	call	L10$pb
-L10$pb:
+	call	L9$pb
+L9$pb:
 	pop	esi
 	mov	eax, dword ptr [ebp + 8]
 	mov	ecx, dword ptr [ebp + 12]
@@ -214,13 +179,13 @@ L10$pb:
 	mov	dword ptr [esp], eax
 	call	_objc_msgSend
 	test	eax, eax
-	je	LBB10_2
+	je	LBB9_2
 	add	esp, 20
 	pop	esi
 	pop	ebp
 	ret
-LBB10_2:
-	lea	eax, [esi + l_anon.[ID].4-L10$pb]
+LBB9_2:
+	lea	eax, [esi + l_anon.[ID].3-L9$pb]
 	mov	dword ptr [esp], eax
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
@@ -255,8 +220,8 @@ _handle_autoreleased_fallible:
 	push	edi
 	push	esi
 	sub	esp, 12
-	call	L12$pb
-L12$pb:
+	call	L11$pb
+L11$pb:
 	pop	ebx
 	mov	edi, dword ptr [ebp + 12]
 	mov	esi, dword ptr [ebp + 8]
@@ -275,16 +240,16 @@ L12$pb:
 	call	_objc_retainAutoreleasedReturnValue
 	add	esp, 16
 	test	eax, eax
-	je	LBB12_2
+	je	LBB11_2
 	add	esp, 12
 	pop	esi
 	pop	edi
 	pop	ebx
 	pop	ebp
 	ret
-LBB12_2:
+LBB11_2:
 	sub	esp, 4
-	lea	eax, [ebx + l_anon.[ID].5-L12$pb]
+	lea	eax, [ebx + l_anon.[ID].4-L11$pb]
 	push	eax
 	push	edi
 	push	esi
@@ -340,21 +305,16 @@ l_anon.[ID].1:
 	.p2align	2, 0x0
 l_anon.[ID].2:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\034\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].3:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\0008\000\000\000\005\000\000"
 
 	.p2align	2, 0x0
 l_anon.[ID].4:
 	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000>\000\000\000\005\000\000"
-
-	.p2align	2, 0x0
-l_anon.[ID].5:
-	.long	l_anon.[ID].0
-	.asciz	"3\000\000\000H\000\000\000\005\000\000"
+	.asciz	"3\000\000\000B\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_id/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/apple-x86_64.s
@@ -38,28 +38,6 @@ _handle_alloc:
 	pop	rbp
 	jmp	_objc_msgSend
 
-	.globl	_handle_alloc_fallible
-	.p2align	4, 0x90
-_handle_alloc_fallible:
-	push	rbp
-	mov	rbp, rsp
-	push	r14
-	push	rbx
-	mov	rbx, rsi
-	mov	r14, rdi
-	call	_objc_msgSend
-	test	rax, rax
-	je	LBB3_2
-	pop	rbx
-	pop	r14
-	pop	rbp
-	ret
-LBB3_2:
-	lea	rdx, [rip + l_anon.[ID].2]
-	mov	rdi, r14
-	mov	rsi, rbx
-	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
-
 	.globl	_handle_init
 	.p2align	4, 0x90
 _handle_init:
@@ -79,13 +57,13 @@ _handle_init_fallible:
 	mov	r14, rdi
 	call	_objc_msgSend
 	test	rax, rax
-	je	LBB5_2
+	je	LBB4_2
 	pop	rbx
 	pop	r14
 	pop	rbp
 	ret
-LBB5_2:
-	lea	rdx, [rip + l_anon.[ID].3]
+LBB4_2:
+	lea	rdx, [rip + l_anon.[ID].2]
 	mov	rdi, r14
 	mov	rsi, rbx
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -149,11 +127,11 @@ _handle_copy_fallible:
 	mov	rbp, rsp
 	call	_objc_msgSend
 	test	rax, rax
-	je	LBB10_2
+	je	LBB9_2
 	pop	rbp
 	ret
-LBB10_2:
-	lea	rdi, [rip + l_anon.[ID].4]
+LBB9_2:
+	lea	rdi, [rip + l_anon.[ID].3]
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 
 	.globl	_handle_autoreleased
@@ -190,13 +168,13 @@ _handle_autoreleased_fallible:
 
 	## InlineAsm End
 	test	rax, rax
-	je	LBB12_2
+	je	LBB11_2
 	pop	rbx
 	pop	r14
 	pop	rbp
 	ret
-LBB12_2:
-	lea	rdx, [rip + l_anon.[ID].5]
+LBB11_2:
+	lea	rdx, [rip + l_anon.[ID].4]
 	mov	rdi, r14
 	mov	rsi, rbx
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
@@ -245,21 +223,16 @@ l_anon.[ID].1:
 	.p2align	3, 0x0
 l_anon.[ID].2:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000\034\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].3:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\0008\000\000\000\005\000\000"
 
 	.p2align	3, 0x0
 l_anon.[ID].4:
 	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000>\000\000\000\005\000\000"
-
-	.p2align	3, 0x0
-l_anon.[ID].5:
-	.quad	l_anon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000H\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000B\000\000\000\005\000\000"
 
 .subsections_via_symbols

--- a/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
@@ -104,48 +104,6 @@ handle_alloc:
 .Lfunc_end2:
 	.size	handle_alloc, .Lfunc_end2-handle_alloc
 
-	.section	.text.handle_alloc_fallible,"ax",@progbits
-	.globl	handle_alloc_fallible
-	.p2align	4, 0x90
-	.type	handle_alloc_fallible,@function
-handle_alloc_fallible:
-	push	ebx
-	push	edi
-	push	esi
-	mov	edi, dword ptr [esp + 20]
-	mov	esi, dword ptr [esp + 16]
-	call	.L3$pb
-.L3$pb:
-	pop	ebx
-.Ltmp3:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp3-.L3$pb)
-	sub	esp, 8
-	push	edi
-	push	esi
-	call	objc_msg_lookup@PLT
-	add	esp, 8
-	push	edi
-	push	esi
-	call	eax
-	add	esp, 16
-	test	eax, eax
-	je	.LBB3_1
-	pop	esi
-	pop	edi
-	pop	ebx
-	ret
-.LBB3_1:
-	sub	esp, 4
-	lea	eax, [ebx + .Lanon.[ID].2@GOTOFF]
-	push	eax
-	push	edi
-	push	esi
-	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
-	add	esp, 16
-	ud2
-.Lfunc_end3:
-	.size	handle_alloc_fallible, .Lfunc_end3-handle_alloc_fallible
-
 	.section	.text.handle_init,"ax",@progbits
 	.globl	handle_init
 	.p2align	4, 0x90
@@ -155,13 +113,13 @@ handle_init:
 	push	edi
 	push	esi
 	mov	esi, dword ptr [esp + 16]
-	call	.L4$pb
-.L4$pb:
+	call	.L3$pb
+.L3$pb:
 	pop	ebx
-.Ltmp4:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp4-.L4$pb)
+.Ltmp3:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp3-.L3$pb)
 	test	esi, esi
-	je	.LBB4_2
+	je	.LBB3_2
 	mov	edi, dword ptr [esp + 20]
 	sub	esp, 8
 	push	edi
@@ -176,14 +134,14 @@ handle_init:
 	pop	edi
 	pop	ebx
 	ret
-.LBB4_2:
+.LBB3_2:
 	xor	eax, eax
 	pop	esi
 	pop	edi
 	pop	ebx
 	ret
-.Lfunc_end4:
-	.size	handle_init, .Lfunc_end4-handle_init
+.Lfunc_end3:
+	.size	handle_init, .Lfunc_end3-handle_init
 
 	.section	.text.handle_init_fallible,"ax",@progbits
 	.globl	handle_init_fallible
@@ -195,13 +153,13 @@ handle_init_fallible:
 	push	esi
 	mov	esi, dword ptr [esp + 16]
 	mov	edi, dword ptr [esp + 20]
-	call	.L5$pb
-.L5$pb:
+	call	.L4$pb
+.L4$pb:
 	pop	ebx
-.Ltmp5:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp5-.L5$pb)
+.Ltmp4:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp4-.L4$pb)
 	test	esi, esi
-	je	.LBB5_2
+	je	.LBB4_2
 	sub	esp, 8
 	push	edi
 	push	esi
@@ -212,22 +170,22 @@ handle_init_fallible:
 	call	eax
 	add	esp, 16
 	test	eax, eax
-	je	.LBB5_2
+	je	.LBB4_2
 	pop	esi
 	pop	edi
 	pop	ebx
 	ret
-.LBB5_2:
+.LBB4_2:
 	sub	esp, 4
-	lea	eax, [ebx + .Lanon.[ID].3@GOTOFF]
+	lea	eax, [ebx + .Lanon.[ID].2@GOTOFF]
 	push	eax
 	push	edi
 	push	esi
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
-.Lfunc_end5:
-	.size	handle_init_fallible, .Lfunc_end5-handle_init_fallible
+.Lfunc_end4:
+	.size	handle_init_fallible, .Lfunc_end4-handle_init_fallible
 
 	.section	.text.handle_alloc_init,"ax",@progbits
 	.globl	handle_alloc_init
@@ -239,11 +197,11 @@ handle_alloc_init:
 	push	esi
 	mov	esi, dword ptr [esp + 16]
 	mov	edi, dword ptr [esp + 20]
-	call	.L6$pb
-.L6$pb:
+	call	.L5$pb
+.L5$pb:
 	pop	ebx
-.Ltmp6:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp6-.L6$pb)
+.Ltmp5:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp5-.L5$pb)
 	sub	esp, 8
 	push	edi
 	push	esi
@@ -254,7 +212,7 @@ handle_alloc_init:
 	call	eax
 	add	esp, 16
 	test	eax, eax
-	je	.LBB6_2
+	je	.LBB5_2
 	mov	edi, dword ptr [esp + 24]
 	mov	esi, eax
 	sub	esp, 8
@@ -270,14 +228,14 @@ handle_alloc_init:
 	pop	edi
 	pop	ebx
 	ret
-.LBB6_2:
+.LBB5_2:
 	xor	eax, eax
 	pop	esi
 	pop	edi
 	pop	ebx
 	ret
-.Lfunc_end6:
-	.size	handle_alloc_init, .Lfunc_end6-handle_alloc_init
+.Lfunc_end5:
+	.size	handle_alloc_init, .Lfunc_end5-handle_alloc_init
 
 	.section	.text.handle_alloc_release,"ax",@progbits
 	.globl	handle_alloc_release
@@ -290,11 +248,11 @@ handle_alloc_release:
 	sub	esp, 16
 	mov	esi, dword ptr [esp + 32]
 	mov	edi, dword ptr [esp + 36]
-	call	.L7$pb
-.L7$pb:
+	call	.L6$pb
+.L6$pb:
 	pop	ebx
-.Ltmp7:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp7-.L7$pb)
+.Ltmp6:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp6-.L6$pb)
 	mov	dword ptr [esp + 4], edi
 	mov	dword ptr [esp], esi
 	call	objc_msg_lookup@PLT
@@ -308,8 +266,8 @@ handle_alloc_release:
 	pop	edi
 	pop	ebx
 	ret
-.Lfunc_end7:
-	.size	handle_alloc_release, .Lfunc_end7-handle_alloc_release
+.Lfunc_end6:
+	.size	handle_alloc_release, .Lfunc_end6-handle_alloc_release
 
 	.section	.text.handle_alloc_init_release,"ax",@progbits
 	.globl	handle_alloc_init_release
@@ -324,11 +282,11 @@ handle_alloc_init_release:
 	mov	esi, dword ptr [esp + 32]
 	mov	ebp, dword ptr [esp + 36]
 	mov	edi, dword ptr [esp + 40]
-	call	.L8$pb
-.L8$pb:
+	call	.L7$pb
+.L7$pb:
 	pop	ebx
-.Ltmp8:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp8-.L8$pb)
+.Ltmp7:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp7-.L7$pb)
 	mov	dword ptr [esp + 4], ebp
 	mov	dword ptr [esp], esi
 	call	objc_msg_lookup@PLT
@@ -350,8 +308,8 @@ handle_alloc_init_release:
 	pop	ebx
 	pop	ebp
 	ret
-.Lfunc_end8:
-	.size	handle_alloc_init_release, .Lfunc_end8-handle_alloc_init_release
+.Lfunc_end7:
+	.size	handle_alloc_init_release, .Lfunc_end7-handle_alloc_init_release
 
 	.section	.text.handle_copy,"ax",@progbits
 	.globl	handle_copy
@@ -363,11 +321,11 @@ handle_copy:
 	push	esi
 	mov	esi, dword ptr [esp + 16]
 	mov	edi, dword ptr [esp + 20]
-	call	.L9$pb
-.L9$pb:
+	call	.L8$pb
+.L8$pb:
 	pop	ebx
-.Ltmp9:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp9-.L9$pb)
+.Ltmp8:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp8-.L8$pb)
 	sub	esp, 8
 	push	edi
 	push	esi
@@ -381,14 +339,51 @@ handle_copy:
 	pop	edi
 	pop	ebx
 	ret
-.Lfunc_end9:
-	.size	handle_copy, .Lfunc_end9-handle_copy
+.Lfunc_end8:
+	.size	handle_copy, .Lfunc_end8-handle_copy
 
 	.section	.text.handle_copy_fallible,"ax",@progbits
 	.globl	handle_copy_fallible
 	.p2align	4, 0x90
 	.type	handle_copy_fallible,@function
 handle_copy_fallible:
+	push	ebx
+	push	edi
+	push	esi
+	sub	esp, 16
+	mov	esi, dword ptr [esp + 32]
+	mov	edi, dword ptr [esp + 36]
+	call	.L9$pb
+.L9$pb:
+	pop	ebx
+.Ltmp9:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp9-.L9$pb)
+	mov	dword ptr [esp + 4], edi
+	mov	dword ptr [esp], esi
+	call	objc_msg_lookup@PLT
+	mov	dword ptr [esp + 4], edi
+	mov	dword ptr [esp], esi
+	call	eax
+	test	eax, eax
+	je	.LBB9_1
+	add	esp, 16
+	pop	esi
+	pop	edi
+	pop	ebx
+	ret
+.LBB9_1:
+	lea	eax, [ebx + .Lanon.[ID].3@GOTOFF]
+	mov	dword ptr [esp], eax
+	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
+	ud2
+.Lfunc_end9:
+	.size	handle_copy_fallible, .Lfunc_end9-handle_copy_fallible
+
+	.section	.text.handle_autoreleased,"ax",@progbits
+	.globl	handle_autoreleased
+	.p2align	4, 0x90
+	.type	handle_autoreleased,@function
+handle_autoreleased:
 	push	ebx
 	push	edi
 	push	esi
@@ -406,43 +401,6 @@ handle_copy_fallible:
 	mov	dword ptr [esp + 4], edi
 	mov	dword ptr [esp], esi
 	call	eax
-	test	eax, eax
-	je	.LBB10_1
-	add	esp, 16
-	pop	esi
-	pop	edi
-	pop	ebx
-	ret
-.LBB10_1:
-	lea	eax, [ebx + .Lanon.[ID].4@GOTOFF]
-	mov	dword ptr [esp], eax
-	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
-	ud2
-.Lfunc_end10:
-	.size	handle_copy_fallible, .Lfunc_end10-handle_copy_fallible
-
-	.section	.text.handle_autoreleased,"ax",@progbits
-	.globl	handle_autoreleased
-	.p2align	4, 0x90
-	.type	handle_autoreleased,@function
-handle_autoreleased:
-	push	ebx
-	push	edi
-	push	esi
-	sub	esp, 16
-	mov	esi, dword ptr [esp + 32]
-	mov	edi, dword ptr [esp + 36]
-	call	.L11$pb
-.L11$pb:
-	pop	ebx
-.Ltmp11:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp11-.L11$pb)
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
-	call	objc_msg_lookup@PLT
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
-	call	eax
 	mov	dword ptr [esp], eax
 	call	objc_retainAutoreleasedReturnValue@PLT
 	add	esp, 16
@@ -450,8 +408,8 @@ handle_autoreleased:
 	pop	edi
 	pop	ebx
 	ret
-.Lfunc_end11:
-	.size	handle_autoreleased, .Lfunc_end11-handle_autoreleased
+.Lfunc_end10:
+	.size	handle_autoreleased, .Lfunc_end10-handle_autoreleased
 
 	.section	.text.handle_autoreleased_fallible,"ax",@progbits
 	.globl	handle_autoreleased_fallible
@@ -463,11 +421,11 @@ handle_autoreleased_fallible:
 	push	esi
 	mov	edi, dword ptr [esp + 20]
 	mov	esi, dword ptr [esp + 16]
-	call	.L12$pb
-.L12$pb:
+	call	.L11$pb
+.L11$pb:
 	pop	ebx
-.Ltmp12:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp12-.L12$pb)
+.Ltmp11:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp11-.L11$pb)
 	sub	esp, 8
 	push	edi
 	push	esi
@@ -481,22 +439,22 @@ handle_autoreleased_fallible:
 	call	objc_retainAutoreleasedReturnValue@PLT
 	add	esp, 16
 	test	eax, eax
-	je	.LBB12_1
+	je	.LBB11_1
 	pop	esi
 	pop	edi
 	pop	ebx
 	ret
-.LBB12_1:
+.LBB11_1:
 	sub	esp, 4
-	lea	eax, [ebx + .Lanon.[ID].5@GOTOFF]
+	lea	eax, [ebx + .Lanon.[ID].4@GOTOFF]
 	push	eax
 	push	edi
 	push	esi
 	call	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	ud2
-.Lfunc_end12:
-	.size	handle_autoreleased_fallible, .Lfunc_end12-handle_autoreleased_fallible
+.Lfunc_end11:
+	.size	handle_autoreleased_fallible, .Lfunc_end11-handle_autoreleased_fallible
 
 	.section	.text.handle_with_out_param,"ax",@progbits
 	.globl	handle_with_out_param
@@ -511,11 +469,11 @@ handle_with_out_param:
 	mov	ebp, dword ptr [esp + 40]
 	mov	eax, dword ptr [esp + 32]
 	mov	esi, dword ptr [esp + 36]
-	call	.L13$pb
-.L13$pb:
+	call	.L12$pb
+.L12$pb:
 	pop	ebx
-.Ltmp13:
-	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp13-.L13$pb)
+.Ltmp12:
+	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp12-.L12$pb)
 	mov	edi, dword ptr [ebp]
 	mov	dword ptr [esp + 4], esi
 	mov	dword ptr [esp], eax
@@ -539,8 +497,8 @@ handle_with_out_param:
 	pop	ebx
 	pop	ebp
 	ret
-.Lfunc_end13:
-	.size	handle_with_out_param, .Lfunc_end13-handle_with_out_param
+.Lfunc_end12:
+	.size	handle_with_out_param, .Lfunc_end12-handle_with_out_param
 
 	.type	.Lanon.[ID].0,@object
 	.section	.rodata..Lanon.[ID].0,"a",@progbits
@@ -561,7 +519,7 @@ handle_with_out_param:
 	.p2align	2, 0x0
 .Lanon.[ID].2:
 	.long	.Lanon.[ID].0
-	.asciz	"3\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\034\000\000\000\005\000\000"
 	.size	.Lanon.[ID].2, 16
 
 	.type	.Lanon.[ID].3,@object
@@ -569,7 +527,7 @@ handle_with_out_param:
 	.p2align	2, 0x0
 .Lanon.[ID].3:
 	.long	.Lanon.[ID].0
-	.asciz	"3\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\0008\000\000\000\005\000\000"
 	.size	.Lanon.[ID].3, 16
 
 	.type	.Lanon.[ID].4,@object
@@ -577,15 +535,7 @@ handle_with_out_param:
 	.p2align	2, 0x0
 .Lanon.[ID].4:
 	.long	.Lanon.[ID].0
-	.asciz	"3\000\000\000>\000\000\000\005\000\000"
+	.asciz	"3\000\000\000B\000\000\000\005\000\000"
 	.size	.Lanon.[ID].4, 16
-
-	.type	.Lanon.[ID].5,@object
-	.section	.data.rel.ro..Lanon.[ID].5,"aw",@progbits
-	.p2align	2, 0x0
-.Lanon.[ID].5:
-	.long	.Lanon.[ID].0
-	.asciz	"3\000\000\000H\000\000\000\005\000\000"
-	.size	.Lanon.[ID].5, 16
 
 	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
@@ -69,42 +69,13 @@ handle_alloc:
 .Lfunc_end2:
 	.size	handle_alloc, .Lfunc_end2-handle_alloc
 
-	.section	.text.handle_alloc_fallible,"ax",@progbits
-	.globl	handle_alloc_fallible
-	.p2align	4, 0x90
-	.type	handle_alloc_fallible,@function
-handle_alloc_fallible:
-	push	r14
-	push	rbx
-	push	rax
-	mov	rbx, rsi
-	mov	r14, rdi
-	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rdi, r14
-	mov	rsi, rbx
-	call	rax
-	test	rax, rax
-	je	.LBB3_1
-	add	rsp, 8
-	pop	rbx
-	pop	r14
-	ret
-.LBB3_1:
-	lea	rdx, [rip + .Lanon.[ID].2]
-	mov	rdi, r14
-	mov	rsi, rbx
-	call	qword ptr [rip + SYM(<objc2::__macro_helpers::method_family::RetainSemantics<2_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
-	ud2
-.Lfunc_end3:
-	.size	handle_alloc_fallible, .Lfunc_end3-handle_alloc_fallible
-
 	.section	.text.handle_init,"ax",@progbits
 	.globl	handle_init
 	.p2align	4, 0x90
 	.type	handle_init,@function
 handle_init:
 	test	rdi, rdi
-	je	.LBB4_1
+	je	.LBB3_1
 	push	r14
 	push	rbx
 	push	rax
@@ -117,11 +88,11 @@ handle_init:
 	pop	rbx
 	pop	r14
 	jmp	rax
-.LBB4_1:
+.LBB3_1:
 	xor	eax, eax
 	ret
-.Lfunc_end4:
-	.size	handle_init, .Lfunc_end4-handle_init
+.Lfunc_end3:
+	.size	handle_init, .Lfunc_end3-handle_init
 
 	.section	.text.handle_init_fallible,"ax",@progbits
 	.globl	handle_init_fallible
@@ -134,7 +105,7 @@ handle_init_fallible:
 	mov	rbx, rsi
 	mov	r14, rdi
 	test	rdi, rdi
-	je	.LBB5_2
+	je	.LBB4_2
 	mov	rdi, r14
 	mov	rsi, rbx
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
@@ -142,19 +113,19 @@ handle_init_fallible:
 	mov	rsi, rbx
 	call	rax
 	test	rax, rax
-	je	.LBB5_2
+	je	.LBB4_2
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB5_2:
-	lea	rdx, [rip + .Lanon.[ID].3]
+.LBB4_2:
+	lea	rdx, [rip + .Lanon.[ID].2]
 	mov	rdi, r14
 	mov	rsi, rbx
 	call	qword ptr [rip + SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
-.Lfunc_end5:
-	.size	handle_init_fallible, .Lfunc_end5-handle_init_fallible
+.Lfunc_end4:
+	.size	handle_init_fallible, .Lfunc_end4-handle_init_fallible
 
 	.section	.text.handle_alloc_init,"ax",@progbits
 	.globl	handle_alloc_init
@@ -172,7 +143,7 @@ handle_alloc_init:
 	mov	rsi, r14
 	call	rax
 	test	rax, rax
-	je	.LBB6_1
+	je	.LBB5_1
 	mov	r14, rax
 	mov	rdi, rax
 	mov	rsi, rbx
@@ -183,14 +154,14 @@ handle_alloc_init:
 	pop	r14
 	pop	r15
 	jmp	rax
-.LBB6_1:
+.LBB5_1:
 	xor	eax, eax
 	pop	rbx
 	pop	r14
 	pop	r15
 	ret
-.Lfunc_end6:
-	.size	handle_alloc_init, .Lfunc_end6-handle_alloc_init
+.Lfunc_end5:
+	.size	handle_alloc_init, .Lfunc_end5-handle_alloc_init
 
 	.section	.text.handle_alloc_release,"ax",@progbits
 	.globl	handle_alloc_release
@@ -211,8 +182,8 @@ handle_alloc_release:
 	pop	rbx
 	pop	r14
 	jmp	qword ptr [rip + objc_release@GOTPCREL]
-.Lfunc_end7:
-	.size	handle_alloc_release, .Lfunc_end7-handle_alloc_release
+.Lfunc_end6:
+	.size	handle_alloc_release, .Lfunc_end6-handle_alloc_release
 
 	.section	.text.handle_alloc_init_release,"ax",@progbits
 	.globl	handle_alloc_init_release
@@ -246,8 +217,8 @@ handle_alloc_init_release:
 	pop	r14
 	pop	r15
 	jmp	qword ptr [rip + objc_release@GOTPCREL]
-.Lfunc_end8:
-	.size	handle_alloc_init_release, .Lfunc_end8-handle_alloc_init_release
+.Lfunc_end7:
+	.size	handle_alloc_init_release, .Lfunc_end7-handle_alloc_init_release
 
 	.section	.text.handle_copy,"ax",@progbits
 	.globl	handle_copy
@@ -266,8 +237,8 @@ handle_copy:
 	pop	rbx
 	pop	r14
 	jmp	rax
-.Lfunc_end9:
-	.size	handle_copy, .Lfunc_end9-handle_copy
+.Lfunc_end8:
+	.size	handle_copy, .Lfunc_end8-handle_copy
 
 	.section	.text.handle_copy_fallible,"ax",@progbits
 	.globl	handle_copy_fallible
@@ -284,17 +255,17 @@ handle_copy_fallible:
 	mov	rsi, rbx
 	call	rax
 	test	rax, rax
-	je	.LBB10_1
+	je	.LBB9_1
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB10_1:
-	lea	rdi, [rip + .Lanon.[ID].4]
+.LBB9_1:
+	lea	rdi, [rip + .Lanon.[ID].3]
 	call	qword ptr [rip + SYM(<objc2::__macro_helpers::method_family::RetainSemantics<4_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
-.Lfunc_end10:
-	.size	handle_copy_fallible, .Lfunc_end10-handle_copy_fallible
+.Lfunc_end9:
+	.size	handle_copy_fallible, .Lfunc_end9-handle_copy_fallible
 
 	.section	.text.handle_autoreleased,"ax",@progbits
 	.globl	handle_autoreleased
@@ -315,8 +286,8 @@ handle_autoreleased:
 	pop	rbx
 	pop	r14
 	jmp	qword ptr [rip + objc_retainAutoreleasedReturnValue@GOTPCREL]
-.Lfunc_end11:
-	.size	handle_autoreleased, .Lfunc_end11-handle_autoreleased
+.Lfunc_end10:
+	.size	handle_autoreleased, .Lfunc_end10-handle_autoreleased
 
 	.section	.text.handle_autoreleased_fallible,"ax",@progbits
 	.globl	handle_autoreleased_fallible
@@ -335,19 +306,19 @@ handle_autoreleased_fallible:
 	mov	rdi, rax
 	call	qword ptr [rip + objc_retainAutoreleasedReturnValue@GOTPCREL]
 	test	rax, rax
-	je	.LBB12_1
+	je	.LBB11_1
 	add	rsp, 8
 	pop	rbx
 	pop	r14
 	ret
-.LBB12_1:
-	lea	rdx, [rip + .Lanon.[ID].5]
+.LBB11_1:
+	lea	rdx, [rip + .Lanon.[ID].4]
 	mov	rdi, r14
 	mov	rsi, rbx
 	call	qword ptr [rip + SYM(<objc2::__macro_helpers::method_family::RetainSemantics<5_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)@GOTPCREL]
 	ud2
-.Lfunc_end12:
-	.size	handle_autoreleased_fallible, .Lfunc_end12-handle_autoreleased_fallible
+.Lfunc_end11:
+	.size	handle_autoreleased_fallible, .Lfunc_end11-handle_autoreleased_fallible
 
 	.section	.text.handle_with_out_param,"ax",@progbits
 	.globl	handle_with_out_param
@@ -380,8 +351,8 @@ handle_with_out_param:
 	pop	r14
 	pop	r15
 	jmp	qword ptr [rip + objc_retainAutoreleasedReturnValue@GOTPCREL]
-.Lfunc_end13:
-	.size	handle_with_out_param, .Lfunc_end13-handle_with_out_param
+.Lfunc_end12:
+	.size	handle_with_out_param, .Lfunc_end12-handle_with_out_param
 
 	.type	.Lanon.[ID].0,@object
 	.section	.rodata..Lanon.[ID].0,"a",@progbits
@@ -402,7 +373,7 @@ handle_with_out_param:
 	.p2align	3, 0x0
 .Lanon.[ID].2:
 	.quad	.Lanon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000\027\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000\034\000\000\000\005\000\000"
 	.size	.Lanon.[ID].2, 24
 
 	.type	.Lanon.[ID].3,@object
@@ -410,7 +381,7 @@ handle_with_out_param:
 	.p2align	3, 0x0
 .Lanon.[ID].3:
 	.quad	.Lanon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000!\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\0008\000\000\000\005\000\000"
 	.size	.Lanon.[ID].3, 24
 
 	.type	.Lanon.[ID].4,@object
@@ -418,15 +389,7 @@ handle_with_out_param:
 	.p2align	3, 0x0
 .Lanon.[ID].4:
 	.quad	.Lanon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000>\000\000\000\005\000\000"
+	.asciz	"3\000\000\000\000\000\000\000B\000\000\000\005\000\000"
 	.size	.Lanon.[ID].4, 24
-
-	.type	.Lanon.[ID].5,@object
-	.section	.data.rel.ro..Lanon.[ID].5,"aw",@progbits
-	.p2align	3, 0x0
-.Lanon.[ID].5:
-	.quad	.Lanon.[ID].0
-	.asciz	"3\000\000\000\000\000\000\000H\000\000\000\005\000\000"
-	.size	.Lanon.[ID].5, 24
 
 	.section	".note.GNU-stack","",@progbits

--- a/crates/test-assembly/crates/test_msg_send_id/lib.rs
+++ b/crates/test-assembly/crates/test_msg_send_id/lib.rs
@@ -14,22 +14,17 @@ unsafe fn handle_new_fallible(cls: &AnyClass, sel: Sel) -> Id<AnyObject> {
 }
 
 #[no_mangle]
-unsafe fn handle_alloc(cls: &AnyClass, sel: Sel) -> Option<Allocated<AnyObject>> {
+unsafe fn handle_alloc(cls: &AnyClass, sel: Sel) -> Allocated<AnyObject> {
     Alloc::send_message_id(cls, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_alloc_fallible(cls: &AnyClass, sel: Sel) -> Allocated<AnyObject> {
-    Alloc::send_message_id(cls, sel, ())
-}
-
-#[no_mangle]
-unsafe fn handle_init(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Option<Id<AnyObject>> {
+unsafe fn handle_init(obj: Allocated<AnyObject>, sel: Sel) -> Option<Id<AnyObject>> {
     Init::send_message_id(obj, sel, ())
 }
 
 #[no_mangle]
-unsafe fn handle_init_fallible(obj: Option<Allocated<AnyObject>>, sel: Sel) -> Id<AnyObject> {
+unsafe fn handle_init_fallible(obj: Allocated<AnyObject>, sel: Sel) -> Id<AnyObject> {
     Init::send_message_id(obj, sel, ())
 }
 
@@ -41,8 +36,7 @@ unsafe fn handle_alloc_init(cls: &AnyClass, sel1: Sel, sel2: Sel) -> Option<Id<A
 
 #[no_mangle]
 unsafe fn handle_alloc_release(cls: &AnyClass, sel: Sel) {
-    let obj: Option<Allocated<AnyObject>> = Alloc::send_message_id(cls, sel, ());
-    let _obj = obj.unwrap_unchecked();
+    let _obj: Allocated<AnyObject> = Alloc::send_message_id(cls, sel, ());
 }
 
 #[no_mangle]

--- a/crates/test-ui/ui/declare_class_invalid_type2.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type2.stderr
@@ -1,11 +1,11 @@
-error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Id<CustomObject>`
+error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Option<Id<CustomObject>>`
  --> ui/declare_class_invalid_type2.rs
   |
   |         fn test_init_not_same_generics(this: Allocated<Self>) -> Id<NSObject> {
-  |                                              ^^^^^^^^^^^^^^^ expected `Id<CustomObject>`, found `Id<NSObject>`
+  |                                              ^^^^^^^^^^^^^^^ expected `Option<Id<CustomObject>>`, found `Option<Id<NSObject>>`
   |
-  = note: expected struct `Id<CustomObject>`
-             found struct `Id<NSObject>`
+  = note: expected enum `Option<Id<CustomObject>>`
+             found enum `Option<Id<NSObject>>`
   = note: required for `RetainSemantics<3>` to implement `MessageRecieveId<Allocated<CustomObject>, Id<NSObject>>`
 
 error[E0277]: the trait bound `i32: MaybeOptionId` is not satisfied

--- a/crates/test-ui/ui/extern_methods_invalid_receiver.rs
+++ b/crates/test-ui/ui/extern_methods_invalid_receiver.rs
@@ -1,0 +1,28 @@
+use objc2::rc::{Allocated, Id};
+use objc2::runtime::NSObject;
+use objc2::{extern_class, extern_methods, mutability, ClassType};
+
+extern_class!(
+    pub struct MyObject;
+
+    unsafe impl ClassType for MyObject {
+        type Super = NSObject;
+        type Mutability = mutability::InteriorMutable;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method_id(initWithMut)]
+        fn init_with_mut(&mut self) -> Option<Id<Self>>;
+    }
+);
+
+extern_methods!(
+    unsafe impl MyObject {
+        #[method_id(initWithOptionAllocated)]
+        fn init_with_option_allocated(this: Option<Allocated<Self>>) -> Option<Id<Self>>;
+    }
+);
+
+fn main() {}

--- a/crates/test-ui/ui/extern_methods_invalid_receiver.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_receiver.stderr
@@ -1,0 +1,45 @@
+error[E0308]: mismatched types
+ --> ui/extern_methods_invalid_receiver.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method_id(initWithMut)]
+  | |         fn init_with_mut(&mut self) -> Option<Id<Self>>;
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `Allocated<_>`, found `&mut MyObject`
+  |   arguments to this function are incorrect
+  |
+  = note:         expected struct `Allocated<_>`
+          found mutable reference `&mut MyObject`
+note: associated function defined here
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id<A: ConvertArguments, R: MaybeUnwrap<Input = U>>(
+  |               ^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/extern_methods_invalid_receiver.rs
+  |
+  | / extern_methods!(
+  | |     unsafe impl MyObject {
+  | |         #[method_id(initWithOptionAllocated)]
+  | |         fn init_with_option_allocated(this: Option<Allocated<Self>>) -> Option<Id<Self>>;
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_expected `Allocated<_>`, found `Option<Allocated<MyObject>>`
+  |   arguments to this function are incorrect
+  |
+  = note: expected struct `Allocated<_>`
+               found enum `Option<Allocated<MyObject>>`
+note: associated function defined here
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id<A: ConvertArguments, R: MaybeUnwrap<Input = U>>(
+  |               ^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_invalid_type.rs
+++ b/crates/test-ui/ui/extern_methods_invalid_type.rs
@@ -28,8 +28,8 @@ extern_methods!(
 
 extern_methods!(
     unsafe impl MyObject {
-        #[method_id(init)]
-        fn init(&mut self) -> Option<Id<Self>>;
+        #[method(c:)]
+        fn c(&self, arg: Box<i32>);
     }
 );
 

--- a/crates/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_type.stderr
@@ -46,7 +46,6 @@ error[E0277]: the trait bound `i32: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -54,28 +53,42 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
+error[E0277]: the trait bound `Box<i32>: Encode` is not satisfied
  --> ui/extern_methods_invalid_type.rs
   |
   | / extern_methods!(
   | |     unsafe impl MyObject {
-  | |         #[method_id(init)]
-  | |         fn init(&mut self) -> Option<Id<Self>>;
+  | |         #[method(c:)]
+  | |         fn c(&self, arg: Box<i32>);
   | |     }
   | | );
   | | ^
   | | |
-  | |_expected `Option<Allocated<_>>`, found `&mut MyObject`
-  |   arguments to this function are incorrect
+  | |_the trait `Encode` is not implemented for `Box<i32>`
+  |   required by a bound introduced by this call
   |
-  = note:           expected enum `Option<Allocated<_>>`
-          found mutable reference `&mut MyObject`
-note: associated function defined here
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  = help: the following other types implement trait `Encode`:
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
+          and $N others
+  = note: required for `Box<i32>` to implement `EncodeArgument`
+  = note: required for `Box<i32>` to implement `ConvertArgument`
+  = note: required for `(Box<i32>,)` to implement `ConvertArguments`
+note: required by a bound in `MsgSend::send_message`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send.rs
   |
-  |     unsafe fn send_message_id<A: ConvertArguments, R: MaybeUnwrap<Input = U>>(
-  |               ^^^^^^^^^^^^^^^
-  = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
+  |     unsafe fn send_message<A, R>(self, sel: Sel, args: A) -> R
+  |               ------------ required by a bound in this associated function
+  |     where
+  |         A: ConvertArguments,
+  |            ^^^^^^^^^^^^^^^^ required by this bound in `MsgSend::send_message`
+  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<(), Id<NSObject>>: Encode` is not satisfied
  --> ui/extern_methods_invalid_type.rs
@@ -125,7 +138,6 @@ error[E0277]: the trait bound `Result<Id<MyObject>, Id<NSObject>>: MaybeUnwrap` 
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |

--- a/crates/test-ui/ui/extern_methods_not_allowed_mutable.stderr
+++ b/crates/test-ui/ui/extern_methods_not_allowed_mutable.stderr
@@ -44,5 +44,5 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   = note: required for `MyObject` to implement `IsAllowedMutable`
   = note: required for `&mut MyObject` to implement `MessageReceiver`
   = note: required for `&mut MyObject` to implement `MsgSend`
-  = note: required for `RetainSemantics<5>` to implement `MsgSendId<&mut MyObject, Id<_>>`
+  = note: required for `RetainSemantics<5>` to implement `MsgSendId<&mut MyObject, Option<Id<_>>>`
   = note: this error originates in the macro `$crate::__rewrite_self_param_inner` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/main_thread_only_not_allocable.stderr
+++ b/crates/test-ui/ui/main_thread_only_not_allocable.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `MainThreadOnly: mutability::MutabilityIsAllocable
 note: required by a bound in `objc2::ClassType::alloc`
  --> $WORKSPACE/crates/objc2/src/top_level_traits.rs
   |
-  |     fn alloc() -> Option<Allocated<Self>>
+  |     fn alloc() -> Allocated<Self>
   |        ----- required by a bound in this associated function
   |     where
   |         Self: IsAllocableAnyThread,

--- a/crates/test-ui/ui/msg_send_id_alloc_init_different.rs
+++ b/crates/test-ui/ui/msg_send_id_alloc_init_different.rs
@@ -1,11 +1,11 @@
 //! Ensure that `init` returns the same type as given from `alloc`.
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{NSObject, AnyObject};
+use objc2::runtime::{AnyObject, NSObject};
 use objc2::{class, msg_send_id};
 
 fn main() {
     let cls = class!(NSObject);
-    let obj: Option<Allocated<NSObject>> = unsafe { msg_send_id![cls, alloc] };
+    let obj: Allocated<NSObject> = unsafe { msg_send_id![cls, alloc] };
 
     let _: Id<AnyObject> = unsafe { msg_send_id![obj, init] };
 }

--- a/crates/test-ui/ui/msg_send_id_alloc_init_different.stderr
+++ b/crates/test-ui/ui/msg_send_id_alloc_init_different.stderr
@@ -1,11 +1,11 @@
-error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == Id<NSObject>`
+error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == Option<Id<NSObject>>`
  --> ui/msg_send_id_alloc_init_different.rs
   |
   |     let _: Id<AnyObject> = unsafe { msg_send_id![obj, init] };
-  |                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<NSObject>`, found `Id<AnyObject>`
+  |                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<Id<NSObject>>`, found `Option<Id<AnyObject>>`
   |
-  = note: expected struct `Id<NSObject>`
-             found struct `Id<AnyObject>`
+  = note: expected enum `Option<Id<NSObject>>`
+             found enum `Option<Id<AnyObject>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |

--- a/crates/test-ui/ui/msg_send_id_invalid_error.rs
+++ b/crates/test-ui/ui/msg_send_id_invalid_error.rs
@@ -1,0 +1,19 @@
+//! Test that msg_send_id! error handling works correctly.
+use objc2::rc::{Allocated, Id};
+use objc2::runtime::{AnyObject, NSObject};
+use objc2::{msg_send_id, ClassType};
+
+fn main() {
+    let obj: &NSObject;
+
+    // Basic bad return type
+    let _: () = unsafe { msg_send_id![obj, a: _] };
+
+    // Bad return type from init
+    let _: Result<Id<AnyObject>, Id<NSObject>> =
+        unsafe { msg_send_id![NSObject::alloc(), initWithError: _] };
+
+    // Erroring `alloc` is not supported automatically.
+    let _: Result<Allocated<NSObject>, Id<NSObject>> =
+        unsafe { msg_send_id![NSObject::class(), allocWithError: _] };
+}

--- a/crates/test-ui/ui/msg_send_id_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_error.stderr
@@ -1,0 +1,47 @@
+error[E0308]: mismatched types
+ --> ui/msg_send_id_invalid_error.rs
+  |
+  |     let _: () = unsafe { msg_send_id![obj, a: _] };
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<Id<_>, Id<_>>`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<Id<_>, Id<_>>`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_id_invalid_error.rs
+  |
+  |         unsafe { msg_send_id![NSObject::alloc(), initWithError: _] };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Id<AnyObject>, Id<NSObject>>`, found `Result<Id<NSObject>, Id<_>>`
+  |
+  = note: expected enum `Result<Id<AnyObject>, Id<NSObject>>`
+             found enum `Result<Id<NSObject>, Id<_>>`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<Option<Id<_>> as MaybeUnwrap>::Input == Allocated<_>`
+ --> ui/msg_send_id_invalid_error.rs
+  |
+  |         unsafe { msg_send_id![NSObject::class(), allocWithError: _] };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Option<Id<_>>`
+  |
+  = note: expected struct `Allocated<_>`
+               found enum `Option<Id<_>>`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
+  |               --------------------- required by a bound in this associated function
+...
+  |         Option<R>: MaybeUnwrap<Input = U>,
+  |                                ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> ui/msg_send_id_invalid_error.rs
+  |
+  |         unsafe { msg_send_id![NSObject::class(), allocWithError: _] };
+  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Allocated<NSObject>, ...>`, found `Result<Id<_>, Id<_>>`
+  |
+  = note: expected enum `Result<Allocated<NSObject>, Id<NSObject>>`
+             found enum `Result<Id<_>, Id<_>>`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -21,10 +21,10 @@ error[E0308]: mismatched types
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
   |                                    -------------^^^-------
   |                                    |            |
-  |                                    |            expected `Option<Allocated<_>>`, found `&NSObject`
+  |                                    |            expected `Allocated<_>`, found `&NSObject`
   |                                    arguments to this function are incorrect
   |
-  = note:   expected enum `Option<Allocated<_>>`
+  = note: expected struct `Allocated<_>`
           found reference `&NSObject`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
@@ -38,10 +38,10 @@ error[E0308]: mismatched types
   |     let _: Id<NSObject> = unsafe { msg_send_id![cls, init] };
   |                                    -------------^^^-------
   |                                    |            |
-  |                                    |            expected `Option<Allocated<_>>`, found `&AnyClass`
+  |                                    |            expected `Allocated<_>`, found `&AnyClass`
   |                                    arguments to this function are incorrect
   |
-  = note:   expected enum `Option<Allocated<_>>`
+  = note: expected struct `Allocated<_>`
           found reference `&AnyClass`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
@@ -55,11 +55,11 @@ error[E0308]: mismatched types
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
   |                                    -------------^^^-------
   |                                    |            |
-  |                                    |            expected `Option<Allocated<_>>`, found `Id<NSObject>`
+  |                                    |            expected `Allocated<_>`, found `Id<NSObject>`
   |                                    arguments to this function are incorrect
   |
-  = note: expected enum `Option<Allocated<_>>`
-           found struct `Id<NSObject>`
+  = note: expected struct `Allocated<_>`
+             found struct `Id<NSObject>`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -72,11 +72,11 @@ error[E0308]: mismatched types
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
   |                                    -------------^^^-------
   |                                    |            |
-  |                                    |            expected `Option<Allocated<_>>`, found `Option<Id<NSObject>>`
+  |                                    |            expected `Allocated<_>`, found `Option<Id<NSObject>>`
   |                                    arguments to this function are incorrect
   |
-  = note: expected enum `Option<Allocated<_>>`
-             found enum `Option<Id<NSObject>>`
+  = note: expected struct `Allocated<_>`
+               found enum `Option<Id<NSObject>>`
 note: associated function defined here
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -93,7 +93,7 @@ error[E0277]: the trait bound `Id<NSObject>: MsgSend` is not satisfied
    |                                    required by a bound introduced by this call
    |
    = note: required for `Id<NSObject>` to implement `MsgSend`
-   = note: required for `RetainSemantics<1>` to implement `MsgSendId<Id<NSObject>, Id<_>>`
+   = note: required for `RetainSemantics<1>` to implement `MsgSendId<Id<NSObject>, Option<Id<_>>>`
 help: consider borrowing here
    |
 19 |     let _: Id<NSObject> = unsafe { msg_send_id![&obj, new] };
@@ -109,7 +109,7 @@ error[E0277]: the trait bound `Id<NSObject>: MsgSend` is not satisfied
    |                                    required by a bound introduced by this call
    |
    = note: required for `Id<NSObject>` to implement `MsgSend`
-   = note: required for `RetainSemantics<4>` to implement `MsgSendId<Id<NSObject>, Id<_>>`
+   = note: required for `RetainSemantics<4>` to implement `MsgSendId<Id<NSObject>, Option<Id<_>>>`
 help: consider borrowing here
    |
 21 |     let _: Id<NSObject> = unsafe { msg_send_id![&obj, copy] };

--- a/crates/test-ui/ui/msg_send_id_invalid_return.rs
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.rs
@@ -1,7 +1,7 @@
 //! Test compiler output with invalid msg_send_id return values.
 use objc2::msg_send_id;
 use objc2::rc::{Allocated, Id};
-use objc2::runtime::{AnyClass, NSObject, AnyObject};
+use objc2::runtime::{AnyClass, AnyObject, NSObject};
 
 fn main() {
     let cls: &AnyClass;
@@ -13,13 +13,15 @@ fn main() {
     let _: Allocated<AnyClass> = unsafe { msg_send_id![cls, alloc] };
     let _: Id<AnyObject> = unsafe { msg_send_id![cls, alloc] };
     // Earlier design worked like this
+    let _: Option<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
+    // And even earlier design like this
     let _: Id<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
 
-    let obj: Option<Allocated<AnyObject>>;
+    let obj: Allocated<AnyObject>;
     let _: &AnyObject = unsafe { msg_send_id![obj, init] };
-    let obj: Option<Allocated<AnyObject>>;
+    let obj: Allocated<AnyObject>;
     let _: Id<AnyClass> = unsafe { msg_send_id![obj, init] };
-    let obj: Option<Allocated<AnyObject>>;
+    let obj: Allocated<AnyObject>;
     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
 
     let obj: &AnyObject;

--- a/crates/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -8,7 +8,6 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -32,7 +31,7 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
             __RcTestObject
             NSObject
             __NSProxy
-  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Option<Id<AnyClass>>>`
 
 error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -50,7 +49,7 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
             __RcTestObject
             NSObject
             __NSProxy
-  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Id<AnyClass>>`
+  = note: required for `RetainSemantics<1>` to implement `MsgSendId<&AnyClass, Option<Id<AnyClass>>>`
 
 error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
@@ -62,7 +61,6 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -92,10 +90,10 @@ error[E0271]: type mismatch resolving `<Id<AnyObject> as MaybeUnwrap>::Input == 
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<AnyObject> = unsafe { msg_send_id![cls, alloc] };
-  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<AnyObject>`
+  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Option<Id<AnyObject>>`
   |
   = note: expected struct `Allocated<_>`
-             found struct `Id<AnyObject>`
+               found enum `Option<Id<AnyObject>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -103,14 +101,28 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0277]: the trait bound `Option<Allocated<AnyObject>>: MaybeUnwrap` is not satisfied
+ --> ui/msg_send_id_invalid_return.rs
+  |
+  |     let _: Option<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
+  |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `Option<Allocated<AnyObject>>`
+  |
+  = help: the trait `MaybeUnwrap` is implemented for `Option<Id<T>>`
+note: required by a bound in `send_message_id`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id<A: ConvertArguments, R: MaybeUnwrap<Input = U>>(
+  |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
+  = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0271]: type mismatch resolving `<Id<Allocated<AnyObject>> as MaybeUnwrap>::Input == Allocated<_>`
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<Allocated<AnyObject>> = unsafe { msg_send_id![cls, alloc] };
-  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Id<Allocated<AnyObject>>`
+  |                                                ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Allocated<_>`, found `Option<Id<Allocated<AnyObject>>>`
   |
   = note: expected struct `Allocated<_>`
-             found struct `Id<Allocated<AnyObject>>`
+               found enum `Option<Id<Allocated<AnyObject>>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -128,7 +140,6 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -136,14 +147,14 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<Id<AnyClass> as MaybeUnwrap>::Input == Id<AnyObject>`
+error[E0271]: type mismatch resolving `<Id<AnyClass> as MaybeUnwrap>::Input == Option<Id<AnyObject>>`
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<AnyClass> = unsafe { msg_send_id![obj, init] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<AnyObject>`, found `Id<AnyClass>`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<Id<AnyObject>>`, found `Option<Id<AnyClass>>`
   |
-  = note: expected struct `Id<AnyObject>`
-             found struct `Id<AnyClass>`
+  = note: expected enum `Option<Id<AnyObject>>`
+             found enum `Option<Id<AnyClass>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -151,14 +162,14 @@ note: required by a bound in `send_message_id`
   |                                                                   ^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Id<AnyObject>`
+error[E0271]: type mismatch resolving `<Id<NSObject> as MaybeUnwrap>::Input == Option<Id<AnyObject>>`
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, init] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Id<AnyObject>`, found `Id<NSObject>`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<Id<AnyObject>>`, found `Option<Id<NSObject>>`
   |
-  = note: expected struct `Id<AnyObject>`
-             found struct `Id<NSObject>`
+  = note: expected enum `Option<Id<AnyObject>>`
+             found enum `Option<Id<NSObject>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -176,7 +187,6 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -194,7 +204,6 @@ error[E0277]: the trait bound `&AnyObject: MaybeUnwrap` is not satisfied
             Id<T>
             Allocated<T>
             Option<Id<T>>
-            Option<Allocated<T>>
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
@@ -208,9 +217,7 @@ error[E0277]: the trait bound `Option<&AnyObject>: MaybeUnwrap` is not satisfied
   |     let _: Option<&AnyObject> = unsafe { msg_send_id![obj, description] };
   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MaybeUnwrap` is not implemented for `Option<&AnyObject>`
   |
-  = help: the following other types implement trait `MaybeUnwrap`:
-            Option<Id<T>>
-            Option<Allocated<T>>
+  = help: the trait `MaybeUnwrap` is implemented for `Option<Id<T>>`
 note: required by a bound in `send_message_id`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |

--- a/crates/test-ui/ui/msg_send_invalid_error.rs
+++ b/crates/test-ui/ui/msg_send_invalid_error.rs
@@ -1,7 +1,7 @@
 //! Test that msg_send! error handling works correctly.
 use icrate::Foundation::NSString;
 use objc2::rc::Id;
-use objc2::{msg_send, msg_send_id, ClassType};
+use objc2::{msg_send, ClassType};
 
 fn main() {
     let obj: &NSString;
@@ -16,5 +16,4 @@ fn main() {
     let _: () = unsafe { msg_send![obj, e: obj, f: _] };
     let _: () = unsafe { msg_send![super(obj), g: _] };
     let _: () = unsafe { msg_send![super(obj, NSString::class()), h: _] };
-    let _: () = unsafe { msg_send_id![obj, i: _] };
 }

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -83,13 +83,3 @@ error[E0308]: mismatched types
   = note: expected unit type `()`
                   found enum `Result<(), Id<_>>`
   = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
- --> ui/msg_send_invalid_error.rs
-  |
-  |     let _: () = unsafe { msg_send_id![obj, i: _] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<Id<_>, Id<_>>`
-  |
-  = note: expected unit type `()`
-                  found enum `Result<Id<_>, Id<_>>`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
+++ b/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
@@ -33,4 +33,4 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   = note: required for `NSThread` to implement `IsAllowedMutable`
   = note: required for `&mut NSThread` to implement `MessageReceiver`
   = note: required for `&mut NSThread` to implement `MsgSend`
-  = note: required for `RetainSemantics<5>` to implement `MsgSendId<&mut NSThread, Id<_>>`
+  = note: required for `RetainSemantics<5>` to implement `MsgSendId<&mut NSThread, Option<Id<_>>>`

--- a/crates/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error.stderr
@@ -39,7 +39,7 @@ error[E0283]: type annotations needed
 note: required by a bound in `send_message_id_error`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
-  |     unsafe fn send_message_id_error<A, E>(obj: T, sel: Sel, args: A) -> Result<U, Id<E>>
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
   |               --------------------- required by a bound in this associated function
   |     where
   |         *mut *mut E: Encode,
@@ -60,7 +60,7 @@ error[E0283]: type annotations needed
 note: required by a bound in `send_message_id_error`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
-  |     unsafe fn send_message_id_error<A, E>(obj: T, sel: Sel, args: A) -> Result<U, Id<E>>
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
   |               --------------------- required by a bound in this associated function
   |     where
   |         *mut *mut E: Encode,
@@ -81,7 +81,7 @@ error[E0283]: type annotations needed
 note: required by a bound in `send_message_id_error`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
   |
-  |     unsafe fn send_message_id_error<A, E>(obj: T, sel: Sel, args: A) -> Result<U, Id<E>>
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
   |               --------------------- required by a bound in this associated function
   |     where
   |         *mut *mut E: Encode,


### PR DESCRIPTION
Arbitary self types (tracking issue: https://github.com/rust-lang/rust/issues/44874) are not yet stable, but whatever form they end up as, we'll need to use a different type than `Option<Allocated<T>>`, since you can't (and won't be able to) use that as `self: Option<Allocated<Self>>`.

~My proposal here is to introduce a new type, since we likely still need to be able to differentiate between "this type is newly allocated, and we don't know the nullability" (such as when sending to `init` methods) vs. "this type is allocated, and we know that it is non-null" (such as when receiving from `init` methods).~

EDIT: See [below](https://github.com/madsmtm/objc2/pull/520#issuecomment-1738839859) for the alternative I'm going with.