### PR TITLE
Work towards removing `malloc_buf`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ env:
   #
   # Note: The `exception` feature is not enabled here, since it requires
   # compiling C code, even if just running a `check`/`clippy` build.
-  INTERESTING_FEATURES: malloc,block,verify,unstable-private
+  INTERESTING_FEATURES: malloc,block,unstable-private
   UNSTABLE_FEATURES: unstable-autoreleasesafe,unstable-c-unwind
   LATEST_MACOS_FEATURE: unstable-frameworks-macos-14
   # Required when we want to use a different runtime than the default `apple`

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `free` method (same as `libc::free`).
+
 
 ## 0.3.2 - 2023-12-03
 

--- a/crates/objc-sys/src/class.rs
+++ b/crates/objc-sys/src/class.rs
@@ -53,6 +53,7 @@ extern_c! {
     pub fn objc_lookUpClass(name: *const c_char) -> *const objc_class;
     #[cfg(any(doc, not(objfw)))]
     pub fn objc_getMetaClass(name: *const c_char) -> *const objc_class;
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyClassList(out_len: *mut c_uint) -> *mut *const objc_class;
     pub fn objc_getClassList(buffer: *mut *const objc_class, buffer_len: c_int) -> c_int;
 
@@ -98,21 +99,25 @@ extern_c! {
         -> BOOL;
 
     #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    /// The return value is deallocated with [`free`][crate::free].
     pub fn class_copyIvarList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_ivar;
     #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyMethodList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_method;
     #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyPropertyList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_property;
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyProtocolList(
         cls: *const objc_class,
         out_len: *mut c_uint,

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -142,9 +142,9 @@ macro_rules! extern_c_unwind {
 
 mod class;
 mod constants;
-
 mod exception;
 mod image_info;
+mod libc;
 mod message;
 mod method;
 mod object;
@@ -155,19 +155,20 @@ mod selector;
 mod types;
 mod various;
 
-pub use class::*;
-pub use constants::*;
-pub use exception::*;
-pub use image_info::*;
-pub use message::*;
-pub use method::*;
-pub use object::*;
-pub use property::*;
-pub use protocol::*;
-pub use rc::*;
-pub use selector::*;
-pub use types::*;
-pub use various::*;
+pub use self::class::*;
+pub use self::constants::*;
+pub use self::exception::*;
+pub use self::image_info::*;
+pub use self::libc::*;
+pub use self::message::*;
+pub use self::method::*;
+pub use self::object::*;
+pub use self::property::*;
+pub use self::protocol::*;
+pub use self::rc::*;
+pub use self::selector::*;
+pub use self::types::*;
+pub use self::various::*;
 
 /// We don't know much about the actual structs, so better mark them `!Send`,
 /// `!Sync`, `!UnwindSafe`, `!RefUnwindSafe`, `!Unpin` and as mutable behind

--- a/crates/objc-sys/src/libc.rs
+++ b/crates/objc-sys/src/libc.rs
@@ -1,0 +1,19 @@
+use core::ffi::c_void;
+
+// SAFETY: The signatures in here are the exact same as in `libc`.
+extern_c! {
+    /// The Objective-C runtime has several methods, usually with "`copy`" in
+    /// their name, whose return value is allocated with C's `malloc` and
+    /// deallocated with C's `free` method.
+    ///
+    /// As such, `free` is actually also part of the Objective-C runtime.
+    ///
+    /// We expose this instead of using [`libc::free`], to avoid having `libc`
+    /// as a dependency.
+    ///
+    /// [`libc::free`]: https://docs.rs/libc/latest/libc/fn.free.html
+    //
+    // Note: This is linked automatically by either `std` or transitively by
+    // `libobjc`.
+    pub fn free(p: *mut c_void);
+}

--- a/crates/objc-sys/src/method.rs
+++ b/crates/objc-sys/src/method.rs
@@ -25,8 +25,10 @@ pub struct objc_method_description {
 
 extern_c! {
     #[cfg(any(doc, not(objfw)))]
+    /// The return value is deallocated with [`free`][crate::free].
     pub fn method_copyArgumentType(method: *const objc_method, index: c_uint) -> *mut c_char;
     #[cfg(any(doc, not(objfw)))]
+    /// The return value is deallocated with [`free`][crate::free].
     pub fn method_copyReturnType(method: *const objc_method) -> *mut c_char;
     #[cfg(any(doc, not(objfw)))]
     pub fn method_exchangeImplementations(method1: *mut objc_method, method2: *mut objc_method);

--- a/crates/objc-sys/src/property.rs
+++ b/crates/objc-sys/src/property.rs
@@ -25,6 +25,7 @@ pub struct objc_property_attribute_t {
 
 extern_c! {
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn property_copyAttributeList(
         property: *const objc_property,
         out_len: *mut c_uint,

--- a/crates/objc-sys/src/protocol.rs
+++ b/crates/objc-sys/src/protocol.rs
@@ -23,6 +23,7 @@ extern_c! {
     #[cfg(any(doc, not(objfw)))]
     pub fn objc_getProtocol(name: *const c_char) -> *const objc_protocol;
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyProtocolList(out_len: *mut c_uint) -> *mut *const objc_protocol;
 
     #[cfg(any(doc, not(objfw)))]
@@ -57,6 +58,7 @@ extern_c! {
     #[cfg(any(doc, not(objfw)))]
     pub fn protocol_addProtocol(proto: *mut objc_protocol, addition: *const objc_protocol);
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyMethodDescriptionList(
         proto: *const objc_protocol,
         is_required_method: BOOL,
@@ -64,11 +66,13 @@ extern_c! {
         out_len: *mut c_uint,
     ) -> *mut objc_method_description;
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyPropertyList(
         proto: *const objc_protocol,
         out_len: *mut c_uint,
     ) -> *mut *const objc_property;
     #[cfg(any(doc, not(objfw)))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyProtocolList(
         proto: *const objc_protocol,
         out_len: *mut c_uint,

--- a/crates/objc-sys/src/various.rs
+++ b/crates/objc-sys/src/various.rs
@@ -64,6 +64,7 @@ extern_c! {
         out_len: *mut c_uint,
     ) -> *mut *const c_char;
     #[cfg(any(doc, apple))]
+    /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyImageNames(out_len: *mut c_uint) -> *mut *const c_char;
 
     #[cfg(any(doc, apple, objfw))]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Made the following runtime methods available without the `"malloc"` feature
+  flag:
+  - `Method::return_type`.
+  - `Method::argument_type`.
+  - `AnyClass::classes`.
+  - `AnyClass::instance_methods`.
+  - `AnyClass::adopted_protocols`.
+  - `AnyClass::instance_variables`.
+  - `AnyProtocol::protocols`.
+  - `AnyProtocol::adopted_protocols`.
+
 ### Changed
 * Moved `ClassBuilder` and `ProtocolBuilder` from the `declare` module to the
   `runtime` module. The old locations are deprecated.

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Moved `ClassBuilder` and `ProtocolBuilder` from the `declare` module to the
   `runtime` module. The old locations are deprecated.
+* Enabled the `"verify"` feature flag's functionality when debug assertions are
+  enabled.
 
 
 ## 0.5.0 - 2023-12-03

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -33,7 +33,7 @@ exception = ["objc-sys/unstable-exception"]
 catch-all = ["exception"]
 
 # Enable all verification steps when debug assertions are enabled.
-verify = ["malloc"]
+verify = []
 
 # Allow `*const c_void` and `*mut c_void` to be used as arguments and return
 # types where other pointers were expected.
@@ -45,10 +45,8 @@ relax-void-encoding = []
 # Enable deprecation of using `msg_send!` without a comma between arguments.
 unstable-msg-send-always-comma = []
 
-# Expose features that require linking to `libc::free`.
-#
-# This is not enabled by default because most users won't need it, and it
-# increases compilation time.
+# This was necessary to access certain functionality in the past, but it is no
+# longer required.
 malloc = ["malloc_buf"]
 
 # Make the `sel!` macro look up the selector statically.
@@ -116,7 +114,7 @@ harness = false
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
-features = ["exception", "malloc", "unstable-docsrs"]
+features = ["exception", "unstable-docsrs"]
 
 targets = [
     # MacOS

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -32,9 +32,6 @@ exception = ["objc-sys/unstable-exception"]
 # Wrap every `objc2::msg_send` call in a `@try/@catch` block
 catch-all = ["exception"]
 
-# Enable all verification steps when debug assertions are enabled.
-verify = []
-
 # Allow `*const c_void` and `*mut c_void` to be used as arguments and return
 # types where other pointers were expected.
 #
@@ -48,6 +45,10 @@ unstable-msg-send-always-comma = []
 # This was necessary to access certain functionality in the past, but it is no
 # longer required.
 malloc = ["malloc_buf"]
+
+# This was necessary to enable certain debug assertions in the past, but it is
+# no longer required.
+verify = []
 
 # Make the `sel!` macro look up the selector statically.
 #

--- a/crates/objc2/examples/introspection.rs
+++ b/crates/objc2/examples/introspection.rs
@@ -37,12 +37,9 @@ fn main() {
         "-[NSObject hash] takes {} parameters",
         method.arguments_count()
     );
-    #[cfg(feature = "malloc")]
-    {
-        let hash_return = method.return_type();
-        println!("-[NSObject hash] return type: {hash_return:?}");
-        assert!(usize::ENCODING.equivalent_to_str(&hash_return));
-    }
+    let hash_return = method.return_type();
+    println!("-[NSObject hash] return type: {hash_return:?}");
+    assert!(usize::ENCODING.equivalent_to_str(&hash_return));
 
     // Create an instance
     let obj = NSObject::new();

--- a/crates/objc2/src/__macro_helpers/declare_class.rs
+++ b/crates/objc2/src/__macro_helpers/declare_class.rs
@@ -1,7 +1,7 @@
-#[cfg(all(debug_assertions, feature = "verify"))]
+#[cfg(debug_assertions)]
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-#[cfg(all(debug_assertions, feature = "verify"))]
+#[cfg(debug_assertions)]
 use std::collections::HashSet;
 
 use crate::encode::{Encode, Encoding};
@@ -9,7 +9,7 @@ use crate::rc::{Allocated, Id};
 use crate::runtime::{
     AnyClass, AnyObject, ClassBuilder, MessageReceiver, MethodImplementation, Sel,
 };
-#[cfg(all(debug_assertions, feature = "verify"))]
+#[cfg(debug_assertions)]
 use crate::runtime::{AnyProtocol, MethodDescription};
 use crate::{ClassType, DeclaredClass, Message, ProtocolType};
 
@@ -243,7 +243,7 @@ impl<T: DeclaredClass> ClassBuilderHelper<T> {
             self.builder.add_protocol(protocol);
         }
 
-        #[cfg(all(debug_assertions, feature = "verify"))]
+        #[cfg(debug_assertions)]
         {
             ClassProtocolMethodsBuilder {
                 builder: self,
@@ -265,7 +265,7 @@ impl<T: DeclaredClass> ClassBuilderHelper<T> {
             }
         }
 
-        #[cfg(not(all(debug_assertions, feature = "verify")))]
+        #[cfg(not(debug_assertions))]
         {
             ClassProtocolMethodsBuilder { builder: self }
         }
@@ -303,19 +303,19 @@ impl<T: DeclaredClass> ClassBuilderHelper<T> {
 #[derive(Debug)]
 pub struct ClassProtocolMethodsBuilder<'a, T: ?Sized> {
     builder: &'a mut ClassBuilderHelper<T>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     protocol: Option<&'static AnyProtocol>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     required_instance_methods: Vec<MethodDescription>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     optional_instance_methods: Vec<MethodDescription>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     registered_instance_methods: HashSet<Sel>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     required_class_methods: Vec<MethodDescription>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     optional_class_methods: Vec<MethodDescription>,
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     registered_class_methods: HashSet<Sel>,
 }
 
@@ -326,7 +326,7 @@ impl<T: DeclaredClass> ClassProtocolMethodsBuilder<'_, T> {
     where
         F: MethodImplementation<Callee = T>,
     {
-        #[cfg(all(debug_assertions, feature = "verify"))]
+        #[cfg(debug_assertions)]
         if let Some(protocol) = self.protocol {
             let _types = self
                 .required_instance_methods
@@ -344,7 +344,7 @@ impl<T: DeclaredClass> ClassProtocolMethodsBuilder<'_, T> {
         // SAFETY: Checked by caller
         unsafe { self.builder.add_method(sel, func) };
 
-        #[cfg(all(debug_assertions, feature = "verify"))]
+        #[cfg(debug_assertions)]
         if !self.registered_instance_methods.insert(sel) {
             unreachable!("already added")
         }
@@ -355,7 +355,7 @@ impl<T: DeclaredClass> ClassProtocolMethodsBuilder<'_, T> {
     where
         F: MethodImplementation<Callee = AnyClass>,
     {
-        #[cfg(all(debug_assertions, feature = "verify"))]
+        #[cfg(debug_assertions)]
         if let Some(protocol) = self.protocol {
             let _types = self
                 .required_class_methods
@@ -373,13 +373,13 @@ impl<T: DeclaredClass> ClassProtocolMethodsBuilder<'_, T> {
         // SAFETY: Checked by caller
         unsafe { self.builder.add_class_method(sel, func) };
 
-        #[cfg(all(debug_assertions, feature = "verify"))]
+        #[cfg(debug_assertions)]
         if !self.registered_class_methods.insert(sel) {
             unreachable!("already added")
         }
     }
 
-    #[cfg(all(debug_assertions, feature = "verify"))]
+    #[cfg(debug_assertions)]
     pub fn finish(self) {
         let superclass = self.builder.builder.superclass();
 
@@ -427,6 +427,6 @@ impl<T: DeclaredClass> ClassProtocolMethodsBuilder<'_, T> {
     }
 
     #[inline]
-    #[cfg(not(all(debug_assertions, feature = "verify")))]
+    #[cfg(not(debug_assertions))]
     pub fn finish(self) {}
 }

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -119,8 +119,7 @@
 //! # panic!("does not panic in release mode, so for testing we make it!");
 //! ```
 //!
-//! This library contains further such debug checks, most of which are enabled
-//! by default. To enable all of them, use the `"verify"` cargo feature.
+//! This library contains further such debug checks.
 //!
 //! [`Vec`]: std::vec::Vec
 //!

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -156,10 +156,10 @@
 /// - A class with the specified name already exists.
 /// - Debug assertions are enabled, and an overriden method's signature is not
 ///   equal to the one on the superclass.
-/// - The `verify` feature and debug assertions are enabled, and the required
-///   protocol methods are not implemented.
+/// - Debug assertions are enabled, and the protocol's required methods are not
+///   implemented.
 ///
-/// And possibly more similar cases.
+/// And possibly more similar cases in the future.
 ///
 ///
 /// # Safety
@@ -279,8 +279,7 @@
 ///         }
 ///
 ///         // If we have tried to add other methods here, or had forgotten
-///         // to implement the method, we would have gotten an error with the
-///         // `verify` feature enabled.
+///         // to implement the method, we would have gotten an error.
 ///     }
 /// );
 ///

--- a/crates/objc2/src/runtime/declare.rs
+++ b/crates/objc2/src/runtime/declare.rs
@@ -781,7 +781,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "malloc")]
     fn test_in_all_classes() {
         fn is_present(cls: *const AnyClass) -> bool {
             // Check whether the class is present in AnyClass::classes()

--- a/crates/objc2/src/runtime/malloc.rs
+++ b/crates/objc2/src/runtime/malloc.rs
@@ -1,0 +1,146 @@
+//! A minimal alternative to crates like `malloc_buf`, `mbox` and `malloced`.
+use core::ffi::CStr;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::ptr::{self, NonNull};
+use core::str;
+use core::str::Utf8Error;
+use std::os::raw::c_char;
+
+use crate::ffi;
+
+#[repr(transparent)]
+pub(crate) struct MallocSlice<T> {
+    ptr: NonNull<[T]>,
+    // Necessary for dropck
+    _p: PhantomData<[T]>,
+}
+
+impl<T> MallocSlice<T> {
+    // Currently has to have the same API as `malloc_buf::Malloc`
+    pub(crate) unsafe fn from_array(mut ptr: *mut T, len: usize) -> Self {
+        // If the length is 0, the pointer is usually NULL, and as such we
+        // need to conjure some other pointer (slices are always non-null).
+        if len == 0 {
+            ptr = NonNull::dangling().as_ptr();
+        }
+
+        let ptr = ptr::slice_from_raw_parts_mut(ptr, len);
+        let ptr = NonNull::new(ptr).expect("tried to construct MallocSlice from a NULL pointer");
+        Self {
+            ptr,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T> Drop for MallocSlice<T> {
+    fn drop(&mut self) {
+        // If the length is 0, then the pointer is dangling from `from_array`
+        // (since the length is immutable), and we can skip calling `free`.
+        if self.ptr.len() != 0 {
+            // SAFETY: We take ownership over the slice elements in
+            // `from_array`.
+            unsafe { ptr::drop_in_place(self.ptr.as_ptr()) };
+            // SAFETY: We take ownership over the pointer in `from_array`,
+            // and the pointer is valid if the length is non-zero.
+            unsafe { ffi::free(self.ptr.cast().as_ptr()) };
+        }
+    }
+}
+
+impl<T> Deref for MallocSlice<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        // SAFETY:
+        // - That the pointer is aligned, dereferenceable and initialized is
+        //   ensured by the caller of `from_array` (which usually get it from
+        //   some external API that will do this for you).
+        // - The lifetime is bound to the `MallocSlice`, which in turn ensures
+        //   the pointer is valid until it is dropped.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for MallocSlice<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> AsRef<[T]> for MallocSlice<T> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self
+    }
+}
+
+// TODO: Change this to `MallocCStr` once we get rid of `malloc_buf` support.
+#[repr(transparent)]
+pub(crate) struct MallocStr {
+    ptr: NonNull<str>,
+}
+
+impl MallocStr {
+    // Currently has to have the same API as `malloc_buf::Malloc`
+    pub(crate) unsafe fn from_c_str(ptr: *mut c_char) -> Result<Self, Utf8Error> {
+        if ptr.is_null() {
+            panic!("tried to construct MallocStr from a NULL pointer");
+        }
+        // SAFETY: We just checked that the pointer is not NULL.
+        //
+        // Further validity of the pointer is ensured by the caller.
+        let cstr = unsafe { CStr::from_ptr(ptr) };
+        // Note that we construct this `NonNull` from an immutable reference
+        // (there is not yet a `CStr::from_mut_ptr`).
+        //
+        // This means that we're (probably) no longer allowed to mutate the
+        // value, if that is desired for `MallocStr` in the future, then we'll
+        // have to implement this method a bit differently.
+        let ptr = NonNull::from(cstr.to_str()?);
+        Ok(Self { ptr })
+    }
+}
+
+impl Drop for MallocStr {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: We take ownership in `from_c_str`.
+        unsafe { ffi::free(self.ptr.cast().as_ptr()) };
+    }
+}
+
+impl Deref for MallocStr {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        // SAFETY: Same as `MallocSlice::deref`
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl fmt::Debug for MallocStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl fmt::Display for MallocStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl AsRef<str> for MallocStr {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self
+    }
+}

--- a/crates/test-ui/ui/msg_send_invalid_error.stderr
+++ b/crates/test-ui/ui/msg_send_invalid_error.stderr
@@ -47,7 +47,7 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
             AnyObject
             NSArray<ObjectType>
             NSMutableArray<ObjectType>
-            __RcTestObject
+            NSDictionary<KeyType, ObjectType>
           and $N others
 note: required by a bound in `send_message_error`
  --> $WORKSPACE/crates/objc2/src/__macro_helpers/msg_send.rs

--- a/crates/test-ui/ui/nsarray_not_message.stderr
+++ b/crates/test-ui/ui/nsarray_not_message.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
             AnyObject
             NSArray<ObjectType>
             NSMutableArray<ObjectType>
-            __RcTestObject
+            NSDictionary<KeyType, ObjectType>
           and $N others
 note: required by a bound in `Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
  --> $WORKSPACE/crates/icrate/src/generated/Foundation/NSArray.rs
@@ -42,8 +42,8 @@ error[E0277]: the trait bound `Id<NSObject>: ClassType` is not satisfied
             __NSProxy
             NSArray<ObjectType>
             NSMutableArray<ObjectType>
-            __RcTestObject
             NSDictionary<KeyType, ObjectType>
+            __RcTestObject
             NSMutableDictionary<KeyType, ObjectType>
             NSSet<ObjectType>
           and $N others

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -14,7 +14,6 @@ default = ["apple", "std", "Foundation_all"]
 std = ["block2/std", "objc2/std", "icrate/std"]
 exception = ["objc2/exception", "Foundation_all"]
 catch-all = ["objc2/catch-all", "exception"]
-verify = ["objc2/verify"]
 # TODO: Fix this
 Foundation_all = [
     "icrate/Foundation",

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -38,8 +38,6 @@ gnustep-1-9 = ["gnustep-1-8", "block2/gnustep-1-9", "objc2/gnustep-1-9", "icrate
 gnustep-2-0 = ["gnustep-1-9", "block2/gnustep-2-0", "objc2/gnustep-2-0", "icrate/gnustep-2-0"]
 gnustep-2-1 = ["gnustep-2-0", "block2/gnustep-2-1", "objc2/gnustep-2-1", "icrate/gnustep-2-1"]
 
-malloc = ["objc2/malloc"]
-
 [dependencies]
 block2 = { path = "../block2", default-features = false }
 block-sys = { path = "../block-sys", default-features = false }

--- a/crates/tests/src/test_declare_class_protocol.rs
+++ b/crates/tests/src/test_declare_class_protocol.rs
@@ -91,7 +91,7 @@ fn test_declare_class_invalid_method() {
 
 #[test]
 #[cfg_attr(
-    all(debug_assertions, feature = "verify"),
+    debug_assertions,
     should_panic = "must implement required protocol method -[NSCopying copyWithZone:]"
 )]
 fn test_declare_class_missing_protocol_method() {
@@ -115,7 +115,7 @@ fn test_declare_class_missing_protocol_method() {
 }
 
 #[test]
-// #[cfg_attr(all(debug_assertions, feature = "verify"), should_panic = "...")]
+// #[cfg_attr(debug_assertions, should_panic = "...")]
 fn test_declare_class_invalid_protocol_method() {
     declare_class!(
         struct Custom;
@@ -142,7 +142,7 @@ fn test_declare_class_invalid_protocol_method() {
 
 #[test]
 #[cfg_attr(
-    all(debug_assertions, feature = "verify"),
+    debug_assertions,
     should_panic = "failed overriding protocol method -[NSCopying someOtherMethod]: method not found"
 )]
 fn test_declare_class_extra_protocol_method() {

--- a/crates/tests/src/test_object.rs
+++ b/crates/tests/src/test_object.rs
@@ -9,7 +9,6 @@ use objc2::rc::{autoreleasepool, AutoreleasePool, Id};
 use objc2::runtime::{
     AnyClass, AnyObject, AnyProtocol, Bool, NSObject, NSObjectProtocol, ProtocolObject,
 };
-#[cfg(feature = "malloc")]
 use objc2::sel;
 use objc2::{
     class, extern_protocol, msg_send, msg_send_id, mutability, ClassType, Message, ProtocolType,
@@ -184,7 +183,6 @@ impl MyTestObject {
     }
 }
 
-#[cfg(feature = "malloc")]
 macro_rules! assert_in {
     ($item:expr, $lst:expr) => {{
         let mut found = false;
@@ -201,7 +199,6 @@ macro_rules! assert_in {
         );
     }};
 }
-#[cfg(feature = "malloc")]
 macro_rules! assert_not_in {
     ($item:expr, $lst:expr) => {{
         let mut found = false;
@@ -224,12 +221,9 @@ fn test_class() {
     let cls = MyTestObject::class();
     assert_eq!(MyTestObject::add_numbers(-3, 15), 12);
 
-    #[cfg(feature = "malloc")]
-    {
-        let classes = AnyClass::classes();
-        assert_eq!(classes.len(), AnyClass::classes_count());
-        assert_in!(cls, classes);
-    }
+    let classes = AnyClass::classes();
+    assert_eq!(classes.len(), AnyClass::classes_count());
+    assert_in!(cls, classes);
 
     // Test objc2::runtime functionality
     assert_eq!(AnyClass::get("MyTestObject"), Some(cls));
@@ -252,23 +246,17 @@ fn test_class() {
     let protocol = AnyProtocol::get("NSObject").unwrap();
     assert!(cls.conforms_to(protocol));
     assert!(!cls.conforms_to(AnyProtocol::get("NSCopying").unwrap()));
-    #[cfg(feature = "malloc")]
-    {
-        assert_not_in!(protocol, cls.adopted_protocols());
-        assert_in!(
-            AnyProtocol::get("MyTestProtocol").unwrap(),
-            cls.adopted_protocols()
-        );
-    }
+    assert_not_in!(protocol, cls.adopted_protocols());
+    assert_in!(
+        AnyProtocol::get("MyTestProtocol").unwrap(),
+        cls.adopted_protocols()
+    );
 
-    #[cfg(feature = "malloc")]
-    {
-        let method = cls.instance_method(sel!(addToVar1:)).unwrap();
-        assert_in!(method, cls.instance_methods());
+    let method = cls.instance_method(sel!(addToVar1:)).unwrap();
+    assert_in!(method, cls.instance_methods());
 
-        let ivar = cls.instance_variable("var1").unwrap();
-        assert_in!(ivar, cls.instance_variables());
-    }
+    let ivar = cls.instance_variable("var1").unwrap();
+    assert_in!(ivar, cls.instance_variables());
 }
 
 #[test]

--- a/helper-scripts/test-local.sh
+++ b/helper-scripts/test-local.sh
@@ -3,7 +3,7 @@
 
 export MACOSX_DEPLOYMENT_TARGET=10.12
 export IPHONEOS_DEPLOYMENT_TARGET=10.0
-export FEATURES=std,block,exception,catch-all,verify,unstable-static-class,unstable-static-sel
+export FEATURES=std,block,exception,catch-all,unstable-static-class,unstable-static-sel
 
 # Start the simulator
 open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app

--- a/helper-scripts/test-local.sh
+++ b/helper-scripts/test-local.sh
@@ -3,7 +3,7 @@
 
 export MACOSX_DEPLOYMENT_TARGET=10.12
 export IPHONEOS_DEPLOYMENT_TARGET=10.0
-export FEATURES=std,malloc,block,exception,catch-all,verify,unstable-static-class,unstable-static-sel
+export FEATURES=std,block,exception,catch-all,verify,unstable-static-class,unstable-static-sel
 
 # Start the simulator
 open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app


### PR DESCRIPTION
`malloc_buf` is [unmaintained and unsound](https://github.com/rustsec/advisory-db/issues/1635), and may be marked as such in the Rustsec Advisory Database in the future, which would be bad for our users; so we should really migrate to something else.

The alternatives [`mbox`](https://github.com/kennytm/mbox), [`malloced`](https://github.com/nvzqz/malloced) and [`malloc-array`](https://github.com/notflan/rs-malloc-array) are either also unsound (usually failing to handle `0`-length arrays properly), or not popular/maintained enough for me to be comfortable with them as a dependency.

So let's just roll our own implementation, it's not really _that_ complex anyhow (since we don't handle allocation, only deallocation), and we should be able to swap it out with `Box<_, MallocAllocator>` in the future.

Part of https://github.com/madsmtm/objc2/issues/500.