### PR TITLE
Improve documentation and usage of `-[NSString UTF8String]`

### DIFF
--- a/crates/objc2/src/runtime/__nsstring.rs
+++ b/crates/objc2/src/runtime/__nsstring.rs
@@ -29,9 +29,19 @@ pub unsafe fn nsstring_len(obj: &NSObject) -> NSUInteger {
 
 /// Extract a [`str`](`prim@str`) representation out of the given NSString.
 ///
+/// Uses [`UTF8String`] under the hood.
+///
+/// [`UTF8String`]: https://developer.apple.com/documentation/foundation/nsstring/1411189-utf8string?language=objc
+///
+///
 /// # Safety
 ///
-/// The object must be an instance of `NSString`.
+/// - The object must be an instance of `NSString`.
+/// - The returned string must not be moved outside the autorelease pool into
+///   which it (may) have been released.
+///
+/// Furthermore, the object must not, as is always the case for strings, be
+/// mutated in parallel.
 //
 // Note: While this is not public, it is still a breaking change to modify,
 // since `objc2-foundation` relies on it.
@@ -42,21 +52,33 @@ pub unsafe fn nsstring_to_str<'r, 's: 'r, 'p: 'r>(
     // This is necessary until `auto` types stabilizes.
     pool.__verify_is_inner();
 
-    // The documentation on `UTF8String` is a bit sparse, but with
-    // educated guesses and testing I've determined that NSString stores
-    // a pointer to the string data, sometimes with an UTF-8 encoding,
-    // (usual for ascii data), sometimes in other encodings (UTF-16?).
+    // The documentation on `UTF8String` is quite sparse, but with educated
+    // guesses, testing, reading the code for `CFString` and a bit of
+    // reverse-engineering, we've determined that `NSString` stores a pointer
+    // to the string data, sometimes with an UTF-8 encoding (usual for ascii
+    // data), sometimes in other encodings (often UTF-16).
     //
     // `UTF8String` then checks the internal encoding:
-    // - If the data is UTF-8 encoded, it returns the internal pointer.
-    // - If the data is in another encoding, it creates a new allocation,
-    //   writes the UTF-8 representation of the string into it,
-    //   autoreleases the allocation and returns a pointer to it.
+    // - If the data is UTF-8 encoded, and (since macOS 10.6) if the string is
+    //   immutable, it returns the internal pointer using
+    //   `CFStringGetCStringPtr`.
+    // - Otherwise, if the data is in another encoding or is mutable, it
+    //   creates a new allocation, writes the UTF-8 representation of the
+    //   string into it, autoreleases the allocation, and returns a pointer to
+    //   it (similar to `CFStringGetCString`).
     //
-    // So the lifetime of the returned pointer is either the same as the
-    // NSString OR the lifetime of the innermost @autoreleasepool.
+    // If the string is a tagged pointer, or a custom subclass, then another
+    // code-path is taken that always creates a new allocation and copies the
+    // string into that using (effectively) `length` and `characterAtIndex:`.
     //
-    // https://developer.apple.com/documentation/foundation/nsstring/1411189-utf8string?language=objc
+    // As a result, the lifetime of the returned pointer is either the same as
+    // the passed-in `NSString` OR the lifetime of the current / innermost
+    // `@autoreleasepool`.
+    //
+    // Furthermore, we can allow creating a `&str` from `&obj`, even if the
+    // string is originally a `NSMutableString` which may be mutated later on,
+    // since in that case the lifetime will be tied to the pool and not the
+    // string.
     let bytes: *const c_char = unsafe { msg_send![obj, UTF8String] };
     let bytes: *const u8 = bytes.cast();
 

--- a/framework-crates/objc2-foundation/examples/basic_usage.rs
+++ b/framework-crates/objc2-foundation/examples/basic_usage.rs
@@ -1,4 +1,3 @@
-use objc2::rc::autoreleasepool;
 use objc2_foundation::{ns_string, NSArray, NSDictionary, NSObject};
 
 fn main() {
@@ -26,13 +25,10 @@ fn main() {
 
     // Create a static NSString
     let string = ns_string!("Hello, world!");
-    // Use an autoreleasepool to get the `str` contents of the NSString
-    autoreleasepool(|pool| {
-        println!("{}", string.as_str(pool));
-    });
-    // Or use the `Display` implementation
-    let _s = string.to_string(); // Using ToString
-    println!("{string}"); // Or Display directly
+    // And use the `ToString` implementation to convert it into a string
+    let _s = string.to_string();
+    // Or use the `Display` implementation directly
+    println!("{string}");
 
     // Create a dictionary mapping strings to objects
     let keys = &[string];

--- a/framework-crates/objc2-foundation/src/tests/dictionary.rs
+++ b/framework-crates/objc2-foundation/src/tests/dictionary.rs
@@ -1,11 +1,12 @@
 #![cfg(feature = "NSDictionary")]
 #![cfg(feature = "NSString")]
 #![cfg(feature = "NSObject")]
+use alloc::string::ToString;
 use alloc::{format, vec};
 
-use objc2::rc::{autoreleasepool, Retained};
+use objc2::rc::Retained;
 
-use crate::Foundation::{NSDictionary, NSObject, NSString};
+use crate::{NSDictionary, NSObject, NSString};
 
 fn sample_dict(key: &str) -> Retained<NSDictionary<NSString, NSObject>> {
     let string = NSString::from_str(key);
@@ -36,9 +37,7 @@ fn test_keys() {
     let keys = dict.keys_vec();
 
     assert_eq!(keys.len(), 1);
-    autoreleasepool(|pool| {
-        assert_eq!(keys[0].as_str(pool), "abcd");
-    });
+    assert_eq!(keys[0].to_string(), "abcd");
 }
 
 #[test]
@@ -56,9 +55,7 @@ fn test_keys_and_objects() {
 
     assert_eq!(keys.len(), 1);
     assert_eq!(objs.len(), 1);
-    autoreleasepool(|pool| {
-        assert_eq!(keys[0].as_str(pool), "abcd");
-    });
+    assert_eq!(keys[0].to_string(), "abcd");
     assert_eq!(objs[0], dict.get(keys[0]).unwrap());
 }
 
@@ -67,9 +64,7 @@ fn test_keys_and_objects() {
 fn test_iter_keys() {
     let dict = sample_dict("abcd");
     assert_eq!(dict.keys().count(), 1);
-    autoreleasepool(|pool| {
-        assert_eq!(dict.keys().next().unwrap().as_str(pool), "abcd");
-    });
+    assert_eq!(dict.keys().next().unwrap().to_string(), "abcd");
 }
 
 #[test]
@@ -86,9 +81,7 @@ fn test_arrays() {
 
     let keys = unsafe { dict.allKeys() };
     assert_eq!(keys.len(), 1);
-    autoreleasepool(|pool| {
-        assert_eq!(keys[0].as_str(pool), "abcd");
-    });
+    assert_eq!(keys[0].to_string(), "abcd");
 
     // let objs = dict.to_array();
     // assert_eq!(objs.len(), 1);

--- a/framework-crates/objc2-foundation/src/tests/mutable_array.rs
+++ b/framework-crates/objc2-foundation/src/tests/mutable_array.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "NSArray")]
 use alloc::vec;
 
-use objc2::rc::{autoreleasepool, Allocated};
+use objc2::rc::Allocated;
 use objc2::{msg_send, ClassType};
 
 #[cfg(feature = "NSValue")]
@@ -112,14 +112,13 @@ fn test_into_vec() {
 #[test]
 #[cfg(all(feature = "NSObjCRuntime", feature = "NSString"))]
 fn test_sort() {
+    use alloc::string::ToString;
     use Foundation::NSString;
 
     let strings = vec![NSString::from_str("hello"), NSString::from_str("hi")];
     let mut strings = NSMutableArray::from_vec(strings);
 
-    autoreleasepool(|pool| {
-        strings.sort_by(|s1, s2| s1.as_str(pool).len().cmp(&s2.as_str(pool).len()));
-        assert_eq!(strings[0].as_str(pool), "hi");
-        assert_eq!(strings[1].as_str(pool), "hello");
-    });
+    strings.sort_by(|s1, s2| s1.len().cmp(&s2.len()));
+    assert_eq!(strings[0].to_string(), "hi");
+    assert_eq!(strings[1].to_string(), "hello");
 }

--- a/framework-crates/objc2-foundation/src/tests/set.rs
+++ b/framework-crates/objc2-foundation/src/tests/set.rs
@@ -193,7 +193,7 @@ fn test_debug() {
 
     let set = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
     assert!(matches!(
-        format!("{set:?}").as_str(),
+        &*format!("{set:?}"),
         "{\"one\", \"two\"}" | "{\"two\", \"one\"}"
     ));
 }

--- a/framework-crates/objc2-foundation/src/tests/string.rs
+++ b/framework-crates/objc2-foundation/src/tests/string.rs
@@ -38,6 +38,9 @@ fn test_empty() {
         assert_eq!(s1.as_str(pool), "");
         assert_eq!(s2.as_str(pool), "");
     });
+
+    assert_eq!(s1.to_string(), "");
+    assert_eq!(s2.to_string(), "");
 }
 
 #[test]
@@ -48,6 +51,7 @@ fn test_utf8() {
     autoreleasepool(|pool| {
         assert_eq!(s.as_str(pool), expected);
     });
+    assert_eq!(s.to_string(), expected);
 }
 
 #[test]
@@ -58,6 +62,7 @@ fn test_nul() {
     autoreleasepool(|pool| {
         assert_eq!(s.as_str(pool), expected);
     });
+    assert_eq!(s.to_string(), expected);
 }
 
 #[test]
@@ -68,6 +73,7 @@ fn test_interior_nul() {
     autoreleasepool(|pool| {
         assert_eq!(s.as_str(pool), expected);
     });
+    assert_eq!(s.to_string(), expected);
 }
 
 #[test]
@@ -108,6 +114,7 @@ fn test_strips_first_leading_zero_width_no_break_space() {
     autoreleasepool(|pool| {
         assert_eq!(ns_string.as_str(pool), expected);
     });
+    assert_eq!(ns_string.to_string(), expected);
     assert_eq!(ns_string.len(), 0);
 
     let s = "\u{feff}\u{feff}a\u{feff}";
@@ -123,6 +130,7 @@ fn test_strips_first_leading_zero_width_no_break_space() {
     autoreleasepool(|pool| {
         assert_eq!(ns_string.as_str(pool), expected);
     });
+    assert_eq!(ns_string.to_string(), expected);
     assert_eq!(ns_string.len(), expected.len());
 }
 


### PR DESCRIPTION
`-[NSString UTF8String]` (or the equivalent `NSString::as_str`) is used several times in our implementation, but when transitioning to https://github.com/madsmtm/objc2/issues/563, we must ensure that this usage is still sound even if the string is interior mutable.

Luckily, Foundation already ensures this for us by checking if the string is mutable in the implementation of `UTF8String` (and does so since macOS 10.6, I checked by downloading and disassembling the old binaries), so we needn't worry here.