### PR TITLE
Ignore signed-ness in encoding

### DIFF
--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Added `Id::autorelease_ptr`.
+* Added the feature flag `"relax-sign-encoding"`, which when enabled, allows
+  using e.g. `NSInteger` in places where you would otherwise have to use
+  `NSUInteger`.
 
 ### Deprecated
 * Deprecated the `apple` Cargo feature flag, it is assumed by default on Apple

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -42,6 +42,13 @@ catch-all = ["exception"]
 # to objc2.
 relax-void-encoding = []
 
+# Make signed and unsigned types interchangable when used as arguments/return
+# types in methods.
+#
+# This may be useful for dealing with Swift code that incorrectly uses `Int`
+# instead of `UInt`.
+relax-sign-encoding = []
+
 # Enable deprecation of using `msg_send!` without a comma between arguments.
 unstable-msg-send-always-comma = []
 

--- a/crates/objc2/src/runtime/declare.rs
+++ b/crates/objc2/src/runtime/declare.rs
@@ -680,13 +680,13 @@ mod tests {
     #[test]
     #[cfg_attr(
         debug_assertions,
-        should_panic = "declared invalid method -[TestClassBuilderInvalidMethod foo]: expected return to have type code 'I', but found 'i'"
+        should_panic = "declared invalid method -[TestClassBuilderInvalidMethod foo]: expected return to have type code 'I', but found 's'"
     )]
     fn invalid_method() {
         let cls = test_utils::custom_class();
         let mut builder = ClassBuilder::new("TestClassBuilderInvalidMethod", cls).unwrap();
 
-        extern "C" fn foo(_this: &NSObject, _cmd: Sel) -> i32 {
+        extern "C" fn foo(_this: &NSObject, _cmd: Sel) -> i16 {
             0
         }
 
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(
-        debug_assertions,
+        all(debug_assertions, not(feature = "relax-sign-encoding")),
         should_panic = "declared invalid method +[TestClassBuilderInvalidClassMethod classFoo]: expected return to have type code 'I', but found 'i'"
     )]
     fn invalid_class_method() {

--- a/crates/objc2/src/test_utils.rs
+++ b/crates/objc2/src/test_utils.rs
@@ -119,6 +119,10 @@ pub(crate) fn custom_class() -> &'static AnyClass {
             7
         }
 
+        extern "C" fn get_nsinteger(_this: &AnyObject, _cmd: Sel) -> ffi::NSInteger {
+            5
+        }
+
         extern "C" fn custom_obj_set_bar(this: &mut AnyObject, _cmd: Sel, bar: u32) {
             let ivar = this.class().instance_variable("_bar").unwrap();
             unsafe { *ivar.load_mut::<u32>(this) = bar }
@@ -182,6 +186,9 @@ pub(crate) fn custom_class() -> &'static AnyClass {
             builder.add_method(sel!(customStruct), get_struct);
             let class_method: extern "C" fn(_, _) -> _ = custom_obj_class_method;
             builder.add_class_method(sel!(classFoo), class_method);
+
+            let get_nsinteger: extern "C" fn(_, _) -> _ = get_nsinteger;
+            builder.add_method(sel!(getNSInteger), get_nsinteger);
 
             let protocol_instance_method: extern "C" fn(_, _, _) = custom_obj_set_bar;
             builder.add_method(sel!(setBar:), protocol_instance_method);


### PR DESCRIPTION
Fixes https://github.com/madsmtm/objc2/issues/566.

Unsure if this is the correct path forwards.

Do signed-ness ever matter ABI-wise? The Rust docs [says](https://doc.rust-lang.org/nightly/std/primitive.fn.html) on ABI of `i32` vs `u32`:

> on some targets, the calling conventions for these types differ in terms of what they guarantee for the remaining bits in the register that are not used by the value.

But is that relevant for any platforms we target? And does it matter for types like `usize`/`isize`, which won't _have_ remaining bits left in any registers?