### PR TITLE
Update nightly Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ env:
     --package=objc2-encode
     --package=objc2-proc-macros
   # The current nightly Rust version. Keep this synced with `rust-toolchain.toml`
-  CURRENT_NIGHTLY: nightly-2024-01-15
+  CURRENT_NIGHTLY: nightly-2024-03-13
   # Various features that we'd usually want to test with
   #
   # Note: The `exception` feature is not enabled here, since it requires
@@ -158,8 +158,7 @@ jobs:
       run: cargo doc --no-deps --document-private-items ${{ matrix.args }}
 
     - name: cargo clippy
-      # Temporarily allow diverging_sub_expression until we figure out how to silence them in declare_class!
-      run: cargo clippy --all-targets ${{ matrix.args }} -- --allow=clippy::diverging_sub_expression
+      run: cargo clippy --all-targets ${{ matrix.args }}
 
   msrv:
     name: Check MSRV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clang"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
+source = "git+https://github.com/madsmtm/clang-rs.git?branch=fix-ub-tokenize#825e933e203cd9c7ee59c9b260ad0fb41f19fb38"
 dependencies = [
  "clang-sys",
  "libc",

--- a/crates/block2/src/block.rs
+++ b/crates/block2/src/block.rs
@@ -130,8 +130,6 @@ mod tests {
     use core::cell::Cell;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
-    use crate::RcBlock;
-
     use super::*;
 
     /// Test that the way you specify lifetimes are as documented in the

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/madsmtm/objc2"
 license = "Zlib OR Apache-2.0 OR MIT"
 
 [dependencies]
-clang = { version = "2.0", features = ["runtime", "clang_10_0"] }
+# https://github.com/KyleMayes/clang-rs/pull/58
+clang = { git = "https://github.com/madsmtm/clang-rs.git", branch = "fix-ub-tokenize", features = ["runtime", "clang_10_0"] }
 clang-sys = { version = "1.4.0" }
 basic-toml = "0.1.2"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/crates/header-translator/src/main.rs
+++ b/crates/header-translator/src/main.rs
@@ -214,13 +214,13 @@ fn parse_sdk(index: &Index<'_>, sdk: &SdkPath, llvm_target: &str, config: &Confi
                 file_span.take();
                 file_span_name = String::new();
 
-                library_span_name = library_name.clone();
+                library_span_name.clone_from(&library_name);
                 library_span = Some(debug_span!("library", name = library_name).entered());
             }
             if file_span_name != file_name {
                 file_span.take();
 
-                file_span_name = file_name.clone();
+                file_span_name.clone_from(&file_name);
                 file_span = Some(debug_span!("file", name = file_name).entered());
             }
 

--- a/crates/icrate/examples/metal.rs
+++ b/crates/icrate/examples/metal.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_op_in_unsafe_fn)]
+#![allow(clippy::incompatible_msrv)]
 
 use core::{cell::OnceCell, ptr::NonNull};
 

--- a/crates/icrate/src/additions/Foundation/__macro_helpers/cached.rs
+++ b/crates/icrate/src/additions/Foundation/__macro_helpers/cached.rs
@@ -13,6 +13,7 @@ pub struct CachedId<T> {
 
 impl<T> CachedId<T> {
     /// Constructs a new [`CachedId`].
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self {
             ptr: AtomicPtr::new(ptr::null_mut()),

--- a/crates/icrate/src/additions/Foundation/data.rs
+++ b/crates/icrate/src/additions/Foundation/data.rs
@@ -11,7 +11,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::slice::{self, SliceIndex};
 
 #[cfg(feature = "block2")]
-use block2::{Block, RcBlock};
+use block2::RcBlock;
 #[cfg(feature = "block2")]
 use objc2::rc::IdFromIterator;
 

--- a/crates/icrate/src/additions/Foundation/dictionary.rs
+++ b/crates/icrate/src/additions/Foundation/dictionary.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::hash::Hash;
 use core::mem;
 use core::ops::{Index, IndexMut};
-use core::ptr::{self, NonNull};
+use core::ptr;
 
 #[cfg(feature = "Foundation_NSObject")]
 use objc2::mutability::IsRetainable;

--- a/crates/icrate/src/additions/Foundation/exception.rs
+++ b/crates/icrate/src/additions/Foundation/exception.rs
@@ -7,7 +7,7 @@ use objc2::exception::Exception;
 use objc2::sel;
 
 use crate::common::*;
-use crate::Foundation::{NSException, NSObject, NSObjectProtocol};
+use crate::Foundation::NSException;
 
 // SAFETY: Exception objects are immutable data containers, and documented as
 // thread safe.

--- a/crates/icrate/src/additions/Foundation/string.rs
+++ b/crates/icrate/src/additions/Foundation/string.rs
@@ -1,16 +1,11 @@
 use core::cmp;
-use core::ffi::c_void;
 use core::fmt;
 use core::ops::AddAssign;
 use core::panic::RefUnwindSafe;
 use core::panic::UnwindSafe;
 #[cfg(feature = "apple")]
-use core::ptr::NonNull;
-#[cfg(feature = "apple")]
 use core::slice;
 use core::str;
-#[cfg(feature = "apple")]
-use std::os::raw::c_char;
 
 use objc2::msg_send_id;
 use objc2::rc::{autoreleasepool_leaking, AutoreleasePool};

--- a/crates/icrate/src/additions/Foundation/thread.rs
+++ b/crates/icrate/src/additions/Foundation/thread.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::marker::PhantomData;
 #[cfg(feature = "dispatch")]
 #[cfg(feature = "Foundation_NSThread")]
 use core::mem::{self, ManuallyDrop};
@@ -11,7 +10,6 @@ use crate::common::*;
 use crate::Foundation::NSThread;
 
 use objc2::msg_send_id;
-use objc2::mutability::IsMainThreadOnly;
 
 #[cfg(feature = "Foundation_NSThread")]
 unsafe impl Send for NSThread {}

--- a/crates/objc2-encode/src/encoding.rs
+++ b/crates/objc2-encode/src/encoding.rs
@@ -259,7 +259,6 @@ impl fmt::Display for Encoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::helper::NestingLevel;
     use crate::static_str::{static_encoding_str_array, static_encoding_str_len};
     use alloc::string::ToString;
     use alloc::vec;

--- a/crates/objc2/src/__macro_helpers/cache.rs
+++ b/crates/objc2/src/__macro_helpers/cache.rs
@@ -15,8 +15,9 @@ pub struct CachedSel {
 
 impl CachedSel {
     /// Constructs a new [`CachedSel`].
-    pub const fn new() -> CachedSel {
-        CachedSel {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
             ptr: AtomicPtr::new(ptr::null_mut()),
         }
     }
@@ -60,6 +61,7 @@ pub struct CachedClass {
 
 impl CachedClass {
     /// Constructs a new [`CachedClass`].
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> CachedClass {
         CachedClass {
             ptr: AtomicPtr::new(ptr::null_mut()),

--- a/crates/objc2/src/__macro_helpers/declared_ivars.rs
+++ b/crates/objc2/src/__macro_helpers/declared_ivars.rs
@@ -429,7 +429,7 @@ mod tests {
     use crate::mutability::{InteriorMutable, Mutable};
     use crate::rc::{Allocated, Id, PartialInit, __RcTestObject, __ThreadTestData};
     use crate::runtime::NSObject;
-    use crate::{declare_class, msg_send, msg_send_id, ClassType, DeclaredClass};
+    use crate::{declare_class, msg_send, msg_send_id};
 
     /// Initialize superclasses, but not own class.
     unsafe fn init_only_superclasses<T: DeclaredClass>(obj: Allocated<T>) -> Id<T>
@@ -720,6 +720,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assigning_clones)]
     fn test_ivar_access() {
         declare_class!(
             struct RcIvar;

--- a/crates/objc2/src/__macro_helpers/msg_send_id.rs
+++ b/crates/objc2/src/__macro_helpers/msg_send_id.rs
@@ -503,15 +503,14 @@ impl<'a> MsgSendIdFailed<'a> for Other {
 mod tests {
     use super::*;
 
-    use core::ptr;
-
     use crate::rc::{__RcTestObject, __ThreadTestData};
-    use crate::runtime::{AnyObject, NSObject, NSZone};
-    use crate::{class, msg_send_id, ClassType};
+    use crate::runtime::{NSObject, NSZone};
+    use crate::{class, msg_send_id};
 
     mod test_trait_disambugated {
         use super::*;
 
+        #[allow(dead_code)]
         trait Abc {
             fn send_message_id(&self) {}
         }

--- a/crates/objc2/src/exception.rs
+++ b/crates/objc2/src/exception.rs
@@ -302,7 +302,6 @@ mod tests {
 
     use super::*;
     use crate::msg_send_id;
-    use crate::runtime::NSObject;
 
     #[test]
     fn test_catch() {

--- a/crates/objc2/src/macros/__msg_send_parse.rs
+++ b/crates/objc2/src/macros/__msg_send_parse.rs
@@ -147,7 +147,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args_inner! {
             ("msg_send")
-            ($crate::__macro_helpers::stringify!(super($obj)), $($args)*)
+            ("super", $crate::__macro_helpers::stringify!(($obj)), $($args)*)
         }
     };
     (
@@ -157,7 +157,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args_inner! {
             ("msg_send")
-            ($crate::__macro_helpers::stringify!(super($obj, $superclass)), $($args)*)
+            ("super", $crate::__macro_helpers::stringify!(($obj, $superclass)), $($args)*)
         }
     };
     (
@@ -180,7 +180,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args_inner! {
             ("msg_send_id")
-            ($crate::__macro_helpers::stringify!(super($obj)), $($args)*)
+            ("super", $crate::__macro_helpers::stringify!(($obj)), $($args)*)
         }
     };
     (
@@ -192,7 +192,7 @@ macro_rules! __comma_between_args {
     ) => {
         $crate::__comma_between_args_inner! {
             ("msg_send_id")
-            ($crate::__macro_helpers::stringify!(super($obj, $superclass)), $($args)*)
+            ("super", $crate::__macro_helpers::stringify!(($obj, $superclass)), $($args)*)
         }
     };
     (

--- a/crates/objc2/src/macros/declare_class.rs
+++ b/crates/objc2/src/macros/declare_class.rs
@@ -976,6 +976,7 @@ macro_rules! __declare_class_method_out_inner {
         ($($body_prefix:tt)*)
     } => {
         $($m_checked)*
+        #[allow(clippy::diverging_sub_expression)]
         $($qualifiers)* extern "C" fn $name(
             $($params_prefix)*
             $($params_converted)*
@@ -1008,6 +1009,7 @@ macro_rules! __declare_class_method_out_inner {
         ($($body_prefix:tt)*)
     } => {
         $($m_checked)*
+        #[allow(clippy::diverging_sub_expression)]
         $($qualifiers)* extern "C" fn $name(
             $($params_prefix)*
             $($params_converted)*

--- a/crates/objc2/src/rc/autorelease.rs
+++ b/crates/objc2/src/rc/autorelease.rs
@@ -518,7 +518,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::marker::Unpin;
     use core::mem;
     use core::panic::{RefUnwindSafe, UnwindSafe};
 

--- a/crates/objc2/src/rc/test_object.rs
+++ b/crates/objc2/src/rc/test_object.rs
@@ -336,7 +336,7 @@ impl RcTestObjectSubclass {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rc::{autoreleasepool, Allocated};
+    use crate::rc::autoreleasepool;
 
     #[test]
     fn ensure_declared_name() {

--- a/crates/objc2/src/runtime/mod.rs
+++ b/crates/objc2/src/runtime/mod.rs
@@ -1328,8 +1328,6 @@ mod tests {
     use core::mem::size_of;
 
     use super::*;
-    use crate::declare::ClassBuilder;
-    use crate::runtime::MessageReceiver;
     use crate::test_utils;
     use crate::{class, msg_send, sel, ClassType};
 
@@ -1525,6 +1523,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        feature = "malloc",
+        ignore = "The `malloc_buf` crate calls `from_raw_parts` unsoundly"
+    )]
     fn test_no_ivars() {
         let cls = ClassBuilder::new("NoIvarObject", NSObject::class())
             .unwrap()

--- a/crates/objc2/src/runtime/protocol_object.rs
+++ b/crates/objc2/src/runtime/protocol_object.rs
@@ -115,10 +115,10 @@ impl<P: ?Sized> ProtocolObject<P> {
 
     /// Get a type-erased object from a type implementing a protocol.
     #[inline]
-    pub fn from_id<T: Message>(obj: Id<T>) -> Id<Self>
+    pub fn from_id<T>(obj: Id<T>) -> Id<Self>
     where
         P: ImplementedBy<T> + 'static,
-        T: 'static,
+        T: Message + 'static,
     {
         // SAFETY:
         // - The type can be represented as the casted-to type.
@@ -193,6 +193,7 @@ where
 
 #[cfg(test)]
 #[allow(clippy::missing_safety_doc)]
+#[allow(dead_code)]
 mod tests {
     use alloc::format;
     use core::mem::ManuallyDrop;
@@ -201,7 +202,7 @@ mod tests {
 
     use super::*;
     use crate::mutability::Mutable;
-    use crate::runtime::{NSObject, NSObjectProtocol};
+    use crate::runtime::NSObject;
     use crate::{
         declare_class, extern_methods, extern_protocol, ClassType, DeclaredClass, ProtocolType,
     };

--- a/crates/test-assembly/crates/test_block/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_block/expected/apple-aarch64.s
@@ -228,9 +228,11 @@ Lloh25:
 	.globl	_create_and_use_stack_block_drop
 	.p2align	2
 _create_and_use_stack_block_drop:
-	sub	sp, sp, #64
-	stp	x29, x30, [sp, #48]
-	add	x29, sp, #48
+	sub	sp, sp, #80
+	stp	x20, x19, [sp, #48]
+	stp	x29, x30, [sp, #64]
+	add	x29, sp, #64
+	mov	x19, x0
 Lloh26:
 	adrp	x8, __NSConcreteStackBlock@GOTPAGE
 Lloh27:
@@ -249,12 +251,13 @@ Lloh31:
 	str	x0, [sp, #40]
 	add	x0, sp, #8
 	bl	_needs_block
-	ldr	x0, [sp, #40]
+	mov	x0, x19
 	mov	w1, #4
 	mov	w2, #4
 	bl	___rust_dealloc
-	ldp	x29, x30, [sp, #48]
-	add	sp, sp, #64
+	ldp	x29, x30, [sp, #64]
+	ldp	x20, x19, [sp, #48]
+	add	sp, sp, #80
 	ret
 	.loh AdrpAdd	Lloh30, Lloh31
 	.loh AdrpAdd	Lloh28, Lloh29

--- a/crates/test-assembly/crates/test_block/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_block/expected/apple-x86_64.s
@@ -229,22 +229,25 @@ _create_and_use_stack_block:
 _create_and_use_stack_block_drop:
 	push	rbp
 	mov	rbp, rsp
-	sub	rsp, 48
+	push	rbx
+	sub	rsp, 40
+	mov	rbx, rdi
 	mov	rax, qword ptr [rip + __NSConcreteStackBlock@GOTPCREL]
-	mov	qword ptr [rbp - 40], rax
-	mov	qword ptr [rbp - 32], 33554432
+	mov	qword ptr [rbp - 48], rax
+	mov	qword ptr [rbp - 40], 33554432
 	lea	rax, [rip + SYM(<_ as block2[CRATE_ID]::traits::IntoBlock<(_,), _>>::__get_invoke_stack_block::invoke::<i32, i32, test_block[CRATE_ID]::create_and_use_stack_block_drop::{closure#0}>, 0)]
-	mov	qword ptr [rbp - 24], rax
+	mov	qword ptr [rbp - 32], rax
 	lea	rax, [rip + l_anon.[ID].4]
-	mov	qword ptr [rbp - 16], rax
-	mov	qword ptr [rbp - 8], rdi
-	lea	rdi, [rbp - 40]
+	mov	qword ptr [rbp - 24], rax
+	mov	qword ptr [rbp - 16], rdi
+	lea	rdi, [rbp - 48]
 	call	_needs_block
-	mov	rdi, qword ptr [rbp - 8]
 	mov	esi, 4
 	mov	edx, 4
+	mov	rdi, rbx
 	call	___rust_dealloc
-	add	rsp, 48
+	add	rsp, 40
+	pop	rbx
 	pop	rbp
 	ret
 

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
@@ -169,9 +169,9 @@ Lloh41:
 	mov	x4, x21
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 Lloh42:
-	adrp	x0, l_anon.[ID].24@PAGE
+	adrp	x0, l_anon.[ID].23@PAGE
 Lloh43:
-	add	x0, x0, l_anon.[ID].24@PAGEOFF
+	add	x0, x0, l_anon.[ID].23@PAGEOFF
 	mov	w1, #8
 	bl	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	cbz	x0, LBB4_4
@@ -180,9 +180,9 @@ Lloh43:
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
 LBB4_4:
 Lloh44:
-	adrp	x0, l_anon.[ID].25@PAGE
+	adrp	x0, l_anon.[ID].24@PAGE
 Lloh45:
-	add	x0, x0, l_anon.[ID].25@PAGEOFF
+	add	x0, x0, l_anon.[ID].24@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	cbz	x0, LBB4_6
@@ -220,24 +220,19 @@ Lloh53:
 	ret
 LBB4_7:
 Lloh54:
-	adrp	x0, l_anon.[ID].19@PAGE
+	adrp	x0, l_anon.[ID].20@PAGE
 Lloh55:
-	add	x0, x0, l_anon.[ID].19@PAGEOFF
-Lloh56:
-	adrp	x2, l_anon.[ID].21@PAGE
-Lloh57:
-	add	x2, x2, l_anon.[ID].21@PAGEOFF
-	mov	w1, #43
-	bl	SYM(core::panicking::panic::GENERATED_ID, 0)
+	add	x0, x0, l_anon.[ID].20@PAGEOFF
+	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB4_8:
-Lloh58:
+Lloh56:
 	adrp	x0, l_anon.[ID].17@PAGE
-Lloh59:
+Lloh57:
 	add	x0, x0, l_anon.[ID].17@PAGEOFF
-Lloh60:
-	adrp	x2, l_anon.[ID].23@PAGE
-Lloh61:
-	add	x2, x2, l_anon.[ID].23@PAGEOFF
+Lloh58:
+	adrp	x2, l_anon.[ID].22@PAGE
+Lloh59:
+	add	x2, x2, l_anon.[ID].22@PAGEOFF
 	mov	w1, #7
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh10, Lloh11
@@ -263,10 +258,9 @@ Lloh61:
 	.loh AdrpAdd	Lloh50, Lloh51
 	.loh AdrpAdd	Lloh48, Lloh49
 	.loh AdrpLdr	Lloh46, Lloh47
-	.loh AdrpAdd	Lloh56, Lloh57
 	.loh AdrpAdd	Lloh54, Lloh55
-	.loh AdrpAdd	Lloh60, Lloh61
 	.loh AdrpAdd	Lloh58, Lloh59
+	.loh AdrpAdd	Lloh56, Lloh57
 
 	.p2align	2
 SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0):
@@ -278,37 +272,37 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	ldrb	w9, [x8]
 	strb	wzr, [x8]
 	cbz	w9, LBB5_5
-Lloh62:
+Lloh60:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
-Lloh63:
+Lloh61:
 	ldr	x8, [x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGEOFF]
-Lloh64:
+Lloh62:
 	ldr	x2, [x8]
-Lloh65:
+Lloh63:
 	adrp	x0, l_anon.[ID].18@PAGE
-Lloh66:
+Lloh64:
 	add	x0, x0, l_anon.[ID].18@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
 	cbz	x0, LBB5_6
 	str	x0, [sp, #24]
-Lloh67:
+Lloh65:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_dealloc@GOTPAGE
-Lloh68:
+Lloh66:
 	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_dealloc@GOTPAGEOFF]
-Lloh69:
+Lloh67:
 	ldr	x1, [x8]
-Lloh70:
+Lloh68:
 	adrp	x19, l_anon.[ID].3@PAGE
-Lloh71:
+Lloh69:
 	add	x19, x19, l_anon.[ID].3@PAGEOFF
-Lloh72:
+Lloh70:
 	adrp	x4, l_anon.[ID].5@PAGE
-Lloh73:
+Lloh71:
 	add	x4, x4, l_anon.[ID].5@PAGEOFF
-Lloh74:
+Lloh72:
 	adrp	x5, SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0)@PAGE
-Lloh75:
+Lloh73:
 	add	x5, x5, SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0)@PAGEOFF
 	add	x0, sp, #24
 	mov	x2, x19
@@ -316,19 +310,19 @@ Lloh75:
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 	ldr	x8, [sp, #24]
 	str	x8, [sp, #8]
-Lloh76:
+Lloh74:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_init@GOTPAGE
-Lloh77:
+Lloh75:
 	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_init@GOTPAGEOFF]
-Lloh78:
+Lloh76:
 	ldr	x1, [x8]
-Lloh79:
+Lloh77:
 	adrp	x4, l_anon.[ID].4@PAGE
-Lloh80:
+Lloh78:
 	add	x4, x4, l_anon.[ID].4@PAGEOFF
-Lloh81:
+Lloh79:
 	adrp	x5, _init_drop_ivars@PAGE
-Lloh82:
+Lloh80:
 	add	x5, x5, _init_drop_ivars@PAGEOFF
 	add	x0, sp, #8
 	mov	x2, x19
@@ -337,16 +331,16 @@ Lloh82:
 	ldr	x8, [sp, #8]
 	str	x8, [sp, #16]
 	mov	w8, #16
-Lloh83:
+Lloh81:
 	adrp	x9, l_anon.[ID].15@PAGE
-Lloh84:
+Lloh82:
 	add	x9, x9, l_anon.[ID].15@PAGEOFF
 	stp	x8, x9, [sp, #32]
 	mov	w8, #27
 	strb	w8, [sp, #24]
-Lloh85:
+Lloh83:
 	adrp	x20, l_anon.[ID].11@PAGE
-Lloh86:
+Lloh84:
 	add	x20, x20, l_anon.[ID].11@PAGEOFF
 	add	x0, sp, #16
 	add	x5, sp, #24
@@ -355,13 +349,13 @@ Lloh86:
 	mov	w3, #16
 	mov	w4, #3
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_ivar_inner_mono::GENERATED_ID, 0)
-Lloh87:
+Lloh85:
 	adrp	x1, l_anon.[ID].12@PAGE
-Lloh88:
+Lloh86:
 	add	x1, x1, l_anon.[ID].12@PAGEOFF
-Lloh89:
+Lloh87:
 	adrp	x5, l_anon.[ID].13@PAGE
-Lloh90:
+Lloh88:
 	add	x5, x5, l_anon.[ID].13@PAGEOFF
 	add	x0, sp, #16
 	mov	w2, #9
@@ -377,22 +371,22 @@ Lloh90:
 	cbz	x0, LBB5_7
 	bl	_ivar_getOffset
 	mov	x20, x0
-Lloh91:
+Lloh89:
 	adrp	x1, l_anon.[ID].12@PAGE
-Lloh92:
+Lloh90:
 	add	x1, x1, l_anon.[ID].12@PAGEOFF
 	mov	x0, x19
 	mov	w2, #9
 	bl	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
 	cbz	x0, LBB5_8
 	bl	_ivar_getOffset
-Lloh93:
+Lloh91:
 	adrp	x8, __MergedGlobals@PAGE+32
 	str	x19, [x8, __MergedGlobals@PAGEOFF+32]
-Lloh94:
+Lloh92:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGE
 	str	x20, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGEOFF]
-Lloh95:
+Lloh93:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGE
 	str	x0, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGEOFF]
 	ldp	x29, x30, [sp, #80]
@@ -400,51 +394,45 @@ Lloh95:
 	add	sp, sp, #96
 	ret
 LBB5_5:
-Lloh96:
-	adrp	x0, l_anon.[ID].19@PAGE
-Lloh97:
-	add	x0, x0, l_anon.[ID].19@PAGEOFF
-Lloh98:
-	adrp	x2, l_anon.[ID].21@PAGE
-Lloh99:
-	add	x2, x2, l_anon.[ID].21@PAGEOFF
-	mov	w1, #43
-	bl	SYM(core::panicking::panic::GENERATED_ID, 0)
+Lloh94:
+	adrp	x0, l_anon.[ID].20@PAGE
+Lloh95:
+	add	x0, x0, l_anon.[ID].20@PAGEOFF
+	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB5_6:
-Lloh100:
+Lloh96:
 	adrp	x0, l_anon.[ID].18@PAGE
-Lloh101:
+Lloh97:
 	add	x0, x0, l_anon.[ID].18@PAGEOFF
-Lloh102:
-	adrp	x2, l_anon.[ID].27@PAGE
-Lloh103:
-	add	x2, x2, l_anon.[ID].27@PAGEOFF
+Lloh98:
+	adrp	x2, l_anon.[ID].26@PAGE
+Lloh99:
+	add	x2, x2, l_anon.[ID].26@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 LBB5_7:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
 LBB5_8:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_drop_flag_failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh65, Lloh66
-	.loh AdrpLdrGotLdr	Lloh62, Lloh63, Lloh64
-	.loh AdrpAdd	Lloh89, Lloh90
+	.loh AdrpAdd	Lloh63, Lloh64
+	.loh AdrpLdrGotLdr	Lloh60, Lloh61, Lloh62
 	.loh AdrpAdd	Lloh87, Lloh88
 	.loh AdrpAdd	Lloh85, Lloh86
 	.loh AdrpAdd	Lloh83, Lloh84
 	.loh AdrpAdd	Lloh81, Lloh82
 	.loh AdrpAdd	Lloh79, Lloh80
-	.loh AdrpLdrGotLdr	Lloh76, Lloh77, Lloh78
-	.loh AdrpAdd	Lloh74, Lloh75
+	.loh AdrpAdd	Lloh77, Lloh78
+	.loh AdrpLdrGotLdr	Lloh74, Lloh75, Lloh76
 	.loh AdrpAdd	Lloh72, Lloh73
 	.loh AdrpAdd	Lloh70, Lloh71
-	.loh AdrpLdrGotLdr	Lloh67, Lloh68, Lloh69
-	.loh AdrpAdd	Lloh91, Lloh92
-	.loh AdrpAdrp	Lloh94, Lloh95
-	.loh AdrpAdrp	Lloh93, Lloh94
+	.loh AdrpAdd	Lloh68, Lloh69
+	.loh AdrpLdrGotLdr	Lloh65, Lloh66, Lloh67
+	.loh AdrpAdd	Lloh89, Lloh90
+	.loh AdrpAdrp	Lloh92, Lloh93
+	.loh AdrpAdrp	Lloh91, Lloh92
+	.loh AdrpAdd	Lloh94, Lloh95
 	.loh AdrpAdd	Lloh98, Lloh99
 	.loh AdrpAdd	Lloh96, Lloh97
-	.loh AdrpAdd	Lloh102, Lloh103
-	.loh AdrpAdd	Lloh100, Lloh101
 
 	.p2align	2
 SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0):
@@ -456,37 +444,37 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	ldrb	w9, [x8]
 	strb	wzr, [x8]
 	cbz	w9, LBB6_4
-Lloh104:
+Lloh100:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
-Lloh105:
+Lloh101:
 	ldr	x8, [x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGEOFF]
-Lloh106:
+Lloh102:
 	ldr	x2, [x8]
-Lloh107:
+Lloh103:
 	adrp	x0, l_anon.[ID].16@PAGE
-Lloh108:
+Lloh104:
 	add	x0, x0, l_anon.[ID].16@PAGEOFF
 	mov	w1, #15
 	bl	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
 	cbz	x0, LBB6_5
 	str	x0, [sp, #8]
-Lloh109:
+Lloh105:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_init@GOTPAGE
-Lloh110:
+Lloh106:
 	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_init@GOTPAGEOFF]
-Lloh111:
+Lloh107:
 	ldr	x1, [x8]
-Lloh112:
+Lloh108:
 	adrp	x2, l_anon.[ID].3@PAGE
-Lloh113:
+Lloh109:
 	add	x2, x2, l_anon.[ID].3@PAGEOFF
-Lloh114:
+Lloh110:
 	adrp	x4, l_anon.[ID].4@PAGE
-Lloh115:
+Lloh111:
 	add	x4, x4, l_anon.[ID].4@PAGEOFF
-Lloh116:
+Lloh112:
 	adrp	x5, _init_forgetable_ivars@PAGE
-Lloh117:
+Lloh113:
 	add	x5, x5, _init_forgetable_ivars@PAGEOFF
 	add	x0, sp, #8
 	mov	x3, #0
@@ -494,16 +482,16 @@ Lloh117:
 	ldr	x8, [sp, #8]
 	str	x8, [sp, #16]
 	mov	w8, #8
-Lloh118:
+Lloh114:
 	adrp	x9, l_anon.[ID].14@PAGE
-Lloh119:
+Lloh115:
 	add	x9, x9, l_anon.[ID].14@PAGEOFF
 	stp	x8, x9, [sp, #32]
 	mov	w8, #27
 	strb	w8, [sp, #24]
-Lloh120:
+Lloh116:
 	adrp	x20, l_anon.[ID].11@PAGE
-Lloh121:
+Lloh117:
 	add	x20, x20, l_anon.[ID].11@PAGEOFF
 	add	x0, sp, #16
 	add	x5, sp, #24
@@ -520,10 +508,10 @@ Lloh121:
 	bl	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
 	cbz	x0, LBB6_6
 	bl	_ivar_getOffset
-Lloh122:
+Lloh118:
 	adrp	x8, __MergedGlobals@PAGE+16
 	str	x19, [x8, __MergedGlobals@PAGEOFF+16]
-Lloh123:
+Lloh119:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGE
 	str	x0, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGEOFF]
 	ldp	x29, x30, [sp, #80]
@@ -531,42 +519,36 @@ Lloh123:
 	add	sp, sp, #96
 	ret
 LBB6_4:
-Lloh124:
-	adrp	x0, l_anon.[ID].19@PAGE
-Lloh125:
-	add	x0, x0, l_anon.[ID].19@PAGEOFF
-Lloh126:
-	adrp	x2, l_anon.[ID].21@PAGE
-Lloh127:
-	add	x2, x2, l_anon.[ID].21@PAGEOFF
-	mov	w1, #43
-	bl	SYM(core::panicking::panic::GENERATED_ID, 0)
+Lloh120:
+	adrp	x0, l_anon.[ID].20@PAGE
+Lloh121:
+	add	x0, x0, l_anon.[ID].20@PAGEOFF
+	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB6_5:
-Lloh128:
+Lloh122:
 	adrp	x0, l_anon.[ID].16@PAGE
-Lloh129:
+Lloh123:
 	add	x0, x0, l_anon.[ID].16@PAGEOFF
-Lloh130:
-	adrp	x2, l_anon.[ID].26@PAGE
-Lloh131:
-	add	x2, x2, l_anon.[ID].26@PAGEOFF
+Lloh124:
+	adrp	x2, l_anon.[ID].25@PAGE
+Lloh125:
+	add	x2, x2, l_anon.[ID].25@PAGEOFF
 	mov	w1, #15
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 LBB6_6:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
-	.loh AdrpAdd	Lloh107, Lloh108
-	.loh AdrpLdrGotLdr	Lloh104, Lloh105, Lloh106
-	.loh AdrpAdd	Lloh120, Lloh121
-	.loh AdrpAdd	Lloh118, Lloh119
+	.loh AdrpAdd	Lloh103, Lloh104
+	.loh AdrpLdrGotLdr	Lloh100, Lloh101, Lloh102
 	.loh AdrpAdd	Lloh116, Lloh117
 	.loh AdrpAdd	Lloh114, Lloh115
 	.loh AdrpAdd	Lloh112, Lloh113
-	.loh AdrpLdrGotLdr	Lloh109, Lloh110, Lloh111
-	.loh AdrpAdrp	Lloh122, Lloh123
-	.loh AdrpAdd	Lloh126, Lloh127
+	.loh AdrpAdd	Lloh110, Lloh111
+	.loh AdrpAdd	Lloh108, Lloh109
+	.loh AdrpLdrGotLdr	Lloh105, Lloh106, Lloh107
+	.loh AdrpAdrp	Lloh118, Lloh119
+	.loh AdrpAdd	Lloh120, Lloh121
 	.loh AdrpAdd	Lloh124, Lloh125
-	.loh AdrpAdd	Lloh130, Lloh131
-	.loh AdrpAdd	Lloh128, Lloh129
+	.loh AdrpAdd	Lloh122, Lloh123
 
 	.p2align	2
 SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0):
@@ -610,16 +592,16 @@ SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]:
 	.globl	_access_forgetable_ivars_class
 	.p2align	2
 _access_forgetable_ivars_class:
-Lloh132:
+Lloh126:
 	adrp	x8, __MergedGlobals@PAGE+24
-Lloh133:
+Lloh127:
 	add	x8, x8, __MergedGlobals@PAGEOFF+24
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB10_2
-Lloh134:
+Lloh128:
 	adrp	x8, __MergedGlobals@PAGE+16
-Lloh135:
+Lloh129:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
 LBB10_2:
@@ -630,47 +612,47 @@ LBB10_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh136:
+Lloh130:
 	adrp	x0, __MergedGlobals@PAGE+24
-Lloh137:
+Lloh131:
 	add	x0, x0, __MergedGlobals@PAGEOFF+24
-Lloh138:
+Lloh132:
 	adrp	x3, l_anon.[ID].2@PAGE
-Lloh139:
+Lloh133:
 	add	x3, x3, l_anon.[ID].2@PAGEOFF
-Lloh140:
-	adrp	x4, l_anon.[ID].26@PAGE
-Lloh141:
-	add	x4, x4, l_anon.[ID].26@PAGEOFF
+Lloh134:
+	adrp	x4, l_anon.[ID].25@PAGE
+Lloh135:
+	add	x4, x4, l_anon.[ID].25@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh142:
+Lloh136:
 	adrp	x8, __MergedGlobals@PAGE+16
-Lloh143:
+Lloh137:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
+	.loh AdrpAdd	Lloh126, Lloh127
+	.loh AdrpLdr	Lloh128, Lloh129
+	.loh AdrpLdr	Lloh136, Lloh137
+	.loh AdrpAdd	Lloh134, Lloh135
 	.loh AdrpAdd	Lloh132, Lloh133
-	.loh AdrpLdr	Lloh134, Lloh135
-	.loh AdrpLdr	Lloh142, Lloh143
-	.loh AdrpAdd	Lloh140, Lloh141
-	.loh AdrpAdd	Lloh138, Lloh139
-	.loh AdrpAdd	Lloh136, Lloh137
+	.loh AdrpAdd	Lloh130, Lloh131
 
 	.globl	_access_forgetable_ivars
 	.p2align	2
 _access_forgetable_ivars:
-Lloh144:
+Lloh138:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGE
-Lloh145:
+Lloh139:
 	ldr	x8, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGEOFF]
 	add	x8, x0, x8
 	ldr	w1, [x8]
 	ldrb	w0, [x8, #4]
 	ret
-	.loh AdrpLdr	Lloh144, Lloh145
+	.loh AdrpLdr	Lloh138, Lloh139
 
 	.globl	SYM(<test_declare_class[CRATE_ID]::DropIvars as core[CRATE_ID]::ops::drop::Drop>::drop, 0)
 	.p2align	2
@@ -682,16 +664,16 @@ SYM(<test_declare_class[CRATE_ID]::DropIvars as core[CRATE_ID]::ops::drop::Drop>
 	.globl	_access_drop_ivars_class
 	.p2align	2
 _access_drop_ivars_class:
-Lloh146:
+Lloh140:
 	adrp	x8, __MergedGlobals@PAGE+40
-Lloh147:
+Lloh141:
 	add	x8, x8, __MergedGlobals@PAGEOFF+40
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB13_2
-Lloh148:
+Lloh142:
 	adrp	x8, __MergedGlobals@PAGE+32
-Lloh149:
+Lloh143:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
 LBB13_2:
@@ -702,60 +684,60 @@ LBB13_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh150:
+Lloh144:
 	adrp	x0, __MergedGlobals@PAGE+40
-Lloh151:
+Lloh145:
 	add	x0, x0, __MergedGlobals@PAGEOFF+40
-Lloh152:
+Lloh146:
 	adrp	x3, l_anon.[ID].1@PAGE
-Lloh153:
+Lloh147:
 	add	x3, x3, l_anon.[ID].1@PAGEOFF
-Lloh154:
-	adrp	x4, l_anon.[ID].27@PAGE
-Lloh155:
-	add	x4, x4, l_anon.[ID].27@PAGEOFF
+Lloh148:
+	adrp	x4, l_anon.[ID].26@PAGE
+Lloh149:
+	add	x4, x4, l_anon.[ID].26@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh156:
+Lloh150:
 	adrp	x8, __MergedGlobals@PAGE+32
-Lloh157:
+Lloh151:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
+	.loh AdrpAdd	Lloh140, Lloh141
+	.loh AdrpLdr	Lloh142, Lloh143
+	.loh AdrpLdr	Lloh150, Lloh151
+	.loh AdrpAdd	Lloh148, Lloh149
 	.loh AdrpAdd	Lloh146, Lloh147
-	.loh AdrpLdr	Lloh148, Lloh149
-	.loh AdrpLdr	Lloh156, Lloh157
-	.loh AdrpAdd	Lloh154, Lloh155
-	.loh AdrpAdd	Lloh152, Lloh153
-	.loh AdrpAdd	Lloh150, Lloh151
+	.loh AdrpAdd	Lloh144, Lloh145
 
 	.globl	_access_drop_ivars
 	.p2align	2
 _access_drop_ivars:
-Lloh158:
+Lloh152:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGE
-Lloh159:
+Lloh153:
 	ldr	x8, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGEOFF]
 	add	x8, x0, x8
 	ldp	x0, x1, [x8]
 	ret
-	.loh AdrpLdr	Lloh158, Lloh159
+	.loh AdrpLdr	Lloh152, Lloh153
 
 	.globl	SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0)
 	.p2align	2
 SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
-Lloh160:
+Lloh154:
 	adrp	x8, __MergedGlobals@PAGE+8
-Lloh161:
+Lloh155:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB15_2
-Lloh162:
+Lloh156:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh163:
+Lloh157:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
 LBB15_2:
@@ -766,48 +748,48 @@ LBB15_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh164:
+Lloh158:
 	adrp	x0, __MergedGlobals@PAGE+8
-Lloh165:
+Lloh159:
 	add	x0, x0, __MergedGlobals@PAGEOFF+8
-Lloh166:
+Lloh160:
 	adrp	x3, l_anon.[ID].0@PAGE
-Lloh167:
+Lloh161:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
-Lloh168:
-	adrp	x4, l_anon.[ID].23@PAGE
-Lloh169:
-	add	x4, x4, l_anon.[ID].23@PAGEOFF
+Lloh162:
+	adrp	x4, l_anon.[ID].22@PAGE
+Lloh163:
+	add	x4, x4, l_anon.[ID].22@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh170:
+Lloh164:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh171:
+Lloh165:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
+	.loh AdrpAdd	Lloh154, Lloh155
+	.loh AdrpLdr	Lloh156, Lloh157
+	.loh AdrpLdr	Lloh164, Lloh165
+	.loh AdrpAdd	Lloh162, Lloh163
 	.loh AdrpAdd	Lloh160, Lloh161
-	.loh AdrpLdr	Lloh162, Lloh163
-	.loh AdrpLdr	Lloh170, Lloh171
-	.loh AdrpAdd	Lloh168, Lloh169
-	.loh AdrpAdd	Lloh166, Lloh167
-	.loh AdrpAdd	Lloh164, Lloh165
+	.loh AdrpAdd	Lloh158, Lloh159
 
 	.globl	_get_class
 	.p2align	2
 _get_class:
-Lloh172:
+Lloh166:
 	adrp	x8, __MergedGlobals@PAGE+8
-Lloh173:
+Lloh167:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB16_2
-Lloh174:
+Lloh168:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh175:
+Lloh169:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
 LBB16_2:
@@ -818,34 +800,34 @@ LBB16_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh176:
+Lloh170:
 	adrp	x0, __MergedGlobals@PAGE+8
-Lloh177:
+Lloh171:
 	add	x0, x0, __MergedGlobals@PAGEOFF+8
-Lloh178:
+Lloh172:
 	adrp	x3, l_anon.[ID].0@PAGE
-Lloh179:
+Lloh173:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
-Lloh180:
-	adrp	x4, l_anon.[ID].23@PAGE
-Lloh181:
-	add	x4, x4, l_anon.[ID].23@PAGEOFF
+Lloh174:
+	adrp	x4, l_anon.[ID].22@PAGE
+Lloh175:
+	add	x4, x4, l_anon.[ID].22@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh182:
+Lloh176:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh183:
+Lloh177:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
+	.loh AdrpAdd	Lloh166, Lloh167
+	.loh AdrpLdr	Lloh168, Lloh169
+	.loh AdrpLdr	Lloh176, Lloh177
+	.loh AdrpAdd	Lloh174, Lloh175
 	.loh AdrpAdd	Lloh172, Lloh173
-	.loh AdrpLdr	Lloh174, Lloh175
-	.loh AdrpLdr	Lloh182, Lloh183
-	.loh AdrpAdd	Lloh180, Lloh181
-	.loh AdrpAdd	Lloh178, Lloh179
-	.loh AdrpAdd	Lloh176, Lloh177
+	.loh AdrpAdd	Lloh170, Lloh171
 
 	.globl	_method_simple
 	.p2align	2
@@ -864,23 +846,23 @@ _method_id:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
-Lloh184:
+Lloh178:
 	adrp	x8, __MergedGlobals@PAGE+8
-Lloh185:
+Lloh179:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB19_2
 LBB19_1:
-Lloh186:
+Lloh180:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh187:
+Lloh181:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
-Lloh188:
+Lloh182:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_new@GOTPAGE
-Lloh189:
+Lloh183:
 	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_new@GOTPAGEOFF]
-Lloh190:
+Lloh184:
 	ldr	x1, [x8]
 	bl	_objc_msgSend
 	bl	_objc_autoreleaseReturnValue
@@ -892,29 +874,29 @@ LBB19_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh191:
+Lloh185:
 	adrp	x0, __MergedGlobals@PAGE+8
-Lloh192:
+Lloh186:
 	add	x0, x0, __MergedGlobals@PAGEOFF+8
-Lloh193:
+Lloh187:
 	adrp	x3, l_anon.[ID].0@PAGE
-Lloh194:
+Lloh188:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
-Lloh195:
-	adrp	x4, l_anon.[ID].23@PAGE
-Lloh196:
-	add	x4, x4, l_anon.[ID].23@PAGEOFF
+Lloh189:
+	adrp	x4, l_anon.[ID].22@PAGE
+Lloh190:
+	add	x4, x4, l_anon.[ID].22@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	b	LBB19_1
-	.loh AdrpAdd	Lloh184, Lloh185
-	.loh AdrpLdrGotLdr	Lloh188, Lloh189, Lloh190
-	.loh AdrpAdrp	Lloh186, Lloh188
-	.loh AdrpLdr	Lloh186, Lloh187
-	.loh AdrpAdd	Lloh195, Lloh196
-	.loh AdrpAdd	Lloh193, Lloh194
-	.loh AdrpAdd	Lloh191, Lloh192
+	.loh AdrpAdd	Lloh178, Lloh179
+	.loh AdrpLdrGotLdr	Lloh182, Lloh183, Lloh184
+	.loh AdrpAdrp	Lloh180, Lloh182
+	.loh AdrpLdr	Lloh180, Lloh181
+	.loh AdrpAdd	Lloh189, Lloh190
+	.loh AdrpAdd	Lloh187, Lloh188
+	.loh AdrpAdd	Lloh185, Lloh186
 
 	.globl	_method_id_with_param
 	.p2align	2
@@ -922,17 +904,16 @@ _method_id_with_param:
 	stp	x20, x19, [sp, #-32]!
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
-	mov	x20, x2
+	mov	x19, x2
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
+	cbz	w19, LBB20_2
 	mov	x19, x0
-	tbz	w20, #0, LBB20_2
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	x20, x0
 	mov	x0, x19
 	bl	_objc_release
-	mov	x19, x20
+	mov	x0, x20
 LBB20_2:
-	mov	x0, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_autoreleaseReturnValue
@@ -943,23 +924,23 @@ _copyWithZone:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
-Lloh197:
+Lloh191:
 	adrp	x8, __MergedGlobals@PAGE+8
-Lloh198:
+Lloh192:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB21_2
 LBB21_1:
-Lloh199:
+Lloh193:
 	adrp	x8, __MergedGlobals@PAGE
-Lloh200:
+Lloh194:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
-Lloh201:
+Lloh195:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_new@GOTPAGE
-Lloh202:
+Lloh196:
 	ldr	x8, [x8, L_OBJC_SELECTOR_REFERENCES_new@GOTPAGEOFF]
-Lloh203:
+Lloh197:
 	ldr	x1, [x8]
 	bl	_objc_msgSend
 	ldp	x29, x30, [sp, #16]
@@ -970,43 +951,43 @@ LBB21_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh204:
+Lloh198:
 	adrp	x0, __MergedGlobals@PAGE+8
-Lloh205:
+Lloh199:
 	add	x0, x0, __MergedGlobals@PAGEOFF+8
-Lloh206:
+Lloh200:
 	adrp	x3, l_anon.[ID].0@PAGE
-Lloh207:
+Lloh201:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
-Lloh208:
-	adrp	x4, l_anon.[ID].23@PAGE
-Lloh209:
-	add	x4, x4, l_anon.[ID].23@PAGEOFF
+Lloh202:
+	adrp	x4, l_anon.[ID].22@PAGE
+Lloh203:
+	add	x4, x4, l_anon.[ID].22@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	b	LBB21_1
-	.loh AdrpAdd	Lloh197, Lloh198
-	.loh AdrpLdrGotLdr	Lloh201, Lloh202, Lloh203
-	.loh AdrpAdrp	Lloh199, Lloh201
-	.loh AdrpLdr	Lloh199, Lloh200
-	.loh AdrpAdd	Lloh208, Lloh209
-	.loh AdrpAdd	Lloh206, Lloh207
-	.loh AdrpAdd	Lloh204, Lloh205
+	.loh AdrpAdd	Lloh191, Lloh192
+	.loh AdrpLdrGotLdr	Lloh195, Lloh196, Lloh197
+	.loh AdrpAdrp	Lloh193, Lloh195
+	.loh AdrpLdr	Lloh193, Lloh194
+	.loh AdrpAdd	Lloh202, Lloh203
+	.loh AdrpAdd	Lloh200, Lloh201
+	.loh AdrpAdd	Lloh198, Lloh199
 
 	.globl	SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0)
 	.p2align	2
 SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
-Lloh210:
+Lloh204:
 	adrp	x8, __MergedGlobals@PAGE+24
-Lloh211:
+Lloh205:
 	add	x8, x8, __MergedGlobals@PAGEOFF+24
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB22_2
-Lloh212:
+Lloh206:
 	adrp	x8, __MergedGlobals@PAGE+16
-Lloh213:
+Lloh207:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
 LBB22_2:
@@ -1017,42 +998,42 @@ LBB22_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh214:
+Lloh208:
 	adrp	x0, __MergedGlobals@PAGE+24
-Lloh215:
+Lloh209:
 	add	x0, x0, __MergedGlobals@PAGEOFF+24
-Lloh216:
+Lloh210:
 	adrp	x3, l_anon.[ID].2@PAGE
-Lloh217:
+Lloh211:
 	add	x3, x3, l_anon.[ID].2@PAGEOFF
-Lloh218:
-	adrp	x4, l_anon.[ID].26@PAGE
-Lloh219:
-	add	x4, x4, l_anon.[ID].26@PAGEOFF
+Lloh212:
+	adrp	x4, l_anon.[ID].25@PAGE
+Lloh213:
+	add	x4, x4, l_anon.[ID].25@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh220:
+Lloh214:
 	adrp	x8, __MergedGlobals@PAGE+16
-Lloh221:
+Lloh215:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
+	.loh AdrpAdd	Lloh204, Lloh205
+	.loh AdrpLdr	Lloh206, Lloh207
+	.loh AdrpLdr	Lloh214, Lloh215
+	.loh AdrpAdd	Lloh212, Lloh213
 	.loh AdrpAdd	Lloh210, Lloh211
-	.loh AdrpLdr	Lloh212, Lloh213
-	.loh AdrpLdr	Lloh220, Lloh221
-	.loh AdrpAdd	Lloh218, Lloh219
-	.loh AdrpAdd	Lloh216, Lloh217
-	.loh AdrpAdd	Lloh214, Lloh215
+	.loh AdrpAdd	Lloh208, Lloh209
 
 	.globl	_init_forgetable_ivars
 	.p2align	2
 _init_forgetable_ivars:
 	cbz	x0, LBB23_2
-Lloh222:
+Lloh216:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGE
-Lloh223:
+Lloh217:
 	ldr	x8, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGEOFF]
 	add	x8, x0, x8
 	mov	w9, #43
@@ -1063,15 +1044,15 @@ LBB23_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
-Lloh224:
+Lloh218:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_af8966656b8b2b6c@PAGE
-Lloh225:
+Lloh219:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_af8966656b8b2b6c@PAGEOFF]
-Lloh226:
+Lloh220:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
-Lloh227:
+Lloh221:
 	ldr	x8, [x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGEOFF]
-Lloh228:
+Lloh222:
 	ldr	x8, [x8]
 	stp	x0, x8, [sp]
 	mov	x0, sp
@@ -1079,24 +1060,24 @@ Lloh228:
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
 	ret
-	.loh AdrpLdr	Lloh222, Lloh223
-	.loh AdrpLdrGotLdr	Lloh226, Lloh227, Lloh228
-	.loh AdrpAdrp	Lloh224, Lloh226
-	.loh AdrpLdr	Lloh224, Lloh225
+	.loh AdrpLdr	Lloh216, Lloh217
+	.loh AdrpLdrGotLdr	Lloh220, Lloh221, Lloh222
+	.loh AdrpAdrp	Lloh218, Lloh220
+	.loh AdrpLdr	Lloh218, Lloh219
 
 	.globl	SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0)
 	.p2align	2
 SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
-Lloh229:
+Lloh223:
 	adrp	x8, __MergedGlobals@PAGE+40
-Lloh230:
+Lloh224:
 	add	x8, x8, __MergedGlobals@PAGEOFF+40
 	ldapr	x8, [x8]
 	cmp	x8, #3
 	b.ne	LBB24_2
-Lloh231:
+Lloh225:
 	adrp	x8, __MergedGlobals@PAGE+32
-Lloh232:
+Lloh226:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
 LBB24_2:
@@ -1107,34 +1088,34 @@ LBB24_2:
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
 	str	x8, [sp, #8]
-Lloh233:
+Lloh227:
 	adrp	x0, __MergedGlobals@PAGE+40
-Lloh234:
+Lloh228:
 	add	x0, x0, __MergedGlobals@PAGEOFF+40
-Lloh235:
+Lloh229:
 	adrp	x3, l_anon.[ID].1@PAGE
-Lloh236:
+Lloh230:
 	add	x3, x3, l_anon.[ID].1@PAGEOFF
-Lloh237:
-	adrp	x4, l_anon.[ID].27@PAGE
-Lloh238:
-	add	x4, x4, l_anon.[ID].27@PAGEOFF
+Lloh231:
+	adrp	x4, l_anon.[ID].26@PAGE
+Lloh232:
+	add	x4, x4, l_anon.[ID].26@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
-Lloh239:
+Lloh233:
 	adrp	x8, __MergedGlobals@PAGE+32
-Lloh240:
+Lloh234:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
+	.loh AdrpAdd	Lloh223, Lloh224
+	.loh AdrpLdr	Lloh225, Lloh226
+	.loh AdrpLdr	Lloh233, Lloh234
+	.loh AdrpAdd	Lloh231, Lloh232
 	.loh AdrpAdd	Lloh229, Lloh230
-	.loh AdrpLdr	Lloh231, Lloh232
-	.loh AdrpLdr	Lloh239, Lloh240
-	.loh AdrpAdd	Lloh237, Lloh238
-	.loh AdrpAdd	Lloh235, Lloh236
-	.loh AdrpAdd	Lloh233, Lloh234
+	.loh AdrpAdd	Lloh227, Lloh228
 
 	.globl	_init_drop_ivars
 	.p2align	2
@@ -1148,34 +1129,34 @@ _init_drop_ivars:
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	x20, x0
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
-	mov	x21, x0
 	adrp	x22, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGE
 	cbz	x19, LBB25_2
-Lloh241:
+Lloh235:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGE
-Lloh242:
+Lloh236:
 	ldr	x8, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGEOFF]
 	add	x8, x19, x8
-	stp	x20, x21, [x8]
+	stp	x20, x0, [x8]
 	ldr	x8, [x22, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGEOFF]
 	mov	w9, #15
 	strb	w9, [x19, x8]
 	b	LBB25_3
 LBB25_2:
+	mov	x21, x0
 	mov	x0, x20
 	bl	_objc_release
 	mov	x0, x21
 	bl	_objc_release
 LBB25_3:
-Lloh243:
+Lloh237:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_6edddcebbded8f32@PAGE
-Lloh244:
+Lloh238:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_6edddcebbded8f32@PAGEOFF]
-Lloh245:
+Lloh239:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
-Lloh246:
+Lloh240:
 	ldr	x8, [x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGEOFF]
-Lloh247:
+Lloh241:
 	ldr	x8, [x8]
 	stp	x19, x8, [sp]
 	mov	x0, sp
@@ -1190,10 +1171,10 @@ LBB25_5:
 	ldp	x22, x21, [sp, #16]
 	add	sp, sp, #64
 	ret
-	.loh AdrpLdr	Lloh241, Lloh242
-	.loh AdrpLdrGotLdr	Lloh245, Lloh246, Lloh247
-	.loh AdrpAdrp	Lloh243, Lloh245
-	.loh AdrpLdr	Lloh243, Lloh244
+	.loh AdrpLdr	Lloh235, Lloh236
+	.loh AdrpLdrGotLdr	Lloh239, Lloh240, Lloh241
+	.loh AdrpAdrp	Lloh237, Lloh239
+	.loh AdrpLdr	Lloh237, Lloh238
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
@@ -1294,37 +1275,34 @@ l_anon.[ID].18:
 	.ascii	"DropIvars"
 
 l_anon.[ID].19:
-	.ascii	"called `Option::unwrap()` on a `None` value"
-
-l_anon.[ID].20:
 	.ascii	"$RUSTC/library/std/src/sync/once.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].21:
-	.quad	l_anon.[ID].20
+l_anon.[ID].20:
+	.quad	l_anon.[ID].19
 	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
-
-	.section	__TEXT,__const
-l_anon.[ID].22:
-	.ascii	"crates/$DIR/lib.rs"
 
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2),8,3
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1),8,3
+	.section	__TEXT,__const
+l_anon.[ID].21:
+	.ascii	"crates/$DIR/lib.rs"
+
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].23:
-	.quad	l_anon.[ID].22
+l_anon.[ID].22:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000\016\000\000\000\001\000\000"
 
 	.section	__TEXT,__literal8,8byte_literals
-l_anon.[ID].24:
+l_anon.[ID].23:
 	.ascii	"NSObject"
 
 	.section	__TEXT,__const
-l_anon.[ID].25:
+l_anon.[ID].24:
 	.ascii	"NSCopying"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -1435,8 +1413,8 @@ L_OBJC_IMAGE_INFO_2837f061c311eb14:
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 2),8,3
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].26:
-	.quad	l_anon.[ID].22
+l_anon.[ID].25:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000O\000\000\000\001\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -1462,8 +1440,8 @@ L_OBJC_IMAGE_INFO_af8966656b8b2b6c:
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0),8,3
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].27:
-	.quad	l_anon.[ID].22
+l_anon.[ID].26:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000x\000\000\000\001\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
@@ -122,7 +122,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rdx, r15
 	mov	r8, r12
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
-	lea	rdi, [rip + L_anon.[ID].24]
+	lea	rdi, [rip + L_anon.[ID].23]
 	mov	esi, 8
 	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	test	rax, rax
@@ -131,7 +131,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rsi, rax
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
 LBB4_4:
-	lea	rdi, [rip + l_anon.[ID].25]
+	lea	rdi, [rip + l_anon.[ID].24]
 	mov	esi, 9
 	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	test	rax, rax
@@ -158,13 +158,11 @@ LBB4_6:
 	pop	rbp
 	ret
 LBB4_7:
-	lea	rdi, [rip + l_anon.[ID].19]
-	lea	rdx, [rip + l_anon.[ID].21]
-	mov	esi, 43
-	call	SYM(core::panicking::panic::GENERATED_ID, 0)
+	lea	rdi, [rip + l_anon.[ID].20]
+	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB4_8:
 	lea	rdi, [rip + l_anon.[ID].17]
-	lea	rdx, [rip + l_anon.[ID].23]
+	lea	rdx, [rip + l_anon.[ID].22]
 	mov	esi, 7
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 
@@ -257,13 +255,11 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	pop	rbp
 	ret
 LBB5_5:
-	lea	rdi, [rip + l_anon.[ID].19]
-	lea	rdx, [rip + l_anon.[ID].21]
-	mov	esi, 43
-	call	SYM(core::panicking::panic::GENERATED_ID, 0)
+	lea	rdi, [rip + l_anon.[ID].20]
+	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB5_6:
 	lea	rdi, [rip + l_anon.[ID].18]
-	lea	rdx, [rip + l_anon.[ID].27]
+	lea	rdx, [rip + l_anon.[ID].26]
 	mov	esi, 9
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 LBB5_7:
@@ -331,13 +327,11 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	pop	rbp
 	ret
 LBB6_4:
-	lea	rdi, [rip + l_anon.[ID].19]
-	lea	rdx, [rip + l_anon.[ID].21]
-	mov	esi, 43
-	call	SYM(core::panicking::panic::GENERATED_ID, 0)
+	lea	rdi, [rip + l_anon.[ID].20]
+	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
 LBB6_5:
 	lea	rdi, [rip + l_anon.[ID].16]
-	lea	rdx, [rip + l_anon.[ID].26]
+	lea	rdx, [rip + l_anon.[ID].25]
 	mov	esi, 15
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 LBB6_6:
@@ -399,7 +393,7 @@ LBB10_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].2]
-	lea	r8, [rip + l_anon.[ID].26]
+	lea	r8, [rip + l_anon.[ID].25]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -446,7 +440,7 @@ LBB13_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].1]
-	lea	r8, [rip + l_anon.[ID].27]
+	lea	r8, [rip + l_anon.[ID].26]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -483,7 +477,7 @@ LBB15_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].23]
+	lea	r8, [rip + l_anon.[ID].22]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -509,7 +503,7 @@ LBB16_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].23]
+	lea	r8, [rip + l_anon.[ID].22]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -562,7 +556,7 @@ LBB19_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].23]
+	lea	r8, [rip + l_anon.[ID].22]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -615,7 +609,7 @@ LBB21_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].23]
+	lea	r8, [rip + l_anon.[ID].22]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -638,7 +632,7 @@ LBB22_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].2]
-	lea	r8, [rip + l_anon.[ID].26]
+	lea	r8, [rip + l_anon.[ID].25]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -687,7 +681,7 @@ LBB24_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].1]
-	lea	r8, [rip + l_anon.[ID].27]
+	lea	r8, [rip + l_anon.[ID].26]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys_common::once::queue::Once::call::GENERATED_ID, 0)
@@ -711,14 +705,14 @@ _init_drop_ivars:
 	call	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	r15, rax
 	test	rbx, rbx
-	je	LBB25_2
+	je	LBB25_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)]
 	mov	qword ptr [rbx + rax], r14
 	mov	qword ptr [rbx + rax + 8], r15
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)]
 	mov	byte ptr [rbx + rax], 15
 	jmp	LBB25_3
-LBB25_2:
+LBB25_1:
 	mov	rdi, r14
 	call	_objc_release
 	mov	rdi, r15
@@ -842,39 +836,36 @@ l_anon.[ID].18:
 	.ascii	"DropIvars"
 
 l_anon.[ID].19:
-	.ascii	"called `Option::unwrap()` on a `None` value"
-
-l_anon.[ID].20:
 	.ascii	"$RUSTC/library/std/src/sync/once.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].21:
-	.quad	l_anon.[ID].20
+l_anon.[ID].20:
+	.quad	l_anon.[ID].19
 	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
-
-	.section	__TEXT,__const
-l_anon.[ID].22:
-	.ascii	"crates/$DIR/lib.rs"
 
 .zerofill __DATA,__bss,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0,8,3
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2),8,3
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1),8,3
+	.section	__TEXT,__const
+l_anon.[ID].21:
+	.ascii	"crates/$DIR/lib.rs"
+
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].23:
-	.quad	l_anon.[ID].22
+l_anon.[ID].22:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000\016\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3
 	.section	__TEXT,__literal8,8byte_literals
-L_anon.[ID].24:
+L_anon.[ID].23:
 	.ascii	"NSObject"
 
 	.section	__TEXT,__const
-l_anon.[ID].25:
+l_anon.[ID].24:
 	.ascii	"NSCopying"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -986,8 +977,8 @@ L_OBJC_IMAGE_INFO_2837f061c311eb14:
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 2),8,3
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].26:
-	.quad	l_anon.[ID].22
+l_anon.[ID].25:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000O\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3
@@ -1015,8 +1006,8 @@ L_OBJC_IMAGE_INFO_af8966656b8b2b6c:
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0),8,3
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].27:
-	.quad	l_anon.[ID].22
+l_anon.[ID].26:
+	.quad	l_anon.[ID].21
 	.asciz	"5\000\000\000\000\000\000\000x\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-aarch64.s
@@ -118,32 +118,31 @@ _use_fns:
 	stp	x20, x19, [sp, #16]
 	stp	x29, x30, [sp, #32]
 	add	x29, sp, #32
-	mov	x19, x8
 Lloh32:
-	adrp	x8, __MergedGlobals@PAGE
+	adrp	x9, __MergedGlobals@PAGE
 Lloh33:
-	ldr	x20, [x8, __MergedGlobals@PAGEOFF]
-	cbz	x20, LBB4_5
+	ldr	x19, [x9, __MergedGlobals@PAGEOFF]
+	cbz	x19, LBB4_5
 Lloh34:
-	adrp	x8, __MergedGlobals@PAGE+8
+	adrp	x9, __MergedGlobals@PAGE+8
 Lloh35:
-	ldr	x21, [x8, __MergedGlobals@PAGEOFF+8]
-	cbz	x21, LBB4_6
+	ldr	x20, [x9, __MergedGlobals@PAGEOFF+8]
+	cbz	x20, LBB4_6
 LBB4_2:
 Lloh36:
-	adrp	x8, __MergedGlobals@PAGE+16
+	adrp	x9, __MergedGlobals@PAGE+16
 Lloh37:
-	ldr	x22, [x8, __MergedGlobals@PAGEOFF+16]
-	cbz	x22, LBB4_7
+	ldr	x21, [x9, __MergedGlobals@PAGEOFF+16]
+	cbz	x21, LBB4_7
 LBB4_3:
 Lloh38:
-	adrp	x8, __MergedGlobals@PAGE+24
+	adrp	x9, __MergedGlobals@PAGE+24
 Lloh39:
-	ldr	x0, [x8, __MergedGlobals@PAGEOFF+24]
+	ldr	x0, [x9, __MergedGlobals@PAGEOFF+24]
 	cbz	x0, LBB4_8
 LBB4_4:
-	stp	x20, x21, [x19]
-	stp	x22, x0, [x19, #16]
+	stp	x19, x20, [x8]
+	stp	x21, x0, [x8, #16]
 	ldp	x29, x30, [sp, #32]
 	ldp	x20, x19, [sp, #16]
 	ldp	x22, x21, [sp], #48
@@ -161,13 +160,15 @@ Lloh44:
 	adrp	x2, l_anon.[ID].2@PAGE
 Lloh45:
 	add	x2, x2, l_anon.[ID].2@PAGEOFF
+	mov	x19, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	x20, x0
+	mov	x8, x19
+	mov	x19, x0
 Lloh46:
-	adrp	x8, __MergedGlobals@PAGE+8
+	adrp	x9, __MergedGlobals@PAGE+8
 Lloh47:
-	ldr	x21, [x8, __MergedGlobals@PAGEOFF+8]
-	cbnz	x21, LBB4_2
+	ldr	x20, [x9, __MergedGlobals@PAGEOFF+8]
+	cbnz	x20, LBB4_2
 LBB4_6:
 Lloh48:
 	adrp	x0, __MergedGlobals@PAGE+8
@@ -181,13 +182,15 @@ Lloh52:
 	adrp	x2, l_anon.[ID].3@PAGE
 Lloh53:
 	add	x2, x2, l_anon.[ID].3@PAGEOFF
+	mov	x20, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	x21, x0
+	mov	x8, x20
+	mov	x20, x0
 Lloh54:
-	adrp	x8, __MergedGlobals@PAGE+16
+	adrp	x9, __MergedGlobals@PAGE+16
 Lloh55:
-	ldr	x22, [x8, __MergedGlobals@PAGEOFF+16]
-	cbnz	x22, LBB4_3
+	ldr	x21, [x9, __MergedGlobals@PAGEOFF+16]
+	cbnz	x21, LBB4_3
 LBB4_7:
 Lloh56:
 	adrp	x0, __MergedGlobals@PAGE+16
@@ -201,12 +204,14 @@ Lloh60:
 	adrp	x2, l_anon.[ID].5@PAGE
 Lloh61:
 	add	x2, x2, l_anon.[ID].5@PAGEOFF
+	mov	x21, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	x22, x0
+	mov	x8, x21
+	mov	x21, x0
 Lloh62:
-	adrp	x8, __MergedGlobals@PAGE+24
+	adrp	x9, __MergedGlobals@PAGE+24
 Lloh63:
-	ldr	x0, [x8, __MergedGlobals@PAGEOFF+24]
+	ldr	x0, [x9, __MergedGlobals@PAGEOFF+24]
 	cbnz	x0, LBB4_4
 LBB4_8:
 Lloh64:
@@ -221,9 +226,10 @@ Lloh68:
 	adrp	x2, l_anon.[ID].9@PAGE
 Lloh69:
 	add	x2, x2, l_anon.[ID].9@PAGEOFF
+	mov	x22, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	stp	x20, x21, [x19]
-	stp	x22, x0, [x19, #16]
+	stp	x19, x20, [x22]
+	stp	x21, x0, [x22, #16]
 	ldp	x29, x30, [sp, #32]
 	ldp	x20, x19, [sp, #16]
 	ldp	x22, x21, [sp], #48
@@ -251,21 +257,18 @@ Lloh69:
 	.globl	_use_same_twice
 	.p2align	2
 _use_same_twice:
-	stp	x22, x21, [sp, #-48]!
-	stp	x20, x19, [sp, #16]
-	stp	x29, x30, [sp, #32]
-	add	x29, sp, #32
-	mov	x19, x8
-	adrp	x21, __MergedGlobals@PAGE
-	ldr	x20, [x21, __MergedGlobals@PAGEOFF]
-	cbz	x20, LBB5_3
-	ldr	x0, [x21, __MergedGlobals@PAGEOFF]
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	add	x29, sp, #16
+	adrp	x20, __MergedGlobals@PAGE
+	ldr	x19, [x20, __MergedGlobals@PAGEOFF]
+	cbz	x19, LBB5_3
+	ldr	x0, [x20, __MergedGlobals@PAGEOFF]
 	cbz	x0, LBB5_4
 LBB5_2:
-	stp	x20, x0, [x19]
-	ldp	x29, x30, [sp, #32]
-	ldp	x20, x19, [sp, #16]
-	ldp	x22, x21, [sp], #48
+	stp	x19, x0, [x8]
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
 	ret
 LBB5_3:
 Lloh70:
@@ -280,9 +283,11 @@ Lloh74:
 	adrp	x2, l_anon.[ID].2@PAGE
 Lloh75:
 	add	x2, x2, l_anon.[ID].2@PAGEOFF
+	mov	x19, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	x20, x0
-	ldr	x0, [x21, __MergedGlobals@PAGEOFF]
+	mov	x8, x19
+	mov	x19, x0
+	ldr	x0, [x20, __MergedGlobals@PAGEOFF]
 	cbnz	x0, LBB5_2
 LBB5_4:
 Lloh76:
@@ -297,11 +302,11 @@ Lloh80:
 	adrp	x2, l_anon.[ID].2@PAGE
 Lloh81:
 	add	x2, x2, l_anon.[ID].2@PAGEOFF
+	mov	x20, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	stp	x20, x0, [x19]
-	ldp	x29, x30, [sp, #32]
-	ldp	x20, x19, [sp, #16]
-	ldp	x22, x21, [sp], #48
+	stp	x19, x0, [x20]
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
 	ret
 	.loh AdrpAdd	Lloh74, Lloh75
 	.loh AdrpAdd	Lloh72, Lloh73

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-armv7s.s
@@ -105,37 +105,34 @@ _use_fns:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
 	push	{r8, r10}
-	movw	r10, :lower16:(__MergedGlobals-(LPC4_0+8))
-	movt	r10, :upper16:(__MergedGlobals-(LPC4_0+8))
+	movw	r8, :lower16:(__MergedGlobals-(LPC4_0+8))
+	movt	r8, :upper16:(__MergedGlobals-(LPC4_0+8))
 LPC4_0:
-	add	r10, pc, r10
-	mov	r4, r0
-	ldr	r8, [r10]
-	cmp	r8, #0
+	add	r8, pc, r8
+	ldr	r4, [r8]
+	cmp	r4, #0
 	beq	LBB4_5
-	ldr	r6, [r10, #4]
-	cmp	r6, #0
+	ldr	r5, [r8, #4]
+	cmp	r5, #0
 	beq	LBB4_6
 LBB4_2:
-	ldr	r5, [r10, #8]
-	cmp	r5, #0
+	ldr	r6, [r8, #8]
+	cmp	r6, #0
 	beq	LBB4_7
 LBB4_3:
-	ldr	r0, [r10, #12]
-	cmp	r0, #0
+	ldr	r1, [r8, #12]
+	cmp	r1, #0
 	beq	LBB4_8
 LBB4_4:
-	str	r8, [r4]
-	str	r6, [r4, #4]
-	str	r5, [r4, #8]
-	str	r0, [r4, #12]
+	stm	r0, {r4, r5, r6}
+	str	r1, [r0, #12]
 	pop	{r8, r10}
 	pop	{r4, r5, r6, r7, pc}
 LBB4_5:
-	movw	r0, :lower16:(__MergedGlobals-(LPC4_1+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC4_1+8))
+	movw	r3, :lower16:(__MergedGlobals-(LPC4_1+8))
+	movt	r3, :upper16:(__MergedGlobals-(LPC4_1+8))
 LPC4_1:
-	add	r0, pc, r0
+	add	r3, pc, r3
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC4_2+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC4_2+8))
 LPC4_2:
@@ -144,13 +141,16 @@ LPC4_2:
 	movt	r2, :upper16:(l_anon.[ID].2-(LPC4_3+8))
 LPC4_3:
 	add	r2, pc, r2
+	mov	r5, r0
+	mov	r0, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	r8, r0
-	ldr	r6, [r10, #4]
-	cmp	r6, #0
+	mov	r4, r0
+	mov	r0, r5
+	ldr	r5, [r8, #4]
+	cmp	r5, #0
 	bne	LBB4_2
 LBB4_6:
-	add	r0, r10, #4
+	add	r3, r8, #4
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC4_4+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC4_4+8))
 LPC4_4:
@@ -159,13 +159,16 @@ LPC4_4:
 	movt	r2, :upper16:(l_anon.[ID].3-(LPC4_5+8))
 LPC4_5:
 	add	r2, pc, r2
-	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	mov	r6, r0
-	ldr	r5, [r10, #8]
-	cmp	r5, #0
+	mov	r0, r3
+	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	r5, r0
+	mov	r0, r6
+	ldr	r6, [r8, #8]
+	cmp	r6, #0
 	bne	LBB4_3
 LBB4_7:
-	add	r0, r10, #8
+	add	r3, r8, #8
 	movw	r1, :lower16:(l_anon.[ID].4-(LPC4_6+8))
 	movt	r1, :upper16:(l_anon.[ID].4-(LPC4_6+8))
 LPC4_6:
@@ -174,13 +177,16 @@ LPC4_6:
 	movt	r2, :upper16:(l_anon.[ID].5-(LPC4_7+8))
 LPC4_7:
 	add	r2, pc, r2
+	mov	r10, r0
+	mov	r0, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	r5, r0
-	ldr	r0, [r10, #12]
-	cmp	r0, #0
+	mov	r6, r0
+	mov	r0, r10
+	ldr	r1, [r8, #12]
+	cmp	r1, #0
 	bne	LBB4_4
 LBB4_8:
-	add	r0, r10, #12
+	add	r3, r8, #12
 	movw	r1, :lower16:(l_anon.[ID].8-(LPC4_8+8))
 	movt	r1, :upper16:(l_anon.[ID].8-(LPC4_8+8))
 LPC4_8:
@@ -189,36 +195,40 @@ LPC4_8:
 	movt	r2, :upper16:(l_anon.[ID].9-(LPC4_9+8))
 LPC4_9:
 	add	r2, pc, r2
+	mov	r8, r0
+	mov	r0, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	b	LBB4_4
+	mov	r1, r0
+	mov	r0, r8
+	stm	r0, {r4, r5, r6}
+	str	r1, [r0, #12]
+	pop	{r8, r10}
+	pop	{r4, r5, r6, r7, pc}
 
 	.globl	_use_same_twice
 	.p2align	2
 	.code	32
 _use_same_twice:
-	push	{r4, r5, r7, lr}
-	add	r7, sp, #8
-	push	{r8}
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
 	movw	r5, :lower16:(__MergedGlobals-(LPC5_0+8))
 	movt	r5, :upper16:(__MergedGlobals-(LPC5_0+8))
 LPC5_0:
 	add	r5, pc, r5
-	mov	r4, r0
-	ldr	r8, [r5]
-	cmp	r8, #0
+	ldr	r4, [r5]
+	cmp	r4, #0
 	beq	LBB5_3
-	ldr	r9, [r5]
-	cmp	r9, #0
+	ldr	r5, [r5]
+	cmp	r5, #0
 	beq	LBB5_4
 LBB5_2:
-	strd	r8, r9, [r4]
-	pop	{r8}
-	pop	{r4, r5, r7, pc}
+	strd	r4, r5, [r0]
+	pop	{r4, r5, r6, r7, pc}
 LBB5_3:
-	movw	r0, :lower16:(__MergedGlobals-(LPC5_1+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC5_1+8))
+	movw	r3, :lower16:(__MergedGlobals-(LPC5_1+8))
+	movt	r3, :upper16:(__MergedGlobals-(LPC5_1+8))
 LPC5_1:
-	add	r0, pc, r0
+	add	r3, pc, r3
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC5_2+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC5_2+8))
 LPC5_2:
@@ -227,16 +237,19 @@ LPC5_2:
 	movt	r2, :upper16:(l_anon.[ID].2-(LPC5_3+8))
 LPC5_3:
 	add	r2, pc, r2
+	mov	r6, r0
+	mov	r0, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	r8, r0
-	ldr	r9, [r5]
-	cmp	r9, #0
+	mov	r4, r0
+	mov	r0, r6
+	ldr	r5, [r5]
+	cmp	r5, #0
 	bne	LBB5_2
 LBB5_4:
-	movw	r0, :lower16:(__MergedGlobals-(LPC5_4+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC5_4+8))
+	movw	r3, :lower16:(__MergedGlobals-(LPC5_4+8))
+	movt	r3, :upper16:(__MergedGlobals-(LPC5_4+8))
 LPC5_4:
-	add	r0, pc, r0
+	add	r3, pc, r3
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC5_5+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC5_5+8))
 LPC5_5:
@@ -245,11 +258,13 @@ LPC5_5:
 	movt	r2, :upper16:(l_anon.[ID].2-(LPC5_6+8))
 LPC5_6:
 	add	r2, pc, r2
+	mov	r6, r0
+	mov	r0, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	r9, r0
-	strd	r8, r9, [r4]
-	pop	{r8}
-	pop	{r4, r5, r7, pc}
+	mov	r5, r0
+	mov	r0, r6
+	strd	r4, r5, [r0]
+	pop	{r4, r5, r6, r7, pc}
 
 	.globl	_use_in_loop
 	.p2align	2

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86.s
@@ -123,28 +123,27 @@ _use_fns:
 	sub	esp, 12
 	call	L4$pb
 L4$pb:
-	pop	edi
-	mov	ecx, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L4$pb]
-	test	ecx, ecx
-	je	LBB4_1
-	mov	edx, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
+	pop	esi
+	mov	edx, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L4$pb]
 	test	edx, edx
+	je	LBB4_1
+	mov	edi, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
+	test	edi, edi
 	je	LBB4_3
 LBB4_4:
-	mov	ebx, dword ptr [ebp + 8]
-	mov	esi, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
-	test	esi, esi
+	mov	eax, dword ptr [ebp + 8]
+	mov	ebx, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
+	test	ebx, ebx
 	je	LBB4_5
 LBB4_6:
-	mov	eax, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
-	test	eax, eax
+	mov	ecx, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
+	test	ecx, ecx
 	je	LBB4_7
 LBB4_8:
-	mov	dword ptr [ebx], ecx
-	mov	dword ptr [ebx + 4], edx
-	mov	dword ptr [ebx + 8], esi
-	mov	dword ptr [ebx + 12], eax
-	mov	eax, ebx
+	mov	dword ptr [eax], edx
+	mov	dword ptr [eax + 4], edi
+	mov	dword ptr [eax + 8], ebx
+	mov	dword ptr [eax + 12], ecx
 	add	esp, 12
 	pop	esi
 	pop	edi
@@ -153,67 +152,67 @@ LBB4_8:
 	ret	4
 LBB4_1:
 	sub	esp, 4
-	lea	eax, [edi + l_anon.[ID].2-L4$pb]
-	lea	ecx, [edi + l_anon.[ID].0-L4$pb]
-	lea	edx, [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L4$pb]
+	lea	eax, [esi + l_anon.[ID].2-L4$pb]
+	lea	ecx, [esi + l_anon.[ID].0-L4$pb]
+	lea	edx, [esi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L4$pb]
 	push	eax
 	push	ecx
 	push	edx
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	add	esp, 16
-	mov	ecx, eax
-	mov	edx, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
-	test	edx, edx
+	mov	edx, eax
+	mov	edi, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
+	test	edi, edi
 	jne	LBB4_4
 LBB4_3:
 	sub	esp, 4
-	lea	eax, [edi + l_anon.[ID].3-L4$pb]
-	mov	esi, ecx
-	lea	ecx, [edi + l_anon.[ID].0-L4$pb]
-	lea	edx, [edi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
+	lea	eax, [esi + l_anon.[ID].3-L4$pb]
+	lea	ecx, [esi + l_anon.[ID].0-L4$pb]
+	mov	edi, edx
+	lea	edx, [esi + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)-L4$pb]
 	push	eax
 	push	ecx
 	push	edx
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	ecx, esi
+	mov	edx, edi
 	add	esp, 16
-	mov	edx, eax
-	mov	ebx, dword ptr [ebp + 8]
-	mov	esi, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
-	test	esi, esi
+	mov	edi, eax
+	mov	eax, dword ptr [ebp + 8]
+	mov	ebx, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
+	test	ebx, ebx
 	jne	LBB4_6
 LBB4_5:
 	sub	esp, 4
-	lea	eax, [edi + l_anon.[ID].5-L4$pb]
-	mov	dword ptr [ebp - 16], ecx
-	lea	ecx, [edi + l_anon.[ID].4-L4$pb]
-	mov	esi, edx
-	lea	edx, [edi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
+	lea	eax, [esi + l_anon.[ID].5-L4$pb]
+	lea	ecx, [esi + l_anon.[ID].4-L4$pb]
+	mov	ebx, edx
+	lea	edx, [esi + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)-L4$pb]
 	push	eax
 	push	ecx
 	push	edx
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	edx, esi
-	mov	ecx, dword ptr [ebp - 16]
+	mov	edx, ebx
 	add	esp, 16
-	mov	esi, eax
-	mov	eax, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
-	test	eax, eax
+	mov	ebx, eax
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [esi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
+	test	ecx, ecx
 	jne	LBB4_8
 LBB4_7:
 	sub	esp, 4
-	lea	eax, [edi + l_anon.[ID].9-L4$pb]
-	mov	dword ptr [ebp - 16], ecx
-	lea	ecx, [edi + l_anon.[ID].8-L4$pb]
-	mov	dword ptr [ebp - 20], edx
-	lea	edx, [edi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
-	push	eax
+	lea	ecx, [esi + l_anon.[ID].9-L4$pb]
+	mov	dword ptr [ebp - 16], edx
+	lea	edx, [esi + l_anon.[ID].8-L4$pb]
+	lea	esi, [esi + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)-L4$pb]
 	push	ecx
 	push	edx
+	push	esi
+	mov	esi, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
-	mov	edx, dword ptr [ebp - 20]
-	mov	ecx, dword ptr [ebp - 16]
+	mov	edx, dword ptr [ebp - 16]
 	add	esp, 16
+	mov	ecx, eax
+	mov	eax, esi
 	jmp	LBB4_8
 
 	.globl	_use_same_twice
@@ -227,18 +226,17 @@ _use_same_twice:
 	sub	esp, 12
 	call	L5$pb
 L5$pb:
-	pop	ebx
-	mov	esi, dword ptr [ebp + 8]
-	mov	edi, dword ptr [ebx + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
-	test	edi, edi
+	pop	edi
+	mov	eax, dword ptr [ebp + 8]
+	mov	esi, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
+	test	esi, esi
 	je	LBB5_1
-	mov	eax, dword ptr [ebx + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
-	test	eax, eax
+	mov	ecx, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
+	test	ecx, ecx
 	je	LBB5_3
 LBB5_4:
-	mov	dword ptr [esi], edi
-	mov	dword ptr [esi + 4], eax
-	mov	eax, esi
+	mov	dword ptr [eax], esi
+	mov	dword ptr [eax + 4], ecx
 	add	esp, 12
 	pop	esi
 	pop	edi
@@ -247,28 +245,33 @@ LBB5_4:
 	ret	4
 LBB5_1:
 	sub	esp, 4
-	lea	eax, [ebx + l_anon.[ID].2-L5$pb]
-	lea	ecx, [ebx + l_anon.[ID].0-L5$pb]
-	lea	edx, [ebx + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
-	push	eax
+	lea	ecx, [edi + l_anon.[ID].2-L5$pb]
+	lea	edx, [edi + l_anon.[ID].0-L5$pb]
+	lea	esi, [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
 	push	ecx
 	push	edx
+	push	esi
+	mov	ebx, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	add	esp, 16
-	mov	edi, eax
-	mov	eax, dword ptr [ebx + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
-	test	eax, eax
+	mov	esi, eax
+	mov	eax, ebx
+	mov	ecx, dword ptr [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
+	test	ecx, ecx
 	jne	LBB5_4
 LBB5_3:
 	sub	esp, 4
-	lea	eax, [ebx + l_anon.[ID].2-L5$pb]
-	lea	ecx, [ebx + l_anon.[ID].0-L5$pb]
-	lea	edx, [ebx + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
-	push	eax
+	lea	ecx, [edi + l_anon.[ID].2-L5$pb]
+	lea	edx, [edi + l_anon.[ID].0-L5$pb]
+	lea	edi, [edi + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)-L5$pb]
 	push	ecx
 	push	edx
+	push	edi
+	mov	edi, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	add	esp, 16
+	mov	ecx, eax
+	mov	eax, edi
 	jmp	LBB5_4
 
 	.globl	_use_in_loop

--- a/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_dynamic_class/expected/apple-x86_64.s
@@ -77,27 +77,26 @@ _use_fns:
 	push	r14
 	push	r12
 	push	rbx
-	mov	rbx, rdi
-	mov	r14, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
-	test	r14, r14
+	mov	rax, rdi
+	mov	rbx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
+	test	rbx, rbx
 	je	LBB4_1
-	mov	r15, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)]
-	test	r15, r15
+	mov	r14, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)]
+	test	r14, r14
 	je	LBB4_3
 LBB4_4:
-	mov	r12, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)]
-	test	r12, r12
+	mov	r15, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)]
+	test	r15, r15
 	je	LBB4_5
 LBB4_6:
-	mov	rax, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)]
-	test	rax, rax
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)]
+	test	rcx, rcx
 	je	LBB4_7
 LBB4_8:
-	mov	qword ptr [rbx], r14
-	mov	qword ptr [rbx + 8], r15
-	mov	qword ptr [rbx + 16], r12
-	mov	qword ptr [rbx + 24], rax
-	mov	rax, rbx
+	mov	qword ptr [rax], rbx
+	mov	qword ptr [rax + 8], r14
+	mov	qword ptr [rax + 16], r15
+	mov	qword ptr [rax + 24], rcx
 	pop	rbx
 	pop	r12
 	pop	r14
@@ -108,34 +107,43 @@ LBB4_1:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
 	lea	rdx, [rip + l_anon.[ID].2]
-	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	mov	r14, rax
-	mov	r15, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)]
-	test	r15, r15
+	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	rbx, rax
+	mov	rax, r14
+	mov	r14, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)]
+	test	r14, r14
 	jne	LBB4_4
 LBB4_3:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::get_same_class::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
 	lea	rdx, [rip + l_anon.[ID].3]
-	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	mov	r15, rax
-	mov	r12, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)]
-	test	r12, r12
+	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	r14, rax
+	mov	rax, r15
+	mov	r15, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)]
+	test	r15, r15
 	jne	LBB4_6
 LBB4_5:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::get_different_class::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].4]
 	lea	rdx, [rip + l_anon.[ID].5]
-	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	mov	r12, rax
-	mov	rax, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)]
-	test	rax, rax
+	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	r15, rax
+	mov	rax, r12
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)]
+	test	rcx, rcx
 	jne	LBB4_8
 LBB4_7:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::use_fns::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].8]
 	lea	rdx, [rip + l_anon.[ID].9]
+	mov	r12, rax
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	rcx, rax
+	mov	rax, r12
 	jmp	LBB4_8
 
 	.globl	_use_same_twice
@@ -145,17 +153,16 @@ _use_same_twice:
 	mov	rbp, rsp
 	push	r14
 	push	rbx
-	mov	rbx, rdi
-	mov	r14, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
-	test	r14, r14
+	mov	rax, rdi
+	mov	rbx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
+	test	rbx, rbx
 	je	LBB5_1
-	mov	rax, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
-	test	rax, rax
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
+	test	rcx, rcx
 	je	LBB5_3
 LBB5_4:
-	mov	qword ptr [rbx], r14
-	mov	qword ptr [rbx + 8], rax
-	mov	rax, rbx
+	mov	qword ptr [rax], rbx
+	mov	qword ptr [rax + 8], rcx
 	pop	rbx
 	pop	r14
 	pop	rbp
@@ -164,16 +171,21 @@ LBB5_1:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
 	lea	rdx, [rip + l_anon.[ID].2]
-	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
 	mov	r14, rax
-	mov	rax, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
-	test	rax, rax
+	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	rbx, rax
+	mov	rax, r14
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
+	test	rcx, rcx
 	jne	LBB5_4
 LBB5_3:
 	lea	rdi, [rip + SYM(test_dynamic_class[CRATE_ID]::get_class::CACHED_CLASS, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
 	lea	rdx, [rip + l_anon.[ID].2]
+	mov	r14, rax
 	call	SYM(objc2::__macro_helpers::cache::CachedClass::fetch::GENERATED_ID, 0)
+	mov	rcx, rax
+	mov	rax, r14
 	jmp	LBB5_4
 
 	.globl	_use_in_loop

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-aarch64.s
@@ -52,15 +52,14 @@ _get_common_twice:
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
 Lloh12:
-	adrp	x20, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+	adrp	x19, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh13:
-	ldr	x20, [x20, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
-	ldr	x19, [x20]
-	cbz	x19, LBB2_3
-	ldr	x1, [x20]
+	ldr	x19, [x19, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x0, [x19]
+	cbz	x0, LBB2_3
+	ldr	x1, [x19]
 	cbz	x1, LBB2_4
 LBB2_2:
-	mov	x0, x19
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	ret
@@ -74,18 +73,19 @@ Lloh16:
 Lloh17:
 	add	x1, x1, l_anon.[ID].1@PAGEOFF
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	x19, x0
-	ldr	x1, [x20]
+	ldr	x1, [x19]
 	cbnz	x1, LBB2_2
 LBB2_4:
 Lloh18:
-	adrp	x0, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
+	adrp	x8, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh19:
-	ldr	x0, [x0, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x8, [x8, SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
 Lloh20:
 	adrp	x1, l_anon.[ID].1@PAGE
 Lloh21:
 	add	x1, x1, l_anon.[ID].1@PAGEOFF
+	mov	x19, x0
+	mov	x0, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	x1, x0
 	mov	x0, x19
@@ -151,32 +151,31 @@ _use_fns:
 	stp	x20, x19, [sp, #16]
 	stp	x29, x30, [sp, #32]
 	add	x29, sp, #32
-	mov	x19, x8
 Lloh34:
-	adrp	x8, __MergedGlobals@PAGE
+	adrp	x9, __MergedGlobals@PAGE
 Lloh35:
-	ldr	x20, [x8, __MergedGlobals@PAGEOFF]
-	cbz	x20, LBB5_5
+	ldr	x19, [x9, __MergedGlobals@PAGEOFF]
+	cbz	x19, LBB5_5
 Lloh36:
-	adrp	x8, __MergedGlobals@PAGE+8
+	adrp	x9, __MergedGlobals@PAGE+8
 Lloh37:
-	ldr	x21, [x8, __MergedGlobals@PAGEOFF+8]
-	cbz	x21, LBB5_6
+	ldr	x20, [x9, __MergedGlobals@PAGEOFF+8]
+	cbz	x20, LBB5_6
 LBB5_2:
 Lloh38:
-	adrp	x8, __MergedGlobals@PAGE+16
+	adrp	x9, __MergedGlobals@PAGE+16
 Lloh39:
-	ldr	x22, [x8, __MergedGlobals@PAGEOFF+16]
-	cbz	x22, LBB5_7
+	ldr	x21, [x9, __MergedGlobals@PAGEOFF+16]
+	cbz	x21, LBB5_7
 LBB5_3:
 Lloh40:
-	adrp	x8, __MergedGlobals@PAGE+24
+	adrp	x9, __MergedGlobals@PAGE+24
 Lloh41:
-	ldr	x0, [x8, __MergedGlobals@PAGEOFF+24]
+	ldr	x0, [x9, __MergedGlobals@PAGEOFF+24]
 	cbz	x0, LBB5_8
 LBB5_4:
-	stp	x20, x21, [x19]
-	stp	x22, x0, [x19, #16]
+	stp	x19, x20, [x8]
+	stp	x21, x0, [x8, #16]
 	ldp	x29, x30, [sp, #32]
 	ldp	x20, x19, [sp, #16]
 	ldp	x22, x21, [sp], #48
@@ -190,13 +189,15 @@ Lloh44:
 	adrp	x1, l_anon.[ID].0@PAGE
 Lloh45:
 	add	x1, x1, l_anon.[ID].0@PAGEOFF
+	mov	x19, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	x20, x0
+	mov	x8, x19
+	mov	x19, x0
 Lloh46:
-	adrp	x8, __MergedGlobals@PAGE+8
+	adrp	x9, __MergedGlobals@PAGE+8
 Lloh47:
-	ldr	x21, [x8, __MergedGlobals@PAGEOFF+8]
-	cbnz	x21, LBB5_2
+	ldr	x20, [x9, __MergedGlobals@PAGEOFF+8]
+	cbnz	x20, LBB5_2
 LBB5_6:
 Lloh48:
 	adrp	x0, __MergedGlobals@PAGE+8
@@ -206,13 +207,15 @@ Lloh50:
 	adrp	x1, l_anon.[ID].0@PAGE
 Lloh51:
 	add	x1, x1, l_anon.[ID].0@PAGEOFF
+	mov	x20, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	x21, x0
+	mov	x8, x20
+	mov	x20, x0
 Lloh52:
-	adrp	x8, __MergedGlobals@PAGE+16
+	adrp	x9, __MergedGlobals@PAGE+16
 Lloh53:
-	ldr	x22, [x8, __MergedGlobals@PAGEOFF+16]
-	cbnz	x22, LBB5_3
+	ldr	x21, [x9, __MergedGlobals@PAGEOFF+16]
+	cbnz	x21, LBB5_3
 LBB5_7:
 Lloh54:
 	adrp	x0, __MergedGlobals@PAGE+16
@@ -222,12 +225,14 @@ Lloh56:
 	adrp	x1, l_anon.[ID].2@PAGE
 Lloh57:
 	add	x1, x1, l_anon.[ID].2@PAGEOFF
+	mov	x21, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	x22, x0
+	mov	x8, x21
+	mov	x21, x0
 Lloh58:
-	adrp	x8, __MergedGlobals@PAGE+24
+	adrp	x9, __MergedGlobals@PAGE+24
 Lloh59:
-	ldr	x0, [x8, __MergedGlobals@PAGEOFF+24]
+	ldr	x0, [x9, __MergedGlobals@PAGEOFF+24]
 	cbnz	x0, LBB5_4
 LBB5_8:
 Lloh60:
@@ -238,9 +243,10 @@ Lloh62:
 	adrp	x1, l_anon.[ID].4@PAGE
 Lloh63:
 	add	x1, x1, l_anon.[ID].4@PAGEOFF
+	mov	x22, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	stp	x20, x21, [x19]
-	stp	x22, x0, [x19, #16]
+	stp	x19, x20, [x22]
+	stp	x21, x0, [x22, #16]
 	ldp	x29, x30, [sp, #32]
 	ldp	x20, x19, [sp, #16]
 	ldp	x22, x21, [sp], #48
@@ -264,21 +270,18 @@ Lloh63:
 	.globl	_use_same_twice
 	.p2align	2
 _use_same_twice:
-	stp	x22, x21, [sp, #-48]!
-	stp	x20, x19, [sp, #16]
-	stp	x29, x30, [sp, #32]
-	add	x29, sp, #32
-	mov	x19, x8
-	adrp	x21, __MergedGlobals@PAGE
-	ldr	x20, [x21, __MergedGlobals@PAGEOFF]
-	cbz	x20, LBB6_3
-	ldr	x0, [x21, __MergedGlobals@PAGEOFF]
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	add	x29, sp, #16
+	adrp	x20, __MergedGlobals@PAGE
+	ldr	x19, [x20, __MergedGlobals@PAGEOFF]
+	cbz	x19, LBB6_3
+	ldr	x0, [x20, __MergedGlobals@PAGEOFF]
 	cbz	x0, LBB6_4
 LBB6_2:
-	stp	x20, x0, [x19]
-	ldp	x29, x30, [sp, #32]
-	ldp	x20, x19, [sp, #16]
-	ldp	x22, x21, [sp], #48
+	stp	x19, x0, [x8]
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
 	ret
 LBB6_3:
 Lloh64:
@@ -289,9 +292,11 @@ Lloh66:
 	adrp	x1, l_anon.[ID].0@PAGE
 Lloh67:
 	add	x1, x1, l_anon.[ID].0@PAGEOFF
+	mov	x19, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	x20, x0
-	ldr	x0, [x21, __MergedGlobals@PAGEOFF]
+	mov	x8, x19
+	mov	x19, x0
+	ldr	x0, [x20, __MergedGlobals@PAGEOFF]
 	cbnz	x0, LBB6_2
 LBB6_4:
 Lloh68:
@@ -302,11 +307,11 @@ Lloh70:
 	adrp	x1, l_anon.[ID].0@PAGE
 Lloh71:
 	add	x1, x1, l_anon.[ID].0@PAGEOFF
+	mov	x20, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	stp	x20, x0, [x19]
-	ldp	x29, x30, [sp, #32]
-	ldp	x20, x19, [sp, #16]
-	ldp	x22, x21, [sp], #48
+	stp	x19, x0, [x20]
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
 	ret
 	.loh AdrpAdd	Lloh66, Lloh67
 	.loh AdrpAdd	Lloh64, Lloh65

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-armv7s.s
@@ -45,21 +45,34 @@ LPC1_1:
 	.p2align	2
 	.code	32
 _get_common_twice:
-	push	{r4, r5, r7, lr}
-	add	r7, sp, #8
-	movw	r5, :lower16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_0+8))
-	movt	r5, :upper16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_0+8))
+	push	{r4, r7, lr}
+	add	r7, sp, #4
+	movw	r4, :lower16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_0+8))
+	movt	r4, :upper16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_0+8))
 LPC2_0:
-	ldr	r5, [pc, r5]
-	ldr	r4, [r5]
-	cmp	r4, #0
+	ldr	r4, [pc, r4]
+	ldr	r0, [r4]
+	cmp	r0, #0
 	beq	LBB2_3
-	ldr	r1, [r5]
+LBB2_1:
+	ldr	r1, [r4]
 	cmp	r1, #0
-	beq	LBB2_4
+	popne	{r4, r7, pc}
 LBB2_2:
+	movw	r2, :lower16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_3+8))
+	movt	r2, :upper16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_3+8))
+LPC2_3:
+	ldr	r2, [pc, r2]
+	movw	r1, :lower16:(l_anon.[ID].1-(LPC2_4+8))
+	movt	r1, :upper16:(l_anon.[ID].1-(LPC2_4+8))
+LPC2_4:
+	add	r1, pc, r1
+	mov	r4, r0
+	mov	r0, r2
+	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	r1, r0
 	mov	r0, r4
-	pop	{r4, r5, r7, pc}
+	pop	{r4, r7, pc}
 LBB2_3:
 	movw	r0, :lower16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_1+8))
 	movt	r0, :upper16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_1+8))
@@ -70,23 +83,7 @@ LPC2_1:
 LPC2_2:
 	add	r1, pc, r1
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r4, r0
-	ldr	r1, [r5]
-	cmp	r1, #0
-	bne	LBB2_2
-LBB2_4:
-	movw	r0, :lower16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_3+8))
-	movt	r0, :upper16:(LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC2_3+8))
-LPC2_3:
-	ldr	r0, [pc, r0]
-	movw	r1, :lower16:(l_anon.[ID].1-(LPC2_4+8))
-	movt	r1, :upper16:(l_anon.[ID].1-(LPC2_4+8))
-LPC2_4:
-	add	r1, pc, r1
-	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r1, r0
-	mov	r0, r4
-	pop	{r4, r5, r7, pc}
+	b	LBB2_1
 
 	.globl	_get_different_sel
 	.p2align	2
@@ -136,127 +133,142 @@ _use_fns:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
 	push	{r8, r10}
-	movw	r10, :lower16:(__MergedGlobals-(LPC5_0+8))
-	movt	r10, :upper16:(__MergedGlobals-(LPC5_0+8))
+	movw	r8, :lower16:(__MergedGlobals-(LPC5_0+8))
+	movt	r8, :upper16:(__MergedGlobals-(LPC5_0+8))
 LPC5_0:
-	add	r10, pc, r10
-	mov	r4, r0
-	ldr	r8, [r10]
-	cmp	r8, #0
+	add	r8, pc, r8
+	ldr	r4, [r8]
+	cmp	r4, #0
 	beq	LBB5_5
-	ldr	r6, [r10, #4]
-	cmp	r6, #0
+	ldr	r5, [r8, #4]
+	cmp	r5, #0
 	beq	LBB5_6
 LBB5_2:
-	ldr	r5, [r10, #8]
-	cmp	r5, #0
+	ldr	r6, [r8, #8]
+	cmp	r6, #0
 	beq	LBB5_7
 LBB5_3:
-	ldr	r0, [r10, #12]
-	cmp	r0, #0
+	ldr	r1, [r8, #12]
+	cmp	r1, #0
 	beq	LBB5_8
 LBB5_4:
-	str	r8, [r4]
-	str	r6, [r4, #4]
-	str	r5, [r4, #8]
-	str	r0, [r4, #12]
+	stm	r0, {r4, r5, r6}
+	str	r1, [r0, #12]
 	pop	{r8, r10}
 	pop	{r4, r5, r6, r7, pc}
 LBB5_5:
-	movw	r0, :lower16:(__MergedGlobals-(LPC5_1+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC5_1+8))
+	movw	r2, :lower16:(__MergedGlobals-(LPC5_1+8))
+	movt	r2, :upper16:(__MergedGlobals-(LPC5_1+8))
 LPC5_1:
-	add	r0, pc, r0
+	add	r2, pc, r2
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC5_2+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC5_2+8))
 LPC5_2:
 	add	r1, pc, r1
+	mov	r5, r0
+	mov	r0, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r8, r0
-	ldr	r6, [r10, #4]
-	cmp	r6, #0
+	mov	r4, r0
+	mov	r0, r5
+	ldr	r5, [r8, #4]
+	cmp	r5, #0
 	bne	LBB5_2
 LBB5_6:
-	add	r0, r10, #4
+	add	r2, r8, #4
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC5_3+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC5_3+8))
 LPC5_3:
 	add	r1, pc, r1
-	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r6, r0
-	ldr	r5, [r10, #8]
-	cmp	r5, #0
+	mov	r0, r2
+	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	r5, r0
+	mov	r0, r6
+	ldr	r6, [r8, #8]
+	cmp	r6, #0
 	bne	LBB5_3
 LBB5_7:
-	add	r0, r10, #8
+	add	r2, r8, #8
 	movw	r1, :lower16:(L_anon.[ID].2-(LPC5_4+8))
 	movt	r1, :upper16:(L_anon.[ID].2-(LPC5_4+8))
 LPC5_4:
 	add	r1, pc, r1
+	mov	r10, r0
+	mov	r0, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r5, r0
-	ldr	r0, [r10, #12]
-	cmp	r0, #0
+	mov	r6, r0
+	mov	r0, r10
+	ldr	r1, [r8, #12]
+	cmp	r1, #0
 	bne	LBB5_4
 LBB5_8:
-	add	r0, r10, #12
+	add	r2, r8, #12
 	movw	r1, :lower16:(l_anon.[ID].4-(LPC5_5+8))
 	movt	r1, :upper16:(l_anon.[ID].4-(LPC5_5+8))
 LPC5_5:
 	add	r1, pc, r1
+	mov	r8, r0
+	mov	r0, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	b	LBB5_4
+	mov	r1, r0
+	mov	r0, r8
+	stm	r0, {r4, r5, r6}
+	str	r1, [r0, #12]
+	pop	{r8, r10}
+	pop	{r4, r5, r6, r7, pc}
 
 	.globl	_use_same_twice
 	.p2align	2
 	.code	32
 _use_same_twice:
-	push	{r4, r5, r7, lr}
-	add	r7, sp, #8
-	push	{r8}
+	push	{r4, r5, r6, r7, lr}
+	add	r7, sp, #12
 	movw	r5, :lower16:(__MergedGlobals-(LPC6_0+8))
 	movt	r5, :upper16:(__MergedGlobals-(LPC6_0+8))
 LPC6_0:
 	add	r5, pc, r5
-	mov	r4, r0
-	ldr	r8, [r5]
-	cmp	r8, #0
+	ldr	r4, [r5]
+	cmp	r4, #0
 	beq	LBB6_3
-	ldr	r9, [r5]
-	cmp	r9, #0
+	ldr	r5, [r5]
+	cmp	r5, #0
 	beq	LBB6_4
 LBB6_2:
-	strd	r8, r9, [r4]
-	pop	{r8}
-	pop	{r4, r5, r7, pc}
+	strd	r4, r5, [r0]
+	pop	{r4, r5, r6, r7, pc}
 LBB6_3:
-	movw	r0, :lower16:(__MergedGlobals-(LPC6_1+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC6_1+8))
+	movw	r2, :lower16:(__MergedGlobals-(LPC6_1+8))
+	movt	r2, :upper16:(__MergedGlobals-(LPC6_1+8))
 LPC6_1:
-	add	r0, pc, r0
+	add	r2, pc, r2
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC6_2+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC6_2+8))
 LPC6_2:
 	add	r1, pc, r1
+	mov	r6, r0
+	mov	r0, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r8, r0
-	ldr	r9, [r5]
-	cmp	r9, #0
+	mov	r4, r0
+	mov	r0, r6
+	ldr	r5, [r5]
+	cmp	r5, #0
 	bne	LBB6_2
 LBB6_4:
-	movw	r0, :lower16:(__MergedGlobals-(LPC6_3+8))
-	movt	r0, :upper16:(__MergedGlobals-(LPC6_3+8))
+	movw	r2, :lower16:(__MergedGlobals-(LPC6_3+8))
+	movt	r2, :upper16:(__MergedGlobals-(LPC6_3+8))
 LPC6_3:
-	add	r0, pc, r0
+	add	r2, pc, r2
 	movw	r1, :lower16:(l_anon.[ID].0-(LPC6_4+8))
 	movt	r1, :upper16:(l_anon.[ID].0-(LPC6_4+8))
 LPC6_4:
 	add	r1, pc, r1
+	mov	r6, r0
+	mov	r0, r2
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	r9, r0
-	strd	r8, r9, [r4]
-	pop	{r8}
-	pop	{r4, r5, r7, pc}
+	mov	r5, r0
+	mov	r0, r6
+	strd	r4, r5, [r0]
+	pop	{r4, r5, r6, r7, pc}
 
 	.globl	_use_in_loop
 	.p2align	2

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86.s
@@ -57,48 +57,47 @@ LBB1_1:
 _get_common_twice:
 	push	ebp
 	mov	ebp, esp
-	push	ebx
 	push	edi
 	push	esi
-	sub	esp, 12
 	call	L2$pb
 L2$pb:
-	pop	ebx
-	mov	edi, dword ptr [ebx + LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L2$pb]
-	mov	esi, dword ptr [edi]
-	test	esi, esi
+	pop	edi
+	mov	esi, dword ptr [edi + LSYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L2$pb]
+	mov	eax, dword ptr [esi]
+	test	eax, eax
 	je	LBB2_1
-	mov	edx, dword ptr [edi]
+	mov	edx, dword ptr [esi]
 	test	edx, edx
 	je	LBB2_3
 LBB2_4:
-	mov	eax, esi
-	add	esp, 12
 	pop	esi
 	pop	edi
-	pop	ebx
 	pop	ebp
 	ret
 LBB2_1:
 	sub	esp, 8
-	lea	eax, [ebx + l_anon.[ID].1-L2$pb]
+	lea	eax, [edi + l_anon.[ID].1-L2$pb]
 	push	eax
-	push	edi
+	push	esi
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
-	mov	esi, eax
-	mov	edx, dword ptr [edi]
+	mov	edx, dword ptr [esi]
 	test	edx, edx
 	jne	LBB2_4
 LBB2_3:
 	sub	esp, 8
-	lea	eax, [ebx + l_anon.[ID].1-L2$pb]
-	push	eax
-	push	edi
+	lea	ecx, [edi + l_anon.[ID].1-L2$pb]
+	push	ecx
+	push	esi
+	mov	esi, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
 	mov	edx, eax
-	jmp	LBB2_4
+	mov	eax, esi
+	pop	esi
+	pop	edi
+	pop	ebp
+	ret
 
 	.globl	_get_different_sel
 	.p2align	4, 0x90
@@ -163,28 +162,27 @@ _use_fns:
 	sub	esp, 12
 	call	L5$pb
 L5$pb:
-	pop	edi
-	mov	ecx, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L5$pb]
-	test	ecx, ecx
-	je	LBB5_1
-	mov	edx, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
+	pop	esi
+	mov	edx, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L5$pb]
 	test	edx, edx
+	je	LBB5_1
+	mov	edi, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
+	test	edi, edi
 	je	LBB5_3
 LBB5_4:
-	mov	ebx, dword ptr [ebp + 8]
-	mov	esi, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
-	test	esi, esi
+	mov	eax, dword ptr [ebp + 8]
+	mov	ebx, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
+	test	ebx, ebx
 	je	LBB5_5
 LBB5_6:
-	mov	eax, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
-	test	eax, eax
+	mov	ecx, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
+	test	ecx, ecx
 	je	LBB5_7
 LBB5_8:
-	mov	dword ptr [ebx], ecx
-	mov	dword ptr [ebx + 4], edx
-	mov	dword ptr [ebx + 8], esi
-	mov	dword ptr [ebx + 12], eax
-	mov	eax, ebx
+	mov	dword ptr [eax], edx
+	mov	dword ptr [eax + 4], edi
+	mov	dword ptr [eax + 8], ebx
+	mov	dword ptr [eax + 12], ecx
 	add	esp, 12
 	pop	esi
 	pop	edi
@@ -193,59 +191,59 @@ LBB5_8:
 	ret	4
 LBB5_1:
 	sub	esp, 8
-	lea	eax, [edi + l_anon.[ID].0-L5$pb]
-	lea	ecx, [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L5$pb]
+	lea	eax, [esi + l_anon.[ID].0-L5$pb]
+	lea	ecx, [esi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L5$pb]
 	push	eax
 	push	ecx
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
-	mov	ecx, eax
-	mov	edx, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
-	test	edx, edx
+	mov	edx, eax
+	mov	edi, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
+	test	edi, edi
 	jne	LBB5_4
 LBB5_3:
 	sub	esp, 8
-	lea	eax, [edi + l_anon.[ID].0-L5$pb]
-	mov	esi, ecx
-	lea	ecx, [edi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
-	push	eax
-	push	ecx
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	ecx, esi
-	add	esp, 16
-	mov	edx, eax
-	mov	ebx, dword ptr [ebp + 8]
-	mov	esi, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
-	test	esi, esi
-	jne	LBB5_6
-LBB5_5:
-	sub	esp, 8
-	lea	eax, [edi + L_anon.[ID].2-L5$pb]
-	mov	dword ptr [ebp - 16], ecx
-	lea	ecx, [edi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
-	push	eax
-	push	ecx
-	mov	esi, edx
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	edx, esi
-	mov	ecx, dword ptr [ebp - 16]
-	add	esp, 16
-	mov	esi, eax
-	mov	eax, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
-	test	eax, eax
-	jne	LBB5_8
-LBB5_7:
-	sub	esp, 8
-	lea	eax, [edi + l_anon.[ID].4-L5$pb]
-	mov	dword ptr [ebp - 16], ecx
-	lea	ecx, [edi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
+	lea	eax, [esi + l_anon.[ID].0-L5$pb]
+	lea	ecx, [esi + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)-L5$pb]
 	push	eax
 	push	ecx
 	mov	edi, edx
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	edx, edi
-	mov	ecx, dword ptr [ebp - 16]
 	add	esp, 16
+	mov	edi, eax
+	mov	eax, dword ptr [ebp + 8]
+	mov	ebx, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
+	test	ebx, ebx
+	jne	LBB5_6
+LBB5_5:
+	sub	esp, 8
+	lea	eax, [esi + L_anon.[ID].2-L5$pb]
+	lea	ecx, [esi + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)-L5$pb]
+	push	eax
+	push	ecx
+	mov	ebx, edx
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	edx, ebx
+	add	esp, 16
+	mov	ebx, eax
+	mov	eax, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [esi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
+	test	ecx, ecx
+	jne	LBB5_8
+LBB5_7:
+	sub	esp, 8
+	lea	ecx, [esi + l_anon.[ID].4-L5$pb]
+	mov	dword ptr [ebp - 16], edx
+	lea	edx, [esi + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)-L5$pb]
+	push	ecx
+	push	edx
+	mov	esi, eax
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	edx, dword ptr [ebp - 16]
+	add	esp, 16
+	mov	ecx, eax
+	mov	eax, esi
 	jmp	LBB5_8
 
 	.globl	_use_same_twice
@@ -259,18 +257,17 @@ _use_same_twice:
 	sub	esp, 12
 	call	L6$pb
 L6$pb:
-	pop	ebx
-	mov	esi, dword ptr [ebp + 8]
-	mov	edi, dword ptr [ebx + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
-	test	edi, edi
+	pop	edi
+	mov	eax, dword ptr [ebp + 8]
+	mov	esi, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
+	test	esi, esi
 	je	LBB6_1
-	mov	eax, dword ptr [ebx + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
-	test	eax, eax
+	mov	ecx, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
+	test	ecx, ecx
 	je	LBB6_3
 LBB6_4:
-	mov	dword ptr [esi], edi
-	mov	dword ptr [esi + 4], eax
-	mov	eax, esi
+	mov	dword ptr [eax], esi
+	mov	dword ptr [eax + 4], ecx
 	add	esp, 12
 	pop	esi
 	pop	edi
@@ -279,24 +276,29 @@ LBB6_4:
 	ret	4
 LBB6_1:
 	sub	esp, 8
-	lea	eax, [ebx + l_anon.[ID].0-L6$pb]
-	lea	ecx, [ebx + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
-	push	eax
+	lea	ecx, [edi + l_anon.[ID].0-L6$pb]
+	lea	edx, [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
 	push	ecx
+	push	edx
+	mov	ebx, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
-	mov	edi, eax
-	mov	eax, dword ptr [ebx + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
-	test	eax, eax
+	mov	esi, eax
+	mov	eax, ebx
+	mov	ecx, dword ptr [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
+	test	ecx, ecx
 	jne	LBB6_4
 LBB6_3:
 	sub	esp, 8
-	lea	eax, [ebx + l_anon.[ID].0-L6$pb]
-	lea	ecx, [ebx + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
-	push	eax
+	lea	ecx, [edi + l_anon.[ID].0-L6$pb]
+	lea	edx, [edi + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)-L6$pb]
 	push	ecx
+	push	edx
+	mov	edi, eax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
+	mov	ecx, eax
+	mov	eax, edi
 	jmp	LBB6_4
 
 	.globl	_use_in_loop

--- a/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_dynamic_sel/expected/apple-x86_64.s
@@ -37,35 +37,38 @@ LBB1_2:
 _get_common_twice:
 	push	rbp
 	mov	rbp, rsp
-	push	r14
 	push	rbx
-	mov	r14, qword ptr [rip + SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	mov	rbx, qword ptr [r14]
-	test	rbx, rbx
+	push	rax
+	mov	rbx, qword ptr [rip + SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	rax, qword ptr [rbx]
+	test	rax, rax
 	je	LBB2_1
-	mov	rdx, qword ptr [r14]
+	mov	rdx, qword ptr [rbx]
 	test	rdx, rdx
 	je	LBB2_3
 LBB2_4:
-	mov	rax, rbx
+	add	rsp, 8
 	pop	rbx
-	pop	r14
 	pop	rbp
 	ret
 LBB2_1:
 	mov	rdi, qword ptr [rip + SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	rsi, [rip + l_anon.[ID].1]
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	rbx, rax
-	mov	rdx, qword ptr [r14]
+	mov	rdx, qword ptr [rbx]
 	test	rdx, rdx
 	jne	LBB2_4
 LBB2_3:
 	mov	rdi, qword ptr [rip + SYM(objc2::__macro_helpers::common_selectors::alloc_sel::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	rsi, [rip + l_anon.[ID].1]
+	mov	rbx, rax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	rdx, rax
-	jmp	LBB2_4
+	mov	rax, rbx
+	add	rsp, 8
+	pop	rbx
+	pop	rbp
+	ret
 
 	.globl	_get_different_sel
 	.p2align	4, 0x90
@@ -108,27 +111,26 @@ _use_fns:
 	push	r14
 	push	r12
 	push	rbx
-	mov	rbx, rdi
-	mov	r14, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
-	test	r14, r14
+	mov	rax, rdi
+	mov	rbx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
+	test	rbx, rbx
 	je	LBB5_1
-	mov	r15, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)]
-	test	r15, r15
+	mov	r14, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)]
+	test	r14, r14
 	je	LBB5_3
 LBB5_4:
-	mov	r12, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)]
-	test	r12, r12
+	mov	r15, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)]
+	test	r15, r15
 	je	LBB5_5
 LBB5_6:
-	mov	rax, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)]
-	test	rax, rax
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)]
+	test	rcx, rcx
 	je	LBB5_7
 LBB5_8:
-	mov	qword ptr [rbx], r14
-	mov	qword ptr [rbx + 8], r15
-	mov	qword ptr [rbx + 16], r12
-	mov	qword ptr [rbx + 24], rax
-	mov	rax, rbx
+	mov	qword ptr [rax], rbx
+	mov	qword ptr [rax + 8], r14
+	mov	qword ptr [rax + 16], r15
+	mov	qword ptr [rax + 24], rcx
 	pop	rbx
 	pop	r12
 	pop	r14
@@ -138,31 +140,40 @@ LBB5_8:
 LBB5_1:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r14, rax
-	mov	r15, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)]
-	test	r15, r15
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rbx, rax
+	mov	rax, r14
+	mov	r14, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)]
+	test	r14, r14
 	jne	LBB5_4
 LBB5_3:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::get_same_sel::CACHED_SEL, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r15, rax
-	mov	r12, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)]
-	test	r12, r12
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	r14, rax
+	mov	rax, r15
+	mov	r15, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)]
+	test	r15, r15
 	jne	LBB5_6
 LBB5_5:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::get_different_sel::CACHED_SEL, 0)]
 	lea	rsi, [rip + L_anon.[ID].2]
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r12, rax
-	mov	rax, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)]
-	test	rax, rax
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	r15, rax
+	mov	rax, r12
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)]
+	test	rcx, rcx
 	jne	LBB5_8
 LBB5_7:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::use_fns::CACHED_SEL, 0)]
 	lea	rsi, [rip + l_anon.[ID].4]
+	mov	r12, rax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rcx, rax
+	mov	rax, r12
 	jmp	LBB5_8
 
 	.globl	_use_same_twice
@@ -172,17 +183,16 @@ _use_same_twice:
 	mov	rbp, rsp
 	push	r14
 	push	rbx
-	mov	rbx, rdi
-	mov	r14, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
-	test	r14, r14
+	mov	rax, rdi
+	mov	rbx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
+	test	rbx, rbx
 	je	LBB6_1
-	mov	rax, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
-	test	rax, rax
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
+	test	rcx, rcx
 	je	LBB6_3
 LBB6_4:
-	mov	qword ptr [rbx], r14
-	mov	qword ptr [rbx + 8], rax
-	mov	rax, rbx
+	mov	qword ptr [rax], rbx
+	mov	qword ptr [rax + 8], rcx
 	pop	rbx
 	pop	r14
 	pop	rbp
@@ -190,15 +200,20 @@ LBB6_4:
 LBB6_1:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r14, rax
-	mov	rax, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
-	test	rax, rax
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rbx, rax
+	mov	rax, r14
+	mov	rcx, qword ptr [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
+	test	rcx, rcx
 	jne	LBB6_4
 LBB6_3:
 	lea	rdi, [rip + SYM(test_dynamic_sel[CRATE_ID]::get_sel::CACHED_SEL, 0)]
 	lea	rsi, [rip + l_anon.[ID].0]
+	mov	r14, rax
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rcx, rax
+	mov	rax, r14
 	jmp	LBB6_4
 
 	.globl	_use_in_loop

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
@@ -2,9 +2,8 @@
 	.globl	_iter_create
 	.p2align	2
 _iter_create:
-	stp	xzr, xzr, [x8, #192]
+	str	x0, [x8]
 	movi.2d	v0, #0000000000000000
-	stp	q0, q0, [x8, #160]
 	stur	q0, [x8, #8]
 	stur	q0, [x8, #24]
 	stur	q0, [x8, #40]
@@ -13,37 +12,33 @@ _iter_create:
 	stur	q0, [x8, #88]
 	stur	q0, [x8, #104]
 	stur	q0, [x8, #120]
-	str	x0, [x8]
-	stp	xzr, xzr, [x8, #144]
-	str	xzr, [x8, #136]
-	str	xzr, [x8, #208]
+	stur	q0, [x8, #136]
+	stur	q0, [x8, #152]
+	stur	q0, [x8, #168]
+	stur	q0, [x8, #184]
+	stur	q0, [x8, #200]
 	ret
 
 	.globl	_iter_once
 	.p2align	2
 _iter_once:
-	stp	x22, x21, [sp, #-48]!
-	stp	x20, x19, [sp, #16]
-	stp	x29, x30, [sp, #32]
-	add	x29, sp, #32
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	add	x29, sp, #16
 	mov	x19, x0
 	ldp	x8, x9, [x0, #200]
 	cmp	x8, x9
 	b.lo	LBB1_3
-	add	x20, x19, #8
-	ldr	x21, [x19]
-	add	x22, x19, #136
+	ldr	x0, [x19]
 Lloh0:
 	adrp	x8, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh1:
 	ldr	x8, [x8, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
-Lloh2:
 	ldr	x1, [x8]
 	cbz	x1, LBB1_5
 LBB1_2:
-	mov	x0, x21
-	mov	x2, x22
-	mov	x3, x20
+	add	x2, x19, #136
+	add	x3, x19, #8
 	mov	w4, #16
 	bl	_objc_msgSend
 	mov	x8, #0
@@ -55,25 +50,22 @@ LBB1_3:
 	str	x10, [x19, #200]
 	ldr	x0, [x9, x8, lsl #3]
 LBB1_4:
-	ldp	x29, x30, [sp, #32]
-	ldp	x20, x19, [sp, #16]
-	ldp	x22, x21, [sp], #48
+	ldp	x29, x30, [sp, #16]
+	ldp	x20, x19, [sp], #32
 	ret
 LBB1_5:
-Lloh3:
-	adrp	x0, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
-Lloh4:
-	ldr	x0, [x0, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
-Lloh5:
+Lloh2:
 	adrp	x1, l_anon.[ID].0@PAGE
-Lloh6:
+Lloh3:
 	add	x1, x1, l_anon.[ID].0@PAGEOFF
+	mov	x20, x0
+	mov	x0, x8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	x1, x0
+	mov	x0, x20
 	b	LBB1_2
-	.loh AdrpLdrGotLdr	Lloh0, Lloh1, Lloh2
-	.loh AdrpAdd	Lloh5, Lloh6
-	.loh AdrpLdrGot	Lloh3, Lloh4
+	.loh AdrpLdrGot	Lloh0, Lloh1
+	.loh AdrpAdd	Lloh2, Lloh3
 
 	.globl	_use_obj
 	.p2align	2
@@ -90,37 +82,34 @@ _use_obj:
 	.p2align	2
 _iter:
 	sub	sp, sp, #288
-	stp	x24, x23, [sp, #224]
+	stp	x28, x27, [sp, #224]
 	stp	x22, x21, [sp, #240]
 	stp	x20, x19, [sp, #256]
 	stp	x29, x30, [sp, #272]
 	add	x29, sp, #272
-	mov	x21, x0
 	mov	x9, #0
 	mov	x8, #0
 	stp	xzr, xzr, [sp, #200]
 	movi.2d	v0, #0000000000000000
 	stur	q0, [sp, #184]
 	stur	q0, [sp, #168]
-	add	x10, sp, #8
-	add	x19, x10, #8
+	add	x21, sp, #8
 	stp	q0, q0, [sp, #16]
 	stp	q0, q0, [sp, #48]
 	stp	q0, q0, [sp, #80]
 	stp	q0, q0, [sp, #112]
 	str	x0, [sp, #8]
-	add	x20, x10, #136
 	stp	xzr, xzr, [sp, #152]
 	str	xzr, [sp, #144]
 	str	xzr, [sp, #216]
+Lloh4:
+	adrp	x19, l_anon.[ID].0@PAGE
+Lloh5:
+	add	x19, x19, l_anon.[ID].0@PAGEOFF
+Lloh6:
+	adrp	x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh7:
-	adrp	x22, l_anon.[ID].0@PAGE
-Lloh8:
-	add	x22, x22, l_anon.[ID].0@PAGEOFF
-Lloh9:
-	adrp	x23, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
-Lloh10:
-	ldr	x23, [x23, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x20, [x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
 	b	LBB3_2
 LBB3_1:
 	ldr	x9, [sp, #152]
@@ -128,145 +117,152 @@ LBB3_1:
 	str	x10, [sp, #208]
 	ldr	x0, [x9, x8, lsl #3]
 	bl	_use_obj
-	ldr	x21, [sp, #8]
+	ldr	x0, [sp, #8]
 	ldp	x8, x9, [sp, #208]
 LBB3_2:
 	cmp	x8, x9
 	b.lo	LBB3_1
-	ldr	x1, [x23]
+	ldr	x1, [x20]
 	cbz	x1, LBB3_6
-LBB3_4:
-	mov	x0, x21
-	mov	x2, x20
-	mov	x3, x19
+	add	x2, x21, #136
+	add	x3, x21, #8
 	mov	w4, #16
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
 	cbz	x0, LBB3_7
+LBB3_5:
 	mov	x8, #0
 	b	LBB3_1
 LBB3_6:
-	mov	x0, x23
-	mov	x1, x22
+	mov	x22, x0
+	mov	x0, x20
+	mov	x1, x19
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	x1, x0
-	b	LBB3_4
+	mov	x0, x22
+	add	x2, x21, #136
+	add	x3, x21, #8
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbnz	x0, LBB3_5
 LBB3_7:
 	ldp	x29, x30, [sp, #272]
 	ldp	x20, x19, [sp, #256]
 	ldp	x22, x21, [sp, #240]
-	ldp	x24, x23, [sp, #224]
+	ldp	x28, x27, [sp, #224]
 	add	sp, sp, #288
 	ret
-	.loh AdrpLdrGot	Lloh9, Lloh10
-	.loh AdrpAdd	Lloh7, Lloh8
+	.loh AdrpLdrGot	Lloh6, Lloh7
+	.loh AdrpAdd	Lloh4, Lloh5
 
 	.globl	_iter_noop
 	.p2align	2
 _iter_noop:
 	sub	sp, sp, #288
-	stp	x24, x23, [sp, #224]
+	stp	x28, x27, [sp, #224]
 	stp	x22, x21, [sp, #240]
 	stp	x20, x19, [sp, #256]
 	stp	x29, x30, [sp, #272]
 	add	x29, sp, #272
-	mov	x20, x0
-	mov	x0, #0
 	mov	x8, #0
+	mov	x9, #0
 	stp	xzr, xzr, [sp, #200]
 	movi.2d	v0, #0000000000000000
 	stur	q0, [sp, #184]
 	stur	q0, [sp, #168]
-	add	x9, sp, #8
-	add	x19, x9, #8
+	add	x21, sp, #8
 	stp	q0, q0, [sp, #16]
 	stp	q0, q0, [sp, #48]
 	stp	q0, q0, [sp, #80]
 	stp	q0, q0, [sp, #112]
-	str	x20, [sp, #8]
-	add	x21, x9, #136
+	str	x0, [sp, #8]
 	stp	xzr, xzr, [sp, #152]
 	str	xzr, [sp, #144]
 	str	xzr, [sp, #216]
+Lloh8:
+	adrp	x19, l_anon.[ID].0@PAGE
+Lloh9:
+	add	x19, x19, l_anon.[ID].0@PAGEOFF
+Lloh10:
+	adrp	x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh11:
-	adrp	x22, l_anon.[ID].0@PAGE
-Lloh12:
-	add	x22, x22, l_anon.[ID].0@PAGEOFF
-Lloh13:
-	adrp	x23, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
-Lloh14:
-	ldr	x23, [x23, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x20, [x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
 	b	LBB4_2
 LBB4_1:
-	add	x8, x8, #1
-	str	x8, [sp, #208]
+	add	x9, x9, #1
+	str	x9, [sp, #208]
 LBB4_2:
-	cmp	x8, x0
+	cmp	x9, x8
 	b.lo	LBB4_1
-	ldr	x1, [x23]
+	ldr	x1, [x20]
 	cbz	x1, LBB4_6
-LBB4_4:
-	mov	x0, x20
-	mov	x2, x21
-	mov	x3, x19
+	add	x2, x21, #136
+	add	x3, x21, #8
 	mov	w4, #16
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
 	cbz	x0, LBB4_7
-	mov	x8, #0
-	ldr	x20, [sp, #8]
+LBB4_5:
+	mov	x8, x0
+	mov	x9, #0
+	ldr	x0, [sp, #8]
 	b	LBB4_1
 LBB4_6:
-	mov	x0, x23
-	mov	x1, x22
+	mov	x22, x0
+	mov	x0, x20
+	mov	x1, x19
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	x1, x0
-	b	LBB4_4
+	mov	x0, x22
+	add	x2, x21, #136
+	add	x3, x21, #8
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbnz	x0, LBB4_5
 LBB4_7:
 	ldp	x29, x30, [sp, #272]
 	ldp	x20, x19, [sp, #256]
 	ldp	x22, x21, [sp, #240]
-	ldp	x24, x23, [sp, #224]
+	ldp	x28, x27, [sp, #224]
 	add	sp, sp, #288
 	ret
-	.loh AdrpLdrGot	Lloh13, Lloh14
-	.loh AdrpAdd	Lloh11, Lloh12
+	.loh AdrpLdrGot	Lloh10, Lloh11
+	.loh AdrpAdd	Lloh8, Lloh9
 
 	.globl	_iter_retained
 	.p2align	2
 _iter_retained:
 	sub	sp, sp, #288
-	stp	x24, x23, [sp, #224]
+	stp	x28, x27, [sp, #224]
 	stp	x22, x21, [sp, #240]
 	stp	x20, x19, [sp, #256]
 	stp	x29, x30, [sp, #272]
 	add	x29, sp, #272
-	mov	x23, x0
 	mov	x9, #0
 	mov	x8, #0
 	stp	xzr, xzr, [sp, #200]
 	movi.2d	v0, #0000000000000000
 	stur	q0, [sp, #184]
 	stur	q0, [sp, #168]
-	add	x10, sp, #8
-	add	x19, x10, #8
+	add	x22, sp, #8
 	stp	q0, q0, [sp, #16]
 	stp	q0, q0, [sp, #48]
 	stp	q0, q0, [sp, #80]
 	stp	q0, q0, [sp, #112]
 	str	x0, [sp, #8]
-	add	x20, x10, #136
 	stp	xzr, xzr, [sp, #152]
 	str	xzr, [sp, #144]
 	str	xzr, [sp, #216]
+Lloh12:
+	adrp	x19, l_anon.[ID].0@PAGE
+Lloh13:
+	add	x19, x19, l_anon.[ID].0@PAGEOFF
+Lloh14:
+	adrp	x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh15:
-	adrp	x21, l_anon.[ID].0@PAGE
-Lloh16:
-	add	x21, x21, l_anon.[ID].0@PAGEOFF
-Lloh17:
-	adrp	x22, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
-Lloh18:
-	ldr	x22, [x22, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
+	ldr	x20, [x20, SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
 	b	LBB5_2
 LBB5_1:
 	ldr	x9, [sp, #152]
@@ -274,42 +270,48 @@ LBB5_1:
 	str	x10, [sp, #208]
 	ldr	x0, [x9, x8, lsl #3]
 	bl	_objc_retain
-	mov	x23, x0
+	mov	x21, x0
 	bl	_use_obj
-	mov	x0, x23
+	mov	x0, x21
 	bl	_objc_release
-	ldr	x23, [sp, #8]
+	ldr	x0, [sp, #8]
 	ldp	x8, x9, [sp, #208]
 LBB5_2:
 	cmp	x8, x9
 	b.lo	LBB5_1
-	ldr	x1, [x22]
+	ldr	x1, [x20]
 	cbz	x1, LBB5_6
-LBB5_4:
-	mov	x0, x23
-	mov	x2, x20
-	mov	x3, x19
+	add	x2, x22, #136
+	add	x3, x22, #8
 	mov	w4, #16
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
 	cbz	x0, LBB5_7
+LBB5_5:
 	mov	x8, #0
 	b	LBB5_1
 LBB5_6:
-	mov	x0, x22
-	mov	x1, x21
+	mov	x21, x0
+	mov	x0, x20
+	mov	x1, x19
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	x1, x0
-	b	LBB5_4
+	mov	x0, x21
+	add	x2, x22, #136
+	add	x3, x22, #8
+	mov	w4, #16
+	bl	_objc_msgSend
+	str	x0, [sp, #216]
+	cbnz	x0, LBB5_5
 LBB5_7:
 	ldp	x29, x30, [sp, #272]
 	ldp	x20, x19, [sp, #256]
 	ldp	x22, x21, [sp, #240]
-	ldp	x24, x23, [sp, #224]
+	ldp	x28, x27, [sp, #224]
 	add	sp, sp, #288
 	ret
-	.loh AdrpLdrGot	Lloh17, Lloh18
-	.loh AdrpAdd	Lloh15, Lloh16
+	.loh AdrpLdrGot	Lloh14, Lloh15
+	.loh AdrpAdd	Lloh12, Lloh13
 
 	.section	__TEXT,__const
 l_anon.[ID].0:

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
@@ -4,22 +4,18 @@
 	.p2align	2
 	.code	32
 _iter_create:
-	add	r2, r0, #80
-	vmov.i32	q8, #0x0
-	vst1.32	{d16, d17}, [r2]!
-	mov	r3, #0
-	str	r3, [r2]
-	add	r2, r0, #4
-	vst1.32	{d16, d17}, [r2]!
-	vst1.32	{d16, d17}, [r2]!
-	vst1.32	{d16, d17}, [r2]!
-	vst1.32	{d16, d17}, [r2]!
 	str	r1, [r0]
-	str	r3, [r2]
-	str	r3, [r0, #72]
-	str	r3, [r0, #76]
-	str	r3, [r0, #100]
-	str	r3, [r0, #104]
+	add	r1, r0, #4
+	vmov.i32	q8, #0x0
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r1]!
+	vst1.32	{d16, d17}, [r1]!
+	mov	r2, #0
+	str	r2, [r0, #104]
+	str	r2, [r1]
 	bx	lr
 
 	.globl	_iter_once
@@ -28,28 +24,24 @@ _iter_create:
 _iter_once:
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
-	push	{r8}
 	sub	sp, sp, #4
 	mov	r4, r0
 	ldrd	r0, r1, [r0, #100]
 	cmp	r0, r1
 	blo	LBB1_3
-	add	r8, r4, #4
-	ldr	r6, [r4]
-	movw	r0, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_0+8))
-	movt	r0, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_0+8))
+	add	r3, r4, #4
+	movw	r1, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_0+8))
+	movt	r1, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_0+8))
 LPC1_0:
-	ldr	r0, [pc, r0]
-	add	r5, r4, #68
-	ldr	r1, [r0]
+	ldr	r1, [pc, r1]
+	ldr	r0, [r4]
+	ldr	r1, [r1]
 	cmp	r1, #0
 	beq	LBB1_5
 LBB1_2:
-	mov	r0, #16
-	str	r0, [sp]
-	mov	r0, r6
-	mov	r2, r5
-	mov	r3, r8
+	add	r2, r4, #68
+	mov	r6, #16
+	str	r6, [sp]
 	bl	_objc_msgSend
 	mov	r1, r0
 	mov	r0, #0
@@ -62,16 +54,24 @@ LBB1_3:
 	str	r2, [r4, #100]
 	ldr	r0, [r1, r0, lsl #2]
 LBB1_4:
-	sub	sp, r7, #16
-	pop	{r8}
+	sub	sp, r7, #12
 	pop	{r4, r5, r6, r7, pc}
 LBB1_5:
-	movw	r1, :lower16:(l_anon.[ID].0-(LPC1_1+8))
-	movt	r1, :upper16:(l_anon.[ID].0-(LPC1_1+8))
+	movw	r2, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_1+8))
+	movt	r2, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC1_1+8))
 LPC1_1:
+	ldr	r2, [pc, r2]
+	movw	r1, :lower16:(l_anon.[ID].0-(LPC1_2+8))
+	movt	r1, :upper16:(l_anon.[ID].0-(LPC1_2+8))
+LPC1_2:
 	add	r1, pc, r1
+	mov	r5, r0
+	mov	r0, r2
+	mov	r6, r3
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	r3, r6
 	mov	r1, r0
+	mov	r0, r5
 	b	LBB1_2
 
 	.globl	_use_obj
@@ -95,65 +95,65 @@ _iter:
 	push	{r8, r10, r11}
 	sub	sp, sp, #120
 	bfc	sp, #0, #3
-	add	r1, sp, #8
-	add	r2, r1, #80
+	add	r2, sp, #8
+	add	r3, r2, #80
 	vmov.i32	q8, #0x0
-	vst1.64	{d16, d17}, [r2]!
-	mov	r6, r0
-	mov	r0, #0
-	orr	r4, r1, #4
+	vst1.64	{d16, d17}, [r3]!
+	mov	r1, #0
+	orr	r4, r2, #4
 	mov	r5, r4
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
-	str	r0, [r2]
-	str	r6, [sp, #8]
-	str	r0, [r5]
-	str	r0, [sp, #80]
-	str	r0, [sp, #84]
-	str	r0, [sp, #108]
-	movw	r10, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC3_0+8))
-	movt	r10, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC3_0+8))
+	str	r1, [r3]
+	str	r0, [sp, #8]
+	str	r1, [r5]
+	str	r1, [sp, #80]
+	str	r1, [sp, #84]
+	str	r1, [sp, #108]
+	movw	r6, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC3_0+8))
+	movt	r6, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC3_0+8))
 LPC3_0:
-	ldr	r10, [pc, r10]
+	ldr	r6, [pc, r6]
 	movw	r8, :lower16:(l_anon.[ID].0-(LPC3_1+8))
 	movt	r8, :upper16:(l_anon.[ID].0-(LPC3_1+8))
 LPC3_1:
 	add	r8, pc, r8
-	str	r0, [sp, #112]
-	mov	r11, #16
-	mov	r1, #0
+	str	r1, [sp, #112]
+	mov	r10, #16
+	mov	r2, #0
 	b	LBB3_3
 LBB3_1:
-	str	r11, [sp]
-	mov	r0, r6
+	str	r10, [sp]
 	mov	r2, r5
 	mov	r3, r4
 	bl	_objc_msgSend
 	str	r0, [sp, #112]
-	mov	r1, #0
+	mov	r2, #0
 	cmp	r0, #0
 	beq	LBB3_6
 LBB3_2:
 	ldr	r0, [sp, #80]
-	add	r2, r1, #1
-	str	r2, [sp, #108]
-	ldr	r0, [r0, r1, lsl #2]
+	add	r1, r2, #1
+	str	r1, [sp, #108]
+	ldr	r0, [r0, r2, lsl #2]
 	bl	_use_obj
-	ldr	r6, [sp, #8]
-	ldr	r1, [sp, #108]
-	ldr	r0, [sp, #112]
+	ldr	r0, [sp, #8]
+	ldr	r2, [sp, #108]
+	ldr	r1, [sp, #112]
 LBB3_3:
-	cmp	r1, r0
+	cmp	r2, r1
 	blo	LBB3_2
-	ldr	r1, [r10]
+	ldr	r1, [r6]
 	cmp	r1, #0
 	bne	LBB3_1
-	mov	r0, r10
+	mov	r11, r0
+	mov	r0, r6
 	mov	r1, r8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r1, r0
+	mov	r0, r11
 	b	LBB3_1
 LBB3_6:
 	sub	sp, r7, #24
@@ -169,62 +169,63 @@ _iter_noop:
 	push	{r8, r10, r11}
 	sub	sp, sp, #120
 	bfc	sp, #0, #3
-	add	r1, sp, #8
-	add	r2, r1, #80
+	add	r2, sp, #8
+	add	r3, r2, #80
 	vmov.i32	q8, #0x0
-	vst1.64	{d16, d17}, [r2]!
-	mov	r6, r0
-	mov	r0, #0
-	orr	r4, r1, #4
+	vst1.64	{d16, d17}, [r3]!
+	mov	r1, #0
+	orr	r4, r2, #4
 	mov	r5, r4
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
-	str	r0, [r2]
-	str	r6, [sp, #8]
-	str	r0, [r5]
-	str	r0, [sp, #80]
-	str	r0, [sp, #84]
-	str	r0, [sp, #108]
-	movw	r8, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
-	movt	r8, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
+	str	r1, [r3]
+	str	r0, [sp, #8]
+	str	r1, [r5]
+	str	r1, [sp, #80]
+	str	r1, [sp, #84]
+	str	r1, [sp, #108]
+	movw	r6, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
+	movt	r6, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
 LPC4_0:
-	ldr	r8, [pc, r8]
-	movw	r10, :lower16:(l_anon.[ID].0-(LPC4_1+8))
-	movt	r10, :upper16:(l_anon.[ID].0-(LPC4_1+8))
+	ldr	r6, [pc, r6]
+	movw	r8, :lower16:(l_anon.[ID].0-(LPC4_1+8))
+	movt	r8, :upper16:(l_anon.[ID].0-(LPC4_1+8))
 LPC4_1:
-	add	r10, pc, r10
-	str	r0, [sp, #112]
-	mov	r11, #16
-	mov	r1, #0
+	add	r8, pc, r8
+	str	r1, [sp, #112]
+	mov	r10, #16
+	mov	r2, #0
 	b	LBB4_2
 LBB4_1:
-	add	r1, r1, #1
-	str	r1, [sp, #108]
+	add	r2, r2, #1
+	str	r2, [sp, #108]
 LBB4_2:
-	cmp	r1, r0
+	cmp	r2, r1
 	blo	LBB4_1
-	ldr	r1, [r8]
+	ldr	r1, [r6]
 	cmp	r1, #0
 	beq	LBB4_6
 LBB4_4:
-	str	r11, [sp]
-	mov	r0, r6
+	str	r10, [sp]
 	mov	r2, r5
 	mov	r3, r4
 	bl	_objc_msgSend
 	str	r0, [sp, #112]
 	cmp	r0, #0
 	beq	LBB4_7
-	mov	r1, #0
-	ldr	r6, [sp, #8]
+	mov	r1, r0
+	mov	r2, #0
+	ldr	r0, [sp, #8]
 	b	LBB4_1
 LBB4_6:
-	mov	r0, r8
-	mov	r1, r10
+	mov	r11, r0
+	mov	r0, r6
+	mov	r1, r8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r1, r0
+	mov	r0, r11
 	b	LBB4_4
 LBB4_7:
 	sub	sp, r7, #24
@@ -240,24 +241,23 @@ _iter_retained:
 	push	{r8, r10, r11}
 	sub	sp, sp, #120
 	bfc	sp, #0, #3
-	add	r1, sp, #8
-	add	r2, r1, #80
+	add	r2, sp, #8
+	add	r3, r2, #80
 	vmov.i32	q8, #0x0
-	vst1.64	{d16, d17}, [r2]!
-	mov	r6, r0
-	mov	r0, #0
-	orr	r4, r1, #4
+	vst1.64	{d16, d17}, [r3]!
+	mov	r1, #0
+	orr	r4, r2, #4
 	mov	r5, r4
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
-	str	r0, [r2]
-	str	r6, [sp, #8]
-	str	r0, [r5]
-	str	r0, [sp, #80]
-	str	r0, [sp, #84]
-	str	r0, [sp, #108]
+	str	r1, [r3]
+	str	r0, [sp, #8]
+	str	r1, [r5]
+	str	r1, [sp, #80]
+	str	r1, [sp, #84]
+	str	r1, [sp, #108]
 	movw	r10, :lower16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC5_0+8))
 	movt	r10, :upper16:(LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC5_0+8))
 LPC5_0:
@@ -266,43 +266,44 @@ LPC5_0:
 	movt	r8, :upper16:(l_anon.[ID].0-(LPC5_1+8))
 LPC5_1:
 	add	r8, pc, r8
-	str	r0, [sp, #112]
+	str	r1, [sp, #112]
 	mov	r11, #16
-	mov	r1, #0
+	mov	r2, #0
 	b	LBB5_3
 LBB5_1:
 	str	r11, [sp]
-	mov	r0, r6
 	mov	r2, r5
 	mov	r3, r4
 	bl	_objc_msgSend
 	str	r0, [sp, #112]
-	mov	r1, #0
+	mov	r2, #0
 	cmp	r0, #0
 	beq	LBB5_6
 LBB5_2:
 	ldr	r0, [sp, #80]
-	add	r2, r1, #1
-	str	r2, [sp, #108]
-	ldr	r0, [r0, r1, lsl #2]
+	add	r1, r2, #1
+	str	r1, [sp, #108]
+	ldr	r0, [r0, r2, lsl #2]
 	bl	_objc_retain
 	mov	r6, r0
 	bl	_use_obj
 	mov	r0, r6
 	bl	_objc_release
-	ldr	r6, [sp, #8]
-	ldr	r1, [sp, #108]
-	ldr	r0, [sp, #112]
+	ldr	r0, [sp, #8]
+	ldr	r2, [sp, #108]
+	ldr	r1, [sp, #112]
 LBB5_3:
-	cmp	r1, r0
+	cmp	r2, r1
 	blo	LBB5_2
 	ldr	r1, [r10]
 	cmp	r1, #0
 	bne	LBB5_1
+	mov	r6, r0
 	mov	r0, r10
 	mov	r1, r8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r1, r0
+	mov	r0, r6
 	b	LBB5_1
 LBB5_6:
 	sub	sp, r7, #24

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
@@ -7,33 +7,21 @@ _iter_create:
 	mov	ebp, esp
 	mov	eax, dword ptr [ebp + 8]
 	mov	ecx, dword ptr [ebp + 12]
-	mov	dword ptr [eax + 84], 0
-	mov	dword ptr [eax + 80], 0
-	mov	dword ptr [eax + 92], 0
-	mov	dword ptr [eax + 88], 0
-	mov	dword ptr [eax + 96], 0
 	mov	dword ptr [eax], ecx
-	mov	dword ptr [eax + 8], 0
-	mov	dword ptr [eax + 4], 0
-	mov	dword ptr [eax + 16], 0
-	mov	dword ptr [eax + 12], 0
-	mov	dword ptr [eax + 24], 0
-	mov	dword ptr [eax + 20], 0
-	mov	dword ptr [eax + 32], 0
-	mov	dword ptr [eax + 28], 0
-	mov	dword ptr [eax + 40], 0
-	mov	dword ptr [eax + 36], 0
-	mov	dword ptr [eax + 48], 0
-	mov	dword ptr [eax + 44], 0
-	mov	dword ptr [eax + 56], 0
-	mov	dword ptr [eax + 52], 0
-	mov	dword ptr [eax + 64], 0
-	mov	dword ptr [eax + 60], 0
-	mov	dword ptr [eax + 72], 0
-	mov	dword ptr [eax + 68], 0
-	mov	dword ptr [eax + 76], 0
-	mov	dword ptr [eax + 100], 0
-	mov	dword ptr [eax + 104], 0
+	xorps	xmm0, xmm0
+	movsd	qword ptr [eax + 4], xmm0
+	movsd	qword ptr [eax + 12], xmm0
+	movsd	qword ptr [eax + 20], xmm0
+	movsd	qword ptr [eax + 28], xmm0
+	movsd	qword ptr [eax + 36], xmm0
+	movsd	qword ptr [eax + 44], xmm0
+	movsd	qword ptr [eax + 52], xmm0
+	movsd	qword ptr [eax + 60], xmm0
+	movsd	qword ptr [eax + 68], xmm0
+	movsd	qword ptr [eax + 76], xmm0
+	movsd	qword ptr [eax + 84], xmm0
+	movsd	qword ptr [eax + 92], xmm0
+	movsd	qword ptr [eax + 100], xmm0
 	pop	ebp
 	ret	4
 
@@ -54,20 +42,19 @@ L1$pb:
 	cmp	eax, dword ptr [esi + 104]
 	jb	LBB1_4
 	lea	ebx, [esi + 4]
-	mov	eax, dword ptr [esi]
-	mov	dword ptr [ebp - 16], eax
-	lea	edi, [esi + 68]
+	mov	edi, dword ptr [esi]
 	mov	edx, dword ptr [ecx + LSYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L1$pb]
 	mov	eax, dword ptr [edx]
 	test	eax, eax
 	je	LBB1_2
 LBB1_3:
+	lea	ecx, [esi + 68]
 	sub	esp, 12
 	push	16
 	push	ebx
-	push	edi
+	push	ecx
 	push	eax
-	push	dword ptr [ebp - 16]
+	push	edi
 	call	_objc_msgSend
 	add	esp, 32
 	mov	ecx, eax
@@ -125,31 +112,21 @@ _iter:
 L3$pb:
 	pop	eax
 	mov	ebx, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 40], 0
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 36], 0
+	xorps	xmm0, xmm0
+	movsd	qword ptr [ebp - 36], xmm0
+	movsd	qword ptr [ebp - 44], xmm0
 	mov	dword ptr [ebp - 28], 0
 	mov	dword ptr [ebp - 124], ebx
 	lea	edi, [ebp - 56]
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 52], 0
-	mov	dword ptr [ebp - 56], 0
+	movsd	qword ptr [ebp - 120], xmm0
+	movsd	qword ptr [ebp - 112], xmm0
+	movsd	qword ptr [ebp - 104], xmm0
+	movsd	qword ptr [ebp - 96], xmm0
+	movsd	qword ptr [ebp - 88], xmm0
+	movsd	qword ptr [ebp - 80], xmm0
+	movsd	qword ptr [ebp - 72], xmm0
+	movsd	qword ptr [ebp - 64], xmm0
+	movsd	qword ptr [ebp - 56], xmm0
 	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
 	mov	dword ptr [ebp - 20], 0
@@ -218,31 +195,21 @@ _iter_noop:
 L4$pb:
 	pop	eax
 	mov	ebx, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 40], 0
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 36], 0
+	xorps	xmm0, xmm0
+	movsd	qword ptr [ebp - 36], xmm0
+	movsd	qword ptr [ebp - 44], xmm0
 	mov	dword ptr [ebp - 28], 0
 	mov	dword ptr [ebp - 124], ebx
 	lea	edi, [ebp - 56]
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 52], 0
-	mov	dword ptr [ebp - 56], 0
+	movsd	qword ptr [ebp - 120], xmm0
+	movsd	qword ptr [ebp - 112], xmm0
+	movsd	qword ptr [ebp - 104], xmm0
+	movsd	qword ptr [ebp - 96], xmm0
+	movsd	qword ptr [ebp - 88], xmm0
+	movsd	qword ptr [ebp - 80], xmm0
+	movsd	qword ptr [ebp - 72], xmm0
+	movsd	qword ptr [ebp - 64], xmm0
+	movsd	qword ptr [ebp - 56], xmm0
 	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
 	mov	dword ptr [ebp - 20], 0
@@ -306,31 +273,21 @@ _iter_retained:
 L5$pb:
 	pop	eax
 	mov	esi, dword ptr [ebp + 8]
-	mov	dword ptr [ebp - 40], 0
-	mov	dword ptr [ebp - 44], 0
-	mov	dword ptr [ebp - 32], 0
-	mov	dword ptr [ebp - 36], 0
+	xorps	xmm0, xmm0
+	movsd	qword ptr [ebp - 36], xmm0
+	movsd	qword ptr [ebp - 44], xmm0
 	mov	dword ptr [ebp - 28], 0
 	mov	dword ptr [ebp - 124], esi
 	lea	ebx, [ebp - 56]
-	mov	dword ptr [ebp - 116], 0
-	mov	dword ptr [ebp - 120], 0
-	mov	dword ptr [ebp - 108], 0
-	mov	dword ptr [ebp - 112], 0
-	mov	dword ptr [ebp - 100], 0
-	mov	dword ptr [ebp - 104], 0
-	mov	dword ptr [ebp - 92], 0
-	mov	dword ptr [ebp - 96], 0
-	mov	dword ptr [ebp - 84], 0
-	mov	dword ptr [ebp - 88], 0
-	mov	dword ptr [ebp - 76], 0
-	mov	dword ptr [ebp - 80], 0
-	mov	dword ptr [ebp - 68], 0
-	mov	dword ptr [ebp - 72], 0
-	mov	dword ptr [ebp - 60], 0
-	mov	dword ptr [ebp - 64], 0
-	mov	dword ptr [ebp - 52], 0
-	mov	dword ptr [ebp - 56], 0
+	movsd	qword ptr [ebp - 120], xmm0
+	movsd	qword ptr [ebp - 112], xmm0
+	movsd	qword ptr [ebp - 104], xmm0
+	movsd	qword ptr [ebp - 96], xmm0
+	movsd	qword ptr [ebp - 88], xmm0
+	movsd	qword ptr [ebp - 80], xmm0
+	movsd	qword ptr [ebp - 72], xmm0
+	movsd	qword ptr [ebp - 64], xmm0
+	movsd	qword ptr [ebp - 56], xmm0
 	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
 	mov	dword ptr [ebp - 20], 0

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
@@ -5,34 +5,16 @@
 _iter_create:
 	push	rbp
 	mov	rbp, rsp
-	mov	rax, rdi
-	mov	qword ptr [rdi + 192], 0
-	mov	qword ptr [rdi + 184], 0
-	mov	qword ptr [rdi + 176], 0
-	mov	qword ptr [rdi + 168], 0
-	mov	qword ptr [rdi + 160], 0
-	mov	qword ptr [rdi + 8], 0
-	mov	qword ptr [rdi + 16], 0
-	mov	qword ptr [rdi + 24], 0
-	mov	qword ptr [rdi + 32], 0
-	mov	qword ptr [rdi + 40], 0
-	mov	qword ptr [rdi + 48], 0
-	mov	qword ptr [rdi + 56], 0
-	mov	qword ptr [rdi + 64], 0
-	mov	qword ptr [rdi + 72], 0
-	mov	qword ptr [rdi + 80], 0
-	mov	qword ptr [rdi + 88], 0
-	mov	qword ptr [rdi + 96], 0
-	mov	qword ptr [rdi + 104], 0
-	mov	qword ptr [rdi + 112], 0
-	mov	qword ptr [rdi + 120], 0
-	mov	qword ptr [rdi + 128], 0
+	push	rbx
+	push	rax
+	mov	rbx, rdi
 	mov	qword ptr [rdi], rsi
-	mov	qword ptr [rdi + 152], 0
-	mov	qword ptr [rdi + 144], 0
-	mov	qword ptr [rdi + 136], 0
-	mov	qword ptr [rdi + 208], 0
-	mov	qword ptr [rdi + 200], 0
+	add	rdi, 8
+	mov	esi, 208
+	call	___bzero
+	mov	rax, rbx
+	add	rsp, 8
+	pop	rbx
 	pop	rbp
 	ret
 
@@ -43,24 +25,21 @@ _iter_once:
 	mov	rbp, rsp
 	push	r15
 	push	r14
-	push	r12
 	push	rbx
+	push	rax
 	mov	rbx, rdi
 	mov	rax, qword ptr [rdi + 200]
 	cmp	rax, qword ptr [rdi + 208]
 	jb	LBB1_4
-	lea	r14, [rbx + 8]
-	mov	r15, qword ptr [rbx]
-	lea	r12, [rbx + 136]
+	lea	rcx, [rbx + 8]
+	mov	rdi, qword ptr [rbx]
 	mov	rax, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	mov	rsi, qword ptr [rax]
 	test	rsi, rsi
 	je	LBB1_2
 LBB1_3:
+	lea	rdx, [rbx + 136]
 	mov	r8d, 16
-	mov	rdi, r15
-	mov	rdx, r12
-	mov	rcx, r14
 	call	_objc_msgSend
 	mov	rcx, rax
 	mov	qword ptr [rbx + 208], rax
@@ -74,16 +53,21 @@ LBB1_4:
 	mov	qword ptr [rbx + 200], rdx
 	mov	rax, qword ptr [rcx + 8*rax]
 LBB1_5:
+	add	rsp, 8
 	pop	rbx
-	pop	r12
 	pop	r14
 	pop	r15
 	pop	rbp
 	ret
 LBB1_2:
-	mov	rdi, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	rax, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	rsi, [rip + l_anon.[ID].0]
+	mov	r14, rdi
+	mov	rdi, rax
+	mov	r15, rcx
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rdi, r14
+	mov	rcx, r15
 	mov	rsi, rax
 	jmp	LBB1_3
 
@@ -110,180 +94,6 @@ _iter:
 	push	r12
 	push	rbx
 	sub	rsp, 216
-	mov	r14, rdi
-	mov	qword ptr [rbp - 64], 0
-	mov	qword ptr [rbp - 72], 0
-	mov	qword ptr [rbp - 80], 0
-	mov	qword ptr [rbp - 88], 0
-	mov	qword ptr [rbp - 96], 0
-	lea	rbx, [rbp - 248]
-	mov	qword ptr [rbp - 248], 0
-	mov	qword ptr [rbp - 240], 0
-	mov	qword ptr [rbp - 232], 0
-	mov	qword ptr [rbp - 224], 0
-	mov	qword ptr [rbp - 216], 0
-	mov	qword ptr [rbp - 208], 0
-	mov	qword ptr [rbp - 200], 0
-	mov	qword ptr [rbp - 192], 0
-	mov	qword ptr [rbp - 184], 0
-	mov	qword ptr [rbp - 176], 0
-	mov	qword ptr [rbp - 168], 0
-	mov	qword ptr [rbp - 160], 0
-	mov	qword ptr [rbp - 152], 0
-	mov	qword ptr [rbp - 144], 0
-	mov	qword ptr [rbp - 136], 0
-	mov	qword ptr [rbp - 128], 0
-	mov	qword ptr [rbp - 256], rdi
-	lea	r15, [rbp - 120]
-	mov	qword ptr [rbp - 104], 0
-	mov	qword ptr [rbp - 112], 0
-	mov	qword ptr [rbp - 120], 0
-	mov	qword ptr [rbp - 48], 0
-	mov	qword ptr [rbp - 56], 0
-	xor	ecx, ecx
-	mov	r12, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	lea	r13, [rip + l_anon.[ID].0]
-	xor	eax, eax
-	jmp	LBB3_1
-	.p2align	4, 0x90
-LBB3_6:
-	mov	rcx, qword ptr [rbp - 112]
-	lea	rdx, [rax + 1]
-	mov	qword ptr [rbp - 56], rdx
-	mov	rdi, qword ptr [rcx + 8*rax]
-	call	_use_obj
-	mov	r14, qword ptr [rbp - 256]
-	mov	rax, qword ptr [rbp - 56]
-	mov	rcx, qword ptr [rbp - 48]
-LBB3_1:
-	cmp	rax, rcx
-	jb	LBB3_6
-	mov	rsi, qword ptr [r12]
-	test	rsi, rsi
-	je	LBB3_3
-LBB3_4:
-	mov	r8d, 16
-	mov	rdi, r14
-	mov	rdx, r15
-	mov	rcx, rbx
-	call	_objc_msgSend
-	mov	qword ptr [rbp - 48], rax
-	test	rax, rax
-	je	LBB3_7
-	xor	eax, eax
-	jmp	LBB3_6
-LBB3_3:
-	mov	rdi, r12
-	mov	rsi, r13
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	rsi, rax
-	jmp	LBB3_4
-LBB3_7:
-	add	rsp, 216
-	pop	rbx
-	pop	r12
-	pop	r13
-	pop	r14
-	pop	r15
-	pop	rbp
-	ret
-
-	.globl	_iter_noop
-	.p2align	4, 0x90
-_iter_noop:
-	push	rbp
-	mov	rbp, rsp
-	push	r15
-	push	r14
-	push	r13
-	push	r12
-	push	rbx
-	sub	rsp, 216
-	mov	r14, rdi
-	mov	qword ptr [rbp - 64], 0
-	mov	qword ptr [rbp - 72], 0
-	mov	qword ptr [rbp - 80], 0
-	mov	qword ptr [rbp - 88], 0
-	mov	qword ptr [rbp - 96], 0
-	lea	rbx, [rbp - 248]
-	mov	qword ptr [rbp - 248], 0
-	mov	qword ptr [rbp - 240], 0
-	mov	qword ptr [rbp - 232], 0
-	mov	qword ptr [rbp - 224], 0
-	mov	qword ptr [rbp - 216], 0
-	mov	qword ptr [rbp - 208], 0
-	mov	qword ptr [rbp - 200], 0
-	mov	qword ptr [rbp - 192], 0
-	mov	qword ptr [rbp - 184], 0
-	mov	qword ptr [rbp - 176], 0
-	mov	qword ptr [rbp - 168], 0
-	mov	qword ptr [rbp - 160], 0
-	mov	qword ptr [rbp - 152], 0
-	mov	qword ptr [rbp - 144], 0
-	mov	qword ptr [rbp - 136], 0
-	mov	qword ptr [rbp - 128], 0
-	mov	qword ptr [rbp - 256], rdi
-	lea	r15, [rbp - 120]
-	mov	qword ptr [rbp - 104], 0
-	mov	qword ptr [rbp - 112], 0
-	mov	qword ptr [rbp - 120], 0
-	mov	qword ptr [rbp - 48], 0
-	mov	qword ptr [rbp - 56], 0
-	xor	eax, eax
-	mov	r12, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	lea	r13, [rip + l_anon.[ID].0]
-	xor	ecx, ecx
-	jmp	LBB4_1
-	.p2align	4, 0x90
-LBB4_6:
-	inc	rcx
-	mov	qword ptr [rbp - 56], rcx
-LBB4_1:
-	cmp	rcx, rax
-	jb	LBB4_6
-	mov	rsi, qword ptr [r12]
-	test	rsi, rsi
-	je	LBB4_3
-LBB4_4:
-	mov	r8d, 16
-	mov	rdi, r14
-	mov	rdx, r15
-	mov	rcx, rbx
-	call	_objc_msgSend
-	mov	qword ptr [rbp - 48], rax
-	test	rax, rax
-	je	LBB4_7
-	mov	r14, qword ptr [rbp - 256]
-	xor	ecx, ecx
-	jmp	LBB4_6
-LBB4_3:
-	mov	rdi, r12
-	mov	rsi, r13
-	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
-	mov	rsi, rax
-	jmp	LBB4_4
-LBB4_7:
-	add	rsp, 216
-	pop	rbx
-	pop	r12
-	pop	r13
-	pop	r14
-	pop	r15
-	pop	rbp
-	ret
-
-	.globl	_iter_retained
-	.p2align	4, 0x90
-_iter_retained:
-	push	rbp
-	mov	rbp, rsp
-	push	r15
-	push	r14
-	push	r13
-	push	r12
-	push	rbx
-	sub	rsp, 216
-	mov	r15, rdi
 	mov	qword ptr [rbp - 64], 0
 	mov	qword ptr [rbp - 72], 0
 	mov	qword ptr [rbp - 80], 0
@@ -314,8 +124,181 @@ _iter_retained:
 	mov	qword ptr [rbp - 48], 0
 	mov	qword ptr [rbp - 56], 0
 	xor	ecx, ecx
-	mov	r12, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	lea	r13, [rip + l_anon.[ID].0]
+	mov	r15, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
+	xor	eax, eax
+	jmp	LBB3_1
+	.p2align	4, 0x90
+LBB3_6:
+	mov	rcx, qword ptr [rbp - 112]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbp - 56], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	call	_use_obj
+	mov	rdi, qword ptr [rbp - 256]
+	mov	rax, qword ptr [rbp - 56]
+	mov	rcx, qword ptr [rbp - 48]
+LBB3_1:
+	cmp	rax, rcx
+	jb	LBB3_6
+	mov	rsi, qword ptr [r15]
+	test	rsi, rsi
+	je	LBB3_3
+LBB3_4:
+	mov	r8d, 16
+	mov	rdx, r14
+	mov	rcx, rbx
+	call	_objc_msgSend
+	mov	qword ptr [rbp - 48], rax
+	test	rax, rax
+	je	LBB3_7
+	xor	eax, eax
+	jmp	LBB3_6
+LBB3_3:
+	mov	r13, rdi
+	mov	rdi, r15
+	mov	rsi, r12
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rdi, r13
+	mov	rsi, rax
+	jmp	LBB3_4
+LBB3_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.globl	_iter_noop
+	.p2align	4, 0x90
+_iter_noop:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	qword ptr [rbp - 64], 0
+	mov	qword ptr [rbp - 72], 0
+	mov	qword ptr [rbp - 80], 0
+	mov	qword ptr [rbp - 88], 0
+	mov	qword ptr [rbp - 96], 0
+	lea	rbx, [rbp - 248]
+	mov	qword ptr [rbp - 248], 0
+	mov	qword ptr [rbp - 240], 0
+	mov	qword ptr [rbp - 232], 0
+	mov	qword ptr [rbp - 224], 0
+	mov	qword ptr [rbp - 216], 0
+	mov	qword ptr [rbp - 208], 0
+	mov	qword ptr [rbp - 200], 0
+	mov	qword ptr [rbp - 192], 0
+	mov	qword ptr [rbp - 184], 0
+	mov	qword ptr [rbp - 176], 0
+	mov	qword ptr [rbp - 168], 0
+	mov	qword ptr [rbp - 160], 0
+	mov	qword ptr [rbp - 152], 0
+	mov	qword ptr [rbp - 144], 0
+	mov	qword ptr [rbp - 136], 0
+	mov	qword ptr [rbp - 128], 0
+	mov	qword ptr [rbp - 256], rdi
+	lea	r14, [rbp - 120]
+	mov	qword ptr [rbp - 104], 0
+	mov	qword ptr [rbp - 112], 0
+	mov	qword ptr [rbp - 120], 0
+	mov	qword ptr [rbp - 48], 0
+	mov	qword ptr [rbp - 56], 0
+	xor	eax, eax
+	mov	r15, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
+	xor	ecx, ecx
+	jmp	LBB4_1
+	.p2align	4, 0x90
+LBB4_6:
+	inc	rcx
+	mov	qword ptr [rbp - 56], rcx
+LBB4_1:
+	cmp	rcx, rax
+	jb	LBB4_6
+	mov	rsi, qword ptr [r15]
+	test	rsi, rsi
+	je	LBB4_3
+LBB4_4:
+	mov	r8d, 16
+	mov	rdx, r14
+	mov	rcx, rbx
+	call	_objc_msgSend
+	mov	qword ptr [rbp - 48], rax
+	test	rax, rax
+	je	LBB4_7
+	mov	rdi, qword ptr [rbp - 256]
+	xor	ecx, ecx
+	jmp	LBB4_6
+LBB4_3:
+	mov	r13, rdi
+	mov	rdi, r15
+	mov	rsi, r12
+	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rdi, r13
+	mov	rsi, rax
+	jmp	LBB4_4
+LBB4_7:
+	add	rsp, 216
+	pop	rbx
+	pop	r12
+	pop	r13
+	pop	r14
+	pop	r15
+	pop	rbp
+	ret
+
+	.globl	_iter_retained
+	.p2align	4, 0x90
+_iter_retained:
+	push	rbp
+	mov	rbp, rsp
+	push	r15
+	push	r14
+	push	r13
+	push	r12
+	push	rbx
+	sub	rsp, 216
+	mov	qword ptr [rbp - 64], 0
+	mov	qword ptr [rbp - 72], 0
+	mov	qword ptr [rbp - 80], 0
+	mov	qword ptr [rbp - 88], 0
+	mov	qword ptr [rbp - 96], 0
+	lea	rbx, [rbp - 248]
+	mov	qword ptr [rbp - 248], 0
+	mov	qword ptr [rbp - 240], 0
+	mov	qword ptr [rbp - 232], 0
+	mov	qword ptr [rbp - 224], 0
+	mov	qword ptr [rbp - 216], 0
+	mov	qword ptr [rbp - 208], 0
+	mov	qword ptr [rbp - 200], 0
+	mov	qword ptr [rbp - 192], 0
+	mov	qword ptr [rbp - 184], 0
+	mov	qword ptr [rbp - 176], 0
+	mov	qword ptr [rbp - 168], 0
+	mov	qword ptr [rbp - 160], 0
+	mov	qword ptr [rbp - 152], 0
+	mov	qword ptr [rbp - 144], 0
+	mov	qword ptr [rbp - 136], 0
+	mov	qword ptr [rbp - 128], 0
+	mov	qword ptr [rbp - 256], rdi
+	lea	r14, [rbp - 120]
+	mov	qword ptr [rbp - 104], 0
+	mov	qword ptr [rbp - 112], 0
+	mov	qword ptr [rbp - 120], 0
+	mov	qword ptr [rbp - 48], 0
+	mov	qword ptr [rbp - 56], 0
+	xor	ecx, ecx
+	mov	r15, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	lea	r12, [rip + l_anon.[ID].0]
 	xor	eax, eax
 	jmp	LBB5_1
 	.p2align	4, 0x90
@@ -325,23 +308,22 @@ LBB5_6:
 	mov	qword ptr [rbp - 56], rdx
 	mov	rdi, qword ptr [rcx + 8*rax]
 	call	_objc_retain
-	mov	r15, rax
+	mov	r13, rax
 	mov	rdi, rax
 	call	_use_obj
-	mov	rdi, r15
+	mov	rdi, r13
 	call	_objc_release
-	mov	r15, qword ptr [rbp - 256]
+	mov	rdi, qword ptr [rbp - 256]
 	mov	rax, qword ptr [rbp - 56]
 	mov	rcx, qword ptr [rbp - 48]
 LBB5_1:
 	cmp	rax, rcx
 	jb	LBB5_6
-	mov	rsi, qword ptr [r12]
+	mov	rsi, qword ptr [r15]
 	test	rsi, rsi
 	je	LBB5_3
 LBB5_4:
 	mov	r8d, 16
-	mov	rdi, r15
 	mov	rdx, r14
 	mov	rcx, rbx
 	call	_objc_msgSend
@@ -351,9 +333,11 @@ LBB5_4:
 	xor	eax, eax
 	jmp	LBB5_6
 LBB5_3:
-	mov	rdi, r12
-	mov	rsi, r13
+	mov	r13, rdi
+	mov	rdi, r15
+	mov	rsi, r12
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
+	mov	rdi, r13
 	mov	rsi, rax
 	jmp	LBB5_4
 LBB5_7:

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
@@ -7,33 +7,21 @@
 iter_create:
 	mov	eax, dword ptr [esp + 4]
 	mov	ecx, dword ptr [esp + 8]
-	mov	dword ptr [eax + 84], 0
-	mov	dword ptr [eax + 80], 0
-	mov	dword ptr [eax + 92], 0
-	mov	dword ptr [eax + 88], 0
-	mov	dword ptr [eax + 96], 0
+	xorps	xmm0, xmm0
 	mov	dword ptr [eax], ecx
-	mov	dword ptr [eax + 8], 0
-	mov	dword ptr [eax + 4], 0
-	mov	dword ptr [eax + 16], 0
-	mov	dword ptr [eax + 12], 0
-	mov	dword ptr [eax + 24], 0
-	mov	dword ptr [eax + 20], 0
-	mov	dword ptr [eax + 32], 0
-	mov	dword ptr [eax + 28], 0
-	mov	dword ptr [eax + 40], 0
-	mov	dword ptr [eax + 36], 0
-	mov	dword ptr [eax + 48], 0
-	mov	dword ptr [eax + 44], 0
-	mov	dword ptr [eax + 56], 0
-	mov	dword ptr [eax + 52], 0
-	mov	dword ptr [eax + 64], 0
-	mov	dword ptr [eax + 60], 0
-	mov	dword ptr [eax + 72], 0
-	mov	dword ptr [eax + 68], 0
-	mov	dword ptr [eax + 76], 0
-	mov	dword ptr [eax + 100], 0
-	mov	dword ptr [eax + 104], 0
+	movsd	qword ptr [eax + 4], xmm0
+	movsd	qword ptr [eax + 12], xmm0
+	movsd	qword ptr [eax + 20], xmm0
+	movsd	qword ptr [eax + 28], xmm0
+	movsd	qword ptr [eax + 36], xmm0
+	movsd	qword ptr [eax + 44], xmm0
+	movsd	qword ptr [eax + 52], xmm0
+	movsd	qword ptr [eax + 60], xmm0
+	movsd	qword ptr [eax + 68], xmm0
+	movsd	qword ptr [eax + 76], xmm0
+	movsd	qword ptr [eax + 84], xmm0
+	movsd	qword ptr [eax + 92], xmm0
+	movsd	qword ptr [eax + 100], xmm0
 	ret	4
 .Lfunc_end0:
 	.size	iter_create, .Lfunc_end0-iter_create
@@ -60,13 +48,13 @@ iter_once:
 	lea	eax, [edi + 4]
 	mov	ebp, dword ptr [edi]
 	mov	dword ptr [esp + 8], eax
-	lea	eax, [edi + 68]
-	mov	dword ptr [esp + 4], eax
 	mov	eax, dword ptr [ebx + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
 	mov	esi, dword ptr [eax]
 	test	esi, esi
 	je	.LBB1_2
 .LBB1_3:
+	lea	eax, [edi + 68]
+	mov	dword ptr [esp + 4], eax
 	sub	esp, 8
 	push	esi
 	push	ebp
@@ -138,38 +126,28 @@ iter:
 	call	.L3$pb
 .L3$pb:
 	pop	ebx
-	mov	edi, dword ptr [esp + 144]
+	mov	ebp, dword ptr [esp + 144]
+	xorps	xmm0, xmm0
 	xor	eax, eax
-	mov	dword ptr [esp + 100], 0
-	mov	dword ptr [esp + 96], 0
-	mov	dword ptr [esp + 108], 0
-	mov	dword ptr [esp + 104], 0
 	mov	dword ptr [esp + 112], 0
 .Ltmp1:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp1-.L3$pb)
-	mov	ebp, dword ptr [ebx + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
+	movsd	qword ptr [esp + 104], xmm0
+	movsd	qword ptr [esp + 96], xmm0
+	mov	edi, dword ptr [ebx + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
 	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
 	mov	dword ptr [esp + 12], ecx
 	xor	ecx, ecx
-	mov	dword ptr [esp + 16], edi
-	mov	dword ptr [esp + 24], 0
-	mov	dword ptr [esp + 20], 0
-	mov	dword ptr [esp + 32], 0
-	mov	dword ptr [esp + 28], 0
-	mov	dword ptr [esp + 40], 0
-	mov	dword ptr [esp + 36], 0
-	mov	dword ptr [esp + 48], 0
-	mov	dword ptr [esp + 44], 0
-	mov	dword ptr [esp + 56], 0
-	mov	dword ptr [esp + 52], 0
-	mov	dword ptr [esp + 64], 0
-	mov	dword ptr [esp + 60], 0
-	mov	dword ptr [esp + 72], 0
-	mov	dword ptr [esp + 68], 0
-	mov	dword ptr [esp + 80], 0
-	mov	dword ptr [esp + 76], 0
-	mov	dword ptr [esp + 88], 0
-	mov	dword ptr [esp + 84], 0
+	mov	dword ptr [esp + 16], ebp
+	movsd	qword ptr [esp + 20], xmm0
+	movsd	qword ptr [esp + 28], xmm0
+	movsd	qword ptr [esp + 36], xmm0
+	movsd	qword ptr [esp + 44], xmm0
+	movsd	qword ptr [esp + 52], xmm0
+	movsd	qword ptr [esp + 60], xmm0
+	movsd	qword ptr [esp + 68], xmm0
+	movsd	qword ptr [esp + 76], xmm0
+	movsd	qword ptr [esp + 84], xmm0
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0
@@ -178,7 +156,7 @@ iter:
 .LBB3_4:
 	sub	esp, 8
 	push	esi
-	push	edi
+	push	ebp
 	call	objc_msg_lookup@PLT
 	add	esp, 4
 	push	16
@@ -187,7 +165,7 @@ iter:
 	lea	ecx, [esp + 104]
 	push	ecx
 	push	esi
-	push	edi
+	push	ebp
 	call	eax
 	add	esp, 32
 	xor	ecx, ecx
@@ -202,18 +180,18 @@ iter:
 	push	dword ptr [eax + 4*ecx]
 	call	use_obj@PLT
 	add	esp, 16
-	mov	edi, dword ptr [esp + 16]
+	mov	ebp, dword ptr [esp + 16]
 	mov	ecx, dword ptr [esp + 116]
 	mov	eax, dword ptr [esp + 120]
 .LBB3_1:
 	cmp	ecx, eax
 	jb	.LBB3_6
-	mov	esi, dword ptr [ebp]
+	mov	esi, dword ptr [edi]
 	test	esi, esi
 	jne	.LBB3_4
 	sub	esp, 8
 	push	dword ptr [esp + 20]
-	push	ebp
+	push	edi
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)@PLT
 	add	esp, 16
 	mov	esi, eax
@@ -242,37 +220,27 @@ iter_noop:
 .L4$pb:
 	pop	ebx
 	mov	edi, dword ptr [esp + 144]
+	xorps	xmm0, xmm0
 	xor	eax, eax
-	mov	dword ptr [esp + 100], 0
-	mov	dword ptr [esp + 96], 0
-	mov	dword ptr [esp + 108], 0
-	mov	dword ptr [esp + 104], 0
 	mov	dword ptr [esp + 112], 0
 .Ltmp2:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp2-.L4$pb)
+	movsd	qword ptr [esp + 104], xmm0
+	movsd	qword ptr [esp + 96], xmm0
 	mov	ebp, dword ptr [ebx + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
 	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
 	mov	dword ptr [esp + 12], ecx
 	xor	ecx, ecx
 	mov	dword ptr [esp + 16], edi
-	mov	dword ptr [esp + 24], 0
-	mov	dword ptr [esp + 20], 0
-	mov	dword ptr [esp + 32], 0
-	mov	dword ptr [esp + 28], 0
-	mov	dword ptr [esp + 40], 0
-	mov	dword ptr [esp + 36], 0
-	mov	dword ptr [esp + 48], 0
-	mov	dword ptr [esp + 44], 0
-	mov	dword ptr [esp + 56], 0
-	mov	dword ptr [esp + 52], 0
-	mov	dword ptr [esp + 64], 0
-	mov	dword ptr [esp + 60], 0
-	mov	dword ptr [esp + 72], 0
-	mov	dword ptr [esp + 68], 0
-	mov	dword ptr [esp + 80], 0
-	mov	dword ptr [esp + 76], 0
-	mov	dword ptr [esp + 88], 0
-	mov	dword ptr [esp + 84], 0
+	movsd	qword ptr [esp + 20], xmm0
+	movsd	qword ptr [esp + 28], xmm0
+	movsd	qword ptr [esp + 36], xmm0
+	movsd	qword ptr [esp + 44], xmm0
+	movsd	qword ptr [esp + 52], xmm0
+	movsd	qword ptr [esp + 60], xmm0
+	movsd	qword ptr [esp + 68], xmm0
+	movsd	qword ptr [esp + 76], xmm0
+	movsd	qword ptr [esp + 84], xmm0
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0
@@ -340,37 +308,27 @@ iter_retained:
 .L5$pb:
 	pop	ebx
 	mov	ebp, dword ptr [esp + 144]
+	xorps	xmm0, xmm0
 	xor	eax, eax
-	mov	dword ptr [esp + 100], 0
-	mov	dword ptr [esp + 96], 0
-	mov	dword ptr [esp + 108], 0
-	mov	dword ptr [esp + 104], 0
 	mov	dword ptr [esp + 112], 0
 .Ltmp3:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp3-.L5$pb)
+	movsd	qword ptr [esp + 104], xmm0
+	movsd	qword ptr [esp + 96], xmm0
 	mov	edi, dword ptr [ebx + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
 	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
 	mov	dword ptr [esp + 12], ecx
 	xor	ecx, ecx
 	mov	dword ptr [esp + 16], ebp
-	mov	dword ptr [esp + 24], 0
-	mov	dword ptr [esp + 20], 0
-	mov	dword ptr [esp + 32], 0
-	mov	dword ptr [esp + 28], 0
-	mov	dword ptr [esp + 40], 0
-	mov	dword ptr [esp + 36], 0
-	mov	dword ptr [esp + 48], 0
-	mov	dword ptr [esp + 44], 0
-	mov	dword ptr [esp + 56], 0
-	mov	dword ptr [esp + 52], 0
-	mov	dword ptr [esp + 64], 0
-	mov	dword ptr [esp + 60], 0
-	mov	dword ptr [esp + 72], 0
-	mov	dword ptr [esp + 68], 0
-	mov	dword ptr [esp + 80], 0
-	mov	dword ptr [esp + 76], 0
-	mov	dword ptr [esp + 88], 0
-	mov	dword ptr [esp + 84], 0
+	movsd	qword ptr [esp + 20], xmm0
+	movsd	qword ptr [esp + 28], xmm0
+	movsd	qword ptr [esp + 36], xmm0
+	movsd	qword ptr [esp + 44], xmm0
+	movsd	qword ptr [esp + 52], xmm0
+	movsd	qword ptr [esp + 60], xmm0
+	movsd	qword ptr [esp + 68], xmm0
+	movsd	qword ptr [esp + 76], xmm0
+	movsd	qword ptr [esp + 84], xmm0
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
@@ -6,10 +6,8 @@
 	.type	iter_create,@function
 iter_create:
 	mov	rax, rdi
+	mov	qword ptr [rdi], rsi
 	xorps	xmm0, xmm0
-	movups	xmmword ptr [rdi + 176], xmm0
-	movups	xmmword ptr [rdi + 160], xmm0
-	mov	qword ptr [rdi + 192], 0
 	movups	xmmword ptr [rdi + 8], xmm0
 	movups	xmmword ptr [rdi + 24], xmm0
 	movups	xmmword ptr [rdi + 40], xmm0
@@ -18,9 +16,10 @@ iter_create:
 	movups	xmmword ptr [rdi + 88], xmm0
 	movups	xmmword ptr [rdi + 104], xmm0
 	movups	xmmword ptr [rdi + 120], xmm0
-	mov	qword ptr [rdi], rsi
 	movups	xmmword ptr [rdi + 136], xmm0
-	mov	qword ptr [rdi + 152], 0
+	movups	xmmword ptr [rdi + 152], xmm0
+	movups	xmmword ptr [rdi + 168], xmm0
+	movups	xmmword ptr [rdi + 184], xmm0
 	movups	xmmword ptr [rdi + 200], xmm0
 	ret
 .Lfunc_end0:
@@ -42,19 +41,19 @@ iter_once:
 	jb	.LBB1_4
 	lea	r14, [rbx + 8]
 	mov	r15, qword ptr [rbx]
-	lea	r12, [rbx + 136]
 	mov	rax, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	mov	r13, qword ptr [rax]
-	test	r13, r13
+	mov	r12, qword ptr [rax]
+	test	r12, r12
 	je	.LBB1_2
 .LBB1_3:
+	lea	r13, [rbx + 136]
 	mov	rdi, r15
-	mov	rsi, r13
+	mov	rsi, r12
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
 	mov	r8d, 16
 	mov	rdi, r15
-	mov	rsi, r13
-	mov	rdx, r12
+	mov	rsi, r12
+	mov	rdx, r13
 	mov	rcx, r14
 	call	rax
 	mov	rcx, rax
@@ -79,7 +78,7 @@ iter_once:
 	mov	rdi, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	rsi, [rip + .Lanon.[ID].0]
 	call	qword ptr [rip + SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)@GOTPCREL]
-	mov	r13, rax
+	mov	r12, rax
 	jmp	.LBB1_3
 .Lfunc_end1:
 	.size	iter_once, .Lfunc_end1-iter_once
@@ -109,7 +108,7 @@ iter:
 	push	r12
 	push	rbx
 	sub	rsp, 216
-	mov	r15, rdi
+	mov	r13, rdi
 	xorps	xmm0, xmm0
 	movups	xmmword ptr [rsp + 176], xmm0
 	movups	xmmword ptr [rsp + 160], xmm0
@@ -128,8 +127,8 @@ iter:
 	mov	qword ptr [rsp + 152], 0
 	movups	xmmword ptr [rsp + 200], xmm0
 	xor	ecx, ecx
-	mov	r13, qword ptr [rip + use_obj@GOTPCREL]
-	mov	r12, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	r12, qword ptr [rip + use_obj@GOTPCREL]
+	mov	r15, qword ptr [rip + SYM(icrate::generated::Foundation::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	mov	rbx, qword ptr [rip + objc_msg_lookup@GOTPCREL]
 	xor	eax, eax
 	jmp	.LBB3_1
@@ -139,22 +138,22 @@ iter:
 	lea	rdx, [rax + 1]
 	mov	qword ptr [rsp + 200], rdx
 	mov	rdi, qword ptr [rcx + 8*rax]
-	call	r13
-	mov	r15, qword ptr [rsp]
+	call	r12
+	mov	r13, qword ptr [rsp]
 	mov	rax, qword ptr [rsp + 200]
 	mov	rcx, qword ptr [rsp + 208]
 .LBB3_1:
 	cmp	rax, rcx
 	jb	.LBB3_6
-	mov	rbp, qword ptr [r12]
+	mov	rbp, qword ptr [r15]
 	test	rbp, rbp
 	je	.LBB3_3
 .LBB3_4:
-	mov	rdi, r15
+	mov	rdi, r13
 	mov	rsi, rbp
 	call	rbx
 	mov	r8d, 16
-	mov	rdi, r15
+	mov	rdi, r13
 	mov	rsi, rbp
 	mov	rdx, r14
 	lea	rcx, [rsp + 8]
@@ -165,7 +164,7 @@ iter:
 	xor	eax, eax
 	jmp	.LBB3_6
 .LBB3_3:
-	mov	rdi, r12
+	mov	rdi, r15
 	lea	rsi, [rip + .Lanon.[ID].0]
 	call	qword ptr [rip + SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)@GOTPCREL]
 	mov	rbp, rax

--- a/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_error/expected/gnustep-x86_64.s
@@ -120,12 +120,12 @@ error_init:
 	mov	qword ptr [rsp], 0
 	test	rdi, rdi
 	je	.LBB4_1
-	mov	rbx, rsi
-	mov	r14, rdi
+	mov	rbx, rdi
+	mov	r14, rsi
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
 	mov	rdx, rsp
-	mov	rdi, r14
-	mov	rsi, rbx
+	mov	rdi, rbx
+	mov	rsi, r14
 	call	rax
 	test	rax, rax
 	je	.LBB4_4

--- a/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86.s
@@ -209,15 +209,15 @@ handle_alloc_init:
 	add	esp, 16
 	test	eax, eax
 	je	.LBB5_2
-	mov	edi, dword ptr [esp + 24]
-	mov	esi, eax
+	mov	esi, dword ptr [esp + 24]
 	sub	esp, 8
-	push	edi
+	push	esi
 	push	eax
+	mov	edi, eax
 	call	objc_msg_lookup@PLT
 	add	esp, 8
-	push	edi
 	push	esi
+	push	edi
 	call	eax
 	add	esp, 16
 	pop	esi

--- a/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_id/expected/gnustep-x86_64.s
@@ -78,11 +78,11 @@ handle_init:
 	push	r14
 	push	rbx
 	push	rax
-	mov	rbx, rsi
-	mov	r14, rdi
+	mov	rbx, rdi
+	mov	r14, rsi
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rdi, r14
-	mov	rsi, rbx
+	mov	rdi, rbx
+	mov	rsi, r14
 	add	rsp, 8
 	pop	rbx
 	pop	r14

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -21,9 +21,9 @@ _handle_alloc_init:
 	movt	r1, :upper16:(LL_OBJC_SELECTOR_REFERENCES_init$non_lazy_ptr-(LPC1_0+8))
 LPC1_0:
 	ldr	r1, [pc, r1]
-	mov	r5, r0
-	ldr	r4, [r1]
-	mov	r1, r4
+	mov	r4, r0
+	ldr	r5, [r1]
+	mov	r1, r5
 	bl	_objc_msgSend
 	cmp	r0, #0
 	popne	{r4, r5, r7, pc}
@@ -32,8 +32,8 @@ LBB1_1:
 	movt	r2, :upper16:(l_anon.[ID].1-(LPC1_1+8))
 LPC1_1:
 	add	r2, pc, r2
-	mov	r0, r5
-	mov	r1, r4
+	mov	r0, r4
+	mov	r1, r5
 	mov	lr, pc
 	b	SYM(<objc2::__macro_helpers::method_family::RetainSemantics<3_u8> as objc2::__macro_helpers::msg_send_id::MsgSendIdFailed>::failed::GENERATED_ID, 0)
 

--- a/crates/test-assembly/crates/test_out_parameters/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/apple-aarch64.s
@@ -28,13 +28,13 @@ _null_nonnull:
 	stp	x20, x19, [sp, #16]
 	stp	x29, x30, [sp, #32]
 	add	x29, sp, #32
-	mov	x19, x2
-	ldr	x20, [x2]
+	ldr	x19, [x2]
+	mov	x20, x2
 	bl	_objc_msgSend
 	mov	x21, x0
-	ldr	x0, [x19]
+	ldr	x0, [x20]
 	bl	_objc_retain
-	mov	x0, x20
+	mov	x0, x19
 	bl	_objc_release
 	mov	x0, x21
 	ldp	x29, x30, [sp, #32]
@@ -75,8 +75,8 @@ _null_null:
 	stp	x20, x19, [sp, #16]
 	stp	x29, x30, [sp, #32]
 	add	x29, sp, #32
-	mov	x21, x2
 	ldr	x19, [x2]
+	mov	x21, x2
 	bl	_objc_msgSend
 	mov	x20, x0
 	ldr	x0, [x21]

--- a/crates/test-assembly/crates/test_out_parameters/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/apple-armv7s.s
@@ -25,13 +25,13 @@ _null_nonnull:
 	beq	LBB1_2
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
-	mov	r4, r2
-	ldr	r5, [r2]
+	ldr	r4, [r2]
+	mov	r5, r2
 	bl	_objc_msgSend
 	mov	r6, r0
-	ldr	r0, [r4]
+	ldr	r0, [r5]
 	bl	_objc_retain
-	mov	r0, r5
+	mov	r0, r4
 	bl	_objc_release
 	mov	r0, r6
 	pop	{r4, r5, r6, r7, pc}
@@ -67,8 +67,8 @@ _null_null:
 	beq	LBB3_4
 	push	{r4, r5, r6, r7, lr}
 	add	r7, sp, #12
-	mov	r6, r2
 	ldr	r4, [r2]
+	mov	r6, r2
 	bl	_objc_msgSend
 	mov	r5, r0
 	ldr	r0, [r6]

--- a/crates/test-assembly/crates/test_out_parameters/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/apple-x86_64.s
@@ -36,13 +36,13 @@ _null_nonnull:
 	push	r14
 	push	rbx
 	push	rax
-	mov	rbx, rdx
-	mov	r14, qword ptr [rdx]
+	mov	rbx, qword ptr [rdx]
+	mov	r14, rdx
 	call	_objc_msgSend
 	mov	r15, rax
-	mov	rdi, qword ptr [rbx]
+	mov	rdi, qword ptr [r14]
 	call	_objc_retain
-	mov	rdi, r14
+	mov	rdi, rbx
 	call	_objc_release
 	mov	rax, r15
 	add	rsp, 8
@@ -94,8 +94,8 @@ _null_null:
 	push	r14
 	push	rbx
 	push	rax
-	mov	r15, rdx
 	mov	rbx, qword ptr [rdx]
+	mov	r15, rdx
 	call	_objc_msgSend
 	mov	r14, rax
 	mov	rdi, qword ptr [r15]

--- a/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86.s
@@ -53,39 +53,39 @@ null_nonnull:
 	push	edi
 	push	esi
 	sub	esp, 28
-	mov	ebp, dword ptr [esp + 56]
-	mov	edi, dword ptr [esp + 52]
-	mov	esi, dword ptr [esp + 48]
+	mov	edi, dword ptr [esp + 56]
+	mov	esi, dword ptr [esp + 52]
+	mov	ebp, dword ptr [esp + 48]
 	call	.L1$pb
 .L1$pb:
 	pop	ebx
 .Ltmp1:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp1-.L1$pb)
-	test	ebp, ebp
+	test	edi, edi
 	je	.LBB1_1
-	mov	eax, dword ptr [ebp]
+	mov	eax, dword ptr [edi]
 	mov	dword ptr [esp + 24], eax
 	jmp	.LBB1_3
 .LBB1_1:
 .LBB1_3:
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ebp
 	call	objc_msg_lookup@PLT
-	mov	dword ptr [esp + 8], ebp
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
+	mov	dword ptr [esp + 8], edi
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ebp
 	call	eax
-	mov	esi, eax
-	test	ebp, ebp
+	test	edi, edi
 	je	.LBB1_5
-	mov	eax, dword ptr [ebp]
-	mov	dword ptr [esp], eax
+	mov	ecx, dword ptr [edi]
+	mov	esi, eax
+	mov	dword ptr [esp], ecx
 	call	objc_retain@PLT
 	mov	eax, dword ptr [esp + 24]
 	mov	dword ptr [esp], eax
 	call	objc_release@PLT
-.LBB1_5:
 	mov	eax, esi
+.LBB1_5:
 	add	esp, 28
 	pop	esi
 	pop	edi
@@ -150,10 +150,10 @@ null_null:
 	push	ebx
 	push	edi
 	push	esi
-	sub	esp, 28
-	mov	ebp, dword ptr [esp + 56]
-	mov	edi, dword ptr [esp + 52]
-	mov	esi, dword ptr [esp + 48]
+	sub	esp, 12
+	mov	ebp, dword ptr [esp + 40]
+	mov	esi, dword ptr [esp + 36]
+	mov	ecx, dword ptr [esp + 32]
 	call	.L3$pb
 .L3$pb:
 	pop	ebx
@@ -161,17 +161,17 @@ null_null:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp3-.L3$pb)
 	test	ebp, ebp
 	je	.LBB3_1
-	mov	eax, dword ptr [ebp]
-	mov	dword ptr [esp + 24], eax
+	mov	edi, dword ptr [ebp]
 	jmp	.LBB3_3
 .LBB3_1:
 .LBB3_3:
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ecx
 	call	objc_msg_lookup@PLT
+	mov	ecx, dword ptr [esp + 32]
 	mov	dword ptr [esp + 8], ebp
-	mov	dword ptr [esp + 4], edi
-	mov	dword ptr [esp], esi
+	mov	dword ptr [esp + 4], esi
+	mov	dword ptr [esp], ecx
 	call	eax
 	mov	esi, eax
 	test	ebp, ebp
@@ -179,14 +179,13 @@ null_null:
 	mov	eax, dword ptr [ebp]
 	mov	dword ptr [esp], eax
 	call	objc_retain@PLT
-	cmp	dword ptr [esp + 24], 0
+	test	edi, edi
 	je	.LBB3_6
-	mov	eax, dword ptr [esp + 24]
-	mov	dword ptr [esp], eax
+	mov	dword ptr [esp], edi
 	call	objc_release@PLT
 .LBB3_6:
 	mov	eax, esi
-	add	esp, 28
+	add	esp, 12
 	pop	esi
 	pop	edi
 	pop	ebx

--- a/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_out_parameters/expected/gnustep-x86_64.s
@@ -45,30 +45,30 @@ null_nonnull:
 	push	rbx
 	push	rax
 	mov	rbx, rdx
-	mov	r15, rsi
-	mov	r12, rdi
+	mov	r12, rsi
+	mov	r15, rdi
 	test	rdx, rdx
 	je	.LBB1_1
 	mov	r14, qword ptr [rbx]
 	jmp	.LBB1_3
 .LBB1_1:
 .LBB1_3:
-	mov	rdi, r12
-	mov	rsi, r15
+	mov	rdi, r15
+	mov	rsi, r12
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rdi, r12
-	mov	rsi, r15
+	mov	rdi, r15
+	mov	rsi, r12
 	mov	rdx, rbx
 	call	rax
-	mov	r15, rax
 	test	rbx, rbx
 	je	.LBB1_5
 	mov	rdi, qword ptr [rbx]
+	mov	rbx, rax
 	call	qword ptr [rip + objc_retain@GOTPCREL]
 	mov	rdi, r14
 	call	qword ptr [rip + objc_release@GOTPCREL]
+	mov	rax, rbx
 .LBB1_5:
-	mov	rax, r15
 	add	rsp, 8
 	pop	rbx
 	pop	r12
@@ -126,19 +126,19 @@ null_null:
 	push	rbx
 	push	rax
 	mov	r14, rdx
-	mov	r15, rsi
-	mov	r12, rdi
+	mov	r12, rsi
+	mov	r15, rdi
 	test	rdx, rdx
 	je	.LBB3_1
 	mov	rbx, qword ptr [r14]
 	jmp	.LBB3_3
 .LBB3_1:
 .LBB3_3:
-	mov	rdi, r12
-	mov	rsi, r15
+	mov	rdi, r15
+	mov	rsi, r12
 	call	qword ptr [rip + objc_msg_lookup@GOTPCREL]
-	mov	rdi, r12
-	mov	rsi, r15
+	mov	rdi, r15
+	mov	rsi, r12
 	mov	rdx, r14
 	call	rax
 	mov	r15, rax

--- a/crates/test-ui/ui/add_method_no_bool.rs
+++ b/crates/test-ui/ui/add_method_no_bool.rs
@@ -5,9 +5,9 @@ use objc2::declare::ClassBuilder;
 use objc2::runtime::{NSObject, Sel};
 use objc2::sel;
 
-extern "C" fn my_bool_taking_method(obj: &NSObject, sel: Sel, arg: bool) {}
+extern "C" fn my_bool_taking_method(_obj: &NSObject, _sel: Sel, _arg: bool) {}
 
-extern "C" fn my_bool_returning_method(obj: &NSObject, sel: Sel) -> bool {
+extern "C" fn my_bool_returning_method(_obj: &NSObject, _sel: Sel) -> bool {
     true
 }
 

--- a/crates/test-ui/ui/add_method_no_bool.stderr
+++ b/crates/test-ui/ui/add_method_no_bool.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
  --> ui/add_method_no_bool.rs
   |
   |     builder.add_method(sel!(myBoolTakingMethod:), method);
-  |             ----------                            ^^^^^^ the trait `Encode` is not implemented for `bool`
+  |             ----------                            ^^^^^^ the trait `Encode` is not implemented for `bool`, which is required by `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel, bool): MethodImplementation`
   |             |
   |             required by a bound introduced by this call
   |
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
  --> ui/add_method_no_bool.rs
   |
   |     builder.add_method(sel!(myBoolReturningMethod), method);
-  |             ----------                              ^^^^^^ the trait `Encode` is not implemented for `bool`
+  |             ----------                              ^^^^^^ the trait `Encode` is not implemented for `bool`, which is required by `unsafe extern "C" fn(&NSObject, objc2::runtime::Sel) -> bool: MethodImplementation`
   |             |
   |             required by a bound introduced by this call
   |

--- a/crates/test-ui/ui/array_iter_invalid.stderr
+++ b/crates/test-ui/ui/array_iter_invalid.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `&mut Id<NSArray<NSString>>: IntoIterator` is not satisfied
+error[E0277]: `&mut Id<NSArray<NSString>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSString>>`
+  |              ^^^^^^^^ `&mut Id<NSArray<NSString>>` is not an iterator
   |
+  = help: the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSString>>`
   = note: `IntoIterator` is implemented for `&Id<NSArray<NSString>>`, but not for `&mut Id<NSArray<NSString>>`
 help: consider removing the leading `&`-reference
   |
@@ -11,24 +12,26 @@ help: consider removing the leading `&`-reference
 6 +     for s in arr {
   |
 
-error[E0277]: the trait bound `&mut Id<NSArray<NSMutableString>>: IntoIterator` is not satisfied
+error[E0277]: `&mut Id<NSArray<NSMutableString>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSMutableString>>`
+  |              ^^^^^^^^ `&mut Id<NSArray<NSMutableString>>` is not an iterator
   |
+  = help: the trait `IntoIterator` is not implemented for `&mut Id<NSArray<NSMutableString>>`
   = help: the following other types implement trait `IntoIterator`:
             Id<T>
             &'a Id<T>
             &'a mut Id<T>
   = note: `IntoIterator` is implemented for `&Id<NSArray<NSMutableString>>`, but not for `&mut Id<NSArray<NSMutableString>>`
 
-error[E0277]: the trait bound `&mut Id<NSMutableArray<NSString>>: IntoIterator` is not satisfied
+error[E0277]: `&mut Id<NSMutableArray<NSString>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ the trait `IntoIterator` is not implemented for `&mut Id<NSMutableArray<NSString>>`
+  |              ^^^^^^^^ `&mut Id<NSMutableArray<NSString>>` is not an iterator
   |
+  = help: the trait `IntoIterator` is not implemented for `&mut Id<NSMutableArray<NSString>>`
   = note: `IntoIterator` is implemented for `&Id<NSMutableArray<NSString>>`, but not for `&mut Id<NSMutableArray<NSString>>`
 help: consider removing the leading `&`-reference
   |
@@ -36,12 +39,13 @@ help: consider removing the leading `&`-reference
 16 +     for s in arr {
    |
 
-error[E0277]: the trait bound `Id<NSArray<NSMutableString>>: IntoIterator` is not satisfied
+error[E0277]: `Id<NSArray<NSMutableString>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for _ in arr {}
-  |              ^^^ the trait `IntoIterator` is not implemented for `Id<NSArray<NSMutableString>>`
+  |              ^^^ `Id<NSArray<NSMutableString>>` is not an iterator
   |
+  = help: the trait `IntoIterator` is not implemented for `Id<NSArray<NSMutableString>>`
   = help: the following other types implement trait `IntoIterator`:
             Id<T>
             &'a Id<T>

--- a/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
+++ b/crates/test-ui/ui/autoreleasepool_not_send_sync.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   |     needs_sync::<AutoreleasePool<'_>>();
   |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
-  = help: within `AutoreleasePool<'_>`, the trait `Sync` is not implemented for `*mut c_void`
+  = help: within `AutoreleasePool<'_>`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `AutoreleasePool<'_>: Sync`
 note: required because it appears within the type `objc2::rc::autorelease::Pool`
  --> $WORKSPACE/crates/objc2/src/rc/autorelease.rs
   |
@@ -33,7 +33,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   |     needs_send::<AutoreleasePool<'_>>();
   |                  ^^^^^^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
   |
-  = help: within `objc2::rc::autorelease::Pool`, the trait `Sync` is not implemented for `*mut c_void`
+  = help: within `objc2::rc::autorelease::Pool`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `AutoreleasePool<'_>: Send`
 note: required because it appears within the type `objc2::rc::autorelease::Pool`
  --> $WORKSPACE/crates/objc2/src/rc/autorelease.rs
   |

--- a/crates/test-ui/ui/declare_add_bad_method.rs
+++ b/crates/test-ui/ui/declare_add_bad_method.rs
@@ -32,7 +32,7 @@ fn main() {
 
     // Test arguments
     unsafe {
-        fn foo(_obj: &NSObject, _sel: Sel, item: bool) {}
+        fn foo(_obj: &NSObject, _sel: Sel, _item: bool) {}
         builder.add_method(sel!(foo:), foo as fn(_, _, _));
     }
 }

--- a/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.stderr
+++ b/crates/test-ui/ui/declare_class_delegate_not_mainthreadonly.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsMainThre
  --> ui/declare_class_delegate_not_mainthreadonly.rs
   |
   |     unsafe impl NSApplicationDelegate for CustomObject {
-  |                                           ^^^^^^^^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `InteriorMutable`
+  |                                           ^^^^^^^^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `InteriorMutable`, which is required by `CustomObject: IsMainThreadOnly`
   |
   = help: the trait `mutability::MutabilityIsMainThreadOnly` is implemented for `MainThreadOnly`
   = note: required for `CustomObject` to implement `IsMainThreadOnly`

--- a/crates/test-ui/ui/declare_class_invalid_receiver.rs
+++ b/crates/test-ui/ui/declare_class_invalid_receiver.rs
@@ -1,3 +1,4 @@
+#![allow(unused_variables)]
 use objc2::rc::{Allocated, Id};
 use objc2::runtime::{AnyClass, NSObject};
 use objc2::{declare_class, mutability, ClassType, DeclaredClass};

--- a/crates/test-ui/ui/declare_class_invalid_receiver.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_receiver.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `Box<CustomObject>: MessageReceiver` is not satisf
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
+  | |_the trait `MessageReceiver` is not implemented for `Box<CustomObject>`, which is required by `extern "C" fn(Box<CustomObject>, objc2::runtime::Sel): MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -44,7 +44,7 @@ error[E0277]: the trait bound `Id<CustomObject>: MessageReceiver` is not satisfi
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `Id<CustomObject>`
+  | |_the trait `MessageReceiver` is not implemented for `Id<CustomObject>`, which is required by `extern "C" fn(Id<CustomObject>, objc2::runtime::Sel): MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `CustomObject: MessageReceiver` is not satisfied
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `CustomObject`
+  | |_the trait `MessageReceiver` is not implemented for `CustomObject`, which is required by `extern "C" fn(CustomObject, objc2::runtime::Sel): MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -162,7 +162,7 @@ error[E0277]: the trait bound `Box<CustomObject>: MessageReceiver` is not satisf
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
+  | |_the trait `MessageReceiver` is not implemented for `Box<CustomObject>`, which is required by `extern "C" fn(Box<CustomObject>, objc2::runtime::Sel) -> IdReturnValue: MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -196,7 +196,7 @@ error[E0277]: the trait bound `Id<CustomObject>: MessageReceiver` is not satisfi
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `Id<CustomObject>`
+  | |_the trait `MessageReceiver` is not implemented for `Id<CustomObject>`, which is required by `extern "C" fn(Id<CustomObject>, objc2::runtime::Sel) -> IdReturnValue: MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -230,7 +230,7 @@ error[E0277]: the trait bound `CustomObject: MessageReceiver` is not satisfied
   | | );
   | | ^
   | | |
-  | |_the trait `MessageReceiver` is not implemented for `CustomObject`
+  | |_the trait `MessageReceiver` is not implemented for `CustomObject`, which is required by `extern "C" fn(CustomObject, objc2::runtime::Sel) -> IdReturnValue: MethodImplementation`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `MessageReceiver`:
@@ -262,7 +262,7 @@ error[E0277]: the trait bound `Box<CustomObject>: MessageReceiver` is not satisf
 ... |
   | |     }
   | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Box<CustomObject>`
+  | |_^ the trait `MessageReceiver` is not implemented for `Box<CustomObject>`, which is required by `RetainSemantics<5>: MessageRecieveId<Box<CustomObject>, Id<CustomObject>>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>
@@ -285,7 +285,7 @@ error[E0277]: the trait bound `Id<CustomObject>: MessageReceiver` is not satisfi
 ... |
   | |     }
   | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Id<CustomObject>`
+  | |_^ the trait `MessageReceiver` is not implemented for `Id<CustomObject>`, which is required by `RetainSemantics<5>: MessageRecieveId<Id<CustomObject>, Id<CustomObject>>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>
@@ -308,7 +308,7 @@ error[E0277]: the trait bound `CustomObject: MessageReceiver` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `CustomObject`
+  | |_^ the trait `MessageReceiver` is not implemented for `CustomObject`, which is required by `RetainSemantics<5>: MessageRecieveId<CustomObject, Id<CustomObject>>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>
@@ -331,7 +331,7 @@ error[E0277]: the trait bound `Allocated<CustomObject>: MessageReceiver` is not 
 ... |
   | |     }
   | | );
-  | |_^ the trait `MessageReceiver` is not implemented for `Allocated<CustomObject>`
+  | |_^ the trait `MessageReceiver` is not implemented for `Allocated<CustomObject>`, which is required by `RetainSemantics<5>: MessageRecieveId<Allocated<CustomObject>, Id<CustomObject>>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Id<CustomObject>: Encode` is not satisfied
+error[E0277]: the trait bound `Id<CustomObject>: EncodeReturn` is not satisfied
  --> ui/declare_class_invalid_type.rs
   |
   | / declare_class!(
@@ -8,18 +8,9 @@ error[E0277]: the trait bound `Id<CustomObject>: Encode` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Id<CustomObject>`
+  | |_^ the trait `Encode` is not implemented for `Id<CustomObject>`, which is required by `Id<CustomObject>: __macro_helpers::convert::return_private::Sealed`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `EncodeReturn` is implemented for `()`
   = note: required for `Id<CustomObject>` to implement `EncodeReturn`
   = note: required for `Id<CustomObject>` to implement `__macro_helpers::convert::return_private::Sealed`
 note: required by a bound in `ConvertReturn`
@@ -33,7 +24,7 @@ note: required by a bound in `ConvertReturn`
             T
   = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
+error[E0277]: the trait bound `Vec<()>: EncodeReturn` is not satisfied
  --> ui/declare_class_invalid_type.rs
   |
   | / declare_class!(
@@ -43,18 +34,9 @@ error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Vec<()>`
+  | |_^ the trait `Encode` is not implemented for `Vec<()>`, which is required by `Vec<()>: __macro_helpers::convert::return_private::Sealed`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `EncodeReturn` is implemented for `()`
   = note: required for `Vec<()>` to implement `EncodeReturn`
   = note: required for `Vec<()>` to implement `__macro_helpers::convert::return_private::Sealed`
 note: required by a bound in `ConvertReturn`
@@ -68,6 +50,206 @@ note: required by a bound in `ConvertReturn`
             T
   = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0277]: the trait bound `Box<u32>: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Box<u32>`, which is required by `Box<u32>: __macro_helpers::convert::argument_private::Sealed`
+  |
+  = help: the following other types implement trait `__macro_helpers::convert::argument_private::Sealed`:
+            bool
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `Box<u32>` to implement `EncodeArgument`
+  = note: required for `Box<u32>` to implement `__macro_helpers::convert::argument_private::Sealed`
+note: required by a bound in `ConvertArgument`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/convert.rs
+  |
+  | pub trait ConvertArgument: argument_private::Sealed {
+  |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
+  = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            &mut objc2::rc::Id<T>
+            &mut std::option::Option<objc2::rc::Id<T>>
+            bool
+            std::option::Option<&mut objc2::rc::Id<T>>
+            std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+            T
+  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `CustomObject: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `CustomObject`, which is required by `CustomObject: __macro_helpers::convert::argument_private::Sealed`
+  |
+  = help: the following other types implement trait `__macro_helpers::convert::argument_private::Sealed`:
+            bool
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `CustomObject` to implement `EncodeArgument`
+  = note: required for `CustomObject` to implement `__macro_helpers::convert::argument_private::Sealed`
+note: required by a bound in `ConvertArgument`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/convert.rs
+  |
+  | pub trait ConvertArgument: argument_private::Sealed {
+  |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
+  = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+  = help: the following types implement the trait:
+            &mut objc2::rc::Id<T>
+            &mut std::option::Option<objc2::rc::Id<T>>
+            bool
+            std::option::Option<&mut objc2::rc::Id<T>>
+            std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+            T
+  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Id<CustomObject>: EncodeReturn` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Id<CustomObject>`, which is required by `Id<CustomObject>: ConvertReturn`
+  |
+  = help: the trait `EncodeReturn` is implemented for `()`
+  = note: required for `Id<CustomObject>` to implement `EncodeReturn`
+  = note: required for `Id<CustomObject>` to implement `ConvertReturn`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Id<CustomObject>: Encode` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_the trait `Encode` is not implemented for `Id<CustomObject>`, which is required by `extern "C" fn(&AnyClass, objc2::runtime::Sel) -> Id<CustomObject>: MethodImplementation`
+  |   required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `Encode`:
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
+          and $N others
+  = note: required for `Id<CustomObject>` to implement `EncodeReturn`
+  = note: required for `extern "C" fn(&AnyClass, objc2::runtime::Sel) -> Id<CustomObject>` to implement `MethodImplementation`
+note: required by a bound in `ClassBuilderHelper::<T>::add_class_method`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/declare_class.rs
+  |
+  |     pub unsafe fn add_class_method<F>(&mut self, sel: Sel, func: F)
+  |                   ---------------- required by a bound in this associated function
+  |     where
+  |         F: MethodImplementation<Callee = AnyClass>,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilderHelper::<T>::add_class_method`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<()>: EncodeReturn` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Vec<()>`, which is required by `Vec<()>: ConvertReturn`
+  |
+  = help: the trait `EncodeReturn` is implemented for `()`
+  = note: required for `Vec<()>` to implement `EncodeReturn`
+  = note: required for `Vec<()>` to implement `ConvertReturn`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<()>: Encode` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | | ^
+  | | |
+  | |_the trait `Encode` is not implemented for `Vec<()>`, which is required by `extern "C" fn(&AnyClass, objc2::runtime::Sel) -> Vec<()>: MethodImplementation`
+  |   required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `Encode`:
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
+            u8
+            u16
+          and $N others
+  = note: required for `Vec<()>` to implement `EncodeReturn`
+  = note: required for `extern "C" fn(&AnyClass, objc2::runtime::Sel) -> Vec<()>` to implement `MethodImplementation`
+note: required by a bound in `ClassBuilderHelper::<T>::add_class_method`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/declare_class.rs
+  |
+  |     pub unsafe fn add_class_method<F>(&mut self, sel: Sel, func: F)
+  |                   ---------------- required by a bound in this associated function
+  |     where
+  |         F: MethodImplementation<Callee = AnyClass>,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilderHelper::<T>::add_class_method`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Box<u32>: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Box<u32>`, which is required by `Box<u32>: ConvertArgument`
+  |
+  = help: the following other types implement trait `ConvertArgument`:
+            bool
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `Box<u32>` to implement `EncodeArgument`
+  = note: required for `Box<u32>` to implement `ConvertArgument`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
  --> ui/declare_class_invalid_type.rs
   |
@@ -78,7 +260,10 @@ error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Box<u32>`
+  | | ^
+  | | |
+  | |_the trait `Encode` is not implemented for `Box<u32>`, which is required by `extern "C" fn(&CustomObject, objc2::runtime::Sel, Box<u32>): MethodImplementation`
+  |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -91,21 +276,38 @@ error[E0277]: the trait bound `Box<u32>: Encode` is not satisfied
             u16
           and $N others
   = note: required for `Box<u32>` to implement `EncodeArgument`
-  = note: required for `Box<u32>` to implement `__macro_helpers::convert::argument_private::Sealed`
-note: required by a bound in `ConvertArgument`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/convert.rs
+  = note: required for `extern "C" fn(&CustomObject, objc2::runtime::Sel, Box<u32>)` to implement `MethodImplementation`
+note: required by a bound in `ClassBuilderHelper::<T>::add_method`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/declare_class.rs
   |
-  | pub trait ConvertArgument: argument_private::Sealed {
-  |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
-  = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following types implement the trait:
-            std::option::Option<&mut objc2::rc::Id<T>>
-            std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+  |     pub unsafe fn add_method<F>(&mut self, sel: Sel, func: F)
+  |                   ---------- required by a bound in this associated function
+  |     where
+  |         F: MethodImplementation<Callee = T>,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilderHelper::<T>::add_method`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `CustomObject: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `CustomObject`, which is required by `CustomObject: ConvertArgument`
+  |
+  = help: the following other types implement trait `ConvertArgument`:
             bool
-            &mut objc2::rc::Id<T>
-            &mut std::option::Option<objc2::rc::Id<T>>
-            T
-  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `CustomObject` to implement `EncodeArgument`
+  = note: required for `CustomObject` to implement `ConvertArgument`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
  --> ui/declare_class_invalid_type.rs
@@ -117,7 +319,10 @@ error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `CustomObject`
+  | | ^
+  | | |
+  | |_the trait `Encode` is not implemented for `CustomObject`, which is required by `extern "C" fn(&CustomObject, objc2::runtime::Sel, CustomObject): MethodImplementation`
+  |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -130,18 +335,91 @@ error[E0277]: the trait bound `CustomObject: Encode` is not satisfied
             u16
           and $N others
   = note: required for `CustomObject` to implement `EncodeArgument`
-  = note: required for `CustomObject` to implement `__macro_helpers::convert::argument_private::Sealed`
-note: required by a bound in `ConvertArgument`
- --> $WORKSPACE/crates/objc2/src/__macro_helpers/convert.rs
+  = note: required for `extern "C" fn(&CustomObject, objc2::runtime::Sel, CustomObject)` to implement `MethodImplementation`
+note: required by a bound in `ClassBuilderHelper::<T>::add_method`
+ --> $WORKSPACE/crates/objc2/src/__macro_helpers/declare_class.rs
   |
-  | pub trait ConvertArgument: argument_private::Sealed {
-  |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
-  = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
-  = help: the following types implement the trait:
-            std::option::Option<&mut objc2::rc::Id<T>>
-            std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+  |     pub unsafe fn add_method<F>(&mut self, sel: Sel, func: F)
+  |                   ---------- required by a bound in this associated function
+  |     where
+  |         F: MethodImplementation<Callee = T>,
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ClassBuilderHelper::<T>::add_method`
+  = note: this error originates in the macro `$crate::__declare_class_register_out` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Id<CustomObject>: EncodeReturn` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Id<CustomObject>`, which is required by `Id<CustomObject>: ConvertReturn`
+  |
+  = help: the trait `EncodeReturn` is implemented for `()`
+  = note: required for `Id<CustomObject>` to implement `EncodeReturn`
+  = note: required for `Id<CustomObject>` to implement `ConvertReturn`
+  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Vec<()>: EncodeReturn` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Vec<()>`, which is required by `Vec<()>: ConvertReturn`
+  |
+  = help: the trait `EncodeReturn` is implemented for `()`
+  = note: required for `Vec<()>` to implement `EncodeReturn`
+  = note: required for `Vec<()>` to implement `ConvertReturn`
+  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Box<u32>: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `Box<u32>`, which is required by `Box<u32>: ConvertArgument`
+  |
+  = help: the following other types implement trait `ConvertArgument`:
             bool
-            &mut objc2::rc::Id<T>
-            &mut std::option::Option<objc2::rc::Id<T>>
-            T
-  = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `Box<u32>` to implement `EncodeArgument`
+  = note: required for `Box<u32>` to implement `ConvertArgument`
+  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `CustomObject: EncodeArgument` is not satisfied
+ --> ui/declare_class_invalid_type.rs
+  |
+  | / declare_class!(
+  | |     struct CustomObject;
+  | |
+  | |     unsafe impl ClassType for CustomObject {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `Encode` is not implemented for `CustomObject`, which is required by `CustomObject: ConvertArgument`
+  |
+  = help: the following other types implement trait `ConvertArgument`:
+            bool
+            Option<&mut Id<T>>
+            Option<&mut Option<Id<T>>>
+            &mut Id<T>
+            &mut Option<Id<T>>
+  = note: required for `CustomObject` to implement `EncodeArgument`
+  = note: required for `CustomObject` to implement `ConvertArgument`
+  = note: this error originates in the macro `$crate::__declare_class_method_out_inner` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/declare_class_invalid_type2.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type2.stderr
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `i32: MaybeOptionId` is not satisfied
 ... |
   | |     }
   | | );
-  | |_^ the trait `MaybeOptionId` is not implemented for `i32`
+  | |_^ the trait `MaybeOptionId` is not implemented for `i32`, which is required by `RetainSemantics<5>: MessageRecieveId<&CustomObject, i32>`
   |
   = help: the following other types implement trait `MaybeOptionId`:
             Id<T>

--- a/crates/test-ui/ui/declare_class_mut_self_not_mutable.stderr
+++ b/crates/test-ui/ui/declare_class_mut_self_not_mutable.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut CustomObject: MessageReceiver`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut CustomObject: MessageReceiver`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
@@ -74,7 +74,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut CustomObject: MessageReceiver`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
@@ -104,7 +104,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
 ... |
   | |     }
   | | );
-  | |_^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `RetainSemantics<5>: MessageRecieveId<&mut CustomObject, Id<CustomObject>>`
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
             Root

--- a/crates/test-ui/ui/extern_class_subclass_object.stderr
+++ b/crates/test-ui/ui/extern_class_subclass_object.stderr
@@ -65,3 +65,22 @@ error[E0119]: conflicting implementations of trait `BorrowMut<AnyObject>` for ty
   |   conflicting implementation for `MyRootClass`
   |
   = note: this error originates in the macro `$crate::__impl_as_ref_borrow` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `AnyObject: ClassType` is not satisfied
+ --> ui/extern_class_subclass_object.rs
+  |
+  | / extern_class!(
+  | |     pub struct MyRootClass;
+  | |
+  | |     unsafe impl ClassType for MyRootClass {
+... |
+  | |     }
+  | | );
+  | |_^ the trait `ClassType` is not implemented for `AnyObject`
+  |
+  = help: the following other types implement trait `ClassType`:
+            MyRootClass
+            NSObject
+            __NSProxy
+            __RcTestObject
+  = note: this error originates in the macro `$crate::__inner_extern_class` which comes from the expansion of the macro `extern_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/test-ui/ui/extern_methods_feature_flag.stderr
+++ b/crates/test-ui/ui/extern_methods_feature_flag.stderr
@@ -14,37 +14,41 @@ error[E0599]: no function or associated item named `disabled` found for struct `
   |               ^^^^^^^^ function or associated item not found in `MyTest`
 
 error[E0599]: no function or associated item named `disabled_inner1` found for struct `MyTest` in the current scope
- --> ui/extern_methods_feature_flag.rs
-  |
-  | / extern_class!(
-  | |     pub struct MyTest;
-  | |
-  | |     unsafe impl ClassType for MyTest {
-... |
-  | |     }
-  | | );
-  | |_- function or associated item `disabled_inner1` not found for this struct
+  --> ui/extern_methods_feature_flag.rs
+   |
+   | / extern_class!(
+   | |     pub struct MyTest;
+   | |
+   | |     unsafe impl ClassType for MyTest {
+...  |
+   | |     }
+   | | );
+   | |_- function or associated item `disabled_inner1` not found for this struct
 ...
-  |       MyTest::disabled_inner1();
-  |               ^^^^^^^^^^^^^^^
-  |               |
-  |               function or associated item not found in `MyTest`
-  |               help: there is an associated function with a similar name: `enabled_inner1`
+   |       MyTest::disabled_inner1();
+   |               ^^^^^^^^^^^^^^^ function or associated item not found in `MyTest`
+   |
+help: there is an associated function `enabled_inner1` with a similar name
+   |
+51 |     MyTest::enabled_inner1();
+   |             ~~~~~~~~~~~~~~
 
 error[E0599]: no function or associated item named `disabled_inner2` found for struct `MyTest` in the current scope
- --> ui/extern_methods_feature_flag.rs
-  |
-  | / extern_class!(
-  | |     pub struct MyTest;
-  | |
-  | |     unsafe impl ClassType for MyTest {
-... |
-  | |     }
-  | | );
-  | |_- function or associated item `disabled_inner2` not found for this struct
+  --> ui/extern_methods_feature_flag.rs
+   |
+   | / extern_class!(
+   | |     pub struct MyTest;
+   | |
+   | |     unsafe impl ClassType for MyTest {
+...  |
+   | |     }
+   | | );
+   | |_- function or associated item `disabled_inner2` not found for this struct
 ...
-  |       MyTest::disabled_inner2();
-  |               ^^^^^^^^^^^^^^^
-  |               |
-  |               function or associated item not found in `MyTest`
-  |               help: there is an associated function with a similar name: `enabled_inner2`
+   |       MyTest::disabled_inner2();
+   |               ^^^^^^^^^^^^^^^ function or associated item not found in `MyTest`
+   |
+help: there is an associated function `enabled_inner2` with a similar name
+   |
+52 |     MyTest::enabled_inner2();
+   |             ~~~~~~~~~~~~~~

--- a/crates/test-ui/ui/extern_methods_invalid_type.stderr
+++ b/crates/test-ui/ui/extern_methods_invalid_type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Id<MyObject>: Encode` is not satisfied
+error[E0277]: the trait bound `Id<MyObject>: ConvertReturn` is not satisfied
  --> ui/extern_methods_invalid_type.rs
   |
   | / extern_methods!(
@@ -7,18 +7,9 @@ error[E0277]: the trait bound `Id<MyObject>: Encode` is not satisfied
   | |         fn a(&self) -> Id<Self>;
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Id<MyObject>`
+  | |_^ the trait `Encode` is not implemented for `Id<MyObject>`, which is required by `Id<MyObject>: ConvertReturn`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `ConvertReturn` is implemented for `bool`
   = note: required for `Id<MyObject>` to implement `EncodeReturn`
   = note: required for `Id<MyObject>` to implement `ConvertReturn`
 note: required by a bound in `MsgSend::send_message`
@@ -62,7 +53,7 @@ error[E0277]: the trait bound `Box<i32>: Encode` is not satisfied
   | |         fn c(&self, arg: Box<i32>);
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Box<i32>`
+  | |_^ the trait `Encode` is not implemented for `Box<i32>`, which is required by `(Box<i32>,): ConvertArguments`
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -87,7 +78,7 @@ note: required by a bound in `MsgSend::send_message`
   |            ^^^^^^^^^^^^^^^^ required by this bound in `MsgSend::send_message`
   = note: this error originates in the macro `$crate::__msg_send_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Result<(), Id<NSObject>>: Encode` is not satisfied
+error[E0277]: the trait bound `Result<(), Id<NSObject>>: ConvertReturn` is not satisfied
  --> ui/extern_methods_invalid_type.rs
   |
   | / extern_methods!(
@@ -96,18 +87,9 @@ error[E0277]: the trait bound `Result<(), Id<NSObject>>: Encode` is not satisfie
   | |         fn error(arg: i32) -> Result<(), Id<NSObject>>;
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `Result<(), Id<NSObject>>`
+  | |_^ the trait `Encode` is not implemented for `Result<(), Id<NSObject>>`, which is required by `Result<(), Id<NSObject>>: ConvertReturn`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `ConvertReturn` is implemented for `bool`
   = note: required for `Result<(), Id<NSObject>>` to implement `EncodeReturn`
   = note: required for `Result<(), Id<NSObject>>` to implement `ConvertReturn`
 note: required by a bound in `MsgSend::send_message`
@@ -142,7 +124,7 @@ note: required by a bound in `send_message_id`
   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MsgSendId::send_message_id`
   = note: this error originates in the macro `$crate::__msg_send_id_helper` which comes from the expansion of the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MainThreadMarker: Encode` is not satisfied
+error[E0277]: the trait bound `MainThreadMarker: ConvertReturn` is not satisfied
  --> ui/extern_methods_invalid_type.rs
   |
   | / extern_methods!(
@@ -151,18 +133,9 @@ error[E0277]: the trait bound `MainThreadMarker: Encode` is not satisfied
   | |         fn main_thread_marker_as_return() -> MainThreadMarker;
   | |     }
   | | );
-  | |_^ the trait `Encode` is not implemented for `MainThreadMarker`
+  | |_^ the trait `Encode` is not implemented for `MainThreadMarker`, which is required by `MainThreadMarker: ConvertReturn`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `ConvertReturn` is implemented for `bool`
   = note: required for `MainThreadMarker` to implement `EncodeReturn`
   = note: required for `MainThreadMarker` to implement `ConvertReturn`
 note: required by a bound in `MsgSend::send_message`

--- a/crates/test-ui/ui/extern_methods_not_allowed_mutable.stderr
+++ b/crates/test-ui/ui/extern_methods_not_allowed_mutable.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   | | );
   | | ^
   | | |
-  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut MyObject: MsgSend`
   |   required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   | |         fn test_id(&mut self) -> Id<Self>;
   | |     }
   | | );
-  | |_^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  | |_^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `RetainSemantics<5>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
             Root

--- a/crates/test-ui/ui/global_block_not_encode.stderr
+++ b/crates/test-ui/ui/global_block_not_encode.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `Box<i32>: objc2::encode::Encode` is not satisfied
   | / global_block! {
   | |     pub static BLOCK = |_b: Box<i32>| {};
   | | }
-  | |_^ the trait `objc2::encode::Encode` is not implemented for `Box<i32>`
+  | |_^ the trait `objc2::encode::Encode` is not implemented for `Box<i32>`, which is required by `GlobalBlock<(dyn Fn(Box<i32>) + 'static)>: Sync`
   |
   = help: the following other types implement trait `objc2::encode::Encode`:
             isize

--- a/crates/test-ui/ui/main_thread_only_not_allocable.stderr
+++ b/crates/test-ui/ui/main_thread_only_not_allocable.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MainThreadOnly: mutability::MutabilityIsAllocable
  --> ui/main_thread_only_not_allocable.rs
   |
   |     let _ = MyMainThreadOnlyClass::alloc();
-  |             ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`
+  |             ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsAllocableAnyThread` is not implemented for `MainThreadOnly`, which is required by `MyMainThreadOnlyClass: IsAllocableAnyThread`
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllocableAnyThread`:
             Root

--- a/crates/test-ui/ui/mainthreadmarker_from_nsobject.stderr
+++ b/crates/test-ui/ui/mainthreadmarker_from_nsobject.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Root: mutability::MutabilityIsMainThreadOnly` is 
  --> ui/mainthreadmarker_from_nsobject.rs
   |
   |     let mtm = MainThreadMarker::from(&*obj);
-  |               ^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `Root`
+  |               ^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsMainThreadOnly` is not implemented for `Root`, which is required by `MainThreadMarker: From<&NSObject>`
   |
   = help: the trait `mutability::MutabilityIsMainThreadOnly` is implemented for `MainThreadOnly`
   = note: required for `NSObject` to implement `IsMainThreadOnly`

--- a/crates/test-ui/ui/mainthreadmarker_not_send_sync.stderr
+++ b/crates/test-ui/ui/mainthreadmarker_not_send_sync.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
   |     needs_sync::<MainThreadMarker>();
   |                  ^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
   |
-  = help: within `MainThreadMarker`, the trait `Sync` is not implemented for `*mut ()`
+  = help: within `MainThreadMarker`, the trait `Sync` is not implemented for `*mut ()`, which is required by `MainThreadMarker: Sync`
 note: required because it appears within the type `PhantomData<*mut ()>`
  --> $RUST/core/src/marker.rs
   |
@@ -27,7 +27,7 @@ error[E0277]: `*mut ()` cannot be sent between threads safely
   |     needs_send::<MainThreadMarker>();
   |                  ^^^^^^^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
   |
-  = help: within `MainThreadMarker`, the trait `Send` is not implemented for `*mut ()`
+  = help: within `MainThreadMarker`, the trait `Send` is not implemented for `*mut ()`, which is required by `MainThreadMarker: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
  --> $RUST/core/src/marker.rs
   |

--- a/crates/test-ui/ui/message_receiver_simple.stderr
+++ b/crates/test-ui/ui/message_receiver_simple.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Id<NSObject>: Message` is not satisfied
+error[E0277]: the trait bound `&Id<NSObject>: runtime::message_receiver::private::Sealed` is not satisfied
   --> ui/message_receiver_simple.rs
    |
    |     let _: usize = unsafe { MessageReceiver::send_message(&obj, sel!(hash), ()) };
-   |                             -----------------------------  ^^^ the trait `Message` is not implemented for `Id<NSObject>`
+   |                             -----------------------------  ^^^ the trait `Message` is not implemented for `&Id<NSObject>`, which is required by `&Id<NSObject>: runtime::message_receiver::private::Sealed`
    |                             |
    |                             required by a bound introduced by this call
    |
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
  --> ui/message_receiver_simple.rs
   |
   |     let _: () = unsafe { MessageReceiver::send_message(&*obj, sel!(hash:), (true,)) };
-  |                          -----------------------------                      ^^^^ the trait `Encode` is not implemented for `bool`
+  |                          -----------------------------                      ^^^^ the trait `Encode` is not implemented for `bool`, which is required by `(bool,): EncodeArguments`
   |                          |
   |                          required by a bound introduced by this call
   |
@@ -46,22 +46,13 @@ note: required by a bound in `objc2::runtime::MessageReceiver::send_message`
   |     unsafe fn send_message<A: EncodeArguments, R: EncodeReturn>(self, sel: Sel, args: A) -> R {
   |                               ^^^^^^^^^^^^^^^ required by this bound in `MessageReceiver::send_message`
 
-error[E0277]: the trait bound `bool: Encode` is not satisfied
+error[E0277]: the trait bound `bool: EncodeReturn` is not satisfied
  --> ui/message_receiver_simple.rs
   |
   |     let _: bool = unsafe { MessageReceiver::send_message(&*obj, sel!(hash), ()) };
-  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `bool`
+  |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `bool`, which is required by `bool: EncodeReturn`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `EncodeReturn` is implemented for `()`
   = note: required for `bool` to implement `EncodeReturn`
 note: required by a bound in `objc2::runtime::MessageReceiver::send_message`
  --> $WORKSPACE/crates/objc2/src/runtime/message_receiver.rs

--- a/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_receiver.stderr
@@ -87,7 +87,7 @@ error[E0277]: the trait bound `Id<NSObject>: MessageReceiver` is not satisfied
  --> ui/msg_send_id_invalid_receiver.rs
   |
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, new] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<NSObject>`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<NSObject>`, which is required by `RetainSemantics<1>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>
@@ -105,7 +105,7 @@ error[E0277]: the trait bound `Id<NSObject>: MessageReceiver` is not satisfied
  --> ui/msg_send_id_invalid_receiver.rs
   |
   |     let _: Id<NSObject> = unsafe { msg_send_id![obj, copy] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<NSObject>`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `MessageReceiver` is not implemented for `Id<NSObject>`, which is required by `RetainSemantics<4>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `MessageReceiver`:
             NonNull<T>

--- a/crates/test-ui/ui/msg_send_id_invalid_return.stderr
+++ b/crates/test-ui/ui/msg_send_id_invalid_return.stderr
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Id<AnyClass> = unsafe { msg_send_id![cls, new] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `AnyClass`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `AnyClass`, which is required by `RetainSemantics<1>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `Message`:
             Exception
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `AnyClass: Message` is not satisfied
  --> ui/msg_send_id_invalid_return.rs
   |
   |     let _: Option<Id<AnyClass>> = unsafe { msg_send_id![cls, new] };
-  |                                            ^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `AnyClass`
+  |                                            ^^^^^^^^^^^^^^^^^^^^^^ the trait `Message` is not implemented for `AnyClass`, which is required by `RetainSemantics<1>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `Message`:
             Exception

--- a/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
+++ b/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
   |     let _: () = unsafe { msg_send![&mut *obj, test] };
   |                          ----------^^^^^^^^^-------
   |                          |         |
-  |                          |         the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  |                          |         the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut NSThread: MsgSend`
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
  --> ui/msg_send_not_allowed_mutable.rs
   |
   |     let _: Id<NSThread> = unsafe { msg_send_id![obj, test] };
-  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`
+  |                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `RetainSemantics<5>: MsgSendId<_, _>`
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:
             Root

--- a/crates/test-ui/ui/msg_send_not_encode.stderr
+++ b/crates/test-ui/ui/msg_send_not_encode.stderr
@@ -1,19 +1,10 @@
-error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
+error[E0277]: the trait bound `Vec<u8>: ConvertReturn` is not satisfied
  --> ui/msg_send_not_encode.rs
   |
   |         let _: Vec<u8> = msg_send![cls, new];
-  |                          ^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`
+  |                          ^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`, which is required by `Vec<u8>: ConvertReturn`
   |
-  = help: the following other types implement trait `Encode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `ConvertReturn` is implemented for `bool`
   = note: required for `Vec<u8>` to implement `EncodeReturn`
   = note: required for `Vec<u8>` to implement `ConvertReturn`
 note: required by a bound in `MsgSend::send_message`
@@ -30,7 +21,7 @@ error[E0277]: the trait bound `Vec<u8>: Encode` is not satisfied
  --> ui/msg_send_not_encode.rs
   |
   |         let _: () = msg_send![cls, newWith: x];
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Vec<u8>`, which is required by `(Vec<u8>,): ConvertArguments`
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -59,7 +50,7 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
  --> ui/msg_send_not_encode.rs
   |
   |         let _: () = msg_send![cls, unitAsArgument: ()];
-  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `()`
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `()`, which is required by `((),): ConvertArguments`
   |
   = help: the following other types implement trait `Encode`:
             isize

--- a/crates/test-ui/ui/msg_send_only_message.stderr
+++ b/crates/test-ui/ui/msg_send_only_message.stderr
@@ -1,18 +1,14 @@
-error[E0277]: the trait bound `{integer}: MessageReceiver` is not satisfied
+error[E0277]: the trait bound `{integer}: MsgSend` is not satisfied
  --> ui/msg_send_only_message.rs
   |
   |     unsafe { msg_send![1, new] };
   |              ----------^------
   |              |         |
-  |              |         the trait `MessageReceiver` is not implemented for `{integer}`
+  |              |         the trait `MessageReceiver` is not implemented for `{integer}`, which is required by `{integer}: MsgSend`
   |              required by a bound introduced by this call
   |
-  = help: the following other types implement trait `MessageReceiver`:
-            NonNull<T>
-            *const AnyClass
-            *const T
-            *mut T
-            &'a T
-            &'a mut T
-            &'a AnyClass
+  = help: the following other types implement trait `MsgSend`:
+            ManuallyDrop<Id<T>>
+            &'a Id<T>
+            &'a mut Id<T>
   = note: required for `{integer}` to implement `MsgSend`

--- a/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
+++ b/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
@@ -1,13 +1,12 @@
-error[E0277]: the trait bound `CustomStruct: ClassType` is not satisfied
+error[E0277]: the trait bound `CustomStruct: mutability::private_traits::Sealed` is not satisfied
  --> ui/mutability_traits_unimplementable2.rs
   |
   | unsafe impl mutability::IsIdCloneable for CustomStruct {}
-  |                                           ^^^^^^^^^^^^ the trait `ClassType` is not implemented for `CustomStruct`
+  |                                           ^^^^^^^^^^^^ the trait `ClassType` is not implemented for `CustomStruct`, which is required by `CustomStruct: mutability::private_traits::Sealed`
   |
-  = help: the following other types implement trait `ClassType`:
-            NSObject
-            __NSProxy
-            __RcTestObject
+  = help: the following other types implement trait `mutability::private_traits::Sealed`:
+            ProtocolObject<P>
+            AnyObject
   = note: required for `CustomStruct` to implement `mutability::private_traits::Sealed`
 note: required by a bound in `IsIdCloneable`
  --> $WORKSPACE/crates/objc2/src/mutability.rs
@@ -16,20 +15,19 @@ note: required by a bound in `IsIdCloneable`
   |                                 ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `IsIdCloneable`
   = note: `IsIdCloneable` is a "sealed trait", because to implement it you also need to implement `objc2::mutability::private_traits::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            objc2::runtime::ProtocolObject<P>
             objc2::runtime::AnyObject
+            objc2::runtime::ProtocolObject<P>
             T
 
-error[E0277]: the trait bound `CustomStruct: ClassType` is not satisfied
+error[E0277]: the trait bound `CustomStruct: IsAllowedMutable` is not satisfied
  --> ui/mutability_traits_unimplementable2.rs
   |
   | unsafe impl mutability::IsMutable for CustomStruct {}
-  |                                       ^^^^^^^^^^^^ the trait `ClassType` is not implemented for `CustomStruct`
+  |                                       ^^^^^^^^^^^^ the trait `ClassType` is not implemented for `CustomStruct`, which is required by `CustomStruct: IsAllowedMutable`
   |
-  = help: the following other types implement trait `ClassType`:
-            NSObject
-            __NSProxy
-            __RcTestObject
+  = help: the following other types implement trait `IsAllowedMutable`:
+            ProtocolObject<P>
+            AnyObject
   = note: required for `CustomStruct` to implement `IsAllowedMutable`
 note: required by a bound in `IsMutable`
  --> $WORKSPACE/crates/objc2/src/mutability.rs

--- a/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
+++ b/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
@@ -26,12 +26,15 @@ note: the trait `IsIdCloneable` must be implemented
   |
   | pub unsafe trait IsIdCloneable: private_traits::Sealed {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `clone`, perhaps you need to implement it:
+          candidate #1: `Clone`
 
 error[E0277]: the trait bound `Mutable: mutability::MutabilityIsRetainable` is not satisfied
  --> ui/mutable_id_not_clone_not_retain.rs
   |
   |     let _ = obj.retain();
-  |                 ^^^^^^ the trait `mutability::MutabilityIsRetainable` is not implemented for `Mutable`
+  |                 ^^^^^^ the trait `mutability::MutabilityIsRetainable` is not implemented for `Mutable`, which is required by `NSMutableObject: IsRetainable`
   |
   = help: the following other types implement trait `mutability::MutabilityIsRetainable`:
             Immutable

--- a/crates/test-ui/ui/not_encode.stderr
+++ b/crates/test-ui/ui/not_encode.stderr
@@ -42,13 +42,13 @@ note: required by a bound in `is_encode`
   | fn is_encode<T: Encode>() {}
   |                 ^^^^^^ required by this bound in `is_encode`
 
-error[E0277]: the trait bound `(): RefEncode` is not satisfied
+error[E0277]: the trait bound `&(): Encode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<&()>();
-  |                 ^^^ the trait `RefEncode` is not implemented for `()`
+  |                 ^^^ the trait `RefEncode` is not implemented for `&()`, which is required by `&(): Encode`
   |
-  = help: the following other types implement trait `RefEncode`:
+  = help: the following other types implement trait `Encode`:
             isize
             i8
             i16
@@ -69,7 +69,7 @@ error[E0277]: the trait bound `(): RefEncode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<*const ()>();
-  |                 ^^^^^^^^^ the trait `RefEncode` is not implemented for `()`
+  |                 ^^^^^^^^^ the trait `RefEncode` is not implemented for `()`, which is required by `*const (): Encode`
   |
   = help: the following other types implement trait `RefEncode`:
             isize
@@ -114,7 +114,7 @@ error[E0277]: the trait bound `(): Encode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<&Block<dyn Fn((), i32)>>();
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `()`
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `()`, which is required by `&block2::Block<dyn Fn((), i32)>: Encode`
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -140,7 +140,7 @@ error[E0277]: the trait bound `bool: Encode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<&Block<dyn Fn() -> bool>>();
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `bool`
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `bool`, which is required by `&block2::Block<dyn Fn() -> bool>: Encode`
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -228,11 +228,11 @@ note: required by a bound in `is_encode`
   | fn is_encode<T: Encode>() {}
   |                 ^^^^^^ required by this bound in `is_encode`
 
-error[E0277]: the trait bound `objc2::runtime::Sel: RefEncode` is not satisfied
+error[E0277]: the trait bound `&objc2::runtime::Sel: Encode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<&Sel>();
-  |                 ^^^^ the trait `RefEncode` is not implemented for `objc2::runtime::Sel`
+  |                 ^^^^ the trait `RefEncode` is not implemented for `&objc2::runtime::Sel`, which is required by `&objc2::runtime::Sel: Encode`
   |
   = note: required for `&objc2::runtime::Sel` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -250,17 +250,17 @@ error[E0277]: the trait bound `UnsafeCell<&u8>: OptionEncode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<Option<UnsafeCell<&u8>>>();
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `UnsafeCell<&u8>`
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `UnsafeCell<&u8>`, which is required by `Option<UnsafeCell<&u8>>: Encode`
   |
   = help: the following other types implement trait `OptionEncode`:
-            NonNull<T>
-            objc2::runtime::Sel
-            NonZeroU8
-            NonZeroU16
-            NonZeroU32
-            NonZeroU64
-            NonZeroUsize
-            NonZeroI8
+            NonZero<isize>
+            NonZero<i8>
+            NonZero<i16>
+            NonZero<i32>
+            NonZero<i64>
+            NonZero<usize>
+            NonZero<u8>
+            NonZero<u16>
           and $N others
   = note: required for `Option<UnsafeCell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`
@@ -273,17 +273,17 @@ error[E0277]: the trait bound `Cell<&u8>: OptionEncode` is not satisfied
  --> ui/not_encode.rs
   |
   |     is_encode::<Option<Cell<&u8>>>();
-  |                 ^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `Cell<&u8>`
+  |                 ^^^^^^^^^^^^^^^^^ the trait `OptionEncode` is not implemented for `Cell<&u8>`, which is required by `Option<Cell<&u8>>: Encode`
   |
   = help: the following other types implement trait `OptionEncode`:
-            NonNull<T>
-            objc2::runtime::Sel
-            NonZeroU8
-            NonZeroU16
-            NonZeroU32
-            NonZeroU64
-            NonZeroUsize
-            NonZeroI8
+            NonZero<isize>
+            NonZero<i8>
+            NonZero<i16>
+            NonZero<i32>
+            NonZero<i64>
+            NonZero<usize>
+            NonZero<u8>
+            NonZero<u16>
           and $N others
   = note: required for `Option<Cell<&u8>>` to implement `Encode`
 note: required by a bound in `is_encode`

--- a/crates/test-ui/ui/not_writeback.stderr
+++ b/crates/test-ui/ui/not_writeback.stderr
@@ -1,19 +1,10 @@
-error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
+error[E0277]: the trait bound `&mut Id<NSObject>: ConvertReturn` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: &mut Id<NSObject> = unsafe { msg_send![obj, a] };
-  |                                         ^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
+  |                                         ^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `&mut Id<NSObject>`, which is required by `&mut Id<NSObject>: ConvertReturn`
   |
-  = help: the following other types implement trait `RefEncode`:
-            isize
-            i8
-            i16
-            i32
-            i64
-            usize
-            u8
-            u16
-          and $N others
+  = help: the trait `ConvertReturn` is implemented for `bool`
   = note: required for `&mut Id<NSObject>` to implement `Encode`
   = note: required for `&mut Id<NSObject>` to implement `EncodeReturn`
   = note: required for `&mut Id<NSObject>` to implement `ConvertReturn`
@@ -31,7 +22,7 @@ error[E0277]: the trait bound `Id<NSObject>: Encode` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: param] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Id<NSObject>`
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `Id<NSObject>`, which is required by `(Id<NSObject>,): ConvertArguments`
   |
   = help: the following other types implement trait `Encode`:
             isize
@@ -60,7 +51,7 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: &param] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`, which is required by `(&Id<NSObject>,): ConvertArguments`
   |
   = help: the following other types implement trait `RefEncode`:
             isize
@@ -90,7 +81,7 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: Some(&param)] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`, which is required by `(Option<&Id<NSObject>>,): ConvertArguments`
   |
   = help: the following other types implement trait `RefEncode`:
             isize
@@ -122,7 +113,7 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: param] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`, which is required by `(*mut Id<NSObject>,): ConvertArguments`
   |
   = help: the following other types implement trait `RefEncode`:
             isize
@@ -152,7 +143,7 @@ error[E0277]: the trait bound `Id<NSObject>: RefEncode` is not satisfied
  --> ui/not_writeback.rs
   |
   |     let _: () = unsafe { msg_send![obj, a: param] };
-  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RefEncode` is not implemented for `Id<NSObject>`, which is required by `(&mut &mut Id<NSObject>,): ConvertArguments`
   |
   = help: the following other types implement trait `RefEncode`:
             isize

--- a/crates/test-ui/ui/ns_string_not_const.rs
+++ b/crates/test-ui/ui/ns_string_not_const.rs
@@ -1,3 +1,4 @@
+#![allow(unused_variables)]
 use icrate::Foundation::ns_string;
 
 fn main() {

--- a/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
+++ b/crates/test-ui/ui/nsarray_bound_not_send_sync.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |     needs_sync::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`, which is required by `NSArray<NSObject>: Sync`
 note: required because it appears within the type `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -38,7 +38,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |     needs_sync::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `NSArray<NSObject>: Sync`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -77,7 +77,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |     needs_send::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`, which is required by `NSArray<NSObject>: Send`
 note: required because it appears within the type `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -111,7 +111,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |     needs_send::<NSArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `NSArray<NSObject>: Send`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -161,7 +161,7 @@ error[E0277]: `*const NSObject` cannot be shared between threads safely
   |     needs_sync::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be shared between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Sync` is not implemented for `*const NSObject`, which is required by `NSMutableArray<NSObject>: Sync`
 note: required because it appears within the type `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -200,7 +200,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |     needs_sync::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `NSMutableArray<NSObject>: Sync`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -244,7 +244,7 @@ error[E0277]: `*const NSObject` cannot be sent between threads safely
   |     needs_send::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const NSObject` cannot be sent between threads safely
   |
-  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`
+  = help: within `icrate::objc2::rc::id::private::EquivalentType<NSObject>`, the trait `Send` is not implemented for `*const NSObject`, which is required by `NSMutableArray<NSObject>: Send`
 note: required because it appears within the type `icrate::objc2::rc::id::private::UnknownStorage<NSObject>`
  --> $WORKSPACE/crates/objc2/src/rc/id.rs
   |
@@ -283,7 +283,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |     needs_send::<NSMutableArray<NSObject>>();
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `NSMutableArray<NSObject>: Send`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs

--- a/crates/test-ui/ui/nsarray_not_message.stderr
+++ b/crates/test-ui/ui/nsarray_not_message.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `i32: Message` is not satisfied
  --> ui/nsarray_not_message.rs
   |
   |     let _: Id<NSArray<i32>> = NSArray::new();
-  |                               ^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
+  |                               ^^^^^^^^^^^^^^ the trait `Message` is not implemented for `i32`
   |
   = help: the following other types implement trait `Message`:
             Exception
@@ -28,24 +28,15 @@ note: required by a bound in `icrate::generated::Foundation::__NSArray::<impl NS
   | |_^ required by this bound in `icrate::generated::Foundation::__NSArray::<impl NSArray<ObjectType>>::new`
   = note: this error originates in the macro `extern_methods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Id<NSObject>: ClassType` is not satisfied
+error[E0277]: the trait bound `Id<NSObject>: IsRetainable` is not satisfied
  --> ui/nsarray_not_message.rs
   |
   |     let _: Id<NSArray<Id<NSObject>>> = NSArray::from_slice(&[&NSObject::new()]);
-  |                                        ------------------- ^^^^^^^^^^^^^^^^^^^ the trait `ClassType` is not implemented for `Id<NSObject>`
+  |                                        ------------------- ^^^^^^^^^^^^^^^^^^^ the trait `ClassType` is not implemented for `Id<NSObject>`, which is required by `Id<NSObject>: IsRetainable`
   |                                        |
   |                                        required by a bound introduced by this call
   |
-  = help: the following other types implement trait `ClassType`:
-            NSArray<ObjectType>
-            NSObject
-            __NSProxy
-            NSMutableArray<ObjectType>
-            NSDictionary<KeyType, ObjectType>
-            NSMutableDictionary<KeyType, ObjectType>
-            NSSet<ObjectType>
-            NSMutableSet<ObjectType>
-          and $N others
+  = help: the trait `IsRetainable` is implemented for `ProtocolObject<P>`
   = note: required for `Id<NSObject>` to implement `IsRetainable`
 note: required by a bound in `icrate::Foundation::array::<impl NSArray<T>>::from_slice`
  --> $WORKSPACE/crates/icrate/src/additions/Foundation/array.rs

--- a/crates/test-ui/ui/nsobject_not_mutable.stderr
+++ b/crates/test-ui/ui/nsobject_not_mutable.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Root: mutability::MutabilityIsMutable` is not sat
  --> ui/nsobject_not_mutable.rs
   |
   |     let mut_ptr = Id::as_mut_ptr(&mut obj);
-  |                   -------------- ^^^^^^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`
+  |                   -------------- ^^^^^^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`, which is required by `NSObject: IsMutable`
   |                   |
   |                   required by a bound introduced by this call
   |
@@ -23,7 +23,7 @@ error[E0277]: the trait bound `Root: mutability::MutabilityIsMutable` is not sat
  --> ui/nsobject_not_mutable.rs
   |
   |         let mut_ref = Id::autorelease_mut(obj, pool);
-  |                       ------------------- ^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`
+  |                       ------------------- ^^^ the trait `mutability::MutabilityIsMutable` is not implemented for `Root`, which is required by `NSObject: IsMutable`
   |                       |
   |                       required by a bound introduced by this call
   |

--- a/crates/test-ui/ui/nsset_from_nsobject.stderr
+++ b/crates/test-ui/ui/nsset_from_nsobject.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Root: mutability::MutabilityHashIsStable` is not 
  --> ui/nsset_from_nsobject.rs
   |
   |     let _ = NSSet::from_vec(vec![NSObject::new()]);
-  |             --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityHashIsStable` is not implemented for `Root`
+  |             --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `mutability::MutabilityHashIsStable` is not implemented for `Root`, which is required by `NSObject: HasStableHash`
   |             |
   |             required by a bound introduced by this call
   |

--- a/crates/test-ui/ui/object_not_send_sync.stderr
+++ b/crates/test-ui/ui/object_not_send_sync.stderr
@@ -4,7 +4,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |     needs_sync::<AnyObject>();
   |                  ^^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `AnyObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `AnyObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `AnyObject: Sync`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -27,7 +27,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |     needs_send::<AnyObject>();
   |                  ^^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `AnyObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `AnyObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `AnyObject: Send`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -61,7 +61,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |     needs_sync::<NSObject>();
   |                  ^^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `NSObject: Sync`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -89,7 +89,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |     needs_send::<NSObject>();
   |                  ^^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `NSObject: Send`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs
@@ -128,7 +128,7 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |     needs_sync::<NSValue>();
   |                  ^^^^^^^ `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` cannot be shared between threads safely
   |
-  = help: within `NSValue`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSValue`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `NSValue: Sync`
 note: required because it appears within the type `objc_object`
  --> $WORKSPACE/crates/objc-sys/src/object.rs
   |
@@ -161,7 +161,7 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |     needs_send::<NSValue>();
   |                  ^^^^^^^ `*const UnsafeCell<()>` cannot be sent between threads safely
   |
-  = help: within `NSValue`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSValue`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `NSValue: Send`
   = note: required because it appears within the type `(*const UnsafeCell<()>, PhantomPinned)`
 note: required because it appears within the type `PhantomData<(*const UnsafeCell<()>, PhantomPinned)>`
  --> $RUST/core/src/marker.rs

--- a/crates/test-ui/ui/protocol_object_only_protocols.stderr
+++ b/crates/test-ui/ui/protocol_object_only_protocols.stderr
@@ -11,8 +11,8 @@ error[E0277]: the trait bound `NSObject: ImplementedBy<NSObject>` is not satisfi
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -38,8 +38,8 @@ error[E0277]: the trait bound `dyn Send: ImplementedBy<NSObject>` is not satisfi
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -65,8 +65,8 @@ error[E0277]: the trait bound `dyn Foo: ImplementedBy<NSObject>` is not satisfie
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -87,14 +87,14 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                                                           |
   |                                                           required by a bound introduced by this call
   |
-  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `dyn NSObjectProtocol + Send: ImplementedBy<NSObject>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSCopying + 'static)
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -142,14 +142,14 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                                                           |
   |                                                           required by a bound introduced by this call
   |
-  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `dyn NSObjectProtocol + Sync: ImplementedBy<NSObject>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSCopying + 'static)
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -186,14 +186,14 @@ error[E0277]: `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>` 
   |                                                                  |
   |                                                                  required by a bound introduced by this call
   |
-  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`
+  = help: within `NSObject`, the trait `Sync` is not implemented for `UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>`, which is required by `dyn NSObjectProtocol + Send + Sync: ImplementedBy<NSObject>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSCopying + 'static)
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -230,14 +230,14 @@ error[E0277]: `*const UnsafeCell<()>` cannot be sent between threads safely
   |                                                                  |
   |                                                                  required by a bound introduced by this call
   |
-  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`
+  = help: within `NSObject`, the trait `Send` is not implemented for `*const UnsafeCell<()>`, which is required by `dyn NSObjectProtocol + Send + Sync: ImplementedBy<NSObject>`
   = help: the following other types implement trait `ImplementedBy<T>`:
             (dyn NSCopying + 'static)
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others
@@ -281,7 +281,7 @@ error[E0277]: the trait bound `NSObject: NSCopying` is not satisfied
  --> ui/protocol_object_only_protocols.rs
   |
   |     let _: &ProtocolObject<dyn NSCopying> = ProtocolObject::from_ref(&*obj);
-  |                                             ------------------------ ^^^^^ the trait `NSCopying` is not implemented for `NSObject`
+  |                                             ------------------------ ^^^^^ the trait `NSCopying` is not implemented for `NSObject`, which is required by `dyn NSCopying: ImplementedBy<NSObject>`
   |                                             |
   |                                             required by a bound introduced by this call
   |
@@ -318,8 +318,8 @@ error[E0277]: the trait bound `dyn NSCopying + Send: ImplementedBy<NSObject>` is
             (dyn NSMutableCopying + 'static)
             (dyn NSObjectProtocol + 'static)
             (dyn NSObjectProtocol + Sync + 'static)
-            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSObjectProtocol + Send + 'static)
+            (dyn NSObjectProtocol + Send + Sync + 'static)
             (dyn NSFastEnumeration + 'static)
             (dyn NSCoding + 'static)
           and $N others

--- a/crates/test-ui/ui/stack_block_requires_clone.stderr
+++ b/crates/test-ui/ui/stack_block_requires_clone.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Foo: Clone` is not satisfied in `{closure@$DIR/ui
   | |             required by a bound introduced by this call
   | |         let _ = &foo;
   | |     });
-  | |_____^ within `{closure@$DIR/ui/stack_block_requires_clone.rs:7:29: 7:36}`, the trait `Clone` is not implemented for `Foo`
+  | |_____^ within `{closure@$DIR/ui/stack_block_requires_clone.rs:7:29: 7:36}`, the trait `Clone` is not implemented for `Foo`, which is required by `{closure@$DIR/ui/stack_block_requires_clone.rs:7:29: 7:36}: Clone`
   |
 note: required because it's used within this closure
  --> ui/stack_block_requires_clone.rs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Remember to update this in ci.yml as well.
-channel = "nightly-2024-01-15"
+channel = "nightly-2024-03-13"
 profile = "minimal"
 components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
Assembly test changes are:
- Smaller codegen for `Option::unwrap`
- Different register usage, especially around `CachedSel`. Perhaps slightly worse, but unsure, I suspect it might be a correctness fix.
- Some changes to `Box` creation and destruction.

UI test changes are:
- Added "which is required by", generally an improvement.
- "the following other types implement trait" suggestions are shown in fewer situations.
