### PR TITLE
New versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block2"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "objc2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-accessibility"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-accounts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-ad-services"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-ad-support"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-tracking-transparency"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-authentication-services"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-automatic-assessment-configuration"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "objc2",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-automator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-app-kit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-av-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-background-assets"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-background-tasks"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-business-chat"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-app-kit",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-call-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-class-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-contacts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-contacts-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-app-kit",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-bluetooth"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "objc2",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-data"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-image"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-location"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-ml"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-motion"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-wlan"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "objc2",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-data-detection"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-device-check"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -620,7 +620,7 @@ version = "4.0.2"
 
 [[package]]
 name = "objc2-event-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-exception-handling"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-extension-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-app-kit",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-external-accessory"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-file-provider"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-file-provider-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-finder-sync"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-game-controller"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-game-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-health-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-identity-lookup"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-input-method-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-app-kit",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-link-presentation"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-local-authentication"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-local-authentication-embedded-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-mail-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-map-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-media-player"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-metal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-metal-fx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-metal-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-metric-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "objc2",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-ml-compute"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-multipeer-connectivity"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-natural-language"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-nearby-interaction"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-network-extension"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "libc",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-osa-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "objc2",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-photos"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-photos-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -953,7 +953,7 @@ version = "0.1.2"
 
 [[package]]
 name = "objc2-quartz-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-screen-capture-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-sensitive-content-analysis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-service-management"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-social"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-sound-analysis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-speech"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-store-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-symbols"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-uniform-type-identifiers"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-user-notifications"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-virtualization"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-vision"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "objc2",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-web-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
  "block2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "objc2-event-kit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "block2",
  "core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "objc2-proc-macros"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "objc2-quartz-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ shared-version = true # Framework crates share a version number
 tag-prefix = "icrate"
 tag-name = "{{prefix}}-{{version}}"
 enable-features = ["all"]
+owners = ["madsmtm", "simlay"]

--- a/crates/block2/CHANGELOG.md
+++ b/crates/block2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.5.1 - 2024-05-21
+
 ### Deprecated
 * Deprecated the `apple` Cargo feature flag, it is assumed by default on Apple
   platforms.

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -49,7 +49,7 @@ unstable-objfw = []
 unstable-private = []
 
 [dependencies]
-objc2 = { path = "../objc2", version = "0.5.1", default-features = false }
+objc2 = { path = "../objc2", version = "0.5.2", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/crates/block2/Cargo.toml
+++ b/crates/block2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "block2"
 # Remember to update html_root_url in lib.rs
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/block2/src/lib.rs
+++ b/crates/block2/src/lib.rs
@@ -304,7 +304,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/block2/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/block2/0.5.1")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(doc)))]
 

--- a/crates/header-translator/src/lib.rs
+++ b/crates/header-translator/src/lib.rs
@@ -98,4 +98,4 @@ pub(crate) fn to_snake_case(input: impl AsRef<str>) -> String {
     }
 }
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.2.1";

--- a/crates/header-translator/src/library.rs
+++ b/crates/header-translator/src/library.rs
@@ -255,11 +255,11 @@ see that for related crates.", self.data.krate, self.link_name)?;
             let mut table = match *krate {
                 "objc2" => InlineTable::from_iter([
                     ("path", Value::from("../../crates/objc2".to_string())),
-                    ("version", Value::from("0.5.1")),
+                    ("version", Value::from("0.5.2")),
                 ]),
                 "block2" => InlineTable::from_iter([
                     ("path", Value::from("../../crates/block2".to_string())),
-                    ("version", Value::from("0.5.0")),
+                    ("version", Value::from("0.5.1")),
                 ]),
                 // Use a reasonably new version of libc
                 "libc" => InlineTable::from_iter([("version", Value::from("0.2.80"))]),

--- a/crates/objc-sys/CHANGELOG.md
+++ b/crates/objc-sys/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.3.4 - 2024-05-21
+
 ### Deprecated
 * Deprecated the `apple` Cargo feature flag, it is assumed by default on Apple
   platforms.

--- a/crates/objc-sys/Cargo.toml
+++ b/crates/objc-sys/Cargo.toml
@@ -5,7 +5,7 @@ name = "objc-sys"
 #
 # Also, beware of using pre-release versions here, since because of the
 # `links` key, two pre-releases requested with `=...` are incompatible.
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc-sys/src/lib.rs
+++ b/crates/objc-sys/src/lib.rs
@@ -169,7 +169,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.3")]
+#![doc(html_root_url = "https://docs.rs/objc-sys/0.3.4")]
 #![cfg_attr(feature = "unstable-c-unwind", feature(c_unwind))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(doc)))]

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+* Added `Encoding::None`, which represents encodings where the host compiler
+  (i.e. `clang`) couldn't generate an encoding for a given type.
+
+  This is useful when working with SIMD types.
+
 
 ## 4.0.1 - 2024-04-17
 

--- a/crates/objc2-encode/CHANGELOG.md
+++ b/crates/objc2-encode/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 4.0.2 - 2024-05-21
+
 ### Added
 * Added `Encoding::None`, which represents encodings where the host compiler
   (i.e. `clang`) couldn't generate an encoding for a given type.

--- a/crates/objc2-encode/Cargo.toml
+++ b/crates/objc2-encode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-encode"
 # Remember to update html_root_url in lib.rs
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-encode/src/lib.rs
+++ b/crates/objc2-encode/src/lib.rs
@@ -40,7 +40,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-encode/4.0.1")]
+#![doc(html_root_url = "https://docs.rs/objc2-encode/4.0.2")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("the `alloc` feature currently must be enabled");

--- a/crates/objc2-proc-macros/CHANGELOG.md
+++ b/crates/objc2-proc-macros/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.1.2 - 2024-05-21
+
 ### Deprecated
 * Deprecated the `apple` Cargo feature flag, it is assumed by default on Apple
   platforms.

--- a/crates/objc2-proc-macros/Cargo.toml
+++ b/crates/objc2-proc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "objc2-proc-macros"
 # Remember to update html_root_url in lib.rs
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Mads Marquart <mads@marquart.dk>", "Calvin Watford"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2-proc-macros/src/lib.rs
+++ b/crates/objc2-proc-macros/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-proc-macros/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/objc2-proc-macros/0.1.2")]
 
 use core::hash::{Hash, Hasher};
 

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.5.2 - 2024-05-21
+
 ### Added
 * Added `Retained::autorelease_ptr`.
 * Added the feature flag `"relax-sign-encoding"`, which when enabled, allows

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -114,7 +114,7 @@ unstable-compiler-rt = ["gnustep-1-7"]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.3", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "4.0.1", default-features = false }
-objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.1", optional = true }
+objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.2", optional = true }
 
 [dev-dependencies]
 iai = { version = "0.1", git = "https://github.com/madsmtm/iai", branch = "callgrind" }

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -113,7 +113,7 @@ unstable-compiler-rt = ["gnustep-1-7"]
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
 objc-sys = { path = "../objc-sys", version = "0.3.4", default-features = false }
-objc2-encode = { path = "../objc2-encode", version = "4.0.1", default-features = false }
+objc2-encode = { path = "../objc2-encode", version = "4.0.2", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.2", optional = true }
 
 [dev-dependencies]

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -112,7 +112,7 @@ unstable-compiler-rt = ["gnustep-1-7"]
 
 [dependencies]
 malloc_buf = { version = "1.0", optional = true }
-objc-sys = { path = "../objc-sys", version = "0.3.3", default-features = false }
+objc-sys = { path = "../objc-sys", version = "0.3.4", default-features = false }
 objc2-encode = { path = "../objc2-encode", version = "4.0.1", default-features = false }
 objc2-proc-macros = { path = "../objc2-proc-macros", version = "0.1.2", optional = true }
 

--- a/crates/objc2/Cargo.toml
+++ b/crates/objc2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objc2"
-version = "0.5.1" # Remember to update html_root_url in lib.rs
+version = "0.5.2" # Remember to update html_root_url in lib.rs
 authors = ["Steven Sheldon", "Mads Marquart <mads@marquart.dk>"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/objc2/src/__macro_helpers/msg_send_id.rs
+++ b/crates/objc2/src/__macro_helpers/msg_send_id.rs
@@ -1001,7 +1001,12 @@ mod tests {
         let mut expected = ThreadTestData::current();
 
         let cls = RcTestObject::class();
-        test_error_id!(expected, IF_AUTORELEASE_NOT_SKIPPED, idAndShouldError, cls);
+        test_error_id!(
+            expected,
+            IF_AUTORELEASE_NOT_SKIPPED_ARM_HACK,
+            idAndShouldError,
+            cls
+        );
         test_error_id!(expected, 0, newAndShouldError, cls);
 
         let obj = RcTestObject::new();

--- a/crates/objc2/src/lib.rs
+++ b/crates/objc2/src/lib.rs
@@ -157,7 +157,7 @@
 #![warn(clippy::missing_errors_doc)]
 #![warn(clippy::missing_panics_doc)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/objc2/0.5.2")]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -63,6 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   This improves iOS support, as crates like `objc2-app-kit` are no longer
   enabled on this platform.
+* Fix dependency feature flags (e.g. `block2`) not enabling the matching
+  features in dependencies (e.g. not enabling `objc2-foundation/block2`).
 
 ### Removed
 * `objc2-metal`: Removed internal `__MTLPackedFloat3` and made `MTLPackedFloat3` public.

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+
+## 0.2.1 - 2024-05-21
+
 ### Added
 * `NS_OPTIONS` enums are now `bitflags!`-style enums.
 

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -77,10 +77,10 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            std::option::Option<&mut objc2::rc::Retained<T>>
-            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
-            &mut std::option::Option<objc2::rc::Retained<T>>
             &mut objc2::rc::Retained<T>
+            &mut std::option::Option<objc2::rc::Retained<T>>
+            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
+            std::option::Option<&mut objc2::rc::Retained<T>>
             bool
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -112,10 +112,10 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            std::option::Option<&mut objc2::rc::Retained<T>>
-            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
-            &mut std::option::Option<objc2::rc::Retained<T>>
             &mut objc2::rc::Retained<T>
+            &mut std::option::Option<objc2::rc::Retained<T>>
+            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
+            std::option::Option<&mut objc2::rc::Retained<T>>
             bool
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/framework-crates/objc2-accessibility/Cargo.toml
+++ b/framework-crates/objc2-accessibility/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-accessibility"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Accessibility framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-accessibility/src/lib.rs
+++ b/framework-crates/objc2-accessibility/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-accessibility/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-accessibility/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-accounts/Cargo.toml
+++ b/framework-crates/objc2-accounts/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-accounts"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Accounts framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-accounts/src/lib.rs
+++ b/framework-crates/objc2-accounts/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-accounts/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-accounts/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-ad-services/Cargo.toml
+++ b/framework-crates/objc2-ad-services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-ad-services"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AdServices framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-ad-services/src/lib.rs
+++ b/framework-crates/objc2-ad-services/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-ad-services/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-ad-services/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-ad-support/Cargo.toml
+++ b/framework-crates/objc2-ad-support/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-ad-support"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AdSupport framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-ad-support/src/lib.rs
+++ b/framework-crates/objc2-ad-support/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-ad-support/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-ad-support/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-app-kit/Cargo.toml
+++ b/framework-crates/objc2-app-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-app-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AppKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,15 +22,15 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
 libc = { version = "0.2.80", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-objc2-core-data = { path = "../objc2-core-data", version = "0.2.0", default-features = false, optional = true }
-objc2-core-image = { path = "../objc2-core-image", version = "0.2.0", default-features = false, optional = true }
-objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.0", default-features = false, optional = true }
+objc2-core-data = { path = "../objc2-core-data", version = "0.2.1", default-features = false, optional = true }
+objc2-core-image = { path = "../objc2-core-image", version = "0.2.1", default-features = false, optional = true }
+objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-app-kit/src/lib.rs
+++ b/framework-crates/objc2-app-kit/src/lib.rs
@@ -36,7 +36,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-app-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-app-kit/0.2.1")]
 #![recursion_limit = "512"]
 #![allow(non_snake_case)]
 #![allow(unused_imports)]

--- a/framework-crates/objc2-app-tracking-transparency/Cargo.toml
+++ b/framework-crates/objc2-app-tracking-transparency/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-app-tracking-transparency"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AppTrackingTransparency framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-app-tracking-transparency/src/lib.rs
+++ b/framework-crates/objc2-app-tracking-transparency/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-app-tracking-transparency/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-app-tracking-transparency/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-authentication-services/Cargo.toml
+++ b/framework-crates/objc2-authentication-services/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-authentication-services"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AuthenticationServices framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-authentication-services/src/lib.rs
+++ b/framework-crates/objc2-authentication-services/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-authentication-services/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-authentication-services/0.2.1")]
 #![allow(unused_imports)]
 #![allow(dead_code)]
 

--- a/framework-crates/objc2-automatic-assessment-configuration/Cargo.toml
+++ b/framework-crates/objc2-automatic-assessment-configuration/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-automatic-assessment-configuration"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AutomaticAssessmentConfiguration framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,8 +22,8 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-automatic-assessment-configuration/src/lib.rs
+++ b/framework-crates/objc2-automatic-assessment-configuration/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-automatic-assessment-configuration/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-automatic-assessment-configuration/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-automator/Cargo.toml
+++ b/framework-crates/objc2-automator/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-automator"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Automator framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,10 +21,10 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-osa-kit = { path = "../objc2-osa-kit", version = "0.2.0", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-osa-kit = { path = "../objc2-osa-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-automator/src/lib.rs
+++ b/framework-crates/objc2-automator/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-automator/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-automator/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-av-kit/Cargo.toml
+++ b/framework-crates/objc2-av-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-av-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the AVKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-av-kit/src/lib.rs
+++ b/framework-crates/objc2-av-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-av-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-av-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-background-assets/Cargo.toml
+++ b/framework-crates/objc2-background-assets/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-background-assets"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the BackgroundAssets framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-background-assets/src/lib.rs
+++ b/framework-crates/objc2-background-assets/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-background-assets/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-background-assets/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-background-tasks/Cargo.toml
+++ b/framework-crates/objc2-background-tasks/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-background-tasks"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the BackgroundTasks framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-ios"

--- a/framework-crates/objc2-background-tasks/src/lib.rs
+++ b/framework-crates/objc2-background-tasks/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-background-tasks/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-background-tasks/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-business-chat/Cargo.toml
+++ b/framework-crates/objc2-business-chat/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-business-chat"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the BusinessChat framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,11 +21,11 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-business-chat/src/lib.rs
+++ b/framework-crates/objc2-business-chat/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-business-chat/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-business-chat/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-call-kit/Cargo.toml
+++ b/framework-crates/objc2-call-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-call-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CallKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-call-kit/src/lib.rs
+++ b/framework-crates/objc2-call-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-call-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-call-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-class-kit/Cargo.toml
+++ b/framework-crates/objc2-class-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-class-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ClassKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-class-kit/src/lib.rs
+++ b/framework-crates/objc2-class-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-class-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-class-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-cloud-kit/Cargo.toml
+++ b/framework-crates/objc2-cloud-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-cloud-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CloudKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-cloud-kit/src/lib.rs
+++ b/framework-crates/objc2-cloud-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-cloud-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-cloud-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-contacts-ui/Cargo.toml
+++ b/framework-crates/objc2-contacts-ui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-contacts-ui"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ContactsUI framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,12 +21,12 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-contacts = { path = "../objc2-contacts", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-contacts-ui/src/lib.rs
+++ b/framework-crates/objc2-contacts-ui/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-contacts-ui/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-contacts-ui/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-contacts/Cargo.toml
+++ b/framework-crates/objc2-contacts/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-contacts"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Contacts framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-contacts/src/lib.rs
+++ b/framework-crates/objc2-contacts/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-contacts/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-contacts/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-bluetooth/Cargo.toml
+++ b/framework-crates/objc2-core-bluetooth/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-bluetooth"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreBluetooth framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,8 +22,8 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-bluetooth/src/lib.rs
+++ b/framework-crates/objc2-core-bluetooth/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-bluetooth/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-bluetooth/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-data/Cargo.toml
+++ b/framework-crates/objc2-core-data/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-data"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreData framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-data/src/lib.rs
+++ b/framework-crates/objc2-core-data/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-data/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-data/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-image/Cargo.toml
+++ b/framework-crates/objc2-core-image/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-image"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreImage framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,10 +21,10 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-image/src/lib.rs
+++ b/framework-crates/objc2-core-image/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-image/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-image/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-location/Cargo.toml
+++ b/framework-crates/objc2-core-location/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-location"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreLocation framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,12 +21,12 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(not(target_os = "tvos"))'.dependencies]
-objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", default-features = false, optional = true }
+objc2-contacts = { path = "../objc2-contacts", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-location/src/lib.rs
+++ b/framework-crates/objc2-core-location/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-location/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-location/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-ml/Cargo.toml
+++ b/framework-crates/objc2-core-ml/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-ml"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreML framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(not(target_os = "watchos"))'.dependencies]
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false, optional = true }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-ml/src/lib.rs
+++ b/framework-crates/objc2-core-ml/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-ml/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-ml/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-motion/Cargo.toml
+++ b/framework-crates/objc2-core-motion/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-motion"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreMotion framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-motion/src/lib.rs
+++ b/framework-crates/objc2-core-motion/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-motion/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-motion/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-core-wlan/Cargo.toml
+++ b/framework-crates/objc2-core-wlan/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-core-wlan"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the CoreWLAN framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,8 +22,8 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-core-wlan/src/lib.rs
+++ b/framework-crates/objc2-core-wlan/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-core-wlan/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-core-wlan/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-data-detection/Cargo.toml
+++ b/framework-crates/objc2-data-detection/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-data-detection"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the DataDetection framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-data-detection/src/lib.rs
+++ b/framework-crates/objc2-data-detection/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-data-detection/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-data-detection/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-device-check/Cargo.toml
+++ b/framework-crates/objc2-device-check/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-device-check"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the DeviceCheck framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-device-check/src/lib.rs
+++ b/framework-crates/objc2-device-check/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-device-check/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-device-check/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-event-kit/Cargo.toml
+++ b/framework-crates/objc2-event-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-event-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the EventKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,14 +22,14 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-map-kit = { path = "../objc2-map-kit", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-map-kit = { path = "../objc2-map-kit", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-event-kit/src/lib.rs
+++ b/framework-crates/objc2-event-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-event-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-event-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-exception-handling/Cargo.toml
+++ b/framework-crates/objc2-exception-handling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-exception-handling"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ExceptionHandling framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-exception-handling/src/lib.rs
+++ b/framework-crates/objc2-exception-handling/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-exception-handling/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-exception-handling/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-extension-kit/Cargo.toml
+++ b/framework-crates/objc2-extension-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-extension-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ExtensionKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,11 +21,11 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-extension-kit/src/lib.rs
+++ b/framework-crates/objc2-extension-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-extension-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-extension-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-external-accessory/Cargo.toml
+++ b/framework-crates/objc2-external-accessory/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-external-accessory"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ExternalAccessory framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-external-accessory/src/lib.rs
+++ b/framework-crates/objc2-external-accessory/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-external-accessory/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-external-accessory/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-file-provider-ui/Cargo.toml
+++ b/framework-crates/objc2-file-provider-ui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-file-provider-ui"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the FileProviderUI framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,13 +21,13 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-file-provider = { path = "../objc2-file-provider", version = "0.2.0", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-file-provider = { path = "../objc2-file-provider", version = "0.2.1", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-file-provider-ui/src/lib.rs
+++ b/framework-crates/objc2-file-provider-ui/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-file-provider-ui/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-file-provider-ui/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-file-provider/Cargo.toml
+++ b/framework-crates/objc2-file-provider/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-file-provider"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the FileProvider framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-file-provider/src/lib.rs
+++ b/framework-crates/objc2-file-provider/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-file-provider/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-file-provider/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-finder-sync/Cargo.toml
+++ b/framework-crates/objc2-finder-sync/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-finder-sync"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the FinderSync framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,10 +21,10 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true, features = ["NSImage", "NSMenu"] }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false, features = ["NSArray", "NSData", "NSDate", "NSDictionary", "NSError", "NSExtensionContext", "NSExtensionRequestHandling", "NSFileManager", "NSSet", "NSString", "NSURL", "NSXPCConnection"] }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true, features = ["NSImage", "NSMenu"] }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false, features = ["NSArray", "NSData", "NSDate", "NSDictionary", "NSError", "NSExtensionContext", "NSExtensionRequestHandling", "NSFileManager", "NSSet", "NSString", "NSURL", "NSXPCConnection"] }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-finder-sync/src/lib.rs
+++ b/framework-crates/objc2-finder-sync/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-finder-sync/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-finder-sync/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-foundation/Cargo.toml
+++ b/framework-crates/objc2-foundation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-foundation"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Foundation framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
 libc = { version = "0.2.80", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
 dispatch = { version = "0.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/framework-crates/objc2-foundation/src/lib.rs
+++ b/framework-crates/objc2-foundation/src/lib.rs
@@ -65,7 +65,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-foundation/0.2.1")]
 #![allow(non_snake_case)]
 #![recursion_limit = "256"]
 

--- a/framework-crates/objc2-game-controller/Cargo.toml
+++ b/framework-crates/objc2-game-controller/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-game-controller"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the GameController framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-game-controller/src/lib.rs
+++ b/framework-crates/objc2-game-controller/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-game-controller/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-game-controller/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-game-kit/Cargo.toml
+++ b/framework-crates/objc2-game-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-game-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the GameKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,12 +21,12 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-game-kit/src/lib.rs
+++ b/framework-crates/objc2-game-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-game-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-game-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-health-kit/Cargo.toml
+++ b/framework-crates/objc2-health-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-health-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the HealthKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,11 +22,11 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-health-kit/src/lib.rs
+++ b/framework-crates/objc2-health-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-health-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-health-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-identity-lookup/Cargo.toml
+++ b/framework-crates/objc2-identity-lookup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-identity-lookup"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the IdentityLookup framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-identity-lookup/src/lib.rs
+++ b/framework-crates/objc2-identity-lookup/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-identity-lookup/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-identity-lookup/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-input-method-kit/Cargo.toml
+++ b/framework-crates/objc2-input-method-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-input-method-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the InputMethodKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-input-method-kit/src/lib.rs
+++ b/framework-crates/objc2-input-method-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-input-method-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-input-method-kit/0.2.1")]
 #![allow(non_upper_case_globals)]
 
 #[cfg(feature = "alloc")]

--- a/framework-crates/objc2-link-presentation/Cargo.toml
+++ b/framework-crates/objc2-link-presentation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-link-presentation"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the LinkPresentation framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,12 +21,12 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-link-presentation/src/lib.rs
+++ b/framework-crates/objc2-link-presentation/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-link-presentation/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-link-presentation/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
+++ b/framework-crates/objc2-local-authentication-embedded-ui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-local-authentication-embedded-ui"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the LocalAuthenticationEmbeddedUI framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,13 +21,13 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-local-authentication = { path = "../objc2-local-authentication", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-local-authentication = { path = "../objc2-local-authentication", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-local-authentication-embedded-ui/src/lib.rs
+++ b/framework-crates/objc2-local-authentication-embedded-ui/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-local-authentication-embedded-ui/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-local-authentication-embedded-ui/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-local-authentication/Cargo.toml
+++ b/framework-crates/objc2-local-authentication/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-local-authentication"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the LocalAuthentication framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-local-authentication/src/lib.rs
+++ b/framework-crates/objc2-local-authentication/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-local-authentication/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-local-authentication/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-mail-kit/Cargo.toml
+++ b/framework-crates/objc2-mail-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-mail-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MailKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,10 +21,10 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-mail-kit/src/lib.rs
+++ b/framework-crates/objc2-mail-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-mail-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-mail-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-map-kit/Cargo.toml
+++ b/framework-crates/objc2-map-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-map-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MapKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,16 +22,16 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(not(target_os = "tvos"))'.dependencies]
-objc2-contacts = { path = "../objc2-contacts", version = "0.2.0", default-features = false, optional = true }
+objc2-contacts = { path = "../objc2-contacts", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-map-kit/src/lib.rs
+++ b/framework-crates/objc2-map-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-map-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-map-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-media-player/Cargo.toml
+++ b/framework-crates/objc2-media-player/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-media-player"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MediaPlayer framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-media-player/src/lib.rs
+++ b/framework-crates/objc2-media-player/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-media-player/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-media-player/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-metal-fx/Cargo.toml
+++ b/framework-crates/objc2-metal-fx/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-metal-fx"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MetalFX framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-metal-fx/src/lib.rs
+++ b/framework-crates/objc2-metal-fx/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-metal-fx/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-metal-fx/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-metal-kit/Cargo.toml
+++ b/framework-crates/objc2-metal-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-metal-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MetalKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,14 +21,14 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false }
-objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false }
+objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-metal-kit/src/lib.rs
+++ b/framework-crates/objc2-metal-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-metal-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-metal-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-metal/Cargo.toml
+++ b/framework-crates/objc2-metal/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-metal"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Metal framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-metal/src/lib.rs
+++ b/framework-crates/objc2-metal/src/lib.rs
@@ -37,7 +37,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-metal/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-metal/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-metric-kit/Cargo.toml
+++ b/framework-crates/objc2-metric-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-metric-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MetricKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,8 +22,8 @@ workspace = true
 
 [dependencies]
 libc = { version = "0.2.80", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-metric-kit/src/lib.rs
+++ b/framework-crates/objc2-metric-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-metric-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-metric-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-ml-compute/Cargo.toml
+++ b/framework-crates/objc2-ml-compute/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-ml-compute"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MLCompute framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-ml-compute/src/lib.rs
+++ b/framework-crates/objc2-ml-compute/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-ml-compute/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-ml-compute/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-multipeer-connectivity/Cargo.toml
+++ b/framework-crates/objc2-multipeer-connectivity/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-multipeer-connectivity"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the MultipeerConnectivity framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,12 +21,12 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-multipeer-connectivity/src/lib.rs
+++ b/framework-crates/objc2-multipeer-connectivity/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-multipeer-connectivity/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-multipeer-connectivity/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-natural-language/Cargo.toml
+++ b/framework-crates/objc2-natural-language/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-natural-language"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the NaturalLanguage framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-natural-language/src/lib.rs
+++ b/framework-crates/objc2-natural-language/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-natural-language/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-natural-language/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-nearby-interaction/Cargo.toml
+++ b/framework-crates/objc2-nearby-interaction/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-nearby-interaction"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the NearbyInteraction framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-nearby-interaction/src/lib.rs
+++ b/framework-crates/objc2-nearby-interaction/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-nearby-interaction/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-nearby-interaction/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-network-extension/Cargo.toml
+++ b/framework-crates/objc2-network-extension/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-network-extension"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the NetworkExtension framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,10 +21,10 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
 libc = { version = "0.2.80", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-network-extension/src/lib.rs
+++ b/framework-crates/objc2-network-extension/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-network-extension/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-network-extension/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-osa-kit/Cargo.toml
+++ b/framework-crates/objc2-osa-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-osa-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the OSAKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,9 +22,9 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-osa-kit/src/lib.rs
+++ b/framework-crates/objc2-osa-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-osa-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-osa-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-photos-ui/Cargo.toml
+++ b/framework-crates/objc2-photos-ui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-photos-ui"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the PhotosUI framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,15 +22,15 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-map-kit = { path = "../objc2-map-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-photos = { path = "../objc2-photos", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-map-kit = { path = "../objc2-map-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-photos = { path = "../objc2-photos", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-photos-ui/src/lib.rs
+++ b/framework-crates/objc2-photos-ui/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-photos-ui/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-photos-ui/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-photos/Cargo.toml
+++ b/framework-crates/objc2-photos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-photos"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Photos/PhotoKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,17 +22,17 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(not(target_os = "watchos"))'.dependencies]
-objc2-core-image = { path = "../objc2-core-image", version = "0.2.0", default-features = false, optional = true }
+objc2-core-image = { path = "../objc2-core-image", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-photos/src/lib.rs
+++ b/framework-crates/objc2-photos/src/lib.rs
@@ -10,7 +10,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-photos/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-photos/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-quartz-core/Cargo.toml
+++ b/framework-crates/objc2-quartz-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-quartz-core"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the QuartzCore/CoreAnimation framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-metal = { path = "../objc2-metal", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-metal = { path = "../objc2-metal", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-quartz-core/src/lib.rs
+++ b/framework-crates/objc2-quartz-core/src/lib.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-quartz-core/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-quartz-core/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-screen-capture-kit/Cargo.toml
+++ b/framework-crates/objc2-screen-capture-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-screen-capture-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ScreenCaptureKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
 libc = { version = "0.2.80", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-screen-capture-kit/src/lib.rs
+++ b/framework-crates/objc2-screen-capture-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-screen-capture-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-screen-capture-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-sensitive-content-analysis/Cargo.toml
+++ b/framework-crates/objc2-sensitive-content-analysis/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-sensitive-content-analysis"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the SensitiveContentAnalysis framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-sensitive-content-analysis/src/lib.rs
+++ b/framework-crates/objc2-sensitive-content-analysis/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-sensitive-content-analysis/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-sensitive-content-analysis/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-service-management/Cargo.toml
+++ b/framework-crates/objc2-service-management/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-service-management"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the ServiceManagement framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-service-management/src/lib.rs
+++ b/framework-crates/objc2-service-management/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-service-management/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-service-management/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-social/Cargo.toml
+++ b/framework-crates/objc2-social/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-social"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Social framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,13 +21,13 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-accounts = { path = "../objc2-accounts", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-accounts = { path = "../objc2-accounts", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-social/src/lib.rs
+++ b/framework-crates/objc2-social/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-social/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-social/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-sound-analysis/Cargo.toml
+++ b/framework-crates/objc2-sound-analysis/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-sound-analysis"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the SoundAnalysis framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-sound-analysis/src/lib.rs
+++ b/framework-crates/objc2-sound-analysis/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-sound-analysis/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-sound-analysis/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-speech/Cargo.toml
+++ b/framework-crates/objc2-speech/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-speech"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Speech framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-speech/src/lib.rs
+++ b/framework-crates/objc2-speech/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-speech/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-speech/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-store-kit/Cargo.toml
+++ b/framework-crates/objc2-store-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-store-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the StoreKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-store-kit/src/lib.rs
+++ b/framework-crates/objc2-store-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-store-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-store-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-symbols/Cargo.toml
+++ b/framework-crates/objc2-symbols/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-symbols"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Symbols framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,8 +21,8 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-symbols/src/lib.rs
+++ b/framework-crates/objc2-symbols/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-symbols/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-symbols/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-ui-kit/Cargo.toml
+++ b/framework-crates/objc2-ui-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-ui-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the UIKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,20 +22,20 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-cloud-kit = { path = "../objc2-cloud-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-core-data = { path = "../objc2-core-data", version = "0.2.0", default-features = false, optional = true }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
-objc2-symbols = { path = "../objc2-symbols", version = "0.2.0", default-features = false, optional = true }
-objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.0", default-features = false, optional = true }
-objc2-user-notifications = { path = "../objc2-user-notifications", version = "0.2.0", default-features = false, optional = true }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-cloud-kit = { path = "../objc2-cloud-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-core-data = { path = "../objc2-core-data", version = "0.2.1", default-features = false, optional = true }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
+objc2-symbols = { path = "../objc2-symbols", version = "0.2.1", default-features = false, optional = true }
+objc2-uniform-type-identifiers = { path = "../objc2-uniform-type-identifiers", version = "0.2.1", default-features = false, optional = true }
+objc2-user-notifications = { path = "../objc2-user-notifications", version = "0.2.1", default-features = false, optional = true }
 
 [target.'cfg(not(target_os = "watchos"))'.dependencies]
-objc2-core-image = { path = "../objc2-core-image", version = "0.2.0", default-features = false, optional = true }
-objc2-link-presentation = { path = "../objc2-link-presentation", version = "0.2.0", default-features = false, optional = true }
-objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.0", default-features = false, optional = true }
+objc2-core-image = { path = "../objc2-core-image", version = "0.2.1", default-features = false, optional = true }
+objc2-link-presentation = { path = "../objc2-link-presentation", version = "0.2.1", default-features = false, optional = true }
+objc2-quartz-core = { path = "../objc2-quartz-core", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-ios"

--- a/framework-crates/objc2-ui-kit/src/lib.rs
+++ b/framework-crates/objc2-ui-kit/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-ui-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-ui-kit/0.2.1")]
 #![recursion_limit = "256"]
 
 #[cfg(feature = "alloc")]

--- a/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
+++ b/framework-crates/objc2-uniform-type-identifiers/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-uniform-type-identifiers"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the UniformTypeIdentifiers framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,9 +21,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-uniform-type-identifiers/src/lib.rs
+++ b/framework-crates/objc2-uniform-type-identifiers/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-uniform-type-identifiers/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-uniform-type-identifiers/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-user-notifications/Cargo.toml
+++ b/framework-crates/objc2-user-notifications/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-user-notifications"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the UserNotifications framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-location = { path = "../objc2-core-location", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-location = { path = "../objc2-core-location", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-user-notifications/src/lib.rs
+++ b/framework-crates/objc2-user-notifications/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-user-notifications/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-user-notifications/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-virtualization/Cargo.toml
+++ b/framework-crates/objc2-virtualization/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-virtualization"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Virtualization framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,10 +22,10 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-virtualization/src/lib.rs
+++ b/framework-crates/objc2-virtualization/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-virtualization/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-virtualization/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-vision/Cargo.toml
+++ b/framework-crates/objc2-vision/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-vision"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the Vision framework"
 edition = "2021"
 rust-version = "1.60"
@@ -21,11 +21,11 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-core-image = { path = "../objc2-core-image", version = "0.2.0", default-features = false, optional = true }
-objc2-core-ml = { path = "../objc2-core-ml", version = "0.2.0", default-features = false, optional = true }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-core-image = { path = "../objc2-core-image", version = "0.2.1", default-features = false, optional = true }
+objc2-core-ml = { path = "../objc2-core-ml", version = "0.2.1", default-features = false, optional = true }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-vision/src/lib.rs
+++ b/framework-crates/objc2-vision/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-vision/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-vision/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/framework-crates/objc2-web-kit/Cargo.toml
+++ b/framework-crates/objc2-web-kit/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "objc2-web-kit"
-version = "0.2.0" # Remember to update html_root_url in lib.rs
+version = "0.2.1" # Remember to update html_root_url in lib.rs
 description = "Bindings to the WebKit framework"
 edition = "2021"
 rust-version = "1.60"
@@ -22,12 +22,12 @@ workspace = true
 
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true }
-block2 = { path = "../../crates/block2", version = "0.5.0", default-features = false, optional = true }
-objc2 = { path = "../../crates/objc2", version = "0.5.1", default-features = false }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.0", default-features = false }
+block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.1", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.0", default-features = false, optional = true }
+objc2-app-kit = { path = "../objc2-app-kit", version = "0.2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"

--- a/framework-crates/objc2-web-kit/src/lib.rs
+++ b/framework-crates/objc2-web-kit/src/lib.rs
@@ -16,7 +16,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/objc2-web-kit/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/objc2-web-kit/0.2.1")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
Release checklist:
- [x] The branch is named `new-versions`, such that the full CI will run.
- [x] Changelogs have only been modified under the `Unreleased` header.
- [x] Version numbers are bumped in the following order:
    - `objc2-proc-macros`
    - `objc-sys`
    - `objc2-encode`
    - `objc2`
    - `block2`
    - Framework crates
- Local tests have been run (see `helper-scripts/test-local.fish`):
    - [x] macOS 10.14.6 32bit
    - [x] iOS 9.3.6, 1st generation iPad Mini

Post merge:
- [ ] A tag is created on the merge commit for each new version.
