### PR TITLE
Use Cargo's new `[workspace.package]` fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,8 @@ jobs:
 
     - name: Use MSRV toolchain
       run: |
-        rustup toolchain install 1.60 --profile=minimal --no-self-update
-        rustup override set 1.60
+        rustup toolchain install 1.64 --profile=minimal --no-self-update
+        rustup override set 1.64
 
     - name: Install target
       run: rustup target add x86_64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ lto = true
 # Don't emit unwind info; while important to get right, the control flow is
 # very hard to glean from assembly output.
 panic = "abort"
+
+[workspace.package]
+authors = ["Mads Marquart <mads@marquart.dk>"]
+edition = "2021"
+rust-version = "1.64"
+repository = "https://github.com/madsmtm/objc2"
+license = "MIT"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ safe (which we [need your help with][header-data]).
 
 ## Minimum Supported Rust Version (MSRV)
 
-The _currently_ minimum supported Rust version is `1.60`; this is _not_
+The _currently_ minimum supported Rust version is `1.64`; this is _not_
 defined by policy, though, so it may change in at any time in a patch release.
 
 Help us define a policy over in [#203].

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,11 +1,6 @@
 [package]
 name = "block2"
-# Remember to update html_root_url in lib.rs
-version = "0.4.0"
-authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
-edition = "2021"
-rust-version = "1.64"
-
+version = "0.4.0" # Remember to update html_root_url in lib.rs
 description = "Apple's C language extension of blocks"
 keywords = ["objective-c", "macos", "ios", "blocks"]
 categories = [
@@ -14,10 +9,11 @@ categories = [
     "os::macos-apis",
     "external-ffi-bindings",
 ]
-readme = "README.md"
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/block2/"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [features]
 # The default runtime is Apple's. Other platforms will probably error if the

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -4,7 +4,7 @@ name = "block2"
 version = "0.4.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Apple's C language extension of blocks"
 keywords = ["objective-c", "macos", "ios", "blocks"]

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "header-translator"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
-
-repository = "https://github.com/madsmtm/objc2"
+repository.workspace = true
 license = "Zlib OR Apache-2.0 OR MIT"
 
 [dependencies]

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "icrate"
 version = "0.1.0" # Remember to update html_root_url in lib.rs
-authors = ["Mads Marquart <mads@marquart.dk>"]
-edition = "2021"
-rust-version = "1.64"
-
 description = "Bindings to Apple's frameworks"
 keywords = ["macos", "ios", "cocoa", "apple", "framework"]
 categories = [
@@ -14,10 +10,11 @@ categories = [
     "external-ffi-bindings",
     "os::macos-apis",
 ]
-readme = "README.md"
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/icrate/"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/icrate/Cargo.toml
+++ b/crates/icrate/Cargo.toml
@@ -3,7 +3,7 @@ name = "icrate"
 version = "0.1.0" # Remember to update html_root_url in lib.rs
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Bindings to Apple's frameworks"
 keywords = ["macos", "ios", "cocoa", "apple", "framework"]

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -8,7 +8,7 @@ name = "objc-sys"
 version = "0.3.2"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Raw bindings to the Objective-C runtime and ABI"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "sys"]

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -6,10 +6,6 @@ name = "objc-sys"
 # Also, beware of using pre-release versions here, since because of the
 # `links` key, two pre-releases requested with `=...` are incompatible.
 version = "0.3.2"
-authors = ["Mads Marquart <mads@marquart.dk>"]
-edition = "2021"
-rust-version = "1.64"
-
 description = "Raw bindings to the Objective-C runtime and ABI"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "sys"]
 categories = [
@@ -17,11 +13,11 @@ categories = [
     # "no_std" # TODO
     "os::macos-apis",
 ]
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/objc-sys/"
-license = "MIT"
-
-readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # Downstream users can customize the linking to libobjc!
 # See https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -4,7 +4,7 @@ name = "objc2-encode"
 version = "4.0.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Objective-C type-encoding representation and parsing"
 keywords = ["objective-c", "macos", "ios", "encode"]

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -2,10 +2,6 @@
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs
 version = "4.0.0"
-authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
-edition = "2021"
-rust-version = "1.64"
-
 description = "Objective-C type-encoding representation and parsing"
 keywords = ["objective-c", "macos", "ios", "encode"]
 categories = [
@@ -14,10 +10,11 @@ categories = [
     "no-std",
     "os::macos-apis",
 ]
-readme = "README.md"
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/objc2-encode/"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/objc2-proc-macros/Cargo.toml
+++ b/crates/objc2-proc-macros/Cargo.toml
@@ -2,20 +2,17 @@
 name = "objc2-proc-macros"
 # Remember to update html_root_url in lib.rs
 version = "0.1.1"
-authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
-edition = "2021"
-rust-version = "1.64"
-
 description = "Procedural macros for the objc2 project"
 keywords = ["objective-c", "macos", "ios", "proc-macro"]
 categories = [
     "development-tools",
     "os::macos-apis",
 ]
-readme = "README.md"
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/objc2-proc-macros/"
-license = "MIT"
+authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/objc2-proc-macros/Cargo.toml
+++ b/crates/objc2-proc-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "objc2-proc-macros"
 version = "0.1.1"
 authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Procedural macros for the objc2 project"
 keywords = ["objective-c", "macos", "ios", "proc-macro"]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -3,7 +3,7 @@ name = "objc2"
 version = "0.5.0" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 description = "Objective-C interface and runtime bindings"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "objc"]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "objc2"
 version = "0.5.0" # Remember to update html_root_url in lib.rs
-authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
-edition = "2021"
-rust-version = "1.64"
-
 description = "Objective-C interface and runtime bindings"
 keywords = ["objective-c", "macos", "ios", "objc_msgSend", "objc"]
 categories = [
@@ -12,10 +8,11 @@ categories = [
     "development-tools::ffi",
     "os::macos-apis",
 ]
-readme = "README.md"
-repository = "https://github.com/madsmtm/objc2"
-documentation = "https://docs.rs/objc2/"
-license = "MIT"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/test-assembly/Cargo.toml
+++ b/crates/test-assembly/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "test-assembly"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
-
-repository = "https://github.com/madsmtm/objc2"
-license = "MIT"
+repository.workspace = true
+license = "Zlib OR Apache-2.0 OR MIT"
 
 build = "build.rs"
 

--- a/crates/test-assembly/crates/test_autorelease_return/Cargo.toml
+++ b/crates/test-assembly/crates/test_autorelease_return/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_autorelease_return"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_block/Cargo.toml
+++ b/crates/test-assembly/crates/test_block/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_block"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_declare_class/Cargo.toml
+++ b/crates/test-assembly/crates/test_declare_class/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_declare_class"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_dynamic_class/Cargo.toml
+++ b/crates/test-assembly/crates/test_dynamic_class/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_dynamic_class"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_dynamic_sel/Cargo.toml
+++ b/crates/test-assembly/crates/test_dynamic_sel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_dynamic_sel"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_extern_protocol/Cargo.toml
+++ b/crates/test-assembly/crates/test_extern_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_extern_protocol"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_fast_enumeration/Cargo.toml
+++ b/crates/test-assembly/crates/test_fast_enumeration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_fast_enumeration"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_msg_send_error/Cargo.toml
+++ b/crates/test-assembly/crates/test_msg_send_error/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_msg_send_error"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_msg_send_id/Cargo.toml
+++ b/crates/test-assembly/crates/test_msg_send_id/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_msg_send_id"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_msg_send_static_sel/Cargo.toml
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_msg_send_static_sel"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_msg_send_zero_cost/Cargo.toml
+++ b/crates/test-assembly/crates/test_msg_send_zero_cost/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_msg_send_zero_cost"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_ns_string/Cargo.toml
+++ b/crates/test-assembly/crates/test_ns_string/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_ns_string"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_out_parameters/Cargo.toml
+++ b/crates/test-assembly/crates/test_out_parameters/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_out_parameters"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_retain_autoreleased/Cargo.toml
+++ b/crates/test-assembly/crates/test_retain_autoreleased/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_retain_autoreleased"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_static_class/Cargo.toml
+++ b/crates/test-assembly/crates/test_static_class/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_static_class"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-assembly/crates/test_static_sel/Cargo.toml
+++ b/crates/test-assembly/crates/test_static_sel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_static_sel"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/test-fuzz/Cargo.toml
+++ b/crates/test-fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/crates/test-ui/Cargo.toml
+++ b/crates/test-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-ui"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 repository = "https://github.com/madsmtm/objc2"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "tests"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
-
-repository = "https://github.com/madsmtm/objc2"
-license = "MIT"
+repository.workspace = true
+license.workspace = true
 
 build = "build.rs"
 


### PR DESCRIPTION
See [the docs](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table).

This bump MSRV to 1.64, which should be fine, Winit is at 1.70 and `libc` is at 1.71.

This is done as a prerequisite for [splitting `icrate` into multiple crates](https://github.com/madsmtm/objc2/issues/537).