### PR TITLE
New versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "iai",
  "malloc_buf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "objc2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.0"
+version = "4.0.1"
 
 [[package]]
 name = "objc2-event-kit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cc",
 ]

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.5.0 - 2024-04-17
+
 ### Added
 * **BREAKING**: Added `Block::copy` to convert blocks to `RcBlock`. This
   replaces `StackBlock::copy`, but since `StackBlock` implements `Deref`, this

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -54,7 +54,7 @@ unstable-private = []
 unstable-docsrs = []
 
 [dependencies]
-objc2 = { path = "../objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../objc2", version = "0.5.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/block2/src/lib.rs
+++ b/crates/block2/src/lib.rs
@@ -304,7 +304,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/block2/0.5.0")]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]
 

--- a/crates/header-translator/src/default_cargo.toml
+++ b/crates/header-translator/src/default_cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 
 [package.metadata.docs.rs]
 default-target = "UNSET"

--- a/crates/header-translator/src/library.rs
+++ b/crates/header-translator/src/library.rs
@@ -199,7 +199,7 @@ see that for related crates.", self.data.krate, self.link_name)?;
 
         for (krate, required) in &dependencies {
             let (path, version) = match *krate {
-                "block2" => ("../../crates/block2".to_string(), "0.4.0"),
+                "block2" => ("../../crates/block2".to_string(), "0.5.0"),
                 krate => (format!("../{krate}"), VERSION),
             };
             let mut table = InlineTable::from_iter([

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.3 - 2024-04-17
+
 ### Added
 * Added `free` method (same as `libc::free`).
 * Moved documentation from `README.md` to `docs.rs`.

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -5,7 +5,7 @@ name = "objc-sys"
 #
 # Also, beware of using pre-release versions here, since because of the
 # `links` key, two pre-releases requested with `=...` are incompatible.
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -169,7 +169,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.2")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.3")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(feature = "unstable-docsrs", feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(feature = "unstable-docsrs", doc(cfg_hide(doc)))]

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased - YYYY-MM-DD
 
 
+## 4.0.1 - 2024-04-17
+
+### Changed
+* Build documentation on docs.rs on more Apple platforms.
+
+
 ## 4.0.0 - 2023-12-03
 
 ### Changed

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -40,7 +40,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/4.0.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/4.0.1")]
 
 #[cfg(doctest)]
 #[doc = include_str!("../README.md")]

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.5.1 - 2024-04-17
+
 ### Added
 * Made the following runtime methods available without the `"malloc"` feature
   flag:

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -103,7 +103,7 @@ unstable-compiler-rt = ["apple"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "0.3.2", default-features = false }
+objc-sys = { path = "../objc-sys", version = "0.3.3", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "4.0.0", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -104,7 +104,7 @@ unstable-compiler-rt = ["apple"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.3", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "4.0.0", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "4.0.1", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.5.0" # Remember to update html_root_url in lib.rs
+version = "0.5.1" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -159,7 +159,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.5.1")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `NSWindow::convertRectToScreen` and `NSWindow::convertPointFromScreen` as
   safe.
 * Renamed the `block` and `objective-c` feature flags to `block2` and `objc2`.
+* **BREAKING**: Updated `block2` to `v0.5`.
 
 ### Deprecated
 * Deprecated `Foundation::MainThreadMarker::run_on_main`, use the new

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -77,11 +77,11 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            &mut objc2::rc::Id<T>
-            &mut std::option::Option<objc2::rc::Id<T>>
-            bool
             std::option::Option<&mut objc2::rc::Id<T>>
             std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+            bool
+            &mut std::option::Option<objc2::rc::Id<T>>
+            &mut objc2::rc::Id<T>
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -112,11 +112,11 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            &mut objc2::rc::Id<T>
-            &mut std::option::Option<objc2::rc::Id<T>>
-            bool
             std::option::Option<&mut objc2::rc::Id<T>>
             std::option::Option<&mut std::option::Option<objc2::rc::Id<T>>>
+            bool
+            &mut std::option::Option<objc2::rc::Id<T>>
+            &mut objc2::rc::Id<T>
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -26,6 +26,8 @@ all = [
     "objc2-foundation/NSDictionary",
     "objc2-foundation/NSValue",
     "objc2-foundation/NSObject",
+    "objc2-foundation/NSEnumerator",
+    "objc2-foundation/NSObjCRuntime",
 ]
 
 apple = ["block2/apple", "objc2/apple", "objc2-foundation/apple"]

--- a/framework-crates/objc2-accessibility/Cargo.toml
+++ b/framework-crates/objc2-accessibility/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-accessibility/Cargo.toml
+++ b/framework-crates/objc2-accessibility/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-ad-services/Cargo.toml
+++ b/framework-crates/objc2-ad-services/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-ad-support/Cargo.toml
+++ b/framework-crates/objc2-ad-support/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-app-kit/Cargo.modified.toml
+++ b/framework-crates/objc2-app-kit/Cargo.modified.toml
@@ -1,5 +1,5 @@
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 
 [features]

--- a/framework-crates/objc2-app-kit/Cargo.modified.toml
+++ b/framework-crates/objc2-app-kit/Cargo.modified.toml
@@ -1,6 +1,6 @@
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 
 [features]
 default = ["std", "apple"]

--- a/framework-crates/objc2-app-kit/Cargo.toml
+++ b/framework-crates/objc2-app-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 objc2-core-data = { path = "../objc2-core-data", version = "0.2.0", default-features = false, optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
 

--- a/framework-crates/objc2-app-kit/Cargo.toml
+++ b/framework-crates/objc2-app-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 objc2-core-data = { path = "../objc2-core-data", version = "0.2.0", default-features = false, optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }

--- a/framework-crates/objc2-authentication-services/Cargo.toml
+++ b/framework-crates/objc2-authentication-services/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0" }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-authentication-services/Cargo.toml
+++ b/framework-crates/objc2-authentication-services/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0" }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-automatic-assessment-configuration/Cargo.toml
+++ b/framework-crates/objc2-automatic-assessment-configuration/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-automator/Cargo.toml
+++ b/framework-crates/objc2-automator/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-osa-kit = { path = "../objc2-osa-kit", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-background-assets/Cargo.toml
+++ b/framework-crates/objc2-background-assets/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-background-assets/Cargo.toml
+++ b/framework-crates/objc2-background-assets/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-background-tasks/Cargo.toml
+++ b/framework-crates/objc2-background-tasks/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-background-tasks/Cargo.toml
+++ b/framework-crates/objc2-background-tasks/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-business-chat/Cargo.toml
+++ b/framework-crates/objc2-business-chat/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0" }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-call-kit/Cargo.toml
+++ b/framework-crates/objc2-call-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-call-kit/Cargo.toml
+++ b/framework-crates/objc2-call-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-class-kit/Cargo.toml
+++ b/framework-crates/objc2-class-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-class-kit/Cargo.toml
+++ b/framework-crates/objc2-class-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-cloud-kit/Cargo.toml
+++ b/framework-crates/objc2-cloud-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-cloud-kit/Cargo.toml
+++ b/framework-crates/objc2-cloud-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-contacts/Cargo.toml
+++ b/framework-crates/objc2-contacts/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-contacts/Cargo.toml
+++ b/framework-crates/objc2-contacts/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-core-data/Cargo.modified.toml
+++ b/framework-crates/objc2-core-data/Cargo.modified.toml
@@ -1,5 +1,5 @@
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 
 [features]

--- a/framework-crates/objc2-core-data/Cargo.modified.toml
+++ b/framework-crates/objc2-core-data/Cargo.modified.toml
@@ -1,6 +1,6 @@
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 
 [features]
 default = ["std", "apple"]

--- a/framework-crates/objc2-core-data/Cargo.toml
+++ b/framework-crates/objc2-core-data/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
 

--- a/framework-crates/objc2-core-data/Cargo.toml
+++ b/framework-crates/objc2-core-data/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-core-location/Cargo.toml
+++ b/framework-crates/objc2-core-location/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-core-location/Cargo.toml
+++ b/framework-crates/objc2-core-location/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-core-wlan/Cargo.toml
+++ b/framework-crates/objc2-core-wlan/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-data-detection/Cargo.toml
+++ b/framework-crates/objc2-data-detection/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-device-check/Cargo.toml
+++ b/framework-crates/objc2-device-check/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-device-check/Cargo.toml
+++ b/framework-crates/objc2-device-check/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-event-kit/Cargo.toml
+++ b/framework-crates/objc2-event-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-event-kit/Cargo.toml
+++ b/framework-crates/objc2-event-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-exception-handling/Cargo.toml
+++ b/framework-crates/objc2-exception-handling/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-extension-kit/Cargo.toml
+++ b/framework-crates/objc2-extension-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-external-accessory/Cargo.toml
+++ b/framework-crates/objc2-external-accessory/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-external-accessory/Cargo.toml
+++ b/framework-crates/objc2-external-accessory/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-file-provider-ui/Cargo.toml
+++ b/framework-crates/objc2-file-provider-ui/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-file-provider = { path = "../objc2-file-provider", version = "0.2.0" }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-file-provider-ui/Cargo.toml
+++ b/framework-crates/objc2-file-provider-ui/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-file-provider = { path = "../objc2-file-provider", version = "0.2.0" }

--- a/framework-crates/objc2-file-provider/Cargo.toml
+++ b/framework-crates/objc2-file-provider/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", optional = true }
 

--- a/framework-crates/objc2-file-provider/Cargo.toml
+++ b/framework-crates/objc2-file-provider/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-foundation/Cargo.modified.toml
+++ b/framework-crates/objc2-foundation/Cargo.modified.toml
@@ -1,6 +1,6 @@
 [dependencies]
 dispatch = { version = "0.2.0", optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/framework-crates/objc2-foundation/Cargo.modified.toml
+++ b/framework-crates/objc2-foundation/Cargo.modified.toml
@@ -1,7 +1,7 @@
 [dependencies]
 dispatch = { version = "0.2.0", optional = true }
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/framework-crates/objc2-foundation/Cargo.toml
+++ b/framework-crates/objc2-foundation/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-foundation/Cargo.toml
+++ b/framework-crates/objc2-foundation/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
 block2 = { path = "../../crates/block2", version = "0.4.0", default-features = false, optional = true }
 dispatch = { version = "0.2.0", optional = true }
 

--- a/framework-crates/objc2-foundation/src/tests/exception.rs
+++ b/framework-crates/objc2-foundation/src/tests/exception.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "NSException")]
 #![cfg(feature = "NSString")]
 #![cfg(feature = "NSDictionary")]
+#![cfg(feature = "NSObjCRuntime")]
 use alloc::format;
 
 use crate::Foundation::{NSException, NSObject, NSString};

--- a/framework-crates/objc2-foundation/src/tests/mutable_array.rs
+++ b/framework-crates/objc2-foundation/src/tests/mutable_array.rs
@@ -110,7 +110,7 @@ fn test_into_vec() {
 }
 
 #[test]
-#[cfg(feature = "NSString")]
+#[cfg(all(feature = "NSObjCRuntime", feature = "NSString"))]
 fn test_sort() {
     use Foundation::NSString;
 

--- a/framework-crates/objc2-foundation/src/tests/set.rs
+++ b/framework-crates/objc2-foundation/src/tests/set.rs
@@ -200,10 +200,10 @@ fn test_debug() {
 
 /// This currently works, but we should figure out a way to disallow it!
 #[test]
-#[cfg(all(feature = "NSArray", feature = "NSConnection"))]
+#[cfg(all(feature = "NSArray", feature = "NSCalendar"))]
 #[allow(deprecated)]
 fn invalid_generic() {
-    let something_interior_mutable = unsafe { Foundation::NSConnection::defaultConnection() };
+    let something_interior_mutable = unsafe { Foundation::NSCalendar::currentCalendar() };
     let set = NSSet::from_id_slice(&[Foundation::NSArray::from_id_slice(&[
         something_interior_mutable,
     ])]);

--- a/framework-crates/objc2-game-controller/Cargo.toml
+++ b/framework-crates/objc2-game-controller/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-game-controller/Cargo.toml
+++ b/framework-crates/objc2-game-controller/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-game-kit/Cargo.toml
+++ b/framework-crates/objc2-game-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-game-kit/Cargo.toml
+++ b/framework-crates/objc2-game-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-health-kit/Cargo.toml
+++ b/framework-crates/objc2-health-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-health-kit/Cargo.toml
+++ b/framework-crates/objc2-health-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-identity-lookup/Cargo.toml
+++ b/framework-crates/objc2-identity-lookup/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-identity-lookup/Cargo.toml
+++ b/framework-crates/objc2-identity-lookup/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-input-method-kit/Cargo.toml
+++ b/framework-crates/objc2-input-method-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-link-presentation/Cargo.toml
+++ b/framework-crates/objc2-link-presentation/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-link-presentation/Cargo.toml
+++ b/framework-crates/objc2-link-presentation/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
+++ b/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
+++ b/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-local-authentication = { path = "../objc2-local-authentication", version = "0.2.0" }

--- a/framework-crates/objc2-local-authentication/Cargo.toml
+++ b/framework-crates/objc2-local-authentication/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-local-authentication/Cargo.toml
+++ b/framework-crates/objc2-local-authentication/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-mail-kit/Cargo.toml
+++ b/framework-crates/objc2-mail-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-mail-kit/Cargo.toml
+++ b/framework-crates/objc2-mail-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-map-kit/Cargo.toml
+++ b/framework-crates/objc2-map-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-map-kit/Cargo.toml
+++ b/framework-crates/objc2-map-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-media-player/Cargo.toml
+++ b/framework-crates/objc2-media-player/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-media-player/Cargo.toml
+++ b/framework-crates/objc2-media-player/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-metal-fx/Cargo.toml
+++ b/framework-crates/objc2-metal-fx/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-metal = { path = "../objc2-metal", version = "0.2.0" }
 

--- a/framework-crates/objc2-metal-kit/Cargo.toml
+++ b/framework-crates/objc2-metal-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 objc2-metal = { path = "../objc2-metal", version = "0.2.0" }

--- a/framework-crates/objc2-metal-kit/Cargo.toml
+++ b/framework-crates/objc2-metal-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-metal/Cargo.toml
+++ b/framework-crates/objc2-metal/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-metal/Cargo.toml
+++ b/framework-crates/objc2-metal/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-metric-kit/Cargo.toml
+++ b/framework-crates/objc2-metric-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-osa-kit/Cargo.toml
+++ b/framework-crates/objc2-osa-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0" }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-photos/Cargo.toml
+++ b/framework-crates/objc2-photos/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }

--- a/framework-crates/objc2-photos/Cargo.toml
+++ b/framework-crates/objc2-photos/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-quartz-core/Cargo.toml
+++ b/framework-crates/objc2-quartz-core/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-quartz-core/Cargo.toml
+++ b/framework-crates/objc2-quartz-core/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-service-management/Cargo.toml
+++ b/framework-crates/objc2-service-management/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-service-management/Cargo.toml
+++ b/framework-crates/objc2-service-management/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-sound-analysis/Cargo.toml
+++ b/framework-crates/objc2-sound-analysis/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-sound-analysis/Cargo.toml
+++ b/framework-crates/objc2-sound-analysis/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-speech/Cargo.toml
+++ b/framework-crates/objc2-speech/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-speech/Cargo.toml
+++ b/framework-crates/objc2-speech/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-store-kit/Cargo.toml
+++ b/framework-crates/objc2-store-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-store-kit/Cargo.toml
+++ b/framework-crates/objc2-store-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
+++ b/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
+++ b/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-user-notifications/Cargo.toml
+++ b/framework-crates/objc2-user-notifications/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-user-notifications/Cargo.toml
+++ b/framework-crates/objc2-user-notifications/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/framework-crates/objc2-web-kit/Cargo.toml
+++ b/framework-crates/objc2-web-kit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 
 [dependencies]
 objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
-block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }
 

--- a/framework-crates/objc2-web-kit/Cargo.toml
+++ b/framework-crates/objc2-web-kit/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.0", default-features = false, features = ["apple"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false, features = ["apple"] }
 block2 = { path = "../../crates/block2", version = "0.4.0", optional = true }
 objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", optional = true }
 objc2-foundation = { path = "../objc2-foundation", version = "0.2.0" }

--- a/helper-scripts/test-local.sh
+++ b/helper-scripts/test-local.sh
@@ -1,17 +1,33 @@
 #!/bin/bash
 # A test script I use to test on my local devices
 
+set -euxo pipefail
+
+export CARGO_TARGET_DIR=$HOME/Desktop/objc2-target
 export MACOSX_DEPLOYMENT_TARGET=10.12
-export IPHONEOS_DEPLOYMENT_TARGET=10.0
-export FEATURES=std,block,exception,catch-all,unstable-static-class,unstable-static-sel
+export CRATES='--package=block2 --package=objc-sys --package=objc2 --package=objc2-encode --package=objc2-proc-macros --package=tests'
+export FRAMEWORKS_MACOS_10_13='--package=objc2-app-kit --package=objc2-automator --package=objc2-cloud-kit --package=objc2-contacts --package=objc2-core-data --package=objc2-core-wlan --package=objc2-event-kit --package=objc2-exception-handling --package=objc2-external-accessory --package=objc2-foundation --package=objc2-game-controller --package=objc2-game-kit --package=objc2-input-method-kit --package=objc2-local-authentication --package=objc2-map-kit --package=objc2-media-player --package=objc2-metal --package=objc2-metal-kit --package=objc2-osa-kit --package=objc2-quartz-core --package=objc2-service-management --package=objc2-store-kit --package=objc2-web-kit'
+export FRAMEWORKS_IOS_9='--package=objc2-foundation --package=objc2-metal'
+
+# Test on macOS 32bit
+export SDKROOT=$HOME/Desktop/MacOSX10.13.sdk
+cargo test $CRATES
+cargo test $CRATES --features=unstable-static-class,unstable-static-sel
+cargo test $CRATES $FRAMEWORKS_MACOS_10_13 --features=block2,exception,catch-all,all
+cargo test $CRATES --release
+cargo test -Zbuild-std --target=i686-apple-darwin $CRATES
+cargo test -Zbuild-std --target=i686-apple-darwin $CRATES $FRAMEWORKS_MACOS_10_13 --features=block2,exception,catch-all,all
+cargo test -Zbuild-std --target=i686-apple-darwin $CRATES --release
+unset SDKROOT
 
 # Start the simulator
 open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
 
 # Test on the simulator
-cargo dinghy --device sim test
-cargo dinghy --device sim test --features=$FEATURES
-cargo dinghy --device sim test --release
+IPHONEOS_DEPLOYMENT_TARGET=10.0 cargo dinghy --device sim test $CRATES
+IPHONEOS_DEPLOYMENT_TARGET=10.0 cargo dinghy --device sim test $CRATES --features=unstable-static-class,unstable-static-sel
+IPHONEOS_DEPLOYMENT_TARGET=10.0 cargo dinghy --device sim test $CRATES $FRAMEWORKS_IOS_9 --features=block2,exception,catch-all,all
+IPHONEOS_DEPLOYMENT_TARGET=10.0 cargo dinghy --device sim test $CRATES --release
 
 # Test on my iPad mini 1st generation iOS 9.3
 # Followed this guide to set it up:
@@ -19,13 +35,10 @@ cargo dinghy --device sim test --release
 #
 # We use build-std and earlier nightly because the target is armv7-apple-ios, which was removed in:
 # https://github.com/rust-lang/rust/pull/104385
-IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std
-IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std --features=$FEATURES
-IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std --release
-
-# Test on macOS 32bit
-export SDKROOT=(pwd)/ideas/MacOSX10.13.sdk
-export CARGO_BUILD_TARGET=i686-apple-darwin
-cargo +nightly test -Zbuild-std
-cargo +nightly test -Zbuild-std --features=$FEATURES
-cargo +nightly test -Zbuild-std --release
+#
+# Requires: `cargo install cargo-dinghy@0.6.8`
+export DINGHY_LOG=trace
+IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std $CRATES
+IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std $CRATES --features=unstable-static-class,unstable-static-sel
+IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std $CRATES $FRAMEWORKS_IOS_9 --features=block2,exception,catch-all,all
+IPHONEOS_DEPLOYMENT_TARGET=9.0 cargo +nightly-2023-09-23 dinghy --device ipad test -Zbuild-std $CRATES --release


### PR DESCRIPTION
- [x] The branch is named `new-versions`, such that the full CI will run.
- [x] Changelogs have only been modified under the `Unreleased` header.
- [x] Version numbers are bumped in the following order:
    - ~`objc2-proc-macros`~
    - `objc-sys`
    - `objc2-encode`
    - `objc2`
    - `block2`
    - Framework crates (not modified in this PR, set to `v0.2.0` in https://github.com/madsmtm/objc2/pull/592).
- Local tests have been run (see `helper-scripts/test-local.fish`):
    - [x] macOS 10.14.6 32bit
    - [x] iOS 9.3.6, 1st generation iPad Mini

Post merge:
- [x] Crates are published using `cargo publish` (or maybe `cargo release`?)
- [x] A tag is created on the merge commit for each new version.
- [x] `icrate` `v0.1.1` is published, deprecating the crate and linking to the new alternatives.
