### PR TITLE
Future-proof struct encodings

### DIFF
--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Changed
+* **BREAKING**: Changed the type of `EncodingBox::Struct` and
+  `EncodingBox::Union` to no longer contain an `Option`.
+
+### Fixed
+* Fixed encoding equivalence between empty structs and unions.
+
 
 ## 3.0.0 - 2023-07-31
 

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -206,7 +206,7 @@ impl Encoding {
     /// For example, you should not rely on two equivalent encodings to have
     /// the same size or ABI - that is provided on a best-effort basis.
     pub fn equivalent_to(&self, other: &Self) -> bool {
-        compare_encodings(self, NestingLevel::new(), other, NestingLevel::new(), false)
+        compare_encodings(self, other, NestingLevel::new(), false)
     }
 
     /// Check if an encoding is equivalent to the given string representation.
@@ -232,7 +232,7 @@ impl Encoding {
     /// See [`Encoding::equivalent_to`] for details about the meaning of
     /// "equivalence".
     pub fn equivalent_to_box(&self, other: &EncodingBox) -> bool {
-        compare_encodings(self, NestingLevel::new(), other, NestingLevel::new(), false)
+        compare_encodings(self, other, NestingLevel::new(), false)
     }
 }
 
@@ -244,7 +244,7 @@ impl Encoding {
 /// Objective-C compilers.
 impl fmt::Display for Encoding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Helper::new(self, NestingLevel::new()))
+        Helper::new(self).fmt(f, NestingLevel::new())
     }
 }
 

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -135,13 +135,13 @@ impl EncodingBox {
 /// Same formatting as [`Encoding`]'s `Display` implementation.
 impl fmt::Display for EncodingBox {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Helper::from_box(self, NestingLevel::new()))
+        Helper::from_box(self).fmt(f, NestingLevel::new())
     }
 }
 
 impl PartialEq<Encoding> for EncodingBox {
     fn eq(&self, other: &Encoding) -> bool {
-        compare_encodings(self, NestingLevel::new(), other, NestingLevel::new(), true)
+        compare_encodings(self, other, NestingLevel::new(), true)
     }
 }
 

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -17,51 +17,44 @@ impl NestingLevel {
         Self::Top
     }
 
-    const fn bitfield(self) -> Self {
+    pub(crate) const fn bitfield(self) -> Self {
         // This is a bit irrelevant, since bitfields can only contain integral
         // types
         self
     }
 
-    const fn atomic(self) -> Self {
-        // Move all the way down
-        Self::Bottom
-    }
-
-    const fn pointer(self) -> Self {
-        // Move one step down
-        match self {
-            Self::Top => Self::Within,
-            Self::Bottom | Self::Within => Self::Bottom,
+    pub(crate) const fn indirection(self, kind: IndirectionKind) -> Self {
+        match kind {
+            // Move all the way down
+            IndirectionKind::Atomic => Self::Bottom,
+            // Move one step down
+            IndirectionKind::Pointer => match self {
+                Self::Top => Self::Within,
+                Self::Bottom | Self::Within => Self::Bottom,
+            },
         }
     }
 
-    const fn array(self) -> Self {
+    pub(crate) const fn array(self) -> Self {
         // TODO: Is this correct?
         self
     }
 
-    const fn container(self) -> Self {
+    pub(crate) const fn container_include_fields(self) -> Option<Self> {
         match self {
-            // Move top one step down
-            Self::Top | Self::Within => Self::Within,
-            Self::Bottom => Self::Bottom,
-        }
-    }
-
-    pub(crate) const fn include_container_fields(self) -> bool {
-        match self {
-            Self::Top | Self::Within => true,
-            Self::Bottom => false,
+            Self::Top | Self::Within => {
+                // Move top one step down
+                Some(Self::Within)
+            }
+            Self::Bottom => None,
         }
     }
 }
 
 pub(crate) fn compare_encodings<E1: EncodingType, E2: EncodingType>(
     enc1: &E1,
-    level1: NestingLevel,
     enc2: &E2,
-    level2: NestingLevel,
+    level: NestingLevel,
     include_all: bool,
 ) -> bool {
     use Helper::*;
@@ -69,64 +62,50 @@ pub(crate) fn compare_encodings<E1: EncodingType, E2: EncodingType>(
     // should compare equivalent, but we don't bother since in practice a
     // plain `Unknown` will never appear.
 
-    let level1 = if include_all {
+    let level = if include_all {
         NestingLevel::new()
     } else {
-        level1
-    };
-    let level2 = if include_all {
-        NestingLevel::new()
-    } else {
-        level2
+        level
     };
 
-    // TODO: Are level1 and level2 ever different?
-
-    match (enc1.helper(level1), enc2.helper(level2)) {
+    match (enc1.helper(), enc2.helper()) {
         (Primitive(p1), Primitive(p2)) => p1 == p2,
-        (
-            BitField(size1, Some((offset1, type1)), level1),
-            BitField(size2, Some((offset2, type2)), level2),
-        ) => {
+        (BitField(size1, Some((offset1, type1))), BitField(size2, Some((offset2, type2)))) => {
             size1 == size2
                 && offset1 == offset2
-                && compare_encodings(type1, level1, type2, level2, include_all)
+                && compare_encodings(type1, type2, level.bitfield(), include_all)
         }
-        (BitField(size1, None, _level1), BitField(size2, None, _level2)) => size1 == size2,
+        (BitField(size1, None), BitField(size2, None)) => size1 == size2,
         // The type-encoding of a bitfield is always either available, or it
         // is not (depends on platform); so if it was available in one, but
         // not the other, we should compare the encodings unequal.
-        (BitField(_, _, _), BitField(_, _, _)) => false,
-        (Indirection(kind1, t1, level1), Indirection(kind2, t2, level2)) => {
-            kind1 == kind2 && compare_encodings(t1, level1, t2, level2, include_all)
+        (BitField(_, _), BitField(_, _)) => false,
+        (Indirection(kind1, t1), Indirection(kind2, t2)) => {
+            kind1 == kind2 && compare_encodings(t1, t2, level.indirection(kind1), include_all)
         }
-        (Array(len1, item1, level1), Array(len2, item2, level2)) => {
-            len1 == len2 && compare_encodings(item1, level1, item2, level2, include_all)
+        (Array(len1, item1), Array(len2, item2)) => {
+            len1 == len2 && compare_encodings(item1, item2, level.array(), include_all)
         }
-        (Container(kind1, name1, items1, level1), Container(kind2, name2, items2, level2)) => {
-            kind1 == kind2
-                && name1 == name2
-                && match (
-                    items1,
-                    items2,
-                    level1.include_container_fields() && level2.include_container_fields(),
-                ) {
-                    (_, _, false) => true,
-                    // If one container is empty, then they are equivalent
-                    ([], _, true) => true,
-                    (_, [], true) => true,
-                    (items1, items2, true) => {
-                        if items1.len() != items2.len() {
+        (Container(kind1, name1, items1), Container(kind2, name2, items2)) => {
+            kind1 == kind2 && name1 == name2 && {
+                if let Some(level) = level.container_include_fields() {
+                    // If either container is empty, then they are equivalent
+                    if items1.is_empty() || items2.is_empty() {
+                        return true;
+                    }
+                    if items1.len() != items2.len() {
+                        return false;
+                    }
+                    for (item1, item2) in items1.iter().zip(items2.iter()) {
+                        if !compare_encodings(item1, item2, level, include_all) {
                             return false;
                         }
-                        for (item1, item2) in items1.iter().zip(items2.iter()) {
-                            if !compare_encodings(item1, level1, item2, level2, include_all) {
-                                return false;
-                            }
-                        }
-                        true
                     }
+                    true
+                } else {
+                    true
                 }
+            }
         }
         (_, _) => false,
     }
@@ -252,52 +231,61 @@ impl fmt::Display for ContainerKind {
 }
 
 pub(crate) trait EncodingType: Sized + fmt::Debug {
-    fn helper(&self, level: NestingLevel) -> Helper<'_, Self>;
+    fn helper(&self) -> Helper<'_, Self>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub(crate) enum Helper<'a, E = Encoding> {
     Primitive(Primitive),
-    BitField(u8, Option<&'a (u64, E)>, NestingLevel),
-    Indirection(IndirectionKind, &'a E, NestingLevel),
-    Array(u64, &'a E, NestingLevel),
-    Container(ContainerKind, &'a str, &'a [E], NestingLevel),
+    BitField(u8, Option<&'a (u64, E)>),
+    Indirection(IndirectionKind, &'a E),
+    Array(u64, &'a E),
+    Container(ContainerKind, &'a str, &'a [E]),
 }
 
-impl<E: EncodingType> fmt::Display for Helper<'_, E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<E: EncodingType> Helper<'_, E> {
+    pub(crate) fn fmt(&self, f: &mut fmt::Formatter<'_>, level: NestingLevel) -> fmt::Result {
         match self {
-            Self::Primitive(primitive) => write!(f, "{}", primitive.to_str()),
-            Self::BitField(size, None, _level) => {
-                write!(f, "b{size}")
+            Self::Primitive(primitive) => {
+                write!(f, "{}", primitive.to_str())?;
             }
-            Self::BitField(size, Some((offset, t)), level) => {
-                write!(f, "b{offset}{}{size}", t.helper(*level))
+            Self::BitField(size, None) => {
+                write!(f, "b{size}")?;
             }
-            Self::Indirection(kind, t, level) => {
-                write!(f, "{}{}", kind.prefix(), t.helper(*level))
+            Self::BitField(size, Some((offset, t))) => {
+                write!(f, "b{offset}")?;
+                t.helper().fmt(f, level.bitfield())?;
+                write!(f, "{size}")?;
             }
-            Self::Array(len, item, level) => {
-                write!(f, "[{}{}]", len, item.helper(*level))
+            Self::Indirection(kind, t) => {
+                write!(f, "{}", kind.prefix())?;
+                t.helper().fmt(f, level.indirection(*kind))?;
             }
-            Self::Container(kind, name, items, level) => {
+            Self::Array(len, item) => {
+                write!(f, "[")?;
+                write!(f, "{len}")?;
+                item.helper().fmt(f, level.array())?;
+                write!(f, "]")?;
+            }
+            Self::Container(kind, name, items) => {
                 write!(f, "{}", kind.start())?;
                 write!(f, "{name}")?;
-                if level.include_container_fields() {
+                if let Some(level) = level.container_include_fields() {
                     write!(f, "=")?;
                     for item in *items {
-                        write!(f, "{}", item.helper(*level))?;
+                        item.helper().fmt(f, level)?;
                     }
                 }
-                write!(f, "{}", kind.end())
+                write!(f, "{}", kind.end())?;
             }
         }
+        Ok(())
     }
 }
 
 impl Helper<'_> {
-    pub(crate) const fn new(encoding: &Encoding, level: NestingLevel) -> Self {
+    pub(crate) const fn new(encoding: &Encoding) -> Self {
         use Encoding::*;
         match encoding {
             Char => Self::Primitive(Primitive::Char),
@@ -324,28 +312,28 @@ impl Helper<'_> {
             Class => Self::Primitive(Primitive::Class),
             Sel => Self::Primitive(Primitive::Sel),
             Unknown => Self::Primitive(Primitive::Unknown),
-            BitField(b, t) => Self::BitField(*b, *t, level.bitfield()),
-            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t, level.pointer()),
-            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t, level.atomic()),
-            Array(len, item) => Self::Array(*len, item, level.array()),
+            BitField(b, t) => Self::BitField(*b, *t),
+            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t),
+            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t),
+            Array(len, item) => Self::Array(*len, item),
             Struct(name, fields) => {
                 if !verify_name(name) {
                     panic!("Struct name was not a valid identifier");
                 }
-                Self::Container(ContainerKind::Struct, name, fields, level.container())
+                Self::Container(ContainerKind::Struct, name, fields)
             }
             Union(name, members) => {
                 if !verify_name(name) {
                     panic!("Union name was not a valid identifier");
                 }
-                Self::Container(ContainerKind::Union, name, members, level.container())
+                Self::Container(ContainerKind::Union, name, members)
             }
         }
     }
 }
 
 impl<'a> Helper<'a, EncodingBox> {
-    pub(crate) fn from_box(encoding: &'a EncodingBox, level: NestingLevel) -> Self {
+    pub(crate) fn from_box(encoding: &'a EncodingBox) -> Self {
         use EncodingBox::*;
         match encoding {
             Char => Self::Primitive(Primitive::Char),
@@ -372,34 +360,34 @@ impl<'a> Helper<'a, EncodingBox> {
             Class => Self::Primitive(Primitive::Class),
             Sel => Self::Primitive(Primitive::Sel),
             Unknown => Self::Primitive(Primitive::Unknown),
-            BitField(b, t) => Self::BitField(*b, t.as_deref(), level.bitfield()),
-            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t, level.pointer()),
-            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t, level.atomic()),
-            Array(len, item) => Self::Array(*len, item, level.array()),
+            BitField(b, t) => Self::BitField(*b, t.as_deref()),
+            Pointer(t) => Self::Indirection(IndirectionKind::Pointer, t),
+            Atomic(t) => Self::Indirection(IndirectionKind::Atomic, t),
+            Array(len, item) => Self::Array(*len, item),
             Struct(name, fields) => {
                 if !verify_name(name) {
                     panic!("Struct name was not a valid identifier");
                 }
-                Self::Container(ContainerKind::Struct, name, fields, level.container())
+                Self::Container(ContainerKind::Struct, name, fields)
             }
             Union(name, members) => {
                 if !verify_name(name) {
                     panic!("Union name was not a valid identifier");
                 }
-                Self::Container(ContainerKind::Union, name, members, level.container())
+                Self::Container(ContainerKind::Union, name, members)
             }
         }
     }
 }
 
 impl EncodingType for Encoding {
-    fn helper(&self, level: NestingLevel) -> Helper<'_, Self> {
-        Helper::new(self, level)
+    fn helper(&self) -> Helper<'_, Self> {
+        Helper::new(self)
     }
 }
 
 impl EncodingType for EncodingBox {
-    fn helper(&self, level: NestingLevel) -> Helper<'_, Self> {
-        Helper::from_box(self, level)
+    fn helper(&self) -> Helper<'_, Self> {
+        Helper::from_box(self)
     }
 }

--- a/crates/objc2-encode/src/parse.rs
+++ b/crates/objc2-encode/src/parse.rs
@@ -276,8 +276,21 @@ impl Parser<'_> {
             Helper::Container(kind, name, items, level) => {
                 self.expect_byte(kind.start_byte())?;
                 self.expect_str(name)?;
-                if let Some(items) = items {
+                if level.include_container_fields() {
                     self.expect_byte(b'=')?;
+                    // Parse as equal if the container is empty
+                    if items.is_empty() {
+                        while self.try_peek() != Some(kind.end_byte()) {
+                            let _ = self.parse_encoding().ok()?;
+                        }
+                        self.advance();
+                        return Some(());
+                    }
+                    // Parse as equal if the string's container is empty
+                    if self.try_peek() == Some(kind.end_byte()) {
+                        self.advance();
+                        return Some(());
+                    }
                     for item in items {
                         self.expect_encoding(item, level)?;
                     }
@@ -289,10 +302,10 @@ impl Parser<'_> {
 }
 
 impl Parser<'_> {
-    fn parse_container(&mut self, kind: ContainerKind) -> Result<(&str, Option<Vec<EncodingBox>>)> {
+    fn parse_container(&mut self, kind: ContainerKind) -> Result<(&str, Vec<EncodingBox>)> {
         let old_split_point = self.split_point;
 
-        // Parse name until hits `=`
+        // Parse name until hits `=` or `}`/`)`
         let has_items = loop {
             let b = self.try_peek().ok_or(ErrorKind::WrongEndContainer(kind))?;
             if b == b'=' {
@@ -309,25 +322,23 @@ impl Parser<'_> {
             return Err(ErrorKind::InvalidIdentifier(kind));
         }
 
-        self.advance();
-
         if has_items {
-            let mut items = Vec::new();
-            // Parse items until hits end
-            loop {
-                let b = self.try_peek().ok_or(ErrorKind::WrongEndContainer(kind))?;
-                if b == kind.end_byte() {
-                    self.advance();
-                    break;
-                } else {
-                    // Wasn't the end, so try to extract one more encoding
-                    items.push(self.parse_encoding()?);
-                }
-            }
-            Ok((s, Some(items)))
-        } else {
-            Ok((s, None))
+            self.advance();
         }
+
+        let mut items = Vec::new();
+        // Parse items until hits end
+        loop {
+            let b = self.try_peek().ok_or(ErrorKind::WrongEndContainer(kind))?;
+            if b == kind.end_byte() {
+                self.advance();
+                break;
+            } else {
+                // Wasn't the end, so try to extract one more encoding
+                items.push(self.parse_encoding()?);
+            }
+        }
+        Ok((s, items))
     }
 
     pub(crate) fn parse_encoding(&mut self) -> Result<EncodingBox> {
@@ -463,18 +474,18 @@ mod tests {
         const KIND: ContainerKind = ContainerKind::Struct;
 
         #[track_caller]
-        fn assert_name(enc: &str, expected: Result<(&str, Option<Vec<EncodingBox>>)>) {
+        fn assert_name(enc: &str, expected: Result<(&str, Vec<EncodingBox>)>) {
             let mut parser = Parser::new(enc);
             assert_eq!(parser.parse_container(KIND), expected);
         }
 
-        assert_name("abc=}", Ok(("abc", Some(vec![]))));
+        assert_name("abc=}", Ok(("abc", vec![])));
         assert_name(
             "abc=ii}",
-            Ok(("abc", Some(vec![EncodingBox::Int, EncodingBox::Int]))),
+            Ok(("abc", vec![EncodingBox::Int, EncodingBox::Int])),
         );
-        assert_name("_=}.a'", Ok(("_", Some(vec![]))));
-        assert_name("abc}def", Ok(("abc", None)));
+        assert_name("_=}.a'", Ok(("_", vec![])));
+        assert_name("abc}def", Ok(("abc", vec![])));
         assert_name("=def}", Err(ErrorKind::InvalidIdentifier(KIND)));
         assert_name(".=def}", Err(ErrorKind::InvalidIdentifier(KIND)));
         assert_name("}xyz", Err(ErrorKind::InvalidIdentifier(KIND)));
@@ -510,7 +521,7 @@ mod tests {
             "{s=b8C}",
             Ok(EncodingBox::Struct(
                 "s".into(),
-                Some(vec![EncodingBox::BitField(8, None), EncodingBox::UChar]),
+                vec![EncodingBox::BitField(8, None), EncodingBox::UChar],
             )),
         );
 

--- a/crates/objc2-encode/src/static_str.rs
+++ b/crates/objc2-encode/src/static_str.rs
@@ -55,7 +55,7 @@ pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingL
         }
         Container(_, name, items, level) => {
             let mut res = 1 + name.len();
-            if let Some(items) = items {
+            if level.include_container_fields() {
                 res += 1;
                 let mut i = 0;
                 while i < items.len() {
@@ -184,7 +184,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 name_i += 1;
             }
 
-            if let Some(items) = items {
+            if level.include_container_fields() {
                 res[res_i] = b'=';
                 res_i += 1;
 

--- a/crates/objc2-encode/src/static_str.rs
+++ b/crates/objc2-encode/src/static_str.rs
@@ -41,21 +41,21 @@ pub(crate) const fn static_int_str_array<const RES: usize>(mut n: u64) -> [u8; R
 pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingLevel) -> usize {
     use Helper::*;
 
-    match Helper::new(encoding, level) {
+    match Helper::new(encoding) {
         Primitive(primitive) => primitive.to_str().len(),
-        BitField(size, None, _level) => 1 + static_int_str_len(size as u64),
-        BitField(size, Some((offset, t)), level) => {
+        BitField(size, None) => 1 + static_int_str_len(size as u64),
+        BitField(size, Some((offset, t))) => {
             1 + static_int_str_len(*offset)
-                + static_encoding_str_len(t, level)
+                + static_encoding_str_len(t, level.bitfield())
                 + static_int_str_len(size as u64)
         }
-        Indirection(_kind, t, level) => 1 + static_encoding_str_len(t, level),
-        Array(len, item, level) => {
-            1 + static_int_str_len(len) + static_encoding_str_len(item, level) + 1
+        Indirection(kind, t) => 1 + static_encoding_str_len(t, level.indirection(kind)),
+        Array(len, item) => {
+            1 + static_int_str_len(len) + static_encoding_str_len(item, level.array()) + 1
         }
-        Container(_, name, items, level) => {
+        Container(_, name, items) => {
             let mut res = 1 + name.len();
-            if level.include_container_fields() {
+            if let Some(level) = level.container_include_fields() {
                 res += 1;
                 let mut i = 0;
                 while i < items.len() {
@@ -77,7 +77,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
     let mut res: [u8; LEN] = [0; LEN];
     let mut res_i = 0;
 
-    match Helper::new(encoding, level) {
+    match Helper::new(encoding) {
         Primitive(primitive) => {
             let s = primitive.to_str().as_bytes();
             let mut i = 0;
@@ -86,7 +86,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        BitField(size, None, _level) => {
+        BitField(size, None) => {
             res[res_i] = b'b';
             res_i += 1;
 
@@ -99,7 +99,8 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        BitField(size, Some((offset, t)), level) => {
+        BitField(size, Some((offset, t))) => {
+            let level = level.bitfield();
             res[res_i] = b'b';
             res_i += 1;
 
@@ -131,7 +132,8 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        Indirection(kind, t, level) => {
+        Indirection(kind, t) => {
+            let level = level.indirection(kind);
             res[res_i] = kind.prefix_byte();
             res_i += 1;
 
@@ -144,7 +146,8 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 i += 1;
             }
         }
-        Array(len, item, level) => {
+        Array(len, item) => {
+            let level = level.array();
             let mut res_i = 0;
 
             res[res_i] = b'[';
@@ -170,7 +173,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
 
             res[res_i] = b']';
         }
-        Container(kind, name, items, level) => {
+        Container(kind, name, items) => {
             let mut res_i = 0;
 
             res[res_i] = kind.start_byte();
@@ -184,7 +187,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
                 name_i += 1;
             }
 
-            if level.include_container_fields() {
+            if let Some(level) = level.container_include_fields() {
                 res[res_i] = b'=';
                 res_i += 1;
 

--- a/crates/objc2/src/runtime/method_encoding_iter.rs
+++ b/crates/objc2/src/runtime/method_encoding_iter.rs
@@ -179,10 +179,10 @@ mod tests {
                 (
                     EncodingBox::Struct(
                         "bitfield".into(),
-                        Some(vec![
+                        vec![
                             EncodingBox::BitField(64, None),
                             EncodingBox::BitField(1, None),
-                        ]),
+                        ],
                     ),
                     Some(32),
                 ),

--- a/crates/test-fuzz/fuzz_targets/encoding_parse.rs
+++ b/crates/test-fuzz/fuzz_targets/encoding_parse.rs
@@ -5,6 +5,10 @@ use libfuzzer_sys::fuzz_target;
 use objc2::encode::{Encoding, EncodingBox};
 
 fuzz_target!(|s: &str| {
+    // Limit string length to < 1024 so that we don't hit stack overflows
+    if s.len() > 1024 {
+        return;
+    }
     // Check that parsing encodings doesn't panic
     if let Ok(enc) = EncodingBox::from_str(s) {
         // Check a "negative" case of `equivalent_to_box`


### PR DESCRIPTION
In https://github.com/rust-windowing/glutin/issues/1640 the encoding of the `CGLContextObj` object changed between versions of macOS. As such, this is something that we must be prepared to handle in our encoding comparison routines.