### PR TITLE
Reduce amount of custom cfgs in `objc-sys`

### DIFF
--- a/crates/objc-sys/build.rs
+++ b/crates/objc-sys/build.rs
@@ -88,15 +88,6 @@ fn main() {
         _ => panic!("Invalid feature combination; only one runtime may be selected!"),
     };
 
-    // Add `#[cfg(RUNTIME)]` directive
-    let runtime_cfg = match runtime {
-        Runtime::Apple => "apple",
-        // WinObjC can be treated like GNUStep 1.8
-        Runtime::GNUStep(_, _) | Runtime::WinObjC => "gnustep",
-        Runtime::ObjFW(_) => "objfw",
-    };
-    println!("cargo:rustc-cfg={runtime_cfg}");
-
     let clang_objc_runtime = match &runtime {
         // Default to `clang`'s own heuristics.
         //

--- a/crates/objc-sys/build.rs
+++ b/crates/objc-sys/build.rs
@@ -38,7 +38,6 @@ fn main() {
     // println!("cargo:rustc-cfg=libobjc2_strict_apple_compat");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     let mut apple = env::var_os("CARGO_FEATURE_APPLE").is_some();
     let mut gnustep = env::var_os("CARGO_FEATURE_GNUSTEP_1_7").is_some();
@@ -97,16 +96,6 @@ fn main() {
         Runtime::ObjFW(_) => "objfw",
     };
     println!("cargo:rustc-cfg={runtime_cfg}");
-
-    if let Runtime::Apple = &runtime {
-        // A few things are defined differently depending on the __OBJC2__
-        // variable, which is set for all platforms except 32-bit macOS.
-        if target_os == "macos" && target_arch == "x86" {
-            println!("cargo:rustc-cfg=apple_old");
-        } else {
-            println!("cargo:rustc-cfg=apple_new");
-        }
-    }
 
     let clang_objc_runtime = match &runtime {
         // Default to `clang`'s own heuristics.

--- a/crates/objc-sys/src/class.rs
+++ b/crates/objc-sys/src/class.rs
@@ -1,6 +1,6 @@
 use std::os::raw::{c_char, c_int, c_uint};
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use crate::{objc_ivar, objc_method, objc_object, objc_property, objc_property_attribute_t};
 use crate::{objc_protocol, objc_selector, OpaqueData, BOOL, IMP};
 
@@ -13,7 +13,7 @@ pub struct objc_class {
     _p: OpaqueData,
 }
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 /// This is `c_char` in GNUStep's libobjc2 and `uint8_t` in Apple's objc4.
 ///
 /// The pointer represents opaque data, and is definitely not just an integer,
@@ -25,12 +25,12 @@ type ivar_layout_type = u8;
 
 // May call `resolveClassMethod:` or `resolveInstanceMethod:`.
 extern_c_unwind! {
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getClassMethod(
         cls: *const objc_class,
         name: *const objc_selector,
     ) -> *const objc_method;
-    #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    #[cfg(any(doc, not(feature = "unstable-objfw")))] // Available in newer versions
     pub fn class_getInstanceMethod(
         cls: *const objc_class,
         name: *const objc_selector,
@@ -39,10 +39,10 @@ extern_c_unwind! {
     pub fn class_respondsToSelector(cls: *const objc_class, sel: *const objc_selector) -> BOOL;
 
     // #[deprecated = "use class_getMethodImplementation instead"]
-    // #[cfg(any(doc, apple))]
+    // #[cfg(any(doc, feature = "apple"))]
     // pub fn class_lookupMethod
     // #[deprecated = "use class_respondsToSelector instead"]
-    // #[cfg(any(doc, apple))]
+    // #[cfg(any(doc, feature = "apple"))]
     // pub fn class_respondsToMethod
 }
 
@@ -51,7 +51,7 @@ extern_c! {
     pub fn objc_getClass(name: *const c_char) -> *const objc_class;
     pub fn objc_getRequiredClass(name: *const c_char) -> *const objc_class;
     pub fn objc_lookUpClass(name: *const c_char) -> *const objc_class;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_getMetaClass(name: *const c_char) -> *const objc_class;
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyClassList(out_len: *mut c_uint) -> *mut *const objc_class;
@@ -62,17 +62,17 @@ extern_c! {
         name: *const c_char,
         extra_bytes: usize,
     ) -> *mut objc_class;
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_duplicateClass(
         original: *const objc_class,
         name: *const c_char,
         extra_bytes: usize,
     ) -> *mut objc_class;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_disposeClassPair(cls: *mut objc_class);
     pub fn objc_registerClassPair(cls: *mut objc_class);
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_addIvar(
         cls: *mut objc_class,
         name: *const c_char,
@@ -86,64 +86,64 @@ extern_c! {
         imp: IMP,
         types: *const c_char,
     ) -> BOOL;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_addProperty(
         cls: *mut objc_class,
         name: *const c_char,
         attributes: *const objc_property_attribute_t,
         attributes_count: c_uint,
     ) -> BOOL;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_addProtocol(cls: *mut objc_class, protocol: *const objc_protocol) -> BOOL;
     pub fn class_conformsToProtocol(cls: *const objc_class, protocol: *const objc_protocol)
         -> BOOL;
 
-    #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    #[cfg(any(doc, not(feature = "unstable-objfw")))] // Available in newer versions
     /// The return value is deallocated with [`free`][crate::free].
     pub fn class_copyIvarList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_ivar;
-    #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    #[cfg(any(doc, not(feature = "unstable-objfw")))] // Available in newer versions
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyMethodList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_method;
-    #[cfg(any(doc, not(objfw)))] // Available in newer versions
+    #[cfg(any(doc, not(feature = "unstable-objfw")))] // Available in newer versions
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyPropertyList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_property;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn class_copyProtocolList(
         cls: *const objc_class,
         out_len: *mut c_uint,
     ) -> *mut *const objc_protocol;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_createInstance(cls: *const objc_class, extra_bytes: usize) -> *mut objc_object;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getClassVariable(cls: *const objc_class, name: *const c_char) -> *const objc_ivar;
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn class_getImageName(cls: *const objc_class) -> *const c_char;
     pub fn class_getInstanceSize(cls: *const objc_class) -> usize;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getInstanceVariable(
         cls: *const objc_class,
         name: *const c_char,
     ) -> *const objc_ivar;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getIvarLayout(cls: *const objc_class) -> *const ivar_layout_type;
     pub fn class_getName(cls: *const objc_class) -> *const c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getProperty(cls: *const objc_class, name: *const c_char) -> *const objc_property;
     pub fn class_getSuperclass(cls: *const objc_class) -> *const objc_class;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_getVersion(cls: *const objc_class) -> c_int;
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn class_getWeakIvarLayout(cls: *const objc_class) -> *const ivar_layout_type;
     pub fn class_isMetaClass(cls: *const objc_class) -> BOOL;
     pub fn class_replaceMethod(
@@ -152,18 +152,18 @@ extern_c! {
         imp: IMP,
         types: *const c_char,
     ) -> IMP;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_replaceProperty(
         cls: *mut objc_class,
         name: *const c_char,
         attributes: *const objc_property_attribute_t,
         attributes_len: c_uint,
     );
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_setIvarLayout(cls: *mut objc_class, layout: *const ivar_layout_type);
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn class_setVersion(cls: *mut objc_class, version: c_int);
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn class_setWeakIvarLayout(cls: *mut objc_class, layout: *const ivar_layout_type);
 
     // #[deprecated = "not recommended"]

--- a/crates/objc-sys/src/constants.rs
+++ b/crates/objc-sys/src/constants.rs
@@ -1,6 +1,6 @@
 //! Various common #defines and enum constants.
 
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 use std::os::raw::c_int;
 
 use crate::{id, objc_class, BOOL};
@@ -46,15 +46,15 @@ pub const OBJC_ASSOCIATION_RETAIN: objc_AssociationPolicy = 0o1401;
 /// The association is made atomically.
 pub const OBJC_ASSOCIATION_COPY: objc_AssociationPolicy = 0o1403;
 
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 pub const OBJC_SYNC_SUCCESS: c_int = 0;
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 pub const OBJC_SYNC_NOT_OWNING_THREAD_ERROR: c_int = -1;
 /// Only relevant before macOS 10.13
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 pub const OBJC_SYNC_TIMED_OUT: c_int = -2;
 /// Only relevant before macOS 10.13
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 pub const OBJC_SYNC_NOT_INITIALIZED: c_int = -3;
 
 #[cfg(test)]

--- a/crates/objc-sys/src/exception.rs
+++ b/crates/objc-sys/src/exception.rs
@@ -2,28 +2,47 @@
 //! Apple: `objc-exception.h`
 //! GNUStep: `eh_personality.c`, which is a bit brittle to rely on, but I
 //!   think it's fine...
+
+// A few things here are defined differently depending on the __OBJC2__
+// variable, which is set for all platforms except 32-bit macOS.
+
 use core::ffi::c_void;
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 use std::os::raw::c_int;
 #[cfg(feature = "unstable-exception")]
 use std::os::raw::c_uchar;
 
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 use crate::objc_class;
 use crate::objc_object;
 
 /// Remember that this is non-null!
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 pub type objc_exception_matcher =
     unsafe extern "C" fn(catch_type: *mut objc_class, exception: *mut objc_object) -> c_int;
 
 /// Remember that this is non-null!
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 pub type objc_exception_preprocessor =
     unsafe extern "C" fn(exception: *mut objc_object) -> *mut objc_object;
 
 /// Remember that this is non-null!
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 pub type objc_uncaught_exception_handler = unsafe extern "C" fn(exception: *mut objc_object);
 
 #[cfg(objfw)]
@@ -31,7 +50,10 @@ pub type objc_uncaught_exception_handler =
     Option<unsafe extern "C" fn(exception: *mut objc_object)>;
 
 /// Remember that this is non-null!
-#[cfg(any(doc, all(apple_new, target_os = "macos")))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", target_os = "macos", not(target_arch = "x86"))
+))]
 pub type objc_exception_handler =
     unsafe extern "C" fn(unused: *mut objc_object, context: *mut c_void);
 
@@ -47,7 +69,7 @@ extern_c_unwind! {
     #[cold]
     pub fn objc_exception_throw(exception: *mut objc_object) -> !;
 
-    #[cfg(apple_new)]
+    #[cfg(all(feature = "apple", not(all(target_os = "macos", target_arch = "x86"))))]
     #[cold]
     pub fn objc_exception_rethrow() -> !;
 
@@ -57,15 +79,15 @@ extern_c_unwind! {
 }
 
 extern_c! {
-    #[cfg(any(doc, gnustep, apple_new))]
+    #[cfg(any(doc, gnustep, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_begin_catch(exc_buf: *mut c_void) -> *mut objc_object;
-    #[cfg(any(doc, gnustep, apple_new))]
+    #[cfg(any(doc, gnustep, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_end_catch();
 
-    #[cfg(any(doc, apple_old))]
+    #[cfg(any(doc, all(feature = "apple", target_os = "macos", target_arch = "x86")))]
     pub fn objc_exception_try_enter(exception_data: *const c_void);
 
-    #[cfg(any(doc, apple_old))]
+    #[cfg(any(doc, all(feature = "apple", target_os = "macos", target_arch = "x86")))]
     pub fn objc_exception_try_exit(exception_data: *const c_void);
 
     // objc_exception_extract
@@ -73,20 +95,20 @@ extern_c! {
     // objc_exception_get_functions
     // objc_exception_set_functions
 
-    #[cfg(any(doc, apple_new))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_setExceptionMatcher(f: objc_exception_matcher) -> objc_exception_matcher;
-    #[cfg(any(doc, apple_new))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_setExceptionPreprocessor(
         f: objc_exception_preprocessor,
     ) -> objc_exception_preprocessor;
-    #[cfg(any(doc, apple_new, objfw))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86"))), objfw))]
     pub fn objc_setUncaughtExceptionHandler(
         f: objc_uncaught_exception_handler,
     ) -> objc_uncaught_exception_handler;
 
-    #[cfg(any(doc, all(apple_new, target_os = "macos")))]
+    #[cfg(any(doc, all(feature = "apple", target_os = "macos", not(target_arch = "x86"))))]
     pub fn objc_addExceptionHandler(f: objc_exception_handler, context: *mut c_void) -> usize;
-    #[cfg(any(doc, all(apple_new, target_os = "macos")))]
+    #[cfg(any(doc, all(feature = "apple", target_os = "macos", not(target_arch = "x86"))))]
     pub fn objc_removeExceptionHandler(token: usize);
 
     // Only available when ENABLE_OBJCXX is set, and a useable C++ runtime is
@@ -96,7 +118,7 @@ extern_c! {
     // pub fn objc_set_apple_compatible_objcxx_exceptions(newValue: c_int) -> c_int;
 
     #[cold]
-    #[cfg(any(doc, apple_new))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_terminate() -> !;
 }
 

--- a/crates/objc-sys/src/exception.rs
+++ b/crates/objc-sys/src/exception.rs
@@ -45,7 +45,7 @@ pub type objc_exception_preprocessor =
 ))]
 pub type objc_uncaught_exception_handler = unsafe extern "C" fn(exception: *mut objc_object);
 
-#[cfg(objfw)]
+#[cfg(feature = "unstable-objfw")]
 pub type objc_uncaught_exception_handler =
     Option<unsafe extern "C" fn(exception: *mut objc_object)>;
 
@@ -73,15 +73,15 @@ extern_c_unwind! {
     #[cold]
     pub fn objc_exception_rethrow() -> !;
 
-    #[cfg(gnustep)]
+    #[cfg(feature = "gnustep-1-7")]
     #[cold]
     pub fn objc_exception_rethrow(exc_buf: *mut c_void) -> !;
 }
 
 extern_c! {
-    #[cfg(any(doc, gnustep, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
+    #[cfg(any(doc, feature = "gnustep-1-7", all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_begin_catch(exc_buf: *mut c_void) -> *mut objc_object;
-    #[cfg(any(doc, gnustep, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
+    #[cfg(any(doc, feature = "gnustep-1-7", all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_end_catch();
 
     #[cfg(any(doc, all(feature = "apple", target_os = "macos", target_arch = "x86")))]
@@ -101,7 +101,7 @@ extern_c! {
     pub fn objc_setExceptionPreprocessor(
         f: objc_exception_preprocessor,
     ) -> objc_exception_preprocessor;
-    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86"))), objfw))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86"))), feature = "unstable-objfw"))]
     pub fn objc_setUncaughtExceptionHandler(
         f: objc_uncaught_exception_handler,
     ) -> objc_uncaught_exception_handler;
@@ -114,7 +114,7 @@ extern_c! {
     // Only available when ENABLE_OBJCXX is set, and a useable C++ runtime is
     // present when building libobjc2.
     //
-    // #[cfg(any(doc, gnustep))]
+    // #[cfg(any(doc, feature = "gnustep-1-7"))]
     // pub fn objc_set_apple_compatible_objcxx_exceptions(newValue: c_int) -> c_int;
 
     #[cold]

--- a/crates/objc-sys/src/message.rs
+++ b/crates/objc-sys/src/message.rs
@@ -4,7 +4,7 @@
 //!
 //! TODO: Some of these are only supported on _some_ GNUStep targets!
 use crate::{objc_class, objc_object};
-#[cfg(any(doc, gnustep, objfw))]
+#[cfg(any(doc, feature = "gnustep-1-7", feature = "unstable-objfw"))]
 use crate::{objc_selector, IMP};
 
 /// Specifies data used when sending messages to superclasses.
@@ -26,62 +26,62 @@ pub struct objc_super {
 // call hooks, `resolveClassMethod:` and `resolveInstanceMethod:`, so we have
 // to make those "C-unwind" as well!
 extern_c_unwind! {
-    #[cfg(any(doc, gnustep, objfw))]
+    #[cfg(any(doc, feature = "gnustep-1-7", feature = "unstable-objfw"))]
     pub fn objc_msg_lookup(receiver: *mut objc_object, sel: *const objc_selector) -> IMP;
-    #[cfg(any(doc, objfw))]
+    #[cfg(any(doc, feature = "unstable-objfw"))]
     pub fn objc_msg_lookup_stret(receiver: *mut objc_object, sel: *const objc_selector) -> IMP;
-    #[cfg(any(doc, gnustep, objfw))]
+    #[cfg(any(doc, feature = "gnustep-1-7", feature = "unstable-objfw"))]
     pub fn objc_msg_lookup_super(sup: *const objc_super, sel: *const objc_selector) -> IMP;
-    #[cfg(any(doc, objfw))]
+    #[cfg(any(doc, feature = "unstable-objfw"))]
     pub fn objc_msg_lookup_super_stret(sup: *const objc_super, sel: *const objc_selector) -> IMP;
-    // #[cfg(any(doc, gnustep))]
+    // #[cfg(any(doc, feature = "gnustep-1-7"))]
     // objc_msg_lookup_sender
     // objc_msgLookup family available in macOS >= 10.12
 
     // objc_msgSend_noarg
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_msgSend();
     // objc_msgSend_debug
 
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_msgSendSuper();
     // objc_msgSendSuper2
     // objc_msgSendSuper2_debug
 
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn method_invoke();
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn _objc_msgForward();
     pub fn class_getMethodImplementation();
 
     // Struct return. Not available on __arm64__:
 
-    #[cfg(any(doc, all(not(objfw), not(target_arch = "aarch64"))))]
+    #[cfg(any(doc, all(not(feature = "unstable-objfw"), not(target_arch = "aarch64"))))]
     pub fn objc_msgSend_stret();
     // objc_msgSend_stret_debug
 
-    #[cfg(any(doc, all(apple, not(target_arch = "aarch64"))))]
+    #[cfg(any(doc, all(feature = "apple", not(target_arch = "aarch64"))))]
     pub fn objc_msgSendSuper_stret();
     // objc_msgSendSuper2_stret
     // objc_msgSendSuper2_stret_debug
 
-    #[cfg(any(doc, all(apple, not(target_arch = "aarch64"))))]
+    #[cfg(any(doc, all(feature = "apple", not(target_arch = "aarch64"))))]
     pub fn method_invoke_stret();
-    #[cfg(any(doc, all(apple, not(target_arch = "aarch64"))))]
+    #[cfg(any(doc, all(feature = "apple", not(target_arch = "aarch64"))))]
     pub fn _objc_msgForward_stret();
-    #[cfg(any(doc, objfw, not(target_arch = "aarch64")))]
+    #[cfg(any(doc, feature = "unstable-objfw", not(target_arch = "aarch64")))]
     pub fn class_getMethodImplementation_stret();
 
     // __x86_64__ and __i386__
 
-    #[cfg(any(doc, all(not(objfw), any(target_arch = "x86_64", target_arch = "x86"))))]
+    #[cfg(any(doc, all(not(feature = "unstable-objfw"), any(target_arch = "x86_64", target_arch = "x86"))))]
     pub fn objc_msgSend_fpret();
     // objc_msgSend_fpret_debug
 
     // __x86_64__
 
-    #[cfg(any(doc, all(apple, target_arch = "x86_64")))]
+    #[cfg(any(doc, all(feature = "apple", target_arch = "x86_64")))]
     pub fn objc_msgSend_fp2ret();
     // objc_msgSend_fp2ret_debug
 }

--- a/crates/objc-sys/src/method.rs
+++ b/crates/objc-sys/src/method.rs
@@ -1,8 +1,8 @@
 use std::os::raw::c_char;
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use std::os::raw::c_uint;
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use crate::IMP;
 use crate::{objc_selector, OpaqueData};
 
@@ -24,33 +24,33 @@ pub struct objc_method_description {
 }
 
 extern_c! {
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The return value is deallocated with [`free`][crate::free].
     pub fn method_copyArgumentType(method: *const objc_method, index: c_uint) -> *mut c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The return value is deallocated with [`free`][crate::free].
     pub fn method_copyReturnType(method: *const objc_method) -> *mut c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_exchangeImplementations(method1: *mut objc_method, method2: *mut objc_method);
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getArgumentType(
         method: *const objc_method,
         index: c_uint,
         dst: *mut c_char,
         dst_len: usize,
     );
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn method_getDescription(m: *const objc_method) -> *const objc_method_description;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getImplementation(method: *const objc_method) -> IMP;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getName(method: *const objc_method) -> *const objc_selector;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getNumberOfArguments(method: *const objc_method) -> c_uint;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getReturnType(method: *const objc_method, dst: *mut c_char, dst_len: usize);
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_getTypeEncoding(method: *const objc_method) -> *const c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn method_setImplementation(method: *const objc_method, imp: IMP) -> IMP;
 }

--- a/crates/objc-sys/src/object.rs
+++ b/crates/objc-sys/src/object.rs
@@ -1,10 +1,10 @@
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use core::ffi::c_void;
 use std::os::raw::c_char;
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use crate::objc_ivar;
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 use crate::BOOL;
 use crate::{objc_class, OpaqueData};
 
@@ -25,26 +25,26 @@ extern_c! {
     pub fn object_getClass(obj: *const objc_object) -> *const objc_class;
     pub fn object_getClassName(obj: *const objc_object) -> *const c_char;
     pub fn object_setClass(obj: *mut objc_object, cls: *const objc_class) -> *const objc_class;
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn object_isClass(obj: *const objc_object) -> BOOL;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_getIndexedIvars(obj: *const objc_object) -> *const c_void;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_getIvar(obj: *const objc_object, ivar: *const objc_ivar) -> *const objc_object;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_setIvar(obj: *mut objc_object, ivar: *const objc_ivar, value: *mut objc_object);
 
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn object_copy(obj: *const objc_object, size: usize) -> *mut objc_object;
 
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_dispose(obj: *mut objc_object) -> *mut objc_object;
 
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_setInstanceVariable(
         obj: *mut objc_object,
         name: *const c_char,
@@ -53,7 +53,7 @@ extern_c! {
 
     // Available in macOS 10.12
     // #[deprecated = "Not needed since ARC"]
-    // #[cfg(any(doc, apple))]
+    // #[cfg(any(doc, feature = "apple"))]
     // pub fn object_setInstanceVariableWithStrongDefault(
     //     obj: *mut objc_object,
     //     name: *const c_char,
@@ -61,7 +61,7 @@ extern_c! {
     // ) -> *const objc_ivar;
 
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn object_getInstanceVariable(
         obj: *const objc_object,
         name: *const c_char,
@@ -69,13 +69,13 @@ extern_c! {
     ) -> *const objc_ivar;
 
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_getFutureClass(name: *const c_char) -> *const objc_class;
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_constructInstance(cls: *const objc_class, bytes: *mut c_void) -> *mut objc_object;
     #[deprecated = "Not needed since ARC"]
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_destructInstance(obj: *mut objc_object) -> *mut c_void;
 
     // TODO: Unsure if we should expose these; are they useful, and stable?
@@ -106,9 +106,9 @@ extern_c! {
     // );
 
     // #[deprecated = "use object_copy instead"]
-    // #[cfg(any(doc, all(apple, target_os = "macos")))]
+    // #[cfg(any(doc, all(feature = "apple", target_os = "macos")))]
     // object_copyFromZone
     // #[deprecated = "use class_createInstance instead"]
-    // #[cfg(any(doc, all(apple, target_os = "macos")))]
+    // #[cfg(any(doc, all(feature = "apple", target_os = "macos")))]
     // class_createInstanceFromZone
 }

--- a/crates/objc-sys/src/property.rs
+++ b/crates/objc-sys/src/property.rs
@@ -1,5 +1,5 @@
 use std::os::raw::c_char;
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use std::os::raw::c_uint;
 
 use crate::OpaqueData;
@@ -24,19 +24,19 @@ pub struct objc_property_attribute_t {
 }
 
 extern_c! {
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn property_copyAttributeList(
         property: *const objc_property,
         out_len: *mut c_uint,
     ) -> *mut objc_property_attribute_t;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn property_copyAttributeValue(
         property: *const objc_property,
         attribute_name: *const c_char,
     ) -> *mut c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn property_getAttributes(property: *const objc_property) -> *const c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn property_getName(property: *const objc_property) -> *const c_char;
 }

--- a/crates/objc-sys/src/protocol.rs
+++ b/crates/objc-sys/src/protocol.rs
@@ -1,8 +1,8 @@
 use std::os::raw::c_char;
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use std::os::raw::c_uint;
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use crate::{objc_method_description, objc_property, objc_property_attribute_t, objc_selector};
 use crate::{OpaqueData, BOOL};
 
@@ -20,15 +20,15 @@ pub struct objc_protocol {
 }
 
 extern_c! {
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_getProtocol(name: *const c_char) -> *const objc_protocol;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyProtocolList(out_len: *mut c_uint) -> *mut *const objc_protocol;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_allocateProtocol(name: *const c_char) -> *mut objc_protocol;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_registerProtocol(proto: *mut objc_protocol);
 
     pub fn protocol_conformsToProtocol(
@@ -38,7 +38,7 @@ extern_c! {
     pub fn protocol_isEqual(proto: *const objc_protocol, other: *const objc_protocol) -> BOOL;
     pub fn protocol_getName(proto: *const objc_protocol) -> *const c_char;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn protocol_addMethodDescription(
         proto: *mut objc_protocol,
         name: *const objc_selector,
@@ -46,7 +46,7 @@ extern_c! {
         is_required_method: BOOL,
         is_instance_method: BOOL,
     );
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn protocol_addProperty(
         proto: *mut objc_protocol,
         name: *const c_char,
@@ -55,9 +55,9 @@ extern_c! {
         is_required_property: BOOL,
         is_instance_property: BOOL,
     );
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn protocol_addProtocol(proto: *mut objc_protocol, addition: *const objc_protocol);
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyMethodDescriptionList(
         proto: *const objc_protocol,
@@ -65,26 +65,26 @@ extern_c! {
         is_instance_method: BOOL,
         out_len: *mut c_uint,
     ) -> *mut objc_method_description;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyPropertyList(
         proto: *const objc_protocol,
         out_len: *mut c_uint,
     ) -> *mut *const objc_property;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn protocol_copyProtocolList(
         proto: *const objc_protocol,
         out_len: *mut c_uint,
     ) -> *mut *const objc_protocol;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn protocol_getMethodDescription(
         proto: *const objc_protocol,
         sel: *const objc_selector,
         is_required_method: BOOL,
         is_instance_method: BOOL,
     ) -> objc_method_description;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn protocol_getProperty(
         proto: *const objc_protocol,
         name: *const c_char,
@@ -95,6 +95,6 @@ extern_c! {
     // #[cfg(any(doc, macos >= 10.12))]
     // protocol_copyPropertyList2
 
-    // #[cfg(any(doc, gnustep))]
+    // #[cfg(any(doc, feature = "gnustep-1-7"))]
     // _protocol_getMethodTypeEncoding
 }

--- a/crates/objc-sys/src/rc.rs
+++ b/crates/objc-sys/src/rc.rs
@@ -24,9 +24,9 @@ extern_c_unwind! {
     // Autoreleasepool
     // ObjFW: Defined in `autorelease.h`, not available with libobjfw-rt!
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_autoreleasePoolPop(pool: *mut c_void);
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_autoreleasePoolPush() -> *mut c_void;
 
     // Autorelease
@@ -62,7 +62,7 @@ extern_c_unwind! {
         -> *mut objc_object;
 
     // TODO: Decide about nonstandard extensions like these:
-    // #[cfg(any(doc, gnustep))]
+    // #[cfg(any(doc, feature = "gnustep-1-7"))]
     // pub fn objc_delete_weak_refs(obj: *mut objc_object) -> BOOL;
 
     // Fast paths for certain selectors.

--- a/crates/objc-sys/src/rc.rs
+++ b/crates/objc-sys/src/rc.rs
@@ -11,7 +11,10 @@
 //! [ARC]: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#runtime-support
 use core::ffi::c_void;
 
-#[cfg(any(doc, apple_new))]
+#[cfg(any(
+    doc,
+    all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))
+))]
 use crate::objc_class;
 use crate::objc_object;
 
@@ -74,11 +77,11 @@ extern_c_unwind! {
     // <https://github.com/llvm/llvm-project/blob/llvmorg-17.0.5/clang/include/clang/Basic/ObjCRuntime.h#L229>
 
     // Available since macOS 10.9.
-    #[cfg(any(doc, apple_new))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_alloc(value: *const objc_class) -> *mut objc_object;
 
     // Available since macOS 10.9.
-    #[cfg(any(doc, apple_new))]
+    #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     pub fn objc_allocWithZone(value: *const objc_class) -> *mut objc_object;
 
     // TODO: objc_alloc_init once supported

--- a/crates/objc-sys/src/selector.rs
+++ b/crates/objc-sys/src/selector.rs
@@ -16,9 +16,9 @@ extern_c! {
     pub fn sel_isEqual(lhs: *const objc_selector, rhs: *const objc_selector) -> BOOL;
     pub fn sel_registerName(name: *const c_char) -> *const objc_selector;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn sel_getUid(name: *const c_char) -> *const objc_selector;
 
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn sel_isMapped(sel: *const objc_selector) -> BOOL;
 }

--- a/crates/objc-sys/src/types.rs
+++ b/crates/objc-sys/src/types.rs
@@ -9,7 +9,7 @@ use crate::{objc_object, objc_selector};
 /// cfgs are determined experimentally via. cross compiling.
 ///
 /// See also <https://www.jviotti.com/2024/01/05/is-objective-c-bool-a-boolean-type-it-depends.html>.
-#[cfg(apple)]
+#[cfg(feature = "apple")]
 mod inner {
     // __OBJC_BOOL_IS_BOOL
     #[cfg(any(
@@ -37,13 +37,13 @@ mod inner {
 }
 
 // GNUStep's and Microsoft's libobjc2
-#[cfg(all(gnustep, libobjc2_strict_apple_compat))]
+#[cfg(all(feature = "gnustep-1-7", libobjc2_strict_apple_compat))]
 mod inner {
     // C: (explicitly) signed char
     pub(crate) type BOOL = i8;
 }
 
-#[cfg(all(gnustep, not(libobjc2_strict_apple_compat)))]
+#[cfg(all(feature = "gnustep-1-7", not(libobjc2_strict_apple_compat)))]
 mod inner {
     // windows && !32bit-MinGW
     #[cfg(all(windows, not(all(target_pointer_width = "64", target_env = "gnu"))))]
@@ -56,7 +56,7 @@ mod inner {
 }
 
 // ObjFW
-#[cfg(objfw)]
+#[cfg(feature = "unstable-objfw")]
 mod inner {
     // Defined in ObjFW-RT.h
     // C: signed char

--- a/crates/objc-sys/src/various.rs
+++ b/crates/objc-sys/src/various.rs
@@ -1,11 +1,11 @@
 use core::ffi::c_void;
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use std::os::raw::c_char;
 use std::os::raw::c_int;
-#[cfg(any(doc, apple))]
+#[cfg(any(doc, feature = "apple"))]
 use std::os::raw::c_uint;
 
-#[cfg(any(doc, not(objfw)))]
+#[cfg(any(doc, not(feature = "unstable-objfw")))]
 use crate::{objc_AssociationPolicy, BOOL};
 use crate::{objc_object, OpaqueData};
 
@@ -38,56 +38,56 @@ pub type IMP = Option<InnerImp>;
 
 extern_c_unwind! {
     // Instead of being able to change this, it's a weak symbol on GNUStep.
-    #[cfg(any(doc, apple, objfw))]
+    #[cfg(any(doc, feature = "apple", feature = "unstable-objfw"))]
     pub fn objc_enumerationMutation(obj: *mut objc_object);
 }
 
 extern_c! {
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn imp_getBlock(imp: IMP) -> *mut objc_object;
     // See also <https://landonf.org/code/objc/imp_implementationWithBlock.20110413.html>
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn imp_implementationWithBlock(block: *mut objc_object) -> IMP;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn imp_removeBlock(imp: IMP) -> BOOL;
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn ivar_getName(ivar: *const objc_ivar) -> *const c_char;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn ivar_getOffset(ivar: *const objc_ivar) -> isize;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn ivar_getTypeEncoding(ivar: *const objc_ivar) -> *const c_char;
 
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     pub fn objc_copyClassNamesForImage(
         image: *const c_char,
         out_len: *mut c_uint,
     ) -> *mut *const c_char;
-    #[cfg(any(doc, apple))]
+    #[cfg(any(doc, feature = "apple"))]
     /// The returned array is deallocated with [`free`][crate::free].
     pub fn objc_copyImageNames(out_len: *mut c_uint) -> *mut *const c_char;
 
-    #[cfg(any(doc, apple, objfw))]
+    #[cfg(any(doc, feature = "apple", feature = "unstable-objfw"))]
     pub fn objc_setEnumerationMutationHandler(
         handler: Option<unsafe extern "C" fn(obj: *mut objc_object)>,
     );
 
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_getAssociatedObject(
         object: *const objc_object,
         key: *const c_void,
     ) -> *const objc_object;
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_setAssociatedObject(
         object: *mut objc_object,
         key: *const c_void,
         value: *mut objc_object,
         policy: objc_AssociationPolicy,
     );
-    #[cfg(any(doc, not(objfw)))]
+    #[cfg(any(doc, not(feature = "unstable-objfw")))]
     pub fn objc_removeAssociatedObjects(object: *mut objc_object);
 
-    #[cfg(any(doc, apple, objfw))]
+    #[cfg(any(doc, feature = "apple", feature = "unstable-objfw"))]
     pub fn objc_setForwardHandler(fwd: *mut c_void, fwd_stret: *mut c_void);
     // These two are defined in:
     // - Apple: objc-sync.h
@@ -112,9 +112,9 @@ extern_c! {
     // );
 
     // #[deprecated = "not recommended"]
-    // #[cfg(any(doc, apple))]
+    // #[cfg(any(doc, feature = "apple"))]
     // pub fn _objc_flush_caches
 
-    // #[cfg(any(doc, gnustep))]
+    // #[cfg(any(doc, feature = "gnustep-1-7"))]
     // objc_test_capability
 }

--- a/crates/objc-sys/src/various.rs
+++ b/crates/objc-sys/src/various.rs
@@ -27,12 +27,12 @@ type InnerImp = unsafe extern "C-unwind" fn();
 pub type IMP = Option<InnerImp>;
 
 // /// Remember that this is non-null!
-// #[cfg(any(doc, apple_new))]
+// #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
 // pub type objc_hook_getClass =
 //     unsafe extern "C" fn(name: *const c_char, out_cls: *mut *const crate::objc_class) -> BOOL;
 //
 // /// Remember that this is non-null!
-// #[cfg(any(doc, apple_new))]
+// #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
 // pub type objc_hook_lazyClassNamer =
 //     unsafe extern "C" fn(cls: *const crate::objc_class) -> *const c_char;
 
@@ -98,14 +98,14 @@ extern_c! {
 
     // Available in macOS 10.14.4
     // /// Remember that this is non-null!
-    // #[cfg(any(doc, apple_new))]
+    // #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     // pub fn objc_setHook_getClass(
     //     new_value: objc_hook_getClass,
     //     out_old_value: *mut objc_hook_getClass,
     // );
     // Available in macOS 11
     // /// Remember that this is non-null!
-    // #[cfg(any(doc, apple_new))]
+    // #[cfg(any(doc, all(feature = "apple", not(all(target_os = "macos", target_arch = "x86")))))]
     // pub fn objc_setHook_lazyClassNamer(
     //     new_value: objc_hook_lazyClassNamer,
     //     out_old_value: *mut objc_hook_lazyClassNamer,


### PR DESCRIPTION
Once https://github.com/rust-lang/rust/issues/80970 is in our MSRV, we should be able to completely remove the build script, so this is a step towards doing so.