### PR TITLE
Remove `c_void` encoding hack

### DIFF
--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -201,6 +201,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   let ivar = cls.instance_variable("number").unwrap();
   let number = unsafe { *ivar.load::<u32>(&obj) };
   ```
+* Implement `RefEncode` normally for `c_void`. This makes `AtomicPtr<c_void>`
+  implement `Encode`.
 
 ### Removed
 * **BREAKING**: Removed `ProtocolType` implementation for `NSObject`.

--- a/crates/objc2/src/encode.rs
+++ b/crates/objc2/src/encode.rs
@@ -704,28 +704,9 @@ unsafe impl<T: RefEncode> RefEncode for atomic::AtomicPtr<T> {
     const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
-/// [`Encode`] is implemented manually for `*const c_void`, `*mut c_void` and
-/// `NonNull<c_void>`, instead of implementing [`RefEncode`], to discourage
-/// creating `&c_void`/`&mut c_void`.
-unsafe impl Encode for *const c_void {
-    const ENCODING: Encoding = Encoding::Pointer(&Encoding::Void);
+unsafe impl RefEncode for c_void {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Void);
 }
-unsafe impl RefEncode for *const c_void {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-}
-unsafe impl Encode for *mut c_void {
-    const ENCODING: Encoding = Encoding::Pointer(&Encoding::Void);
-}
-unsafe impl RefEncode for *mut c_void {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-}
-unsafe impl Encode for NonNull<c_void> {
-    const ENCODING: Encoding = Encoding::Pointer(&Encoding::Void);
-}
-unsafe impl RefEncode for NonNull<c_void> {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-}
-unsafe impl OptionEncode for NonNull<c_void> {}
 
 unsafe impl<T: Encode, const LENGTH: usize> Encode for [T; LENGTH] {
     const ENCODING: Encoding = Encoding::Array(LENGTH as u64, &T::ENCODING);
@@ -959,9 +940,14 @@ mod tests {
             <*const c_void>::ENCODING,
             Encoding::Pointer(&Encoding::Void)
         );
+        assert_eq!(<&c_void>::ENCODING, Encoding::Pointer(&Encoding::Void));
         assert_eq!(
             <&*const c_void>::ENCODING,
             Encoding::Pointer(&Encoding::Pointer(&Encoding::Void))
+        );
+        assert_eq!(
+            <AtomicPtr<c_void>>::ENCODING,
+            Encoding::Atomic(&Encoding::Pointer(&Encoding::Void))
         );
     }
 

--- a/crates/test-ui/ui/msg_send_id_underspecified_error1.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error1.rs
@@ -1,0 +1,9 @@
+//! Test underspecified msg_send_id! errors.
+use icrate::Foundation::NSString;
+use objc2::msg_send_id;
+use objc2::rc::Id;
+
+fn main() {
+    let obj: &NSString;
+    let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
+}

--- a/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
@@ -3,24 +3,3 @@ error[E0282]: type annotations needed
   |
   |     let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
   |            ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-
-error[E0283]: type annotations needed
- --> ui/msg_send_id_underspecified_error1.rs
-  |
-  |     let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
-  |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_id_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
-  |
-  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
-  |               --------------------- required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
@@ -1,0 +1,26 @@
+error[E0282]: type annotations needed
+ --> ui/msg_send_id_underspecified_error1.rs
+  |
+  |     let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
+  |            ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_id_underspecified_error1.rs
+  |
+  |     let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
+  |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
+  |               --------------------- required by a bound in this associated function
+  |     where
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_id_underspecified_error2.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error2.rs
@@ -1,9 +1,9 @@
-//! Test underspecified msg_send! errors.
+//! Test underspecified msg_send_id! errors.
 use icrate::Foundation::{NSError, NSString};
 use objc2::msg_send_id;
 use objc2::rc::Id;
 
 fn main() {
     let obj: &NSString;
-    let _: Result<Id<_>, Id<NSError>> = unsafe { msg_send_id![obj, a: _] };
+    let _: Result<_, Id<NSError>> = unsafe { msg_send_id![obj, error: _] };
 }

--- a/crates/test-ui/ui/msg_send_id_underspecified_error2.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error2.stderr
@@ -1,0 +1,5 @@
+error[E0282]: type annotations needed
+ --> ui/msg_send_id_underspecified_error2.rs
+  |
+  |     let _: Result<_, Id<NSError>> = unsafe { msg_send_id![obj, error: _] };
+  |            ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type

--- a/crates/test-ui/ui/msg_send_id_underspecified_error3.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error3.rs
@@ -1,0 +1,8 @@
+//! Test underspecified msg_send_id! errors.
+use icrate::Foundation::NSString;
+use objc2::msg_send_id;
+
+fn main() {
+    let obj: &NSString;
+    let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
+}

--- a/crates/test-ui/ui/msg_send_id_underspecified_error3.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error3.stderr
@@ -3,24 +3,3 @@ error[E0282]: type annotations needed
   |
   |     let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
   |            ^^^^^^^^^^^^ cannot infer type
-
-error[E0283]: type annotations needed
- --> ui/msg_send_id_underspecified_error3.rs
-  |
-  |     let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_id_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
-  |
-  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
-  |               --------------------- required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_id_underspecified_error3.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error3.stderr
@@ -1,0 +1,26 @@
+error[E0282]: type annotations needed
+ --> ui/msg_send_id_underspecified_error3.rs
+  |
+  |     let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
+  |            ^^^^^^^^^^^^ cannot infer type
+
+error[E0283]: type annotations needed
+ --> ui/msg_send_id_underspecified_error3.rs
+  |
+  |     let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |
+  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
+          - impl RefEncode for *mut c_void;
+          - impl<T> RefEncode for *mut T
+            where T: RefEncode, T: ?Sized;
+  = note: required for `*mut *mut _` to implement `Encode`
+note: required by a bound in `send_message_id_error`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
+  |
+  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
+  |               --------------------- required by a bound in this associated function
+  |     where
+  |         *mut *mut E: Encode,
+  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
+  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_underspecified_error.rs
+++ b/crates/test-ui/ui/msg_send_underspecified_error.rs
@@ -1,13 +1,8 @@
 //! Test underspecified msg_send! errors.
 use icrate::Foundation::NSString;
-use objc2::rc::Id;
-use objc2::{msg_send, msg_send_id};
+use objc2::msg_send;
 
 fn main() {
     let obj: &NSString;
-    let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
-
-    let _: Result<_, _> = unsafe { msg_send_id![obj, b: _] };
-    let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, c: _] };
-    let _: Result<Id<NSString>, Id<_>> = unsafe { msg_send_id![obj, d: _] };
+    let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
 }

--- a/crates/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error.stderr
@@ -3,24 +3,3 @@ error[E0282]: type annotations needed
   |
   |     let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
   |            ^^^^^^^^^^^^^ cannot infer type
-
-error[E0283]: type annotations needed
- --> ui/msg_send_underspecified_error.rs
-  |
-  |     let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
-  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send.rs
-  |
-  |     unsafe fn send_message_error<A, E>(self, sel: Sel, args: A) -> Result<(), Id<E>>
-  |               ------------------ required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSend::send_message_error`
-  = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_underspecified_error.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error.stderr
@@ -1,14 +1,14 @@
 error[E0282]: type annotations needed
  --> ui/msg_send_underspecified_error.rs
   |
-  |     let _: Result<Id<NSString>, Id<_>> = unsafe { msg_send_id![obj, d: _] };
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+  |     let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
+  |            ^^^^^^^^^^^^^ cannot infer type
 
 error[E0283]: type annotations needed
  --> ui/msg_send_underspecified_error.rs
   |
-  |     let _: Result<(), _> = unsafe { msg_send![obj, a: _] };
-  |                                     ^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
+  |     let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
+  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
   |
   = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
           - impl RefEncode for *mut c_void;
@@ -24,66 +24,3 @@ note: required by a bound in `send_message_error`
   |         *mut *mut E: Encode,
   |                      ^^^^^^ required by this bound in `MsgSend::send_message_error`
   = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0283]: type annotations needed
- --> ui/msg_send_underspecified_error.rs
-  |
-  |     let _: Result<_, _> = unsafe { msg_send_id![obj, b: _] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_id_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
-  |
-  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
-  |               --------------------- required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0283]: type annotations needed
- --> ui/msg_send_underspecified_error.rs
-  |
-  |     let _: Result<Id<NSString>, _> = unsafe { msg_send_id![obj, c: _] };
-  |                                               ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_id_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
-  |
-  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
-  |               --------------------- required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0283]: type annotations needed
- --> ui/msg_send_underspecified_error.rs
-  |
-  |     let _: Result<Id<NSString>, Id<_>> = unsafe { msg_send_id![obj, d: _] };
-  |                                                   ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for raw pointer `*mut _`
-  |
-  = note: multiple `impl`s satisfying `*mut _: RefEncode` found in the `objc2` crate:
-          - impl RefEncode for *mut c_void;
-          - impl<T> RefEncode for *mut T
-            where T: RefEncode, T: ?Sized;
-  = note: required for `*mut *mut _` to implement `Encode`
-note: required by a bound in `send_message_id_error`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send_id.rs
-  |
-  |     unsafe fn send_message_id_error<A, E, R>(obj: T, sel: Sel, args: A) -> Result<R, Id<E>>
-  |               --------------------- required by a bound in this associated function
-  |     where
-  |         *mut *mut E: Encode,
-  |                      ^^^^^^ required by this bound in `MsgSendId::send_message_id_error`
-  = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `msg_send_id` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/msg_send_underspecified_error2.stderr
+++ b/crates/test-ui/ui/msg_send_underspecified_error2.stderr
@@ -1,5 +1,0 @@
-error[E0282]: type annotations needed
- --> ui/msg_send_underspecified_error2.rs
-  |
-  |     let _: Result<Id<_>, Id<NSError>> = unsafe { msg_send_id![obj, a: _] };
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type

--- a/crates/test-ui/ui/not_encode.rs
+++ b/crates/test-ui/ui/not_encode.rs
@@ -15,7 +15,6 @@ fn main() {
     is_encode::<&()>();
     is_encode::<*const ()>();
     is_encode::<c_void>();
-    is_encode::<&c_void>();
     is_encode::<&Block<((), i32), ()>>();
 
     is_encode::<fn() -> &'static ()>();

--- a/crates/test-ui/ui/not_encode.stderr
+++ b/crates/test-ui/ui/not_encode.stderr
@@ -95,24 +95,15 @@ error[E0277]: the trait bound `c_void: Encode` is not satisfied
   |                 ^^^^^^ the trait `Encode` is not implemented for `c_void`
   |
   = help: the following other types implement trait `Encode`:
-            *const c_void
-            *mut c_void
-note: required by a bound in `is_encode`
- --> ui/not_encode.rs
-  |
-  | fn is_encode<T: Encode>() {}
-  |                 ^^^^^^ required by this bound in `is_encode`
-
-error[E0277]: the trait bound `c_void: RefEncode` is not satisfied
- --> ui/not_encode.rs
-  |
-  |     is_encode::<&c_void>();
-  |                 ^^^^^^^ the trait `RefEncode` is not implemented for `c_void`
-  |
-  = help: the following other types implement trait `RefEncode`:
-            *const c_void
-            *mut c_void
-  = note: required for `&c_void` to implement `Encode`
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
+          and $N others
 note: required by a bound in `is_encode`
  --> ui/not_encode.rs
   |
@@ -225,8 +216,8 @@ note: required by a bound in `is_encode`
   |                 ^^^^^^ required by this bound in `is_encode`
 help: consider removing the leading `&`-reference
   |
-25 -     is_encode::<&Sel>();
-25 +     is_encode::<Sel>();
+24 -     is_encode::<&Sel>();
+24 +     is_encode::<Sel>();
    |
 
 error[E0277]: the trait bound `UnsafeCell<&u8>: OptionEncode` is not satisfied
@@ -236,7 +227,6 @@ error[E0277]: the trait bound `UnsafeCell<&u8>: OptionEncode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `UnsafeCell<&u8>`
   |
   = help: the following other types implement trait `OptionEncode`:
-            NonNull<c_void>
             NonNull<T>
             objc2::runtime::Sel
             NonZeroU8
@@ -244,6 +234,7 @@ error[E0277]: the trait bound `UnsafeCell<&u8>: OptionEncode` is not satisfied
             NonZeroU32
             NonZeroU64
             NonZeroUsize
+            NonZeroI8
           and $N others
   = note: required for `Option<UnsafeCell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -259,7 +250,6 @@ error[E0277]: the trait bound `Cell<&u8>: OptionEncode` is not satisfied
   |                 ^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `Cell<&u8>`
   |
   = help: the following other types implement trait `OptionEncode`:
-            NonNull<c_void>
             NonNull<T>
             objc2::runtime::Sel
             NonZeroU8
@@ -267,6 +257,7 @@ error[E0277]: the trait bound `Cell<&u8>: OptionEncode` is not satisfied
             NonZeroU32
             NonZeroU64
             NonZeroUsize
+            NonZeroI8
           and $N others
   = note: required for `Option<Cell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`


### PR DESCRIPTION
This was in theory useful back when references to `c_void` were of higher likelihood, but nowadays I doubt it'll ever be an issue.

Fixes https://github.com/madsmtm/objc2/issues/511.