### PR TITLE
Update to nightly 2024-06-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ env:
   # END AUTOMATICALLY GENERATED
 
   # The current nightly Rust version. Keep this synced with `rust-toolchain.toml`
-  CURRENT_NIGHTLY: nightly-2024-05-01
+  CURRENT_NIGHTLY: nightly-2024-06-13
   # Various features that we'd usually want to test with
   #
   # Note: The `exception` feature is not enabled here, since it requires

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "afl"
-version = "0.15.6"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c35aaa81598ae31b275ed1d9a1d17c47ea49215ed684f34782dc1996caa364f"
+checksum = "1ff7c9e6d8b0f28402139fcbff21a22038212c94c44ecf90812ce92f384308f6"
 dependencies = [
  "home",
  "libc",
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "basic-toml"
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "6d0d8b92cd8358e8d229c11df9358decae64d137c5be540952c5ca7b25aea768"
 
 [[package]]
 name = "memoffset"
@@ -1175,9 +1175,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -1187,9 +1187,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1228,15 +1228,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -1249,33 +1249,33 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -1325,9 +1325,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1502,18 +1502,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1544,18 +1544,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
@@ -1634,12 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.91"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad7eb6319ebadebca3dacf1f85a93bc54b73dd81b9036795f73de7ddfe27d5a"
+checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
 dependencies = [
  "glob",
- "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1765,9 +1764,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.7"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ unreachable_pub = "warn"
 unsafe_op_in_unsafe_fn = "deny"
 
 [workspace.lints.clippy]
-cargo = "warn"
+cargo = { level = "warn", priority = -1 } # Because of `lint_groups_priority`
 ptr_as_ptr = "warn"
 
 [profile.assembly-tests]

--- a/crates/block2/src/global.rs
+++ b/crates/block2/src/global.rs
@@ -48,6 +48,7 @@ impl<F: ?Sized> GlobalBlock<F> {
         BlockFlags(BlockFlags::BLOCK_IS_GLOBAL.0 | BlockFlags::BLOCK_USE_STRET.0);
 
     #[doc(hidden)]
+    #[allow(clippy::declare_interior_mutable_const)]
     pub const __DEFAULT_HEADER: BlockHeader = BlockHeader {
         // Populated in `global_block!`
         isa: ptr::null_mut(),

--- a/crates/header-translator/src/main.rs
+++ b/crates/header-translator/src/main.rs
@@ -211,8 +211,8 @@ fn main() -> Result<(), BoxError> {
 
         // Ensure directories exist
         let generated_dir = workspace_dir.join("generated").join(library_name);
-        fs::create_dir_all(&generated_dir)?;
-        fs::create_dir_all(&crate_dir.join("src"))?;
+        fs::create_dir_all(generated_dir)?;
+        fs::create_dir_all(crate_dir.join("src"))?;
 
         // Recreate symlink to generated directory
         let symlink_path = crate_dir.join("src").join("generated");

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
@@ -1,17 +1,5 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.p2align	2
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	ret
-
-	.p2align	2
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	ret
-
-	.p2align	2
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	ret
-
-	.p2align	2
 SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0):
 	sub	sp, sp, #64
 	stp	x22, x21, [sp, #16]
@@ -25,11 +13,11 @@ Lloh0:
 Lloh1:
 	ldr	x8, [x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGEOFF]
 	ldrb	w8, [x0, x8]
-	cbz	w8, LBB3_5
+	cbz	w8, LBB0_5
 	cmp	w8, #255
-	b.ne	LBB3_3
+	b.ne	LBB0_3
 	bl	SYM(<test_declare_class[CRATE_ID]::DropIvars as core[CRATE_ID]::ops::drop::Drop>::drop, 0)
-LBB3_3:
+LBB0_3:
 Lloh2:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGE
 Lloh3:
@@ -37,10 +25,10 @@ Lloh3:
 	add	x8, x20, x8
 	ldp	x0, x21, [x8]
 	bl	_objc_release
-	cbz	x21, LBB3_5
+	cbz	x21, LBB0_5
 	mov	x0, x21
 	bl	_objc_release
-LBB3_5:
+LBB0_5:
 Lloh4:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
 Lloh5:
@@ -69,7 +57,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	ldr	x8, [x0]
 	ldrb	w9, [x8]
 	strb	wzr, [x8]
-	cbz	w9, LBB4_7
+	cbz	w9, LBB1_7
 Lloh7:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
 Lloh8:
@@ -77,21 +65,21 @@ Lloh8:
 Lloh9:
 	ldr	x2, [x8]
 Lloh10:
-	adrp	x0, l_anon.[ID].19@PAGE
+	adrp	x0, l_anon.[ID].13@PAGE
 Lloh11:
-	add	x0, x0, l_anon.[ID].19@PAGEOFF
+	add	x0, x0, l_anon.[ID].13@PAGEOFF
 	mov	w1, #7
 	bl	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
-	cbz	x0, LBB4_8
+	cbz	x0, LBB1_8
 	str	x0, [sp, #8]
 Lloh12:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_c1ccd9f2c8e68869@PAGE
 Lloh13:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_c1ccd9f2c8e68869@PAGEOFF]
 Lloh14:
-	adrp	x4, l_anon.[ID].9@PAGE
+	adrp	x4, l_anon.[ID].16@PAGE
 Lloh15:
-	add	x4, x4, l_anon.[ID].9@PAGEOFF
+	add	x4, x4, l_anon.[ID].16@PAGEOFF
 Lloh16:
 	adrp	x5, _get_class@PAGE
 Lloh17:
@@ -105,9 +93,9 @@ Lloh18:
 Lloh19:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_654faaf1a88864b3@PAGEOFF]
 Lloh20:
-	adrp	x4, l_anon.[ID].4@PAGE
+	adrp	x4, l_anon.[ID].3@PAGE
 Lloh21:
-	add	x4, x4, l_anon.[ID].4@PAGEOFF
+	add	x4, x4, l_anon.[ID].3@PAGEOFF
 Lloh22:
 	adrp	x5, _method_simple@PAGE
 Lloh23:
@@ -121,9 +109,9 @@ Lloh24:
 Lloh25:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_5d27bc76c3596041@PAGEOFF]
 Lloh26:
-	adrp	x19, l_anon.[ID].5@PAGE
+	adrp	x19, l_anon.[ID].17@PAGE
 Lloh27:
-	add	x19, x19, l_anon.[ID].5@PAGEOFF
+	add	x19, x19, l_anon.[ID].17@PAGEOFF
 Lloh28:
 	adrp	x5, _method_bool@PAGE
 Lloh29:
@@ -138,9 +126,9 @@ Lloh30:
 Lloh31:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_026f8b3b5bb3f00d@PAGEOFF]
 Lloh32:
-	adrp	x20, l_anon.[ID].3@PAGE
+	adrp	x20, l_anon.[ID].18@PAGE
 Lloh33:
-	add	x20, x20, l_anon.[ID].3@PAGEOFF
+	add	x20, x20, l_anon.[ID].18@PAGEOFF
 Lloh34:
 	adrp	x5, _method_id@PAGE
 Lloh35:
@@ -164,39 +152,39 @@ Lloh39:
 	mov	x4, x20
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 Lloh40:
-	adrp	x0, l_anon.[ID].22@PAGE
+	adrp	x0, l_anon.[ID].19@PAGE
 Lloh41:
-	add	x0, x0, l_anon.[ID].22@PAGEOFF
+	add	x0, x0, l_anon.[ID].19@PAGEOFF
 	mov	w1, #8
 	bl	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
-	cbz	x0, LBB4_4
+	cbz	x0, LBB1_4
 	mov	x1, x0
 	add	x0, sp, #8
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
-LBB4_4:
+LBB1_4:
 Lloh42:
-	adrp	x0, l_anon.[ID].23@PAGE
+	adrp	x0, l_anon.[ID].20@PAGE
 Lloh43:
-	add	x0, x0, l_anon.[ID].23@PAGEOFF
+	add	x0, x0, l_anon.[ID].20@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
-	cbz	x0, LBB4_6
+	cbz	x0, LBB1_6
 	mov	x1, x0
 	add	x0, sp, #8
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
-LBB4_6:
+LBB1_6:
 Lloh44:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_f2913b8ffb9882fe@PAGE
 Lloh45:
 	ldr	x1, [x8, L_OBJC_SELECTOR_REFERENCES_f2913b8ffb9882fe@PAGEOFF]
 Lloh46:
-	adrp	x2, l_anon.[ID].8@PAGE
+	adrp	x2, l_anon.[ID].23@PAGE
 Lloh47:
-	add	x2, x2, l_anon.[ID].8@PAGEOFF
+	add	x2, x2, l_anon.[ID].23@PAGEOFF
 Lloh48:
-	adrp	x4, l_anon.[ID].3@PAGE
+	adrp	x4, l_anon.[ID].18@PAGE
 Lloh49:
-	add	x4, x4, l_anon.[ID].3@PAGEOFF
+	add	x4, x4, l_anon.[ID].18@PAGEOFF
 Lloh50:
 	adrp	x5, _copyWithZone@PAGE
 Lloh51:
@@ -212,21 +200,21 @@ Lloh51:
 	ldp	x20, x19, [sp, #16]
 	add	sp, sp, #48
 	ret
-LBB4_7:
+LBB1_7:
 Lloh52:
-	adrp	x0, l_anon.[ID].18@PAGE
+	adrp	x0, l_anon.[ID].12@PAGE
 Lloh53:
-	add	x0, x0, l_anon.[ID].18@PAGEOFF
+	add	x0, x0, l_anon.[ID].12@PAGEOFF
 	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB4_8:
+LBB1_8:
 Lloh54:
-	adrp	x0, l_anon.[ID].19@PAGE
+	adrp	x0, l_anon.[ID].13@PAGE
 Lloh55:
-	add	x0, x0, l_anon.[ID].19@PAGEOFF
+	add	x0, x0, l_anon.[ID].13@PAGEOFF
 Lloh56:
-	adrp	x2, l_anon.[ID].21@PAGE
+	adrp	x2, l_anon.[ID].15@PAGE
 Lloh57:
-	add	x2, x2, l_anon.[ID].21@PAGEOFF
+	add	x2, x2, l_anon.[ID].15@PAGEOFF
 	mov	w1, #7
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh10, Lloh11
@@ -264,7 +252,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	ldr	x8, [x0]
 	ldrb	w9, [x8]
 	strb	wzr, [x8]
-	cbz	w9, LBB5_5
+	cbz	w9, LBB2_5
 Lloh58:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
 Lloh59:
@@ -272,12 +260,12 @@ Lloh59:
 Lloh60:
 	ldr	x2, [x8]
 Lloh61:
-	adrp	x0, l_anon.[ID].16@PAGE
+	adrp	x0, l_anon.[ID].10@PAGE
 Lloh62:
-	add	x0, x0, l_anon.[ID].16@PAGEOFF
+	add	x0, x0, l_anon.[ID].10@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
-	cbz	x0, LBB5_6
+	cbz	x0, LBB2_6
 	str	x0, [sp, #24]
 Lloh63:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_dealloc@GOTPAGE
@@ -286,9 +274,9 @@ Lloh64:
 Lloh65:
 	ldr	x1, [x8]
 Lloh66:
-	adrp	x4, l_anon.[ID].4@PAGE
+	adrp	x4, l_anon.[ID].3@PAGE
 Lloh67:
-	add	x4, x4, l_anon.[ID].4@PAGEOFF
+	add	x4, x4, l_anon.[ID].3@PAGEOFF
 Lloh68:
 	adrp	x5, SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0)@PAGE
 Lloh69:
@@ -306,9 +294,9 @@ Lloh71:
 Lloh72:
 	ldr	x1, [x8]
 Lloh73:
-	adrp	x4, l_anon.[ID].3@PAGE
+	adrp	x4, l_anon.[ID].18@PAGE
 Lloh74:
-	add	x4, x4, l_anon.[ID].3@PAGEOFF
+	add	x4, x4, l_anon.[ID].18@PAGEOFF
 Lloh75:
 	adrp	x5, _init_drop_ivars@PAGE
 Lloh76:
@@ -321,16 +309,16 @@ Lloh76:
 	str	x8, [sp, #16]
 	mov	w8, #16
 Lloh77:
-	adrp	x9, l_anon.[ID].14@PAGE
+	adrp	x9, l_anon.[ID].8@PAGE
 Lloh78:
-	add	x9, x9, l_anon.[ID].14@PAGEOFF
+	add	x9, x9, l_anon.[ID].8@PAGEOFF
 	stp	x8, x9, [sp, #32]
 	mov	w8, #27
 	strb	w8, [sp, #24]
 Lloh79:
-	adrp	x20, l_anon.[ID].10@PAGE
+	adrp	x20, l_anon.[ID].4@PAGE
 Lloh80:
-	add	x20, x20, l_anon.[ID].10@PAGEOFF
+	add	x20, x20, l_anon.[ID].4@PAGEOFF
 	add	x0, sp, #16
 	add	x5, sp, #24
 	mov	x1, x20
@@ -339,13 +327,13 @@ Lloh80:
 	mov	w4, #3
 	bl	SYM(objc2::runtime::declare::ClassBuilder::add_ivar_inner_mono::GENERATED_ID, 0)
 Lloh81:
-	adrp	x1, l_anon.[ID].11@PAGE
+	adrp	x1, l_anon.[ID].5@PAGE
 Lloh82:
-	add	x1, x1, l_anon.[ID].11@PAGEOFF
+	add	x1, x1, l_anon.[ID].5@PAGEOFF
 Lloh83:
-	adrp	x5, l_anon.[ID].12@PAGE
+	adrp	x5, l_anon.[ID].6@PAGE
 Lloh84:
-	add	x5, x5, l_anon.[ID].12@PAGEOFF
+	add	x5, x5, l_anon.[ID].6@PAGEOFF
 	add	x0, sp, #16
 	mov	w2, #9
 	mov	w3, #1
@@ -357,17 +345,17 @@ Lloh84:
 	mov	x1, x20
 	mov	w2, #5
 	bl	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
-	cbz	x0, LBB5_7
+	cbz	x0, LBB2_7
 	bl	_ivar_getOffset
 	mov	x20, x0
 Lloh85:
-	adrp	x1, l_anon.[ID].11@PAGE
+	adrp	x1, l_anon.[ID].5@PAGE
 Lloh86:
-	add	x1, x1, l_anon.[ID].11@PAGEOFF
+	add	x1, x1, l_anon.[ID].5@PAGEOFF
 	mov	x0, x19
 	mov	w2, #9
 	bl	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
-	cbz	x0, LBB5_8
+	cbz	x0, LBB2_8
 	bl	_ivar_getOffset
 Lloh87:
 	adrp	x8, __MergedGlobals@PAGE+32
@@ -382,26 +370,26 @@ Lloh89:
 	ldp	x20, x19, [sp, #64]
 	add	sp, sp, #96
 	ret
-LBB5_5:
+LBB2_5:
 Lloh90:
-	adrp	x0, l_anon.[ID].18@PAGE
+	adrp	x0, l_anon.[ID].12@PAGE
 Lloh91:
-	add	x0, x0, l_anon.[ID].18@PAGEOFF
+	add	x0, x0, l_anon.[ID].12@PAGEOFF
 	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB5_6:
+LBB2_6:
 Lloh92:
-	adrp	x0, l_anon.[ID].16@PAGE
+	adrp	x0, l_anon.[ID].10@PAGE
 Lloh93:
-	add	x0, x0, l_anon.[ID].16@PAGEOFF
+	add	x0, x0, l_anon.[ID].10@PAGEOFF
 Lloh94:
 	adrp	x2, l_anon.[ID].25@PAGE
 Lloh95:
 	add	x2, x2, l_anon.[ID].25@PAGEOFF
 	mov	w1, #9
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
-LBB5_7:
+LBB2_7:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
-LBB5_8:
+LBB2_8:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_drop_flag_failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh61, Lloh62
 	.loh AdrpLdrGotLdr	Lloh58, Lloh59, Lloh60
@@ -431,7 +419,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	ldr	x8, [x0]
 	ldrb	w9, [x8]
 	strb	wzr, [x8]
-	cbz	w9, LBB6_4
+	cbz	w9, LBB3_4
 Lloh96:
 	adrp	x8, L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPAGE
 Lloh97:
@@ -439,12 +427,12 @@ Lloh97:
 Lloh98:
 	ldr	x2, [x8]
 Lloh99:
-	adrp	x0, l_anon.[ID].15@PAGE
+	adrp	x0, l_anon.[ID].9@PAGE
 Lloh100:
-	add	x0, x0, l_anon.[ID].15@PAGEOFF
+	add	x0, x0, l_anon.[ID].9@PAGEOFF
 	mov	w1, #15
 	bl	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
-	cbz	x0, LBB6_5
+	cbz	x0, LBB3_5
 	str	x0, [sp, #8]
 Lloh101:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_init@GOTPAGE
@@ -453,9 +441,9 @@ Lloh102:
 Lloh103:
 	ldr	x1, [x8]
 Lloh104:
-	adrp	x4, l_anon.[ID].3@PAGE
+	adrp	x4, l_anon.[ID].18@PAGE
 Lloh105:
-	add	x4, x4, l_anon.[ID].3@PAGEOFF
+	add	x4, x4, l_anon.[ID].18@PAGEOFF
 Lloh106:
 	adrp	x5, _init_forgetable_ivars@PAGE
 Lloh107:
@@ -468,16 +456,16 @@ Lloh107:
 	ldr	x8, [sp, #8]
 	str	x8, [sp, #16]
 Lloh108:
-	adrp	x8, l_anon.[ID].13@PAGE
+	adrp	x8, l_anon.[ID].7@PAGE
 Lloh109:
-	add	x8, x8, l_anon.[ID].13@PAGEOFF
+	add	x8, x8, l_anon.[ID].7@PAGEOFF
 	stp	x19, x8, [sp, #32]
 	mov	w8, #27
 	strb	w8, [sp, #24]
 Lloh110:
-	adrp	x20, l_anon.[ID].10@PAGE
+	adrp	x20, l_anon.[ID].4@PAGE
 Lloh111:
-	add	x20, x20, l_anon.[ID].10@PAGEOFF
+	add	x20, x20, l_anon.[ID].4@PAGEOFF
 	add	x0, sp, #16
 	add	x5, sp, #24
 	mov	x1, x20
@@ -491,7 +479,7 @@ Lloh111:
 	mov	x1, x20
 	mov	w2, #5
 	bl	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
-	cbz	x0, LBB6_6
+	cbz	x0, LBB3_6
 	bl	_ivar_getOffset
 Lloh112:
 	adrp	x8, __MergedGlobals@PAGE+16
@@ -503,24 +491,24 @@ Lloh113:
 	ldp	x20, x19, [sp, #64]
 	add	sp, sp, #96
 	ret
-LBB6_4:
+LBB3_4:
 Lloh114:
-	adrp	x0, l_anon.[ID].18@PAGE
+	adrp	x0, l_anon.[ID].12@PAGE
 Lloh115:
-	add	x0, x0, l_anon.[ID].18@PAGEOFF
+	add	x0, x0, l_anon.[ID].12@PAGEOFF
 	bl	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB6_5:
+LBB3_5:
 Lloh116:
-	adrp	x0, l_anon.[ID].15@PAGE
+	adrp	x0, l_anon.[ID].9@PAGE
 Lloh117:
-	add	x0, x0, l_anon.[ID].15@PAGEOFF
+	add	x0, x0, l_anon.[ID].9@PAGEOFF
 Lloh118:
 	adrp	x2, l_anon.[ID].24@PAGE
 Lloh119:
 	add	x2, x2, l_anon.[ID].24@PAGEOFF
 	mov	w1, #15
 	bl	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
-LBB6_6:
+LBB3_6:
 	bl	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
 	.loh AdrpAdd	Lloh99, Lloh100
 	.loh AdrpLdrGotLdr	Lloh96, Lloh97, Lloh98
@@ -582,13 +570,13 @@ Lloh121:
 	add	x8, x8, __MergedGlobals@PAGEOFF+24
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB10_2
+	b.ne	LBB7_2
 Lloh122:
 	adrp	x8, __MergedGlobals@PAGE+16
 Lloh123:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
-LBB10_2:
+LBB7_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -654,13 +642,13 @@ Lloh135:
 	add	x8, x8, __MergedGlobals@PAGEOFF+40
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB13_2
+	b.ne	LBB10_2
 Lloh136:
 	adrp	x8, __MergedGlobals@PAGE+32
 Lloh137:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
-LBB13_2:
+LBB10_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -718,13 +706,13 @@ Lloh149:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB15_2
+	b.ne	LBB12_2
 Lloh150:
 	adrp	x8, __MergedGlobals@PAGE
 Lloh151:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
-LBB15_2:
+LBB12_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -741,9 +729,9 @@ Lloh154:
 Lloh155:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
 Lloh156:
-	adrp	x4, l_anon.[ID].21@PAGE
+	adrp	x4, l_anon.[ID].15@PAGE
 Lloh157:
-	add	x4, x4, l_anon.[ID].21@PAGEOFF
+	add	x4, x4, l_anon.[ID].15@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
@@ -770,13 +758,13 @@ Lloh161:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB16_2
+	b.ne	LBB13_2
 Lloh162:
 	adrp	x8, __MergedGlobals@PAGE
 Lloh163:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF]
 	ret
-LBB16_2:
+LBB13_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -793,9 +781,9 @@ Lloh166:
 Lloh167:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
 Lloh168:
-	adrp	x4, l_anon.[ID].21@PAGE
+	adrp	x4, l_anon.[ID].15@PAGE
 Lloh169:
-	add	x4, x4, l_anon.[ID].21@PAGEOFF
+	add	x4, x4, l_anon.[ID].15@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
@@ -836,8 +824,8 @@ Lloh173:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB19_2
-LBB19_1:
+	b.ne	LBB16_2
+LBB16_1:
 Lloh174:
 	adrp	x8, __MergedGlobals@PAGE
 Lloh175:
@@ -853,7 +841,7 @@ Lloh178:
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
 	ret
-LBB19_2:
+LBB16_2:
 	mov	w8, #1
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
@@ -867,13 +855,13 @@ Lloh181:
 Lloh182:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
 Lloh183:
-	adrp	x4, l_anon.[ID].21@PAGE
+	adrp	x4, l_anon.[ID].15@PAGE
 Lloh184:
-	add	x4, x4, l_anon.[ID].21@PAGEOFF
+	add	x4, x4, l_anon.[ID].15@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
-	b	LBB19_1
+	b	LBB16_1
 	.loh AdrpAdd	Lloh172, Lloh173
 	.loh AdrpLdrGotLdr	Lloh176, Lloh177, Lloh178
 	.loh AdrpAdrp	Lloh174, Lloh176
@@ -890,14 +878,14 @@ _method_id_with_param:
 	add	x29, sp, #16
 	mov	x19, x2
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
-	cbz	w19, LBB20_2
+	cbz	w19, LBB17_2
 	mov	x19, x0
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	x20, x0
 	mov	x0, x19
 	bl	_objc_release
 	mov	x0, x20
-LBB20_2:
+LBB17_2:
 	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
 	b	_objc_autoreleaseReturnValue
@@ -914,8 +902,8 @@ Lloh186:
 	add	x8, x8, __MergedGlobals@PAGEOFF+8
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB21_2
-LBB21_1:
+	b.ne	LBB18_2
+LBB18_1:
 Lloh187:
 	adrp	x8, __MergedGlobals@PAGE
 Lloh188:
@@ -930,7 +918,7 @@ Lloh191:
 	ldp	x29, x30, [sp, #16]
 	add	sp, sp, #32
 	ret
-LBB21_2:
+LBB18_2:
 	mov	w8, #1
 	strb	w8, [sp, #7]
 	add	x8, sp, #7
@@ -944,13 +932,13 @@ Lloh194:
 Lloh195:
 	add	x3, x3, l_anon.[ID].0@PAGEOFF
 Lloh196:
-	adrp	x4, l_anon.[ID].21@PAGE
+	adrp	x4, l_anon.[ID].15@PAGE
 Lloh197:
-	add	x4, x4, l_anon.[ID].21@PAGEOFF
+	add	x4, x4, l_anon.[ID].15@PAGEOFF
 	add	x2, sp, #8
 	mov	w1, #0
 	bl	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
-	b	LBB21_1
+	b	LBB18_1
 	.loh AdrpAdd	Lloh185, Lloh186
 	.loh AdrpLdrGotLdr	Lloh189, Lloh190, Lloh191
 	.loh AdrpAdrp	Lloh187, Lloh189
@@ -968,13 +956,13 @@ Lloh199:
 	add	x8, x8, __MergedGlobals@PAGEOFF+24
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB22_2
+	b.ne	LBB19_2
 Lloh200:
 	adrp	x8, __MergedGlobals@PAGE+16
 Lloh201:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+16]
 	ret
-LBB22_2:
+LBB19_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -1014,7 +1002,7 @@ Lloh209:
 	.globl	_init_forgetable_ivars
 	.p2align	2
 _init_forgetable_ivars:
-	cbz	x0, LBB23_2
+	cbz	x0, LBB20_2
 Lloh210:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)@PAGE
 Lloh211:
@@ -1024,7 +1012,7 @@ Lloh211:
 	str	w9, [x8]
 	mov	w9, #42
 	strb	w9, [x8, #4]
-LBB23_2:
+LBB20_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -1058,13 +1046,13 @@ Lloh218:
 	add	x8, x8, __MergedGlobals@PAGEOFF+40
 	ldapr	x8, [x8]
 	cmp	x8, #3
-	b.ne	LBB24_2
+	b.ne	LBB21_2
 Lloh219:
 	adrp	x8, __MergedGlobals@PAGE+32
 Lloh220:
 	ldr	x0, [x8, __MergedGlobals@PAGEOFF+32]
 	ret
-LBB24_2:
+LBB21_2:
 	sub	sp, sp, #32
 	stp	x29, x30, [sp, #16]
 	add	x29, sp, #16
@@ -1114,7 +1102,7 @@ _init_drop_ivars:
 	mov	x20, x0
 	bl	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	adrp	x22, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGE
-	cbz	x19, LBB25_2
+	cbz	x19, LBB22_2
 Lloh229:
 	adrp	x8, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)@PAGE
 Lloh230:
@@ -1124,14 +1112,14 @@ Lloh230:
 	ldr	x8, [x22, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGEOFF]
 	mov	w9, #15
 	strb	w9, [x19, x8]
-	b	LBB25_3
-LBB25_2:
+	b	LBB22_3
+LBB22_2:
 	mov	x21, x0
 	mov	x0, x20
 	bl	_objc_release
 	mov	x0, x21
 	bl	_objc_release
-LBB25_3:
+LBB22_3:
 Lloh231:
 	adrp	x8, L_OBJC_SELECTOR_REFERENCES_46e92b66c48ba6b7@PAGE
 Lloh232:
@@ -1145,11 +1133,11 @@ Lloh235:
 	stp	x19, x8, [sp]
 	mov	x0, sp
 	bl	_objc_msgSendSuper
-	cbz	x0, LBB25_5
+	cbz	x0, LBB22_5
 	ldr	x8, [x22, SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)@PAGEOFF]
 	mov	w9, #255
 	strb	w9, [x0, x8]
-LBB25_5:
+LBB22_5:
 	ldp	x29, x30, [sp, #48]
 	ldp	x20, x19, [sp, #32]
 	ldp	x22, x21, [sp, #16]
@@ -1163,127 +1151,124 @@ LBB25_5:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].0:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.p2align	3, 0x0
 l_anon.[ID].1:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.p2align	3, 0x0
 l_anon.[ID].2:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.section	__TEXT,__const
 	.p2align	3, 0x0
 l_anon.[ID].3:
-	.byte	19
-	.space	39
-
-	.p2align	3, 0x0
-l_anon.[ID].4:
 	.byte	17
 	.space	39
 
-	.p2align	3, 0x0
-l_anon.[ID].5:
-	.byte	16
-	.space	39
-
-l_anon.[ID].6:
-	.ascii	"_NSZone"
-
-	.section	__DATA,__const
-	.p2align	3, 0x0
-l_anon.[ID].7:
-	.byte	28
-	.space	7
-	.quad	l_anon.[ID].6
-	.asciz	"\007\000\000\000\000\000\000"
-	.quad	8
-	.space	8
-
-	.p2align	3, 0x0
-l_anon.[ID].8:
-	.byte	25
-	.space	7
-	.quad	l_anon.[ID].7
-	.space	24
-
-	.section	__TEXT,__const
-	.p2align	3, 0x0
-l_anon.[ID].9:
-	.byte	21
-	.space	39
-
-l_anon.[ID].10:
+l_anon.[ID].4:
 	.ascii	"ivars"
 
-l_anon.[ID].11:
+l_anon.[ID].5:
 	.ascii	"drop_flag"
 
 	.p2align	3, 0x0
-l_anon.[ID].12:
+l_anon.[ID].6:
 	.byte	5
 	.space	39
 
 	.p2align	3, 0x0
-l_anon.[ID].13:
+l_anon.[ID].7:
 	.byte	7
 	.space	39
 
 	.p2align	3, 0x0
-l_anon.[ID].14:
+l_anon.[ID].8:
 	.byte	9
 	.space	39
 
-l_anon.[ID].15:
+l_anon.[ID].9:
 	.ascii	"ForgetableIvars"
 
-l_anon.[ID].16:
+l_anon.[ID].10:
 	.ascii	"DropIvars"
 
-l_anon.[ID].17:
+l_anon.[ID].11:
 	.ascii	"$RUSTC/library/std/src/sync/once.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].18:
-	.quad	l_anon.[ID].17
+l_anon.[ID].12:
+	.quad	l_anon.[ID].11
 	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__const
-l_anon.[ID].19:
+l_anon.[ID].13:
 	.ascii	"NoIvars"
 
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2),8,3
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1),8,3
-l_anon.[ID].20:
+l_anon.[ID].14:
 	.ascii	"crates/$DIR/lib.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].21:
-	.quad	l_anon.[ID].20
+l_anon.[ID].15:
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000\016\000\000\000\001\000\000"
 
+	.section	__TEXT,__const
+	.p2align	3, 0x0
+l_anon.[ID].16:
+	.byte	21
+	.space	39
+
+	.p2align	3, 0x0
+l_anon.[ID].17:
+	.byte	16
+	.space	39
+
+	.p2align	3, 0x0
+l_anon.[ID].18:
+	.byte	19
+	.space	39
+
 	.section	__TEXT,__literal8,8byte_literals
-l_anon.[ID].22:
+l_anon.[ID].19:
 	.ascii	"NSObject"
 
 	.section	__TEXT,__const
-l_anon.[ID].23:
+l_anon.[ID].20:
 	.ascii	"NSCopying"
+
+l_anon.[ID].21:
+	.ascii	"_NSZone"
+
+	.section	__DATA,__const
+	.p2align	3, 0x0
+l_anon.[ID].22:
+	.byte	28
+	.space	7
+	.quad	l_anon.[ID].21
+	.asciz	"\007\000\000\000\000\000\000"
+	.quad	8
+	.space	8
+
+	.p2align	3, 0x0
+l_anon.[ID].23:
+	.byte	25
+	.space	7
+	.quad	l_anon.[ID].22
+	.space	24
 
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_c1ccd9f2c8e68869
@@ -1394,7 +1379,7 @@ L_OBJC_IMAGE_INFO_f2913b8ffb9882fe:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].24:
-	.quad	l_anon.[ID].20
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000O\000\000\000\001\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals
@@ -1421,7 +1406,7 @@ L_OBJC_IMAGE_INFO_dea6e68a0f2fe4ca:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].25:
-	.quad	l_anon.[ID].20
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000x\000\000\000\001\000\000"
 
 	.section	__TEXT,__objc_methname,cstring_literals

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
@@ -1,27 +1,6 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.intel_syntax noprefix
 	.p2align	4, 0x90
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	push	rbp
-	mov	rbp, rsp
-	pop	rbp
-	ret
-
-	.p2align	4, 0x90
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	push	rbp
-	mov	rbp, rsp
-	pop	rbp
-	ret
-
-	.p2align	4, 0x90
-SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0):
-	push	rbp
-	mov	rbp, rsp
-	pop	rbp
-	ret
-
-	.p2align	4, 0x90
 SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0):
 	push	rbp
 	mov	rbp, rsp
@@ -34,20 +13,20 @@ SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_cla
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)]
 	movzx	eax, byte ptr [rdi + rax]
 	test	eax, eax
-	je	LBB3_5
+	je	LBB0_5
 	cmp	eax, 255
-	jne	LBB3_3
+	jne	LBB0_3
 	call	SYM(<test_declare_class[CRATE_ID]::DropIvars as core[CRATE_ID]::ops::drop::Drop>::drop, 0)
-LBB3_3:
+LBB0_3:
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)]
 	mov	rdi, qword ptr [r14 + rax]
 	mov	r15, qword ptr [r14 + rax + 8]
 	call	_objc_release
 	test	r15, r15
-	je	LBB3_5
+	je	LBB0_5
 	mov	rdi, r15
 	call	_objc_release
-LBB3_5:
+LBB0_5:
 	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPCREL]
 	mov	rax, qword ptr [rax]
 	mov	qword ptr [rbp - 40], r14
@@ -73,17 +52,17 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rax, qword ptr [rdi]
 	cmp	byte ptr [rax], 0
 	mov	byte ptr [rax], 0
-	je	LBB4_7
+	je	LBB1_7
 	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPCREL]
 	mov	rdx, qword ptr [rax]
-	lea	rdi, [rip + l_anon.[ID].19]
+	lea	rdi, [rip + l_anon.[ID].13]
 	mov	esi, 7
 	call	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB4_8
+	je	LBB1_8
 	mov	qword ptr [rbp - 32], rax
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_c1ccd9f2c8e68869]
-	lea	r8, [rip + l_anon.[ID].9]
+	lea	r8, [rip + l_anon.[ID].16]
 	lea	r9, [rip + _get_class]
 	lea	rbx, [rbp - 32]
 	mov	edx, 8
@@ -91,14 +70,14 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	xor	ecx, ecx
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_class_method_inner::GENERATED_ID, 0)
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_654faaf1a88864b3]
-	lea	r8, [rip + l_anon.[ID].4]
+	lea	r8, [rip + l_anon.[ID].3]
 	lea	r9, [rip + _method_simple]
 	mov	edx, 8
 	mov	rdi, rbx
 	xor	ecx, ecx
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_5d27bc76c3596041]
-	lea	r14, [rip + l_anon.[ID].5]
+	lea	r14, [rip + l_anon.[ID].17]
 	lea	r9, [rip + _method_bool]
 	mov	ecx, 1
 	mov	rdi, rbx
@@ -106,7 +85,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	r8, r14
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_026f8b3b5bb3f00d]
-	lea	r15, [rip + l_anon.[ID].3]
+	lea	r15, [rip + l_anon.[ID].18]
 	lea	r9, [rip + _method_id]
 	mov	edx, 8
 	mov	rdi, rbx
@@ -120,27 +99,27 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rdx, r14
 	mov	r8, r15
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_method_inner::GENERATED_ID, 0)
-	lea	rdi, [rip + L_anon.[ID].22]
+	lea	rdi, [rip + L_anon.[ID].19]
 	mov	esi, 8
 	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB4_4
+	je	LBB1_4
 	lea	rdi, [rbp - 32]
 	mov	rsi, rax
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
-LBB4_4:
-	lea	rdi, [rip + l_anon.[ID].23]
+LBB1_4:
+	lea	rdi, [rip + l_anon.[ID].20]
 	mov	esi, 9
 	call	SYM(objc2::runtime::AnyProtocol::get::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB4_6
+	je	LBB1_6
 	lea	rdi, [rbp - 32]
 	mov	rsi, rax
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_protocol::GENERATED_ID, 0)
-LBB4_6:
+LBB1_6:
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_f2913b8ffb9882fe]
-	lea	rdx, [rip + l_anon.[ID].8]
-	lea	r8, [rip + l_anon.[ID].3]
+	lea	rdx, [rip + l_anon.[ID].23]
+	lea	r8, [rip + l_anon.[ID].18]
 	lea	r9, [rip + _copyWithZone]
 	lea	rdi, [rbp - 32]
 	mov	ecx, 1
@@ -154,12 +133,12 @@ LBB4_6:
 	pop	r15
 	pop	rbp
 	ret
-LBB4_7:
-	lea	rdi, [rip + l_anon.[ID].18]
+LBB1_7:
+	lea	rdi, [rip + l_anon.[ID].12]
 	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB4_8:
-	lea	rdi, [rip + l_anon.[ID].19]
-	lea	rdx, [rip + l_anon.[ID].21]
+LBB1_8:
+	lea	rdi, [rip + l_anon.[ID].13]
+	lea	rdx, [rip + l_anon.[ID].15]
 	mov	esi, 7
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
 
@@ -173,18 +152,18 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rax, qword ptr [rdi]
 	cmp	byte ptr [rax], 0
 	mov	byte ptr [rax], 0
-	je	LBB5_5
+	je	LBB2_5
 	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPCREL]
 	mov	rdx, qword ptr [rax]
-	lea	rdi, [rip + l_anon.[ID].16]
+	lea	rdi, [rip + l_anon.[ID].10]
 	mov	esi, 9
 	call	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB5_6
+	je	LBB2_6
 	mov	qword ptr [rbp - 72], rax
 	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_dealloc@GOTPCREL]
 	mov	rsi, qword ptr [rax]
-	lea	r8, [rip + l_anon.[ID].4]
+	lea	r8, [rip + l_anon.[ID].3]
 	lea	r9, [rip + SYM(objc2[CRATE_ID]::__macro_helpers::declared_ivars::dealloc::<test_declare_class[CRATE_ID]::DropIvars>, 0)]
 	lea	rdi, [rbp - 72]
 	mov	edx, 8
@@ -194,7 +173,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	qword ptr [rbp - 24], rax
 	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_init@GOTPCREL]
 	mov	rsi, qword ptr [rax]
-	lea	r8, [rip + l_anon.[ID].3]
+	lea	r8, [rip + l_anon.[ID].18]
 	lea	r9, [rip + _init_drop_ivars]
 	lea	rdi, [rbp - 24]
 	mov	edx, 8
@@ -203,10 +182,10 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rax, qword ptr [rbp - 24]
 	mov	qword ptr [rbp - 32], rax
 	mov	qword ptr [rbp - 64], 16
-	lea	rax, [rip + l_anon.[ID].14]
+	lea	rax, [rip + l_anon.[ID].8]
 	mov	qword ptr [rbp - 56], rax
 	mov	byte ptr [rbp - 72], 27
-	lea	r14, [rip + l_anon.[ID].10]
+	lea	r14, [rip + l_anon.[ID].4]
 	lea	rbx, [rbp - 32]
 	lea	r9, [rbp - 72]
 	mov	edx, 5
@@ -215,8 +194,8 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rsi, r14
 	mov	r8d, 3
 	call	SYM(objc2::runtime::declare::ClassBuilder::add_ivar_inner_mono::GENERATED_ID, 0)
-	lea	rsi, [rip + l_anon.[ID].11]
-	lea	r9, [rip + l_anon.[ID].12]
+	lea	rsi, [rip + l_anon.[ID].5]
+	lea	r9, [rip + l_anon.[ID].6]
 	mov	edx, 9
 	mov	ecx, 1
 	mov	rdi, rbx
@@ -230,16 +209,16 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rsi, r14
 	call	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB5_7
+	je	LBB2_7
 	mov	rdi, rax
 	call	_ivar_getOffset
 	mov	r14, rax
-	lea	rsi, [rip + l_anon.[ID].11]
+	lea	rsi, [rip + l_anon.[ID].5]
 	mov	edx, 9
 	mov	rdi, rbx
 	call	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB5_8
+	je	LBB2_8
 	mov	rdi, rax
 	call	_ivar_getOffset
 	mov	qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 1).0], rbx
@@ -250,17 +229,17 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	pop	r14
 	pop	rbp
 	ret
-LBB5_5:
-	lea	rdi, [rip + l_anon.[ID].18]
+LBB2_5:
+	lea	rdi, [rip + l_anon.[ID].12]
 	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB5_6:
-	lea	rdi, [rip + l_anon.[ID].16]
+LBB2_6:
+	lea	rdi, [rip + l_anon.[ID].10]
 	lea	rdx, [rip + l_anon.[ID].25]
 	mov	esi, 9
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
-LBB5_7:
+LBB2_7:
 	call	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
-LBB5_8:
+LBB2_8:
 	call	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_drop_flag_failed::GENERATED_ID, 0)
 
 	.p2align	4, 0x90
@@ -273,18 +252,18 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rax, qword ptr [rdi]
 	cmp	byte ptr [rax], 0
 	mov	byte ptr [rax], 0
-	je	LBB6_4
+	je	LBB3_4
 	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPCREL]
 	mov	rdx, qword ptr [rax]
-	lea	rdi, [rip + l_anon.[ID].15]
+	lea	rdi, [rip + l_anon.[ID].9]
 	mov	esi, 15
 	call	SYM(objc2::runtime::declare::ClassBuilder::new::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB6_5
+	je	LBB3_5
 	mov	qword ptr [rbp - 24], rax
 	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_init@GOTPCREL]
 	mov	rsi, qword ptr [rax]
-	lea	r8, [rip + l_anon.[ID].3]
+	lea	r8, [rip + l_anon.[ID].18]
 	lea	r9, [rip + _init_forgetable_ivars]
 	lea	rdi, [rbp - 24]
 	mov	edx, 8
@@ -293,10 +272,10 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rax, qword ptr [rbp - 24]
 	mov	qword ptr [rbp - 32], rax
 	mov	qword ptr [rbp - 64], 8
-	lea	rax, [rip + l_anon.[ID].13]
+	lea	rax, [rip + l_anon.[ID].7]
 	mov	qword ptr [rbp - 56], rax
 	mov	byte ptr [rbp - 72], 27
-	lea	r14, [rip + l_anon.[ID].10]
+	lea	r14, [rip + l_anon.[ID].4]
 	lea	rdi, [rbp - 32]
 	lea	r9, [rbp - 72]
 	mov	edx, 5
@@ -312,7 +291,7 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	mov	rsi, r14
 	call	SYM(objc2::runtime::AnyClass::instance_variable::GENERATED_ID, 0)
 	test	rax, rax
-	je	LBB6_6
+	je	LBB3_6
 	mov	rdi, rax
 	call	_ivar_getOffset
 	mov	qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 2).0], rbx
@@ -322,15 +301,15 @@ SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]
 	pop	r14
 	pop	rbp
 	ret
-LBB6_4:
-	lea	rdi, [rip + l_anon.[ID].18]
+LBB3_4:
+	lea	rdi, [rip + l_anon.[ID].12]
 	call	SYM(core::option::unwrap_failed::GENERATED_ID, 0)
-LBB6_5:
-	lea	rdi, [rip + l_anon.[ID].15]
+LBB3_5:
+	lea	rdi, [rip + l_anon.[ID].9]
 	lea	rdx, [rip + l_anon.[ID].24]
 	mov	esi, 15
 	call	SYM(objc2::__macro_helpers::declare_class::failed_declaring_class::GENERATED_ID, 0)
-LBB6_6:
+LBB3_6:
 	call	SYM(objc2::__macro_helpers::declared_ivars::register_with_ivars::get_ivar_failed::GENERATED_ID, 0)
 
 	.p2align	4, 0x90
@@ -377,10 +356,10 @@ SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]:
 _access_forgetable_ivars_class:
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB10_1
+	jne	LBB7_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 2).0]
 	ret
-LBB10_1:
+LBB7_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -424,10 +403,10 @@ SYM(<test_declare_class[CRATE_ID]::DropIvars as core[CRATE_ID]::ops::drop::Drop>
 _access_drop_ivars_class:
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB13_1
+	jne	LBB10_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 1).0]
 	ret
-LBB13_1:
+LBB10_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -461,10 +440,10 @@ _access_drop_ivars:
 SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB15_1
+	jne	LBB12_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0]
 	ret
-LBB15_1:
+LBB12_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -473,7 +452,7 @@ LBB15_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].21]
+	lea	r8, [rip + l_anon.[ID].15]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
@@ -487,10 +466,10 @@ LBB15_1:
 _get_class:
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB16_1
+	jne	LBB13_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0]
 	ret
-LBB16_1:
+LBB13_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -499,7 +478,7 @@ LBB16_1:
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].21]
+	lea	r8, [rip + l_anon.[ID].15]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
@@ -535,8 +514,8 @@ _method_id:
 	sub	rsp, 16
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB19_1
-LBB19_2:
+	jne	LBB16_1
+LBB16_2:
 	mov	rdi, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0]
 	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_new@GOTPCREL]
 	mov	rsi, qword ptr [rax]
@@ -546,17 +525,17 @@ LBB19_2:
 	add	rsp, 16
 	pop	rbp
 	ret
-LBB19_1:
+LBB16_1:
 	mov	byte ptr [rbp - 1], 1
 	lea	rax, [rbp - 1]
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].21]
+	lea	r8, [rip + l_anon.[ID].15]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
-	jmp	LBB19_2
+	jmp	LBB16_2
 
 	.globl	_method_id_with_param
 	.p2align	4, 0x90
@@ -569,13 +548,13 @@ _method_id_with_param:
 	call	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	rbx, rax
 	test	r14b, r14b
-	je	LBB20_2
+	je	LBB17_2
 	call	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	r14, rax
 	mov	rdi, rbx
 	call	_objc_release
 	mov	rbx, r14
-LBB20_2:
+LBB17_2:
 	mov	rdi, rbx
 	pop	rbx
 	pop	r14
@@ -590,8 +569,8 @@ _copyWithZone:
 	sub	rsp, 16
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB21_1
-LBB21_2:
+	jne	LBB18_1
+LBB18_2:
 	mov	rdi, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0]
 	mov	rax, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_new@GOTPCREL]
 	mov	rsi, qword ptr [rax]
@@ -599,27 +578,27 @@ LBB21_2:
 	add	rsp, 16
 	pop	rbp
 	ret
-LBB21_1:
+LBB18_1:
 	mov	byte ptr [rbp - 1], 1
 	lea	rax, [rbp - 1]
 	mov	qword ptr [rbp - 16], rax
 	lea	rdi, [rip + SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	lea	rcx, [rip + l_anon.[ID].0]
-	lea	r8, [rip + l_anon.[ID].21]
+	lea	r8, [rip + l_anon.[ID].15]
 	lea	rdx, [rbp - 16]
 	xor	esi, esi
 	call	SYM(std::sys::sync::once::queue::Once::call::GENERATED_ID, 0)
-	jmp	LBB21_2
+	jmp	LBB18_2
 
 	.globl	SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0)
 	.p2align	4, 0x90
 SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB22_1
+	jne	LBB19_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 2).0]
 	ret
-LBB22_1:
+LBB19_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -641,11 +620,11 @@ LBB22_1:
 	.p2align	4, 0x90
 _init_forgetable_ivars:
 	test	rdi, rdi
-	je	LBB23_2
+	je	LBB20_2
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 1)]
 	mov	dword ptr [rdi + rax], 43
 	mov	byte ptr [rdi + rax + 4], 42
-LBB23_2:
+LBB20_2:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -665,10 +644,10 @@ LBB23_2:
 SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class, 0):
 	mov	rax, qword ptr [rip + SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0)]
 	cmp	rax, 3
-	jne	LBB24_1
+	jne	LBB21_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 1).0]
 	ret
-LBB24_1:
+LBB21_1:
 	push	rbp
 	mov	rbp, rsp
 	sub	rsp, 16
@@ -701,19 +680,19 @@ _init_drop_ivars:
 	call	SYM(objc2::runtime::nsobject::NSObject::new::GENERATED_ID, 0)
 	mov	r15, rax
 	test	rbx, rbx
-	je	LBB25_1
+	je	LBB22_1
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 0)]
 	mov	qword ptr [rbx + rax], r14
 	mov	qword ptr [rbx + rax + 8], r15
 	mov	rax, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)]
 	mov	byte ptr [rbx + rax], 15
-	jmp	LBB25_3
-LBB25_1:
+	jmp	LBB22_3
+LBB22_1:
 	mov	rdi, r14
 	call	_objc_release
 	mov	rdi, r15
 	call	_objc_release
-LBB25_3:
+LBB22_3:
 	mov	rsi, qword ptr [rip + L_OBJC_SELECTOR_REFERENCES_46e92b66c48ba6b7]
 	mov	rax, qword ptr [rip + L_OBJC_CLASSLIST_REFERENCES_$_NSObject@GOTPCREL]
 	mov	rax, qword ptr [rax]
@@ -722,10 +701,10 @@ LBB25_3:
 	lea	rdi, [rbp - 40]
 	call	_objc_msgSendSuper
 	test	rax, rax
-	je	LBB25_5
+	je	LBB22_5
 	mov	rcx, qword ptr [rip + SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 0)]
 	mov	byte ptr [rax + rcx], -1
-LBB25_5:
+LBB22_5:
 	add	rsp, 24
 	pop	rbx
 	pop	r14
@@ -736,105 +715,66 @@ LBB25_5:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].0:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.p2align	3, 0x0
 l_anon.[ID].1:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.p2align	3, 0x0
 l_anon.[ID].2:
-	.quad	SYM(core[CRATE_ID]::ptr::drop_in_place::<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}>, 0)
-	.asciz	"\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
+	.asciz	"\000\000\000\000\000\000\000\000\b\000\000\000\000\000\000\000\b\000\000\000\000\000\000"
 	.quad	SYM(<<std[CRATE_ID]::sync::once::Once>::call_once<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0} as core[CRATE_ID]::ops::function::FnOnce<(&std[CRATE_ID]::sync::once::OnceState,)>>::call_once::{shim:vtable#0}, 0)
 	.quad	SYM(<std[CRATE_ID]::sync::once::Once>::call_once::<<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::{closure#0}>::{closure#0}, 0)
 
 	.section	__TEXT,__const
 	.p2align	3, 0x0
 l_anon.[ID].3:
-	.byte	19
-	.space	39
-
-	.p2align	3, 0x0
-l_anon.[ID].4:
 	.byte	17
 	.space	39
 
-	.p2align	3, 0x0
-l_anon.[ID].5:
-	.space	1
-	.space	39
-
-l_anon.[ID].6:
-	.ascii	"_NSZone"
-
-	.section	__DATA,__const
-	.p2align	3, 0x0
-l_anon.[ID].7:
-	.byte	28
-	.space	7
-	.quad	l_anon.[ID].6
-	.asciz	"\007\000\000\000\000\000\000"
-	.quad	8
-	.space	8
-
-	.p2align	3, 0x0
-l_anon.[ID].8:
-	.byte	25
-	.space	7
-	.quad	l_anon.[ID].7
-	.space	24
-
-	.section	__TEXT,__const
-	.p2align	3, 0x0
-l_anon.[ID].9:
-	.byte	21
-	.space	39
-
-l_anon.[ID].10:
+l_anon.[ID].4:
 	.ascii	"ivars"
 
-l_anon.[ID].11:
+l_anon.[ID].5:
 	.ascii	"drop_flag"
 
 	.p2align	3, 0x0
-l_anon.[ID].12:
+l_anon.[ID].6:
 	.byte	5
 	.space	39
 
 	.p2align	3, 0x0
-l_anon.[ID].13:
+l_anon.[ID].7:
 	.byte	7
 	.space	39
 
 	.p2align	3, 0x0
-l_anon.[ID].14:
+l_anon.[ID].8:
 	.byte	9
 	.space	39
 
-l_anon.[ID].15:
+l_anon.[ID].9:
 	.ascii	"ForgetableIvars"
 
-l_anon.[ID].16:
+l_anon.[ID].10:
 	.ascii	"DropIvars"
 
-l_anon.[ID].17:
+l_anon.[ID].11:
 	.ascii	"$RUSTC/library/std/src/sync/once.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].18:
-	.quad	l_anon.[ID].17
+l_anon.[ID].12:
+	.quad	l_anon.[ID].11
 	.asciz	"p\000\000\000\000\000\000\000\225\000\000\0002\000\000"
 
 	.section	__TEXT,__const
-l_anon.[ID].19:
+l_anon.[ID].13:
 	.ascii	"NoIvars"
 
 .zerofill __DATA,__bss,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_CLASS, 0).0,8,3
@@ -842,23 +782,59 @@ l_anon.[ID].19:
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_IVAR_OFFSET, 2),8,3
 	.globl	SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1)
 .zerofill __DATA,__common,SYM(test_declare_class[CRATE_ID]::_::__OBJC2_DROP_FLAG_OFFSET, 1),8,3
-l_anon.[ID].20:
+l_anon.[ID].14:
 	.ascii	"crates/$DIR/lib.rs"
 
 	.section	__DATA,__const
 	.p2align	3, 0x0
-l_anon.[ID].21:
-	.quad	l_anon.[ID].20
+l_anon.[ID].15:
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000\016\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::NoIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3
+	.section	__TEXT,__const
+	.p2align	3, 0x0
+l_anon.[ID].16:
+	.byte	21
+	.space	39
+
+	.p2align	3, 0x0
+l_anon.[ID].17:
+	.space	1
+	.space	39
+
+	.p2align	3, 0x0
+l_anon.[ID].18:
+	.byte	19
+	.space	39
+
 	.section	__TEXT,__literal8,8byte_literals
-L_anon.[ID].22:
+L_anon.[ID].19:
 	.ascii	"NSObject"
 
 	.section	__TEXT,__const
-l_anon.[ID].23:
+l_anon.[ID].20:
 	.ascii	"NSCopying"
+
+l_anon.[ID].21:
+	.ascii	"_NSZone"
+
+	.section	__DATA,__const
+	.p2align	3, 0x0
+l_anon.[ID].22:
+	.byte	28
+	.space	7
+	.quad	l_anon.[ID].21
+	.asciz	"\007\000\000\000\000\000\000"
+	.quad	8
+	.space	8
+
+	.p2align	3, 0x0
+l_anon.[ID].23:
+	.byte	25
+	.space	7
+	.quad	l_anon.[ID].22
+	.space	24
 
 	.section	__TEXT,__objc_methname,cstring_literals
 	.globl	L_OBJC_METH_VAR_NAME_c1ccd9f2c8e68869
@@ -970,7 +946,7 @@ L_OBJC_IMAGE_INFO_f2913b8ffb9882fe:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].24:
-	.quad	l_anon.[ID].20
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000O\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::ForgetableIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3
@@ -999,7 +975,7 @@ L_OBJC_IMAGE_INFO_dea6e68a0f2fe4ca:
 	.section	__DATA,__const
 	.p2align	3, 0x0
 l_anon.[ID].25:
-	.quad	l_anon.[ID].20
+	.quad	l_anon.[ID].14
 	.asciz	"5\000\000\000\000\000\000\000x\000\000\000\001\000\000"
 
 .zerofill __DATA,__bss,SYM(<test_declare_class[CRATE_ID]::DropIvars as objc2[CRATE_ID]::top_level_traits::ClassType>::class::REGISTER_CLASS, 0),8,3

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-aarch64.s
@@ -110,18 +110,9 @@ Lloh6:
 	adrp	x20, SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh7:
 	ldr	x20, [x20, SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
-	b	LBB3_2
-LBB3_1:
-	ldr	x9, [sp, #152]
-	add	x10, x8, #1
-	str	x10, [sp, #208]
-	ldr	x0, [x9, x8, lsl #3]
-	bl	_use_obj
-	ldr	x0, [sp, #8]
-	ldp	x8, x9, [sp, #208]
-LBB3_2:
 	cmp	x8, x9
-	b.lo	LBB3_1
+	b.lo	LBB3_4
+LBB3_1:
 	ldr	x1, [x20]
 	cbz	x1, LBB3_6
 	add	x2, x21, #136
@@ -130,9 +121,20 @@ LBB3_2:
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
 	cbz	x0, LBB3_7
-LBB3_5:
+LBB3_3:
 	mov	x8, #0
-	b	LBB3_1
+LBB3_4:
+	ldr	x9, [sp, #152]
+	add	x10, x8, #1
+	str	x10, [sp, #208]
+	ldr	x0, [x9, x8, lsl #3]
+	cbz	x0, LBB3_7
+	bl	_use_obj
+	ldr	x0, [sp, #8]
+	ldp	x8, x9, [sp, #208]
+	cmp	x8, x9
+	b.hs	LBB3_1
+	b	LBB3_4
 LBB3_6:
 	mov	x22, x0
 	mov	x0, x20
@@ -145,7 +147,7 @@ LBB3_6:
 	mov	w4, #16
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
-	cbnz	x0, LBB3_5
+	cbnz	x0, LBB3_3
 LBB3_7:
 	ldp	x29, x30, [sp, #272]
 	ldp	x20, x19, [sp, #256]
@@ -165,8 +167,10 @@ _iter_noop:
 	stp	x20, x19, [sp, #256]
 	stp	x29, x30, [sp, #272]
 	add	x29, sp, #272
-	mov	x8, #0
+	mov	x8, x0
 	mov	x9, #0
+	mov	x0, #0
+	mov	x10, #0
 	stp	xzr, xzr, [sp, #200]
 	movi.2d	v0, #0000000000000000
 	stur	q0, [sp, #184]
@@ -176,7 +180,7 @@ _iter_noop:
 	stp	q0, q0, [sp, #48]
 	stp	q0, q0, [sp, #80]
 	stp	q0, q0, [sp, #112]
-	str	x0, [sp, #8]
+	str	x8, [sp, #8]
 	stp	xzr, xzr, [sp, #152]
 	str	xzr, [sp, #144]
 	str	xzr, [sp, #216]
@@ -190,11 +194,15 @@ Lloh11:
 	ldr	x20, [x20, SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
 	b	LBB4_2
 LBB4_1:
-	add	x9, x9, #1
-	str	x9, [sp, #208]
+	add	x8, x10, #1
+	str	x8, [sp, #208]
+	ldr	x11, [x9, x10, lsl #3]
+	mov	x10, x8
+	cbz	x11, LBB4_7
 LBB4_2:
-	cmp	x9, x8
+	cmp	x10, x0
 	b.lo	LBB4_1
+	ldr	x0, [sp, #8]
 	ldr	x1, [x20]
 	cbz	x1, LBB4_6
 	add	x2, x21, #136
@@ -204,9 +212,8 @@ LBB4_2:
 	str	x0, [sp, #216]
 	cbz	x0, LBB4_7
 LBB4_5:
-	mov	x8, x0
-	mov	x9, #0
-	ldr	x0, [sp, #8]
+	mov	x10, #0
+	ldr	x9, [sp, #152]
 	b	LBB4_1
 LBB4_6:
 	mov	x22, x0
@@ -263,22 +270,9 @@ Lloh14:
 	adrp	x20, SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGE
 Lloh15:
 	ldr	x20, [x20, SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPAGEOFF]
-	b	LBB5_2
-LBB5_1:
-	ldr	x9, [sp, #152]
-	add	x10, x8, #1
-	str	x10, [sp, #208]
-	ldr	x0, [x9, x8, lsl #3]
-	bl	_objc_retain
-	mov	x21, x0
-	bl	_use_obj
-	mov	x0, x21
-	bl	_objc_release
-	ldr	x0, [sp, #8]
-	ldp	x8, x9, [sp, #208]
-LBB5_2:
 	cmp	x8, x9
-	b.lo	LBB5_1
+	b.lo	LBB5_4
+LBB5_1:
 	ldr	x1, [x20]
 	cbz	x1, LBB5_6
 	add	x2, x22, #136
@@ -287,9 +281,24 @@ LBB5_2:
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
 	cbz	x0, LBB5_7
-LBB5_5:
+LBB5_3:
 	mov	x8, #0
-	b	LBB5_1
+LBB5_4:
+	ldr	x9, [sp, #152]
+	add	x10, x8, #1
+	str	x10, [sp, #208]
+	ldr	x0, [x9, x8, lsl #3]
+	cbz	x0, LBB5_7
+	bl	_objc_retain
+	mov	x21, x0
+	bl	_use_obj
+	mov	x0, x21
+	bl	_objc_release
+	ldr	x0, [sp, #8]
+	ldp	x8, x9, [sp, #208]
+	cmp	x8, x9
+	b.hs	LBB5_1
+	b	LBB5_4
 LBB5_6:
 	mov	x21, x0
 	mov	x0, x20
@@ -302,7 +311,7 @@ LBB5_6:
 	mov	w4, #16
 	bl	_objc_msgSend
 	str	x0, [sp, #216]
-	cbnz	x0, LBB5_5
+	cbnz	x0, LBB5_3
 LBB5_7:
 	ldp	x29, x30, [sp, #272]
 	ldp	x20, x19, [sp, #256]

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-armv7s.s
@@ -131,8 +131,13 @@ LPC3_1:
 	str	r1, [sp, #112]
 	mov	r10, #16
 	mov	r2, #0
-	b	LBB3_3
+	cmp	r2, r1
+	blo	LBB3_3
 LBB3_1:
+	ldr	r1, [r6]
+	cmp	r1, #0
+	beq	LBB3_5
+LBB3_2:
 	str	r10, [sp]
 	mov	r2, r5
 	mov	r3, r4
@@ -141,28 +146,28 @@ LBB3_1:
 	mov	r2, #0
 	cmp	r0, #0
 	beq	LBB3_6
-LBB3_2:
+LBB3_3:
 	ldr	r0, [sp, #80]
 	add	r1, r2, #1
 	str	r1, [sp, #108]
 	ldr	r0, [r0, r2, lsl #2]
+	cmp	r0, #0
+	beq	LBB3_6
 	bl	_use_obj
 	ldr	r0, [sp, #8]
 	ldr	r2, [sp, #108]
 	ldr	r1, [sp, #112]
-LBB3_3:
 	cmp	r2, r1
-	blo	LBB3_2
-	ldr	r1, [r6]
-	cmp	r1, #0
-	bne	LBB3_1
+	bhs	LBB3_1
+	b	LBB3_3
+LBB3_5:
 	mov	r11, r0
 	mov	r0, r6
 	mov	r1, r8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r1, r0
 	mov	r0, r11
-	b	LBB3_1
+	b	LBB3_2
 LBB3_6:
 	sub	sp, r7, #24
 	pop	{r8, r10, r11}
@@ -182,18 +187,19 @@ _iter_noop:
 	vmov.i32	q8, #0x0
 	vst1.64	{d16, d17}, [r3]!
 	mov	r1, #0
+	str	r1, [r3]
 	orr	r4, r2, #4
 	mov	r5, r4
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
 	vst1.32	{d16, d17}, [r5]!
-	str	r1, [r3]
 	str	r0, [sp, #8]
 	str	r1, [r5]
 	str	r1, [sp, #80]
 	str	r1, [sp, #84]
 	str	r1, [sp, #108]
+	str	r1, [sp, #112]
 	movw	r6, :lower16:(LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
 	movt	r6, :upper16:(LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-(LPC4_0+8))
 LPC4_0:
@@ -202,16 +208,21 @@ LPC4_0:
 	movt	r8, :upper16:(l_anon.[ID].0-(LPC4_1+8))
 LPC4_1:
 	add	r8, pc, r8
-	str	r1, [sp, #112]
 	mov	r10, #16
+	mov	r0, #0
 	mov	r2, #0
 	b	LBB4_2
 LBB4_1:
-	add	r2, r2, #1
-	str	r2, [sp, #108]
+	add	r3, r2, #1
+	str	r3, [sp, #108]
+	ldr	r2, [r1, r2, lsl #2]
+	cmp	r2, #0
+	mov	r2, r3
+	beq	LBB4_7
 LBB4_2:
-	cmp	r2, r1
+	cmp	r2, r0
 	blo	LBB4_1
+	ldr	r0, [sp, #8]
 	ldr	r1, [r6]
 	cmp	r1, #0
 	beq	LBB4_6
@@ -223,9 +234,8 @@ LBB4_4:
 	str	r0, [sp, #112]
 	cmp	r0, #0
 	beq	LBB4_7
-	mov	r1, r0
 	mov	r2, #0
-	ldr	r0, [sp, #8]
+	ldr	r1, [sp, #80]
 	b	LBB4_1
 LBB4_6:
 	mov	r11, r0
@@ -277,8 +287,13 @@ LPC5_1:
 	str	r1, [sp, #112]
 	mov	r11, #16
 	mov	r2, #0
-	b	LBB5_3
+	cmp	r2, r1
+	blo	LBB5_3
 LBB5_1:
+	ldr	r1, [r10]
+	cmp	r1, #0
+	beq	LBB5_5
+LBB5_2:
 	str	r11, [sp]
 	mov	r2, r5
 	mov	r3, r4
@@ -287,11 +302,13 @@ LBB5_1:
 	mov	r2, #0
 	cmp	r0, #0
 	beq	LBB5_6
-LBB5_2:
+LBB5_3:
 	ldr	r0, [sp, #80]
 	add	r1, r2, #1
 	str	r1, [sp, #108]
 	ldr	r0, [r0, r2, lsl #2]
+	cmp	r0, #0
+	beq	LBB5_6
 	bl	_objc_retain
 	mov	r6, r0
 	bl	_use_obj
@@ -300,19 +317,17 @@ LBB5_2:
 	ldr	r0, [sp, #8]
 	ldr	r2, [sp, #108]
 	ldr	r1, [sp, #112]
-LBB5_3:
 	cmp	r2, r1
-	blo	LBB5_2
-	ldr	r1, [r10]
-	cmp	r1, #0
-	bne	LBB5_1
+	bhs	LBB5_1
+	b	LBB5_3
+LBB5_5:
 	mov	r6, r0
 	mov	r0, r10
 	mov	r1, r8
 	bl	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	mov	r1, r0
 	mov	r0, r6
-	b	LBB5_1
+	b	LBB5_2
 LBB5_6:
 	sub	sp, r7, #24
 	pop	{r8, r10, r11}

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86.s
@@ -115,7 +115,7 @@ _iter:
 	call	L3$pb
 L3$pb:
 	pop	eax
-	mov	ebx, dword ptr [ebp + 8]
+	mov	esi, dword ptr [ebp + 8]
 	xorps	xmm0, xmm0
 	movsd	qword ptr [ebp - 36], xmm0
 	movsd	qword ptr [ebp - 44], xmm0
@@ -128,20 +128,25 @@ L3$pb:
 	movsd	qword ptr [ebp - 80], xmm0
 	movsd	qword ptr [ebp - 72], xmm0
 	movsd	qword ptr [ebp - 64], xmm0
-	mov	dword ptr [ebp - 124], ebx
+	mov	dword ptr [ebp - 124], esi
 	lea	edi, [ebp - 56]
 	mov	dword ptr [ebp - 56], 0
 	mov	dword ptr [ebp - 52], 0
 	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
 	mov	dword ptr [ebp - 20], 0
-	mov	esi, dword ptr [eax + LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L3$pb]
+	mov	ebx, dword ptr [eax + LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L3$pb]
 	lea	eax, [eax + l_anon.[ID].0-L3$pb]
 	mov	dword ptr [ebp - 16], eax
 	xor	eax, eax
 	xor	ecx, ecx
-	jmp	LBB3_1
+	cmp	ecx, eax
+	jb	LBB3_5
 	.p2align	4, 0x90
+LBB3_2:
+	mov	eax, dword ptr [ebx]
+	test	eax, eax
+	je	LBB3_3
 LBB3_4:
 	sub	esp, 12
 	push	16
@@ -149,37 +154,38 @@ LBB3_4:
 	push	ecx
 	push	edi
 	push	eax
-	push	ebx
+	push	esi
 	call	_objc_msgSend
 	add	esp, 32
 	mov	dword ptr [ebp - 20], eax
 	xor	ecx, ecx
 	test	eax, eax
-	je	LBB3_5
-LBB3_6:
+	je	LBB3_6
+LBB3_5:
 	mov	eax, dword ptr [ebp - 52]
 	lea	edx, [ecx + 1]
 	mov	dword ptr [ebp - 24], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	test	eax, eax
+	je	LBB3_6
 	sub	esp, 12
-	push	dword ptr [eax + 4*ecx]
+	push	eax
 	call	_use_obj
 	add	esp, 16
-	mov	ebx, dword ptr [ebp - 124]
+	mov	esi, dword ptr [ebp - 124]
 	mov	ecx, dword ptr [ebp - 24]
 	mov	eax, dword ptr [ebp - 20]
-LBB3_1:
 	cmp	ecx, eax
-	jb	LBB3_6
-	mov	eax, dword ptr [esi]
-	test	eax, eax
-	jne	LBB3_4
+	jae	LBB3_2
+	jmp	LBB3_5
+LBB3_3:
 	sub	esp, 8
 	push	dword ptr [ebp - 16]
-	push	esi
+	push	ebx
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
 	jmp	LBB3_4
-LBB3_5:
+LBB3_6:
 	add	esp, 124
 	pop	esi
 	pop	edi
@@ -199,7 +205,7 @@ _iter_noop:
 	call	L4$pb
 L4$pb:
 	pop	eax
-	mov	edi, dword ptr [ebp + 8]
+	mov	ecx, dword ptr [ebp + 8]
 	xorps	xmm0, xmm0
 	movsd	qword ptr [ebp - 36], xmm0
 	movsd	qword ptr [ebp - 44], xmm0
@@ -212,27 +218,32 @@ L4$pb:
 	movsd	qword ptr [ebp - 80], xmm0
 	movsd	qword ptr [ebp - 72], xmm0
 	movsd	qword ptr [ebp - 64], xmm0
-	mov	dword ptr [ebp - 124], edi
-	lea	ebx, [ebp - 56]
+	mov	dword ptr [ebp - 124], ecx
+	lea	edi, [ebp - 56]
 	mov	dword ptr [ebp - 56], 0
 	mov	dword ptr [ebp - 52], 0
 	mov	dword ptr [ebp - 48], 0
 	mov	dword ptr [ebp - 24], 0
 	mov	dword ptr [ebp - 20], 0
-	mov	esi, dword ptr [eax + LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L4$pb]
+	xor	ecx, ecx
+	mov	ebx, dword ptr [eax + LSYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)$non_lazy_ptr-L4$pb]
 	lea	eax, [eax + l_anon.[ID].0-L4$pb]
 	mov	dword ptr [ebp - 16], eax
 	xor	eax, eax
-	xor	ecx, ecx
+	xor	edx, edx
 	jmp	LBB4_1
 	.p2align	4, 0x90
 LBB4_6:
-	inc	ecx
-	mov	dword ptr [ebp - 24], ecx
+	lea	esi, [edx + 1]
+	mov	dword ptr [ebp - 24], esi
+	cmp	dword ptr [ecx + 4*edx], 0
+	mov	edx, esi
+	je	LBB4_7
 LBB4_1:
-	cmp	ecx, eax
+	cmp	edx, eax
 	jb	LBB4_6
-	mov	eax, dword ptr [esi]
+	mov	esi, dword ptr [ebp - 124]
+	mov	eax, dword ptr [ebx]
 	test	eax, eax
 	je	LBB4_3
 LBB4_4:
@@ -240,21 +251,21 @@ LBB4_4:
 	push	16
 	lea	ecx, [ebp - 120]
 	push	ecx
-	push	ebx
-	push	eax
 	push	edi
+	push	eax
+	push	esi
 	call	_objc_msgSend
 	add	esp, 32
 	mov	dword ptr [ebp - 20], eax
 	test	eax, eax
 	je	LBB4_7
-	xor	ecx, ecx
-	mov	edi, dword ptr [ebp - 124]
+	xor	edx, edx
+	mov	ecx, dword ptr [ebp - 52]
 	jmp	LBB4_6
 LBB4_3:
 	sub	esp, 8
 	push	dword ptr [ebp - 16]
-	push	esi
+	push	ebx
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
 	jmp	LBB4_4
@@ -303,8 +314,13 @@ L5$pb:
 	mov	dword ptr [ebp - 16], eax
 	xor	eax, eax
 	xor	ecx, ecx
-	jmp	LBB5_1
+	cmp	ecx, eax
+	jb	LBB5_5
 	.p2align	4, 0x90
+LBB5_2:
+	mov	eax, dword ptr [edi]
+	test	eax, eax
+	je	LBB5_3
 LBB5_4:
 	sub	esp, 12
 	push	16
@@ -318,13 +334,16 @@ LBB5_4:
 	mov	dword ptr [ebp - 20], eax
 	xor	ecx, ecx
 	test	eax, eax
-	je	LBB5_5
-LBB5_6:
+	je	LBB5_6
+LBB5_5:
 	mov	eax, dword ptr [ebp - 52]
 	lea	edx, [ecx + 1]
 	mov	dword ptr [ebp - 24], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	test	eax, eax
+	je	LBB5_6
 	sub	esp, 12
-	push	dword ptr [eax + 4*ecx]
+	push	eax
 	call	_objc_retain
 	add	esp, 16
 	mov	esi, eax
@@ -338,19 +357,17 @@ LBB5_6:
 	mov	esi, dword ptr [ebp - 124]
 	mov	ecx, dword ptr [ebp - 24]
 	mov	eax, dword ptr [ebp - 20]
-LBB5_1:
 	cmp	ecx, eax
-	jb	LBB5_6
-	mov	eax, dword ptr [edi]
-	test	eax, eax
-	jne	LBB5_4
+	jae	LBB5_2
+	jmp	LBB5_5
+LBB5_3:
 	sub	esp, 8
 	push	dword ptr [ebp - 16]
 	push	edi
 	call	SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)
 	add	esp, 16
 	jmp	LBB5_4
-LBB5_5:
+LBB5_6:
 	add	esp, 124
 	pop	esi
 	pop	edi

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/apple-x86_64.s
@@ -147,20 +147,10 @@ _iter:
 	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	r12, [rip + l_anon.[ID].0]
 	xor	eax, eax
-	jmp	LBB3_1
-	.p2align	4, 0x90
-LBB3_6:
-	mov	rcx, qword ptr [rbp - 112]
-	lea	rdx, [rax + 1]
-	mov	qword ptr [rbp - 56], rdx
-	mov	rdi, qword ptr [rcx + 8*rax]
-	call	_use_obj
-	mov	rdi, qword ptr [rbp - 256]
-	mov	rax, qword ptr [rbp - 56]
-	mov	rcx, qword ptr [rbp - 48]
-LBB3_1:
 	cmp	rax, rcx
 	jb	LBB3_6
+	.p2align	4, 0x90
+LBB3_2:
 	mov	rsi, qword ptr [r15]
 	test	rsi, rsi
 	je	LBB3_3
@@ -173,6 +163,19 @@ LBB3_4:
 	test	rax, rax
 	je	LBB3_7
 	xor	eax, eax
+LBB3_6:
+	mov	rcx, qword ptr [rbp - 112]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbp - 56], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	test	rdi, rdi
+	je	LBB3_7
+	call	_use_obj
+	mov	rdi, qword ptr [rbp - 256]
+	mov	rax, qword ptr [rbp - 56]
+	mov	rcx, qword ptr [rbp - 48]
+	cmp	rax, rcx
+	jae	LBB3_2
 	jmp	LBB3_6
 LBB3_3:
 	mov	r13, rdi
@@ -232,18 +235,23 @@ _iter_noop:
 	mov	qword ptr [rbp - 120], 0
 	mov	qword ptr [rbp - 48], 0
 	mov	qword ptr [rbp - 56], 0
-	xor	eax, eax
+	xor	ecx, ecx
 	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	r12, [rip + l_anon.[ID].0]
-	xor	ecx, ecx
+	xor	eax, eax
+	xor	edx, edx
 	jmp	LBB4_1
 	.p2align	4, 0x90
 LBB4_6:
-	inc	rcx
-	mov	qword ptr [rbp - 56], rcx
+	lea	rsi, [rdx + 1]
+	mov	qword ptr [rbp - 56], rsi
+	cmp	qword ptr [rcx + 8*rdx], 0
+	mov	rdx, rsi
+	je	LBB4_7
 LBB4_1:
-	cmp	rcx, rax
+	cmp	rdx, rax
 	jb	LBB4_6
+	mov	rdi, qword ptr [rbp - 256]
 	mov	rsi, qword ptr [r15]
 	test	rsi, rsi
 	je	LBB4_3
@@ -255,8 +263,8 @@ LBB4_4:
 	mov	qword ptr [rbp - 48], rax
 	test	rax, rax
 	je	LBB4_7
-	mov	rdi, qword ptr [rbp - 256]
-	xor	ecx, ecx
+	mov	rcx, qword ptr [rbp - 112]
+	xor	edx, edx
 	jmp	LBB4_6
 LBB4_3:
 	mov	r13, rdi
@@ -320,25 +328,10 @@ _iter_retained:
 	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	lea	r12, [rip + l_anon.[ID].0]
 	xor	eax, eax
-	jmp	LBB5_1
-	.p2align	4, 0x90
-LBB5_6:
-	mov	rcx, qword ptr [rbp - 112]
-	lea	rdx, [rax + 1]
-	mov	qword ptr [rbp - 56], rdx
-	mov	rdi, qword ptr [rcx + 8*rax]
-	call	_objc_retain
-	mov	r13, rax
-	mov	rdi, rax
-	call	_use_obj
-	mov	rdi, r13
-	call	_objc_release
-	mov	rdi, qword ptr [rbp - 256]
-	mov	rax, qword ptr [rbp - 56]
-	mov	rcx, qword ptr [rbp - 48]
-LBB5_1:
 	cmp	rax, rcx
 	jb	LBB5_6
+	.p2align	4, 0x90
+LBB5_2:
 	mov	rsi, qword ptr [r15]
 	test	rsi, rsi
 	je	LBB5_3
@@ -351,6 +344,24 @@ LBB5_4:
 	test	rax, rax
 	je	LBB5_7
 	xor	eax, eax
+LBB5_6:
+	mov	rcx, qword ptr [rbp - 112]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rbp - 56], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	test	rdi, rdi
+	je	LBB5_7
+	call	_objc_retain
+	mov	r13, rax
+	mov	rdi, rax
+	call	_use_obj
+	mov	rdi, r13
+	call	_objc_release
+	mov	rdi, qword ptr [rbp - 256]
+	mov	rax, qword ptr [rbp - 56]
+	mov	rcx, qword ptr [rbp - 48]
+	cmp	rax, rcx
+	jae	LBB5_2
 	jmp	LBB5_6
 LBB5_3:
 	mov	r13, rdi

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86.s
@@ -155,8 +155,13 @@ iter:
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0
-	jmp	.LBB3_1
+	cmp	ecx, eax
+	jb	.LBB3_5
 	.p2align	4, 0x90
+.LBB3_2:
+	mov	esi, dword ptr [edi]
+	test	esi, esi
+	je	.LBB3_3
 .LBB3_4:
 	sub	esp, 8
 	push	esi
@@ -175,24 +180,25 @@ iter:
 	xor	ecx, ecx
 	test	eax, eax
 	mov	dword ptr [esp + 120], eax
-	je	.LBB3_5
-.LBB3_6:
+	je	.LBB3_6
+.LBB3_5:
 	mov	eax, dword ptr [esp + 88]
 	lea	edx, [ecx + 1]
 	mov	dword ptr [esp + 116], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	test	eax, eax
+	je	.LBB3_6
 	sub	esp, 12
-	push	dword ptr [eax + 4*ecx]
+	push	eax
 	call	use_obj@PLT
 	add	esp, 16
 	mov	ebp, dword ptr [esp + 16]
 	mov	ecx, dword ptr [esp + 116]
 	mov	eax, dword ptr [esp + 120]
-.LBB3_1:
 	cmp	ecx, eax
-	jb	.LBB3_6
-	mov	esi, dword ptr [edi]
-	test	esi, esi
-	jne	.LBB3_4
+	jae	.LBB3_2
+	jmp	.LBB3_5
+.LBB3_3:
 	sub	esp, 8
 	push	dword ptr [esp + 20]
 	push	edi
@@ -200,7 +206,7 @@ iter:
 	add	esp, 16
 	mov	esi, eax
 	jmp	.LBB3_4
-.LBB3_5:
+.LBB3_6:
 	add	esp, 124
 	pop	esi
 	pop	edi
@@ -223,10 +229,11 @@ iter_noop:
 	call	.L4$pb
 .L4$pb:
 	pop	ebx
-	mov	ebp, dword ptr [esp + 144]
+	mov	eax, dword ptr [esp + 144]
 	xorps	xmm0, xmm0
-	xor	eax, eax
 	mov	dword ptr [esp + 112], 0
+	xor	ecx, ecx
+	xor	edx, edx
 .Ltmp2:
 	add	ebx, offset _GLOBAL_OFFSET_TABLE_+(.Ltmp2-.L4$pb)
 	movsd	qword ptr [esp + 104], xmm0
@@ -240,23 +247,27 @@ iter_noop:
 	movsd	qword ptr [esp + 68], xmm0
 	movsd	qword ptr [esp + 76], xmm0
 	mov	edi, dword ptr [ebx + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOT]
-	lea	ecx, [ebx + .Lanon.[ID].0@GOTOFF]
-	mov	dword ptr [esp + 12], ecx
-	xor	ecx, ecx
-	mov	dword ptr [esp + 16], ebp
+	mov	dword ptr [esp + 16], eax
+	lea	eax, [ebx + .Lanon.[ID].0@GOTOFF]
 	mov	dword ptr [esp + 84], 0
 	mov	dword ptr [esp + 88], 0
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0
+	mov	dword ptr [esp + 12], eax
+	xor	eax, eax
 	jmp	.LBB4_1
 	.p2align	4, 0x90
 .LBB4_6:
-	inc	ecx
-	mov	dword ptr [esp + 116], ecx
+	lea	esi, [edx + 1]
+	mov	dword ptr [esp + 116], esi
+	cmp	dword ptr [ecx + 4*edx], 0
+	mov	edx, esi
+	je	.LBB4_7
 .LBB4_1:
-	cmp	ecx, eax
+	cmp	edx, eax
 	jb	.LBB4_6
+	mov	ebp, dword ptr [esp + 16]
 	mov	esi, dword ptr [edi]
 	test	esi, esi
 	je	.LBB4_3
@@ -278,8 +289,8 @@ iter_noop:
 	test	eax, eax
 	mov	dword ptr [esp + 120], eax
 	je	.LBB4_7
-	mov	ebp, dword ptr [esp + 16]
-	xor	ecx, ecx
+	mov	ecx, dword ptr [esp + 88]
+	xor	edx, edx
 	jmp	.LBB4_6
 .LBB4_3:
 	sub	esp, 8
@@ -338,8 +349,13 @@ iter_retained:
 	mov	dword ptr [esp + 92], 0
 	mov	dword ptr [esp + 116], 0
 	mov	dword ptr [esp + 120], 0
-	jmp	.LBB5_1
+	cmp	ecx, eax
+	jb	.LBB5_5
 	.p2align	4, 0x90
+.LBB5_2:
+	mov	esi, dword ptr [edi]
+	test	esi, esi
+	je	.LBB5_3
 .LBB5_4:
 	sub	esp, 8
 	push	esi
@@ -358,13 +374,16 @@ iter_retained:
 	xor	ecx, ecx
 	test	eax, eax
 	mov	dword ptr [esp + 120], eax
-	je	.LBB5_5
-.LBB5_6:
+	je	.LBB5_6
+.LBB5_5:
 	mov	eax, dword ptr [esp + 88]
 	lea	edx, [ecx + 1]
 	mov	dword ptr [esp + 116], edx
+	mov	eax, dword ptr [eax + 4*ecx]
+	test	eax, eax
+	je	.LBB5_6
 	sub	esp, 12
-	push	dword ptr [eax + 4*ecx]
+	push	eax
 	call	objc_retain@PLT
 	add	esp, 16
 	mov	esi, eax
@@ -378,12 +397,10 @@ iter_retained:
 	mov	ebp, dword ptr [esp + 16]
 	mov	ecx, dword ptr [esp + 116]
 	mov	eax, dword ptr [esp + 120]
-.LBB5_1:
 	cmp	ecx, eax
-	jb	.LBB5_6
-	mov	esi, dword ptr [edi]
-	test	esi, esi
-	jne	.LBB5_4
+	jae	.LBB5_2
+	jmp	.LBB5_5
+.LBB5_3:
 	sub	esp, 8
 	push	dword ptr [esp + 20]
 	push	edi
@@ -391,7 +408,7 @@ iter_retained:
 	add	esp, 16
 	mov	esi, eax
 	jmp	.LBB5_4
-.LBB5_5:
+.LBB5_6:
 	add	esp, 124
 	pop	esi
 	pop	edi

--- a/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
+++ b/crates/test-assembly/crates/test_fast_enumeration/expected/gnustep-x86_64.s
@@ -132,20 +132,10 @@ iter:
 	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
 	mov	rbx, qword ptr [rip + objc_msg_lookup@GOTPCREL]
 	xor	eax, eax
-	jmp	.LBB3_1
-	.p2align	4, 0x90
-.LBB3_6:
-	mov	rcx, qword ptr [rsp + 144]
-	lea	rdx, [rax + 1]
-	mov	qword ptr [rsp + 200], rdx
-	mov	rdi, qword ptr [rcx + 8*rax]
-	call	r12
-	mov	r13, qword ptr [rsp]
-	mov	rax, qword ptr [rsp + 200]
-	mov	rcx, qword ptr [rsp + 208]
-.LBB3_1:
 	cmp	rax, rcx
 	jb	.LBB3_6
+	.p2align	4, 0x90
+.LBB3_2:
 	mov	rbp, qword ptr [r15]
 	test	rbp, rbp
 	je	.LBB3_3
@@ -163,6 +153,19 @@ iter:
 	test	rax, rax
 	je	.LBB3_7
 	xor	eax, eax
+.LBB3_6:
+	mov	rcx, qword ptr [rsp + 144]
+	lea	rdx, [rax + 1]
+	mov	qword ptr [rsp + 200], rdx
+	mov	rdi, qword ptr [rcx + 8*rax]
+	test	rdi, rdi
+	je	.LBB3_7
+	call	r12
+	mov	r13, qword ptr [rsp]
+	mov	rax, qword ptr [rsp + 200]
+	mov	rcx, qword ptr [rsp + 208]
+	cmp	rax, rcx
+	jae	.LBB3_2
 	jmp	.LBB3_6
 .LBB3_3:
 	mov	rdi, r15
@@ -194,7 +197,6 @@ iter_noop:
 	push	r12
 	push	rbx
 	sub	rsp, 216
-	mov	r14, rdi
 	xorps	xmm0, xmm0
 	movups	xmmword ptr [rsp + 176], xmm0
 	movups	xmmword ptr [rsp + 160], xmm0
@@ -209,43 +211,48 @@ iter_noop:
 	movups	xmmword ptr [rsp + 104], xmm0
 	movups	xmmword ptr [rsp + 120], xmm0
 	mov	qword ptr [rsp], rdi
-	lea	r15, [rsp + 136]
+	lea	r14, [rsp + 136]
 	movups	xmmword ptr [rsp + 136], xmm0
 	mov	qword ptr [rsp + 152], 0
 	movups	xmmword ptr [rsp + 200], xmm0
-	xor	eax, eax
-	mov	r12, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	mov	r13, qword ptr [rip + objc_msg_lookup@GOTPCREL]
 	xor	ecx, ecx
+	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
+	mov	r12, qword ptr [rip + objc_msg_lookup@GOTPCREL]
+	xor	eax, eax
+	xor	edx, edx
 	jmp	.LBB4_1
 	.p2align	4, 0x90
 .LBB4_6:
-	inc	rcx
-	mov	qword ptr [rsp + 200], rcx
+	lea	rsi, [rdx + 1]
+	mov	qword ptr [rsp + 200], rsi
+	cmp	qword ptr [rcx + 8*rdx], 0
+	mov	rdx, rsi
+	je	.LBB4_7
 .LBB4_1:
-	cmp	rcx, rax
+	cmp	rdx, rax
 	jb	.LBB4_6
-	mov	rbp, qword ptr [r12]
+	mov	r13, qword ptr [rsp]
+	mov	rbp, qword ptr [r15]
 	test	rbp, rbp
 	je	.LBB4_3
 .LBB4_4:
-	mov	rdi, r14
+	mov	rdi, r13
 	mov	rsi, rbp
-	call	r13
+	call	r12
 	mov	r8d, 16
-	mov	rdi, r14
+	mov	rdi, r13
 	mov	rsi, rbp
-	mov	rdx, r15
+	mov	rdx, r14
 	mov	rcx, rbx
 	call	rax
 	mov	qword ptr [rsp + 208], rax
 	test	rax, rax
 	je	.LBB4_7
-	mov	r14, qword ptr [rsp]
-	xor	ecx, ecx
+	mov	rcx, qword ptr [rsp + 144]
+	xor	edx, edx
 	jmp	.LBB4_6
 .LBB4_3:
-	mov	rdi, r12
+	mov	rdi, r15
 	lea	rsi, [rip + .Lanon.[ID].0]
 	call	qword ptr [rip + SYM(objc2::__macro_helpers::cache::CachedSel::fetch::GENERATED_ID, 0)@GOTPCREL]
 	mov	rbp, rax
@@ -291,31 +298,16 @@ iter_retained:
 	movups	xmmword ptr [rsp + 136], xmm0
 	mov	qword ptr [rsp + 152], 0
 	movups	xmmword ptr [rsp + 200], xmm0
-	xor	ecx, ecx
+	xor	eax, eax
 	mov	r12, qword ptr [rip + objc_retain@GOTPCREL]
 	mov	rbx, qword ptr [rip + use_obj@GOTPCREL]
 	mov	r14, qword ptr [rip + objc_release@GOTPCREL]
 	mov	r15, qword ptr [rip + SYM(objc2_foundation::generated::__NSEnumerator::NSFastEnumeration::countByEnumeratingWithState_objects_count::CACHED_SEL::GENERATED_ID, 0)@GOTPCREL]
-	xor	eax, eax
-	jmp	.LBB5_1
-	.p2align	4, 0x90
-.LBB5_6:
-	mov	rcx, qword ptr [rsp + 144]
-	lea	rdx, [rax + 1]
-	mov	qword ptr [rsp + 200], rdx
-	mov	rdi, qword ptr [rcx + 8*rax]
-	call	r12
-	mov	r13, rax
-	mov	rdi, rax
-	call	rbx
-	mov	rdi, r13
-	call	r14
-	mov	r13, qword ptr [rsp]
-	mov	rax, qword ptr [rsp + 200]
-	mov	rcx, qword ptr [rsp + 208]
-.LBB5_1:
-	cmp	rax, rcx
+	xor	ecx, ecx
+	cmp	rcx, rax
 	jb	.LBB5_6
+	.p2align	4, 0x90
+.LBB5_2:
 	mov	rbp, qword ptr [r15]
 	test	rbp, rbp
 	je	.LBB5_3
@@ -332,7 +324,25 @@ iter_retained:
 	mov	qword ptr [rsp + 208], rax
 	test	rax, rax
 	je	.LBB5_7
-	xor	eax, eax
+	xor	ecx, ecx
+.LBB5_6:
+	mov	rax, qword ptr [rsp + 144]
+	lea	rdx, [rcx + 1]
+	mov	qword ptr [rsp + 200], rdx
+	mov	rdi, qword ptr [rax + 8*rcx]
+	test	rdi, rdi
+	je	.LBB5_7
+	call	r12
+	mov	r13, rax
+	mov	rdi, rax
+	call	rbx
+	mov	rdi, r13
+	call	r14
+	mov	r13, qword ptr [rsp]
+	mov	rcx, qword ptr [rsp + 200]
+	mov	rax, qword ptr [rsp + 208]
+	cmp	rcx, rax
+	jae	.LBB5_2
 	jmp	.LBB5_6
 .LBB5_3:
 	mov	rdi, r15

--- a/crates/test-ui/src/main.rs
+++ b/crates/test-ui/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Use as:
 //! ```
-//! TRYBUILD=overwrite cargo run --features=run --bin test-ui
+//! TRYBUILD=overwrite RUSTFLAGS= cargo run --features=run --bin test-ui
 //! ```
 //!
 //! These are not part of the normal test suite, because trybuild doesn't pass

--- a/crates/test-ui/ui/declare_class_invalid_type.stderr
+++ b/crates/test-ui/ui/declare_class_invalid_type.stderr
@@ -77,11 +77,11 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
-            std::option::Option<&mut objc2::rc::Retained<T>>
+            bool
             &mut objc2::rc::Retained<T>
             &mut std::option::Option<objc2::rc::Retained<T>>
-            bool
+            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
+            std::option::Option<&mut objc2::rc::Retained<T>>
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -112,11 +112,11 @@ note: required by a bound in `ConvertArgument`
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ConvertArgument`
   = note: `ConvertArgument` is a "sealed trait", because to implement it you also need to implement `objc2::__macro_helpers::convert::argument_private::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
-            std::option::Option<&mut objc2::rc::Retained<T>>
+            bool
             &mut objc2::rc::Retained<T>
             &mut std::option::Option<objc2::rc::Retained<T>>
-            bool
+            std::option::Option<&mut std::option::Option<objc2::rc::Retained<T>>>
+            std::option::Option<&mut objc2::rc::Retained<T>>
             T
   = note: this error originates in the macro `$crate::__declare_class_rewrite_params` which comes from the expansion of the macro `declare_class` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/crates/test-ui/ui/extern_class_feature_flag.rs
+++ b/crates/test-ui/ui/extern_class_feature_flag.rs
@@ -2,10 +2,10 @@ use objc2::runtime::NSObject;
 use objc2::{extern_class, mutability, ClassType};
 
 extern_class!(
-    #[cfg(not(feature = "mytest"))]
+    #[cfg(not(test))]
     pub struct MyTestEnabled;
 
-    #[cfg(not(feature = "mytest"))]
+    #[cfg(not(test))]
     unsafe impl ClassType for MyTestEnabled {
         type Super = NSObject;
         type Mutability = mutability::InteriorMutable;
@@ -13,10 +13,10 @@ extern_class!(
 );
 
 extern_class!(
-    #[cfg(feature = "mytest")]
+    #[cfg(test)]
     pub struct MyTestDisabled;
 
-    #[cfg(feature = "mytest")]
+    #[cfg(test)]
     unsafe impl ClassType for MyTestDisabled {
         type Super = NSObject;
         type Mutability = mutability::InteriorMutable;

--- a/crates/test-ui/ui/extern_methods_feature_flag.rs
+++ b/crates/test-ui/ui/extern_methods_feature_flag.rs
@@ -11,13 +11,13 @@ extern_class!(
 );
 
 extern_methods!(
-    #[cfg(not(feature = "mytest"))]
+    #[cfg(not(test))]
     unsafe impl MyTest {
         #[method(enabled)]
         fn enabled();
     }
 
-    #[cfg(feature = "mytest")]
+    #[cfg(test)]
     unsafe impl MyTest {
         #[method(disabled)]
         fn disabled();
@@ -25,18 +25,18 @@ extern_methods!(
 
     unsafe impl MyTest {
         #[method(enabled)]
-        #[cfg(not(feature = "mytest"))]
+        #[cfg(not(test))]
         fn enabled_inner1();
 
-        #[cfg(not(feature = "mytest"))]
+        #[cfg(not(test))]
         #[method(enabled)]
         fn enabled_inner2();
 
         #[method(disabled)]
-        #[cfg(feature = "mytest")]
+        #[cfg(test)]
         fn disabled_inner1();
 
-        #[cfg(feature = "mytest")]
+        #[cfg(test)]
         #[method(disabled)]
         fn disabled_inner2();
     }

--- a/crates/test-ui/ui/extern_methods_variadic.stderr
+++ b/crates/test-ui/ui/extern_methods_variadic.stderr
@@ -68,12 +68,6 @@ error: only foreign or `unsafe extern "C"` functions may be C-variadic
   |         fn variadic_id(arg: i32, arg2: ...) -> Retained<NSObject>;
   |                                  ^^^^^^^^^
 
-error: C-variadic function must be declared with at least one named argument
- --> ui/extern_methods_variadic.rs
-  |
-  |         fn variadic_error(arg2: ...) -> Result<(), Retained<NSObject>>;
-  |                           ^^^^^^^^^
-
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
  --> ui/extern_methods_variadic.rs
   |

--- a/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
+++ b/crates/test-ui/ui/msg_send_not_allowed_mutable.stderr
@@ -2,9 +2,9 @@ error[E0277]: the trait bound `InteriorMutable: mutability::MutabilityIsAllowedM
  --> ui/msg_send_not_allowed_mutable.rs
   |
   |     let _: () = unsafe { msg_send![&mut *obj, test] };
-  |                          ----------^^^^^^^^^-------
-  |                          |         |
-  |                          |         the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut NSThread: MsgSend`
+  |                          ---------------^^^^-------
+  |                          |              |
+  |                          |              the trait `mutability::MutabilityIsAllowedMutable` is not implemented for `InteriorMutable`, which is required by `&mut NSThread: MsgSend`
   |                          required by a bound introduced by this call
   |
   = help: the following other types implement trait `mutability::MutabilityIsAllowedMutable`:

--- a/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
+++ b/crates/test-ui/ui/mutability_traits_unimplementable2.stderr
@@ -15,8 +15,8 @@ note: required by a bound in `IsIdCloneable`
   |                                 ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `IsIdCloneable`
   = note: `IsIdCloneable` is a "sealed trait", because to implement it you also need to implement `objc2::mutability::private_traits::Sealed`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
   = help: the following types implement the trait:
-            objc2::runtime::ProtocolObject<P>
             objc2::runtime::AnyObject
+            objc2::runtime::ProtocolObject<P>
             T
 
 error[E0277]: the trait bound `CustomStruct: IsAllowedMutable` is not satisfied

--- a/crates/test-ui/ui/ns_string_output_not_const.stderr
+++ b/crates/test-ui/ui/ns_string_output_not_const.stderr
@@ -5,5 +5,5 @@ error[E0015]: cannot call non-const fn `CachedId::<NSString>::get::<{closure@$WO
   |                                ^^^^^^^^^^^^^^^^^
   |
   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
-  = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
+  = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
   = note: this error originates in the macro `$crate::__ns_string_inner` which comes from the expansion of the macro `ns_string` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/framework-crates/objc2-foundation/src/tests/value.rs
+++ b/framework-crates/objc2-foundation/src/tests/value.rs
@@ -34,16 +34,15 @@ fn test_equality_across_types() {
 }
 
 #[test]
-#[ignore = "the debug output changes depending on OS version"]
 fn test_debug() {
-    let expected = if cfg!(feature = "gnustep-1-7") {
-        r#"NSValue { encoding: "C", bytes: (C) <ab> }"#
-    } else if cfg!(newer_apple) {
-        r#"NSValue { encoding: "C", bytes: {length = 1, bytes = 0xab} }"#
-    } else {
-        r#"NSValue { encoding: "C", bytes: <ab> }"#
-    };
-    assert_eq!(format!("{:?}", NSValue::new(171u8)), expected);
+    // Output changes depending on OS and OS version
+    let expected = [
+        r#"NSValue { encoding: "C", bytes: (C) <ab> }"#,
+        r#"NSValue { encoding: "C", bytes: {length = 1, bytes = 0xab} }"#,
+        r#"NSValue { encoding: "C", bytes: <ab> }"#,
+    ];
+    let actual = format!("{:?}", NSValue::new(171u8));
+    assert!(expected.contains(&&*actual), "{actual}");
 }
 
 #[test]

--- a/framework-crates/objc2-input-method-kit/src/lib.rs
+++ b/framework-crates/objc2-input-method-kit/src/lib.rs
@@ -26,10 +26,10 @@ extern "C" {
     #[cfg(feature = "IMKInputController")]
     pub static kIMKCommandClientName: &'static objc2_foundation::NSString;
 
-    #[cfg(all(feature = "IMKCandidates", feature = "NSString_TODO"))]
-    pub static IMKCandidatesOpacityAttributeName: &'static objc2_foundation::NSString;
-    #[cfg(all(feature = "IMKCandidates", feature = "NSString_TODO"))]
-    pub static IMKCandidatesSendServerKeyEventFirst: &'static objc2_foundation::NSString;
+    // #[cfg(all(feature = "IMKCandidates", feature = "NSString_TODO"))]
+    // pub static IMKCandidatesOpacityAttributeName: &'static objc2_foundation::NSString;
+    // #[cfg(all(feature = "IMKCandidates", feature = "NSString_TODO"))]
+    // pub static IMKCandidatesSendServerKeyEventFirst: &'static objc2_foundation::NSString;
 
     #[cfg(feature = "IMKServer")]
     pub static IMKModeDictionary: &'static objc2_foundation::NSString;

--- a/framework-crates/objc2-metal/src/device.rs
+++ b/framework-crates/objc2-metal/src/device.rs
@@ -1,17 +1,16 @@
-#![cfg(commented_out)]
-use crate::MTLDevice;
-
-pub trait MTLDeviceExtension {
-    // pub fn system_default() -> Option<Self> {
-    //     MTLCreateSystemDefaultDevice()
-    // }
-    //
-    // pub fn all() -> Retained<NSArray<Self>> {
-    //     #[cfg(target_os = "macos")]
-    //     MTLCopyAllDevices()
-    //     #[cfg(not(target_os = "macos"))]
-    //     NSArray::from(MTLCreateSystemDefaultDevice())
-    // }
-}
-
-impl<P: MTLDevice> MTLDeviceExtension for P {}
+// use crate::MTLDevice;
+//
+// pub trait MTLDeviceExtension {
+//     pub fn system_default() -> Option<Self> {
+//         MTLCreateSystemDefaultDevice()
+//     }
+//
+//     pub fn all() -> Retained<NSArray<Self>> {
+//         #[cfg(target_os = "macos")]
+//         MTLCopyAllDevices()
+//         #[cfg(not(target_os = "macos"))]
+//         NSArray::from(MTLCreateSystemDefaultDevice())
+//     }
+// }
+//
+// impl<P: MTLDevice> MTLDeviceExtension for P {}

--- a/framework-crates/objc2-metal/src/private.rs
+++ b/framework-crates/objc2-metal/src/private.rs
@@ -53,7 +53,7 @@ extern_methods!(
 );
 
 extern_methods!(
-    #[cfg(feature = "MTLSamplerDescriptor")]
+    #[cfg(feature = "MTLSampler")]
     unsafe impl MTLSamplerDescriptor {
         #[method(setLodBias:)]
         pub unsafe fn setLodBias(&self, bias: f32);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Remember to update this in ci.yml as well.
-channel = "nightly-2024-05-01"
+channel = "nightly-2024-06-13"
 profile = "minimal"
 components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
Assembly test changes are:
- The ability to eliminate an empty `Drop` call in `declare_class!` test.
- Code reordering in fast enumeration for unclear reasons?

Clippy lints are positive.

UI test changes are the usual reordering because of current nondeterminism, possibly fixed by https://github.com/rust-lang/rust/pull/120812, and a few cleanups. Note that I had to set `RUSTFLAGS` to something while running `trybuild`, since otherwise it outputs the full list of suggested traits, see https://github.com/dtolnay/trybuild/blob/b1b7064b7ad11e0ab563e9eb843651d86e4545b7/src/cargo.rs#L44.