### PR TITLE
Refactor `rust_type.rs` so that typedefs carry their inner type

### DIFF
--- a/crates/header-translator/src/display_helper.rs
+++ b/crates/header-translator/src/display_helper.rs
@@ -1,0 +1,24 @@
+use core::fmt;
+
+// <https://doc.rust-lang.org/nightly/std/fmt/struct.FormatterFn.html>
+pub struct FormatterFn<F>(pub F)
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result;
+
+impl<F> fmt::Debug for FormatterFn<F>
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self.0)(f)
+    }
+}
+
+impl<F> fmt::Display for FormatterFn<F>
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self.0)(f)
+    }
+}

--- a/crates/header-translator/src/lib.rs
+++ b/crates/header-translator/src/lib.rs
@@ -16,6 +16,7 @@ mod cache;
 mod config;
 mod context;
 mod data;
+mod display_helper;
 mod expr;
 mod feature;
 mod file;

--- a/crates/icrate/CHANGELOG.md
+++ b/crates/icrate/CHANGELOG.md
@@ -49,6 +49,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fixed a few feature gates on methods showing up unnecessarily.
 * **BREAKING**: Added `MainThreadMarker` parameter to a few methods where it
   was erroneously missing.
+* **BREAKING**: Fix the type of `GKMatchProperties` and `NSWindow`'s
+  `restorationClass`.
 
 ## icrate 0.1.0 - 2023-12-23
 


### PR DESCRIPTION
Basically had to rewrite the entire thing because I hadn't documented why the code was written like it was, which meant I couldn't remember. So this... Took a while, but I feel pretty confident it's at a better spot now.