### PR TITLE
Add SIMD support in encodings

### DIFF
--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::str::FromStr;
 
 use crate::helper::{compare_encodings, Helper, NestingLevel};
-use crate::parse::{ParseError, Parser};
+use crate::parse::{ErrorKind, ParseError, Parser};
 use crate::Encoding;
 
 /// The boxed version of [`Encoding`].
@@ -123,6 +123,12 @@ impl EncodingBox {
         parser.strip_leading_qualifiers();
 
         match parser.parse_encoding_or_none() {
+            Err(ErrorKind::Unknown(b'0'..=b'9')) => {
+                let remaining = parser.remaining();
+                *s = remaining;
+
+                Ok(EncodingBox::None)
+            }
             Err(err) => Err(ParseError::new(parser, err)),
             Ok(encoding) => {
                 let remaining = parser.remaining();

--- a/crates/objc2-encode/src/encoding_box.rs
+++ b/crates/objc2-encode/src/encoding_box.rs
@@ -88,6 +88,8 @@ pub enum EncodingBox {
     Struct(String, Vec<Self>),
     /// Same as [`Encoding::Union`].
     Union(String, Vec<Self>),
+    /// Same as [`Encoding::None`].
+    None,
 }
 
 impl EncodingBox {
@@ -120,7 +122,7 @@ impl EncodingBox {
         let mut parser = Parser::new(s);
         parser.strip_leading_qualifiers();
 
-        match parser.parse_encoding() {
+        match parser.parse_encoding_or_none() {
             Err(err) => Err(ParseError::new(parser, err)),
             Ok(encoding) => {
                 let remaining = parser.remaining();
@@ -159,7 +161,7 @@ impl FromStr for EncodingBox {
         parser.strip_leading_qualifiers();
 
         parser
-            .parse_encoding()
+            .parse_encoding_or_none()
             .and_then(|enc| parser.expect_empty().map(|()| enc))
             .map_err(|err| ParseError::new(parser, err))
     }

--- a/crates/objc2-encode/src/helper.rs
+++ b/crates/objc2-encode/src/helper.rs
@@ -107,6 +107,7 @@ pub(crate) fn compare_encodings<E1: EncodingType, E2: EncodingType>(
                 }
             }
         }
+        (NoneInvalid, NoneInvalid) => true,
         (_, _) => false,
     }
 }
@@ -242,6 +243,7 @@ pub(crate) enum Helper<'a, E = Encoding> {
     Indirection(IndirectionKind, &'a E),
     Array(u64, &'a E),
     Container(ContainerKind, &'a str, &'a [E]),
+    NoneInvalid,
 }
 
 impl<E: EncodingType> Helper<'_, E> {
@@ -279,6 +281,7 @@ impl<E: EncodingType> Helper<'_, E> {
                 }
                 write!(f, "{}", kind.end())?;
             }
+            Self::NoneInvalid => {}
         }
         Ok(())
     }
@@ -328,6 +331,7 @@ impl Helper<'_> {
                 }
                 Self::Container(ContainerKind::Union, name, members)
             }
+            None => Self::NoneInvalid,
         }
     }
 }
@@ -376,6 +380,7 @@ impl<'a> Helper<'a, EncodingBox> {
                 }
                 Self::Container(ContainerKind::Union, name, members)
             }
+            None => Self::NoneInvalid,
         }
     }
 }

--- a/crates/objc2-encode/src/static_str.rs
+++ b/crates/objc2-encode/src/static_str.rs
@@ -65,6 +65,7 @@ pub(crate) const fn static_encoding_str_len(encoding: &Encoding, level: NestingL
             }
             res + 1
         }
+        NoneInvalid => 0,
     }
 }
 
@@ -208,6 +209,7 @@ pub(crate) const fn static_encoding_str_array<const LEN: usize>(
 
             res[res_i] = kind.end_byte();
         }
+        NoneInvalid => {}
     };
     res
 }

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -31,8 +31,10 @@ fn main() {
     builder.compiler("clang");
     builder.file("extern/encode_utils.m");
     builder.file("extern/test_object.m");
+    builder.file("extern/test_simd_return.m");
     println!("cargo:rerun-if-changed=extern/encode_utils.m");
     println!("cargo:rerun-if-changed=extern/test_object.m");
+    println!("cargo:rerun-if-changed=extern/test_simd_return.m");
 
     builder.flag("-fblocks");
 

--- a/crates/tests/extern/encode_utils.m
+++ b/crates/tests/extern/encode_utils.m
@@ -2,8 +2,10 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <uuid/uuid.h>
-// For NSInteger / NSUInteger. Linking is not required.
-#include <Foundation/NSObject.h>
+#include <Foundation/NSObject.h> // For NSInteger / NSUInteger. Linking is not required.
+#ifdef TARGET_OS_MAC
+#include <simd/vector.h>
+#endif
 
 #define ENCODING_INNER(name, type) char* ENCODING_ ## name = @encode(type);
 
@@ -202,6 +204,19 @@ ENCODING(PTRDIFF_T, ptrdiff_t);
 // uuid.h
 
 ENCODING_NO_ATOMIC(UUID_T, uuid_t);
+
+// simd
+
+#ifdef TARGET_OS_MAC
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wencode-type"
+ENCODING(SIMD_INT2, simd_int2);
+ENCODING(SIMD_FLOAT1, simd_float1);
+ENCODING(SIMD_FLOAT2, simd_float2);
+ENCODING(SIMD_FLOAT2X4, simd_float2x4);
+ENCODING(SIMD_FLOAT4X2, simd_float4x2);
+# pragma clang diagnostic pop
+#endif
 
 // Possible extras
 

--- a/crates/tests/extern/test_simd_return.m
+++ b/crates/tests/extern/test_simd_return.m
@@ -1,0 +1,55 @@
+#include <Foundation/NSObject.h>
+
+#ifdef TARGET_OS_MAC
+
+#include <simd/simd.h>
+
+@interface TestSimdReturn: NSObject
+@end
+
+#define METHOD(type) + (simd_ ## type) type
+#define METHOD_POW2(type, from) + (simd_ ## type) type { return simd_make_ ## type([self from], [self from]); }
+
+@implementation TestSimdReturn
+METHOD(float1) {
+    return 42;
+}
+METHOD_POW2(float2, float1)
+METHOD(float3) {
+    return simd_make_float3([self float1], [self float1], [self float1]);
+}
+METHOD_POW2(float4, float2)
+METHOD_POW2(float8, float4)
+METHOD_POW2(float16, float8)
+
+METHOD(char1) {
+    return 42;
+}
+METHOD_POW2(char2, char1)
+METHOD(char3) {
+    return simd_make_char3([self char1], [self char1], [self char1]);
+}
+METHOD_POW2(char4, char2)
+METHOD_POW2(char8, char4)
+METHOD_POW2(char16, char8)
+METHOD_POW2(char32, char16)
+METHOD_POW2(char64, char32)
+
+METHOD(quatf) {
+    return simd_quaternion([self float4]);
+}
+
+METHOD(float2x2) {
+    return simd_matrix([self float2], [self float2]);
+}
+
+METHOD(float2x4) {
+    return simd_matrix([self float4], [self float4]);
+}
+
+METHOD(float4x4) {
+    return simd_matrix([self float4], [self float4], [self float4], [self float4]);
+}
+@end
+
+#endif // TARGET_OS_MAC

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This is used so that we don't need to add a `build.rs` script to `block2`.
 #![no_std]
+#![cfg_attr(feature = "apple", feature(repr_simd))]
 
 use std::os::raw::c_void;
 
@@ -21,6 +22,9 @@ mod test_encode_utils;
 mod test_foundation_retain_semantics;
 #[cfg(test)]
 mod test_object;
+#[cfg(test)]
+#[cfg(feature = "apple")]
+mod test_simd_return;
 
 #[no_mangle]
 extern "C" fn debug_block(block: *mut c_void) {

--- a/crates/tests/src/test_encode_utils.rs
+++ b/crates/tests/src/test_encode_utils.rs
@@ -298,6 +298,19 @@ assert_types! {
 
     UUID_T no_atomic => enc Encoding::Array(16, &u8::ENCODING),
 
+    // simd
+
+    #[cfg(feature = "apple")]
+    SIMD_INT2 => enc Encoding::None,
+    #[cfg(feature = "apple")]
+    SIMD_FLOAT1 => c_float,
+    #[cfg(feature = "apple")]
+    SIMD_FLOAT2 => enc Encoding::None,
+    #[cfg(feature = "apple")]
+    SIMD_FLOAT2X4 => enc Encoding::Struct("?", &[Encoding::Array(2, &Encoding::None)]),
+    #[cfg(feature = "apple")]
+    SIMD_FLOAT4X2 => enc Encoding::Struct("?", &[Encoding::Array(4, &Encoding::None)]),
+
     // Possible extras; need to be #[cfg]-ed somehow
 
     // SIGNED_INT_128 => i128,

--- a/crates/tests/src/test_simd_return.rs
+++ b/crates/tests/src/test_simd_return.rs
@@ -1,0 +1,179 @@
+use core::ffi::{c_char, c_float};
+
+use objc2::runtime::NSObject;
+use objc2::{extern_class, extern_methods, mutability, ClassType, Encode, Encoding};
+
+extern_class!(
+    struct TestSimdReturn;
+
+    unsafe impl ClassType for TestSimdReturn {
+        type Super = NSObject;
+        type Mutability = mutability::InteriorMutable;
+    }
+);
+
+macro_rules! methods {
+    ($(
+        $(#[$($m:tt)*])*
+        $name:ident: $ty:ty { $expr:expr }
+    )*) => {$(
+        #[test]
+        $(#[$($m)*])*
+        fn $name() {
+            extern_methods!(
+                #[allow(non_local_definitions)]
+                unsafe impl TestSimdReturn {
+                    #[method($name)]
+                    fn $name() -> $ty;
+                }
+            );
+
+            let res = TestSimdReturn::$name();
+            assert_eq!(res, $expr);
+        }
+    )*};
+}
+
+macro_rules! encode_none {
+    ($ty:ty) => {
+        unsafe impl Encode for $ty {
+            const ENCODING: Encoding = Encoding::None;
+        }
+    };
+}
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Float2([f32; 2]);
+encode_none!(Float2);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Float3([f32; 3]);
+encode_none!(Float3);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Float4([f32; 4]);
+encode_none!(Float4);
+
+#[repr(transparent)]
+#[derive(PartialEq, Debug)]
+struct Float8([f32; 8]);
+encode_none!(Float8);
+
+#[repr(transparent)]
+#[derive(PartialEq, Debug)]
+struct Float16([f32; 16]);
+encode_none!(Float16);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Char2([i8; 2]);
+encode_none!(Char2);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Char3([i8; 3]);
+encode_none!(Char3);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Char4([i8; 4]);
+encode_none!(Char4);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Char8([i8; 8]);
+encode_none!(Char8);
+
+#[repr(simd)]
+#[derive(PartialEq, Debug)]
+struct Char16([i8; 16]);
+encode_none!(Char16);
+
+#[repr(transparent)]
+#[derive(PartialEq, Debug)]
+struct Char32([i8; 32]);
+encode_none!(Char32);
+
+#[repr(transparent)]
+#[derive(PartialEq, Debug)]
+struct Char64([i8; 64]);
+encode_none!(Char64);
+
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+struct Quatf(Float4);
+unsafe impl Encode for Quatf {
+    const ENCODING: Encoding = Encoding::Struct("?", &[Encoding::None]);
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+struct Float2x2([Float2; 2]);
+unsafe impl Encode for Float2x2 {
+    const ENCODING: Encoding = Encoding::Struct("?", &[Encoding::Array(2, &Encoding::None)]);
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+struct Float2x4([Float4; 2]);
+unsafe impl Encode for Float2x4 {
+    const ENCODING: Encoding = Encoding::Struct("?", &[Encoding::Array(2, &Encoding::None)]);
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug)]
+struct Float4x4([Float4; 4]);
+unsafe impl Encode for Float4x4 {
+    const ENCODING: Encoding = Encoding::Struct("?", &[Encoding::Array(4, &Encoding::None)]);
+}
+
+// Note: Most of these are currently ignored, as Rust does not yet have
+// support for SIMD types in FFI:
+// <https://github.com/rust-lang/rust/issues/63068>
+//
+// Additionally, we're not currently handling them in message sending.
+methods! {
+    float1: c_float { 42.0 }
+    #[cfg_attr(target_pointer_width = "32", ignore = "Rust does not yet support SIMD in FFI")]
+    float2: Float2 { Float2([42.0; 2]) }
+    #[cfg_attr(target_pointer_width = "32", ignore = "Rust does not yet support SIMD in FFI")]
+    float3: Float3 { Float3([42.0; 3]) }
+    #[cfg_attr(target_pointer_width = "32", ignore = "Rust does not yet support SIMD in FFI")]
+    float4: Float4 { Float4([42.0; 4]) }
+    #[cfg_attr(not(target_arch = "aarch64"), ignore = "Rust does not yet support SIMD in FFI")]
+    float8: Float8 { Float8([42.0; 8]) }
+    #[cfg_attr(not(target_arch = "aarch64"), ignore = "Rust does not yet support SIMD in FFI")]
+    float16: Float16 { Float16([42.0; 16]) }
+
+    char1: c_char { 42 }
+    char2: Char2 { Char2([42; 2]) }
+    #[cfg_attr(target_arch = "x86", ignore = "Rust does not yet support SIMD in FFI")]
+    #[cfg_attr(target_arch = "x86_64", ignore = "Rust does not yet support SIMD in FFI")]
+    char3: Char3 { Char3([42; 3]) }
+    #[cfg_attr(target_arch = "x86", ignore = "Rust does not yet support SIMD in FFI")]
+    #[cfg_attr(target_arch = "x86_64", ignore = "Rust does not yet support SIMD in FFI")]
+    char4: Char4 { Char4([42; 4]) }
+    #[cfg_attr(target_pointer_width = "32", ignore = "Rust does not yet support SIMD in FFI")]
+    char8: Char8 { Char8([42; 8]) }
+    #[cfg_attr(target_pointer_width = "32", ignore = "Rust does not yet support SIMD in FFI")]
+    char16: Char16 { Char16([42; 16]) }
+    #[cfg_attr(not(target_arch = "aarch64"), ignore = "Rust does not yet support SIMD in FFI")]
+    char32: Char32 { Char32([42; 32]) }
+    #[cfg_attr(not(target_arch = "aarch64"), ignore = "Rust does not yet support SIMD in FFI")]
+    char64: Char64 { Char64([42; 64]) }
+
+    #[cfg_attr(target_arch = "arm", ignore = "Rust does not yet support SIMD in FFI")]
+    quatf: Quatf { Quatf(Float4([42.0; 4])) }
+
+    #[cfg_attr(target_arch = "arm", ignore = "Rust does not yet support SIMD in FFI")]
+    float2x2: Float2x2 { Float2x2([Float2([42.0; 2]), Float2([42.0; 2])]) }
+    #[cfg_attr(target_arch = "arm", ignore = "Rust does not yet support SIMD in FFI")]
+    #[cfg_attr(target_arch = "aarch64", ignore = "Rust does not yet support SIMD in FFI")]
+    float2x4: Float2x4 { Float2x4([Float4([42.0; 4]), Float4([42.0; 4])]) }
+    #[cfg_attr(target_arch = "arm", ignore = "Rust does not yet support SIMD in FFI")]
+    #[cfg_attr(target_arch = "aarch64", ignore = "Rust does not yet support SIMD in FFI")]
+    float4x4: Float4x4 { Float4x4([Float4([42.0; 4]), Float4([42.0; 4]), Float4([42.0; 4]), Float4([42.0; 4])]) }
+}


### PR DESCRIPTION
Fixes https://github.com/madsmtm/objc2/issues/582 as far as we can right now, Rust/Clang/GCC still needs to figure out the ABI of these types when passing them across FFI.

Tested on the major architectures we support:
- [x] Armv7
- [x] AArch64
- [x] x86_64
- [x] x86

You can see a quick summary of the places that this currently doesn't work in the `test_simd_return.rs` test.