### PR TITLE
Generate external categories

### DIFF
--- a/crates/header-translator/src/availability.rs
+++ b/crates/header-translator/src/availability.rs
@@ -139,11 +139,10 @@ impl Availability {
             _swift,
         }
     }
-}
 
-impl fmt::Display for Availability {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.deprecated {
+    pub fn is_deprecated(&self) -> bool {
+        !matches!(
+            self.deprecated,
             Versions {
                 ios: None,
                 ios_app_extension: None,
@@ -153,7 +152,15 @@ impl fmt::Display for Availability {
                 watchos: None,
                 tvos: None,
                 visionos: None,
-            } => {
+            }
+        )
+    }
+}
+
+impl fmt::Display for Availability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.deprecated {
+            _ if !self.is_deprecated() => {
                 // Not deprecated
             }
             Versions { .. } => {

--- a/crates/header-translator/src/cache.rs
+++ b/crates/header-translator/src/cache.rs
@@ -78,7 +78,10 @@ impl<'a> Cache<'a> {
         let mut names = BTreeMap::<(ItemIdentifier, String), &mut Method>::new();
         for stmt in file.stmts.iter_mut() {
             match stmt {
-                Stmt::ClassMethods {
+                Stmt::ExternMethods {
+                    cls: id, methods, ..
+                }
+                | Stmt::ExternCategory {
                     cls: id, methods, ..
                 }
                 | Stmt::ProtocolDecl { id, methods, .. } => {
@@ -114,7 +117,10 @@ impl<'a> Cache<'a> {
         // Add `mainthreadonly` to relevant methods
         for stmt in file.stmts.iter_mut() {
             match stmt {
-                Stmt::ClassMethods {
+                Stmt::ExternMethods {
+                    cls: id, methods, ..
+                }
+                | Stmt::ExternCategory {
                     cls: id, methods, ..
                 }
                 | Stmt::ProtocolDecl { id, methods, .. } => {

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -1385,12 +1385,6 @@ NSCancelButton = { skipped = true }
 NSFileHandlingPanelCancelButton = { skipped = true }
 NSFileHandlingPanelOKButton = { skipped = true }
 
-# Categories for classes defined in other frameworks
-[class.CIImage]
-skipped = true
-[class.CIColor]
-skipped = true
-
 # Different definitions depending on target
 [enum.NSImageResizingMode]
 skipped = true

--- a/crates/header-translator/translation-config.toml
+++ b/crates/header-translator/translation-config.toml
@@ -603,11 +603,9 @@ skipped = true
 [class.NSBundle.methods."localizedAttributedStringForKey:value:table:"]
 skipped = true
 
-# Root classes, defined in `objc2` for now
+# Root class, defined in `objc2` for now
 [class.NSProxy]
 skipped = true
-[class.NSObject]
-skipped = true # Also ignore categories on NSObject for now
 
 [protocol.NSObject]
 renamed = "NSObjectProtocol"

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -19,10 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Marked `NSView::isFlipped`, `NSView::convertRect_toView`,
   `NSWindow::convertRectToScreen` and `NSWindow::convertPointFromScreen` as
   safe.
+* **BREAKING**: Changed how categories are handled; now, when a library has
+  defined methods on a class defined in a different framework, a helper trait
+  is output with the methods, instead of the methods being implemented
+  directly on the type.
 
 ### Deprecated
-* Deprecated `MainThreadMarker::run_on_main`, use the new free-standing function
-  `run_on_main` instead.
+* Deprecated `Foundation::MainThreadMarker::run_on_main`, use the new
+  free-standing function `Foundation::run_on_main` instead.
 
 ### Removed
 * Removed private functionality in the `Speech` framework. This was never

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## icrate Unreleased - YYYY-MM-DD
 
+### Added
+* Added `NSObject` categories, notably those used by key-value coding and
+  observing.
+
 ### Changed
 * Updated SDK from Xcode 15.0.1 to 15.2.
 

--- a/crates/icrate/src/common.rs
+++ b/crates/icrate/src/common.rs
@@ -25,8 +25,8 @@ pub(crate) use objc2::runtime::{AnyClass, AnyObject, Bool, Sel};
 pub(crate) use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
 #[cfg(feature = "objective-c")]
 pub(crate) use objc2::{
-    __inner_extern_class, extern_class, extern_methods, extern_protocol, ClassType, Message,
-    ProtocolType,
+    __inner_extern_class, extern_category, extern_class, extern_methods, extern_protocol,
+    ClassType, Message, ProtocolType,
 };
 
 #[cfg(feature = "block")]

--- a/crates/objc2/src/macros/extern_category.rs
+++ b/crates/objc2/src/macros/extern_category.rs
@@ -1,0 +1,33 @@
+/// Not yet public API.
+//
+// Note: While this is not public, it is still a breaking change to change
+// the API for this, since `icrate` relies on it.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! extern_category {
+    (
+        $(#[$m:meta])*
+        $v:vis unsafe trait $name:ident {
+            $($methods:tt)*
+        }
+
+        $(#[$impl_m:meta])*
+        unsafe impl $category:ident for $ty:ty {}
+    ) => {
+        $(#[$m])*
+        $v unsafe trait $name: ClassType {
+            // TODO: Do this better
+            $crate::__extern_protocol_rewrite_methods! {
+                $($methods)*
+            }
+
+            #[doc(hidden)]
+            const __UNSAFE_INNER: ();
+        }
+
+        $(#[$impl_m])*
+        unsafe impl $category for $ty {
+            const __UNSAFE_INNER: () = ();
+        }
+    };
+}

--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -3,6 +3,7 @@ mod __method_msg_send;
 mod __msg_send_parse;
 mod __rewrite_self_param;
 mod declare_class;
+mod extern_category;
 mod extern_class;
 mod extern_methods;
 mod extern_protocol;


### PR DESCRIPTION
Categories are a way for Objective-C code to add extra methods to a class. There are basically two ways we could handle these in `header-translator`:
1. Emit `extern_methods!` directly on the class (done currently).

    This breaks when the class is defined in a different library/framework than the category, because of Rust's coherence rules.
2. Create a trait, and implement that for the class (done in `uikit-sys`, and now by `extern_category!`).
  
    One problem here is that the category name is not part of the API in Objective-C, so we actually have no stable name to refer to. Relatedly, it's annoying to have to import category traits with confusing names all the time.

Both approaches have issues, so I've tried to strike a nice balance; we now emit `extern_methods!` when the category is defined in the same library/framework as the class, and `extern_category!` otherwise. This doesn't completely resolve the issues around categories not having a stable name, but it does somewhat alleviate them.

This allows us to fix https://github.com/madsmtm/objc2/issues/531, we now emit the missing key-value coding categories (and other such categories on `NSObject`). This should also help with splitting `icrate` up into multiple crates in the future, instead of it being a big monolithic one. Finally, this is required for `header-translator` to work on user-defined categories in the future (see https://github.com/madsmtm/objc2/issues/501).

CC @simlay as you've gone with the second approach in `bindgen`'s Objective-C support, wanted to hear your thoughts about this combined solution? I note that yours is currently better, since it implements the category trait for subclasses as well.