### PR TITLE
clippy: Enable `semicolon_if_nothing_returned`

### DIFF
--- a/crates/objc2/benches/autorelease.rs
+++ b/crates/objc2/benches/autorelease.rs
@@ -10,7 +10,7 @@ const BYTES: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 fn empty() {}
 
 fn pool_cleanup() {
-    autoreleasepool(|_| {})
+    autoreleasepool(|_| {});
 }
 
 fn class() -> &'static AnyClass {

--- a/crates/objc2/src/rc/autorelease.rs
+++ b/crates/objc2/src/rc/autorelease.rs
@@ -76,7 +76,7 @@ impl Drop for Pool {
                 c.borrow_mut().pop(),
                 Some(self.context),
                 "popped pool that was not the innermost pool"
-            )
+            );
         });
     }
 }
@@ -187,7 +187,7 @@ impl<'pool> AutoreleasePool<'pool> {
                     c.borrow().last(),
                     Some(&pool.context),
                     "tried to use lifetime from pool that was not innermost"
-                )
+                );
             });
         }
     }

--- a/crates/objc2/src/rc/id_forwarding_impls.rs
+++ b/crates/objc2/src/rc/id_forwarding_impls.rs
@@ -69,7 +69,7 @@ impl<T: Ord + ?Sized> Ord for Id<T> {
 
 impl<T: hash::Hash + ?Sized> hash::Hash for Id<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        (**self).hash(state)
+        (**self).hash(state);
     }
 }
 
@@ -78,43 +78,43 @@ impl<T: hash::Hasher + ?Sized + IsMutable> hash::Hasher for Id<T> {
         (**self).finish()
     }
     fn write(&mut self, bytes: &[u8]) {
-        (**self).write(bytes)
+        (**self).write(bytes);
     }
     fn write_u8(&mut self, i: u8) {
-        (**self).write_u8(i)
+        (**self).write_u8(i);
     }
     fn write_u16(&mut self, i: u16) {
-        (**self).write_u16(i)
+        (**self).write_u16(i);
     }
     fn write_u32(&mut self, i: u32) {
-        (**self).write_u32(i)
+        (**self).write_u32(i);
     }
     fn write_u64(&mut self, i: u64) {
-        (**self).write_u64(i)
+        (**self).write_u64(i);
     }
     fn write_u128(&mut self, i: u128) {
-        (**self).write_u128(i)
+        (**self).write_u128(i);
     }
     fn write_usize(&mut self, i: usize) {
-        (**self).write_usize(i)
+        (**self).write_usize(i);
     }
     fn write_i8(&mut self, i: i8) {
-        (**self).write_i8(i)
+        (**self).write_i8(i);
     }
     fn write_i16(&mut self, i: i16) {
-        (**self).write_i16(i)
+        (**self).write_i16(i);
     }
     fn write_i32(&mut self, i: i32) {
-        (**self).write_i32(i)
+        (**self).write_i32(i);
     }
     fn write_i64(&mut self, i: i64) {
-        (**self).write_i64(i)
+        (**self).write_i64(i);
     }
     fn write_i128(&mut self, i: i128) {
-        (**self).write_i128(i)
+        (**self).write_i128(i);
     }
     fn write_isize(&mut self, i: isize) {
-        (**self).write_isize(i)
+        (**self).write_isize(i);
     }
 }
 
@@ -238,7 +238,7 @@ impl<T: io::BufRead + ?Sized + IsMutable> io::BufRead for Id<T> {
 
     #[inline]
     fn consume(&mut self, amt: usize) {
-        (**self).consume(amt)
+        (**self).consume(amt);
     }
 
     #[inline]

--- a/crates/objc2/src/runtime/declare.rs
+++ b/crates/objc2/src/runtime/declare.rs
@@ -260,7 +260,7 @@ impl ClassBuilder {
                 F::Arguments::ENCODINGS,
                 &F::Return::ENCODING_RETURN,
                 func.__imp(),
-            )
+            );
         }
     }
 
@@ -324,7 +324,7 @@ impl ClassBuilder {
                 F::Arguments::ENCODINGS,
                 &F::Return::ENCODING_RETURN,
                 func.__imp(),
-            )
+            );
         }
     }
 
@@ -525,7 +525,7 @@ impl ProtocolBuilder {
             &Ret::ENCODING_RETURN,
             required,
             true,
-        )
+        );
     }
 
     /// Adds a class method declaration with a given description.
@@ -540,7 +540,7 @@ impl ProtocolBuilder {
             &Ret::ENCODING_RETURN,
             required,
             false,
-        )
+        );
     }
 
     /// Adds a requirement on another protocol.

--- a/crates/objc2/src/runtime/method_encoding_iter.rs
+++ b/crates/objc2/src/runtime/method_encoding_iter.rs
@@ -104,7 +104,7 @@ impl From<ParseIntError> for EncodingParseError {
 impl fmt::Display for EncodingParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !matches!(self, Self::ParseError(_)) {
-            write!(f, "failed parsing encoding: ")?
+            write!(f, "failed parsing encoding: ")?;
         }
 
         match self {
@@ -114,10 +114,10 @@ impl fmt::Display for EncodingParseError {
             Self::MissingReceiver => write!(f, "receiver type must be present")?,
             Self::MissingSel => write!(f, "selector type must be present")?,
             Self::InvalidReceiver(enc) => {
-                write!(f, "receiver encoding must be '@', but it was '{enc}'")?
+                write!(f, "receiver encoding must be '@', but it was '{enc}'")?;
             }
             Self::InvalidSel(enc) => {
-                write!(f, "selector encoding must be '@', but it was '{enc}'")?
+                write!(f, "selector encoding must be '@', but it was '{enc}'")?;
             }
         }
         write!(f, ". This is likely a bug, please report it!")

--- a/crates/objc2/src/runtime/mod.rs
+++ b/crates/objc2/src/runtime/mod.rs
@@ -292,7 +292,7 @@ impl hash::Hash for Sel {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         // Note: We hash the name instead of the pointer
-        self.name().hash(state)
+        self.name().hash(state);
     }
 }
 

--- a/framework-crates/objc2-foundation/src/array.rs
+++ b/framework-crates/objc2-foundation/src/array.rs
@@ -498,7 +498,7 @@ impl<T: fmt::Debug + Message> fmt::Debug for NSMutableArray<T> {
 
 impl<T: Message> Extend<Id<T>> for NSMutableArray<T> {
     fn extend<I: IntoIterator<Item = Id<T>>>(&mut self, iter: I) {
-        iter.into_iter().for_each(move |item| self.push(item))
+        iter.into_iter().for_each(move |item| self.push(item));
     }
 }
 
@@ -507,7 +507,7 @@ impl<'a, T: Message + IsRetainable> Extend<&'a T> for NSMutableArray<T> {
         // SAFETY: Because of the `T: IsRetainable` bound, it is safe for the
         // array to retain the object here.
         iter.into_iter()
-            .for_each(move |item| unsafe { self.addObject(item) })
+            .for_each(move |item| unsafe { self.addObject(item) });
     }
 }
 

--- a/framework-crates/objc2-foundation/src/data.rs
+++ b/framework-crates/objc2-foundation/src/data.rs
@@ -118,7 +118,7 @@ impl NSMutableData {
     }
 
     pub fn push(&mut self, byte: u8) {
-        self.extend_from_slice(&[byte])
+        self.extend_from_slice(&[byte]);
     }
 
     #[doc(alias = "replaceBytesInRange:withBytes:length:")]

--- a/framework-crates/objc2-foundation/src/number.rs
+++ b/framework-crates/objc2-foundation/src/number.rs
@@ -211,7 +211,7 @@ impl NSNumber {
 impl hash::Hash for NSNumber {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        (**self).hash(state)
+        (**self).hash(state);
     }
 }
 

--- a/framework-crates/objc2-foundation/src/set.rs
+++ b/framework-crates/objc2-foundation/src/set.rs
@@ -567,7 +567,7 @@ impl<T: Message + Eq + Hash + HasStableHash> Extend<Id<T>> for NSMutableSet<T> {
     fn extend<I: IntoIterator<Item = Id<T>>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |item| {
             self.insert_id(item);
-        })
+        });
     }
 }
 
@@ -575,7 +575,7 @@ impl<'a, T: Message + Eq + Hash + HasStableHash + IsRetainable> Extend<&'a T> fo
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |item| {
             self.insert(item);
-        })
+        });
     }
 }
 

--- a/framework-crates/objc2-foundation/src/string.rs
+++ b/framework-crates/objc2-foundation/src/string.rs
@@ -223,7 +223,7 @@ impl Ord for NSMutableString {
 impl AddAssign<&NSString> for NSMutableString {
     #[inline]
     fn add_assign(&mut self, other: &NSString) {
-        self.appendString(other)
+        self.appendString(other);
     }
 }
 

--- a/framework-crates/objc2-foundation/src/tests/thread.rs
+++ b/framework-crates/objc2-foundation/src/tests/thread.rs
@@ -37,7 +37,7 @@ fn test_main_thread_auto_traits() {
 
     fn assert_traits<T: Unpin + UnwindSafe + RefUnwindSafe + Sized>() {}
 
-    assert_traits::<MainThreadMarker>()
+    assert_traits::<MainThreadMarker>();
 }
 
 #[test]

--- a/framework-crates/objc2-foundation/src/value.rs
+++ b/framework-crates/objc2-foundation/src/value.rs
@@ -160,7 +160,7 @@ impl NSValue {
 impl hash::Hash for NSValue {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        (**self).hash(state)
+        (**self).hash(state);
     }
 }
 


### PR DESCRIPTION
One part of this required a change other than semicolons to fix type inferencing in `crates/objc2/src/__macro_helpers/declared_ivars.rs`.
