### PR TITLE
Remove non-interior mutability from non-generic types

### DIFF
--- a/crates/header-translator/README.md
+++ b/crates/header-translator/README.md
@@ -86,8 +86,8 @@ specific API!
 3. If the method can throw an exception if provided with invalid inputs, it is
     not safe. Consider declaring a helper method that checks the preconditions
     first!
-4. Beware of `Mutable` classes (e.g. `NSMutableString`); these usually need to
-    be passed as `&mut T`, or operate on `&mut self`.
+4. Beware of `Mutable` classes; these usually need to be passed as `&mut T`, or
+    operate on `&mut self`.
 
 Note: It is _not_ considered a breaking change for a method to be marked safe,
 so such an improvement can be made in a minor version!

--- a/crates/header-translator/src/config.rs
+++ b/crates/header-translator/src/config.rs
@@ -366,6 +366,24 @@ impl<'de> Deserialize<'de> for Mutability {
                     return Ok(Mutability::MutableWithImmutableSuperclass(item));
                 }
 
+                if let Some(value) = value.strip_prefix("InteriorMutableWithSubclass(") {
+                    let value = value
+                        .strip_suffix(')')
+                        .ok_or(de::Error::custom("end parenthesis"))?;
+                    let item =
+                        parse_itemidentifier(value).ok_or(de::Error::custom("requires ::"))?;
+                    return Ok(Mutability::InteriorMutableWithSubclass(item));
+                }
+
+                if let Some(value) = value.strip_prefix("InteriorMutableWithSuperclass(") {
+                    let value = value
+                        .strip_suffix(')')
+                        .ok_or(de::Error::custom("end parenthesis"))?;
+                    let item =
+                        parse_itemidentifier(value).ok_or(de::Error::custom("requires ::"))?;
+                    return Ok(Mutability::InteriorMutableWithSuperclass(item));
+                }
+
                 match value {
                     "Immutable" => Ok(Mutability::Immutable),
                     "Mutable" => Ok(Mutability::Mutable),

--- a/crates/objc2/CHANGELOG.md
+++ b/crates/objc2/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added the feature flag `"relax-sign-encoding"`, which when enabled, allows
   using e.g. `NSInteger` in places where you would otherwise have to use
   `NSUInteger`.
+* Added new mutability options `InteriorMutableWithSubclass` and
+  `InteriorMutableWithSuperclass`.
 
 ### Changed
 * Renamed `Id` to `Retained`, to better reflect what it represents.

--- a/crates/objc2/src/__framework_prelude.rs
+++ b/crates/objc2/src/__framework_prelude.rs
@@ -14,8 +14,9 @@ pub use std::os::raw::{
 pub use crate::encode::{Encode, Encoding, RefEncode};
 pub use crate::ffi::{NSInteger, NSIntegerMax, NSUInteger, NSUIntegerMax, IMP};
 pub use crate::mutability::{
-    Immutable, ImmutableWithMutableSubclass, InteriorMutable, IsIdCloneable, IsMainThreadOnly,
-    IsRetainable, MainThreadOnly, Mutable, MutableWithImmutableSuperclass,
+    Immutable, ImmutableWithMutableSubclass, InteriorMutable, InteriorMutableWithSubclass,
+    InteriorMutableWithSuperclass, IsIdCloneable, IsMainThreadOnly, IsRetainable, MainThreadOnly,
+    Mutable, MutableWithImmutableSuperclass,
 };
 pub use crate::rc::{Allocated, DefaultId, DefaultRetained, Id, Retained};
 pub use crate::runtime::{

--- a/crates/objc2/src/__macro_helpers/declare_class.rs
+++ b/crates/objc2/src/__macro_helpers/declare_class.rs
@@ -149,6 +149,13 @@ where
 {
 }
 impl ValidSubclassMutability<mutability::InteriorMutable> for mutability::Root {}
+impl<MS, IS> ValidSubclassMutability<mutability::InteriorMutableWithSubclass<MS>>
+    for mutability::Root
+where
+    MS: ?Sized + ClassType<Mutability = mutability::InteriorMutableWithSuperclass<IS>>,
+    IS: ?Sized + ClassType<Mutability = mutability::InteriorMutableWithSubclass<MS>>,
+{
+}
 impl ValidSubclassMutability<mutability::MainThreadOnly> for mutability::Root {}
 
 // Immutable
@@ -181,6 +188,25 @@ impl<IS: ?Sized + ClassType> ValidSubclassMutability<mutability::Mutable>
 // InteriorMutable
 impl ValidSubclassMutability<mutability::InteriorMutable> for mutability::InteriorMutable {}
 impl ValidSubclassMutability<mutability::MainThreadOnly> for mutability::InteriorMutable {}
+
+// InteriorMutableWithSubclass
+impl<MS, IS> ValidSubclassMutability<mutability::InteriorMutableWithSuperclass<IS>>
+    for mutability::InteriorMutableWithSubclass<MS>
+where
+    MS: ?Sized + ClassType<Mutability = mutability::InteriorMutableWithSuperclass<IS>>,
+    IS: ?Sized + ClassType<Mutability = mutability::InteriorMutableWithSubclass<MS>>,
+{
+}
+impl<S: ?Sized + ClassType> ValidSubclassMutability<mutability::InteriorMutable>
+    for mutability::InteriorMutableWithSubclass<S>
+{
+}
+
+// InteriorMutableWithSuperclass
+impl<S: ?Sized + ClassType> ValidSubclassMutability<mutability::InteriorMutable>
+    for mutability::InteriorMutableWithSuperclass<S>
+{
+}
 
 // MainThreadOnly
 impl ValidSubclassMutability<mutability::MainThreadOnly> for mutability::MainThreadOnly {}

--- a/crates/objc2/src/macros/extern_class.rs
+++ b/crates/objc2/src/macros/extern_class.rs
@@ -456,14 +456,14 @@ macro_rules! __extern_class_impl_traits {
         // consideration, the lifetime of `&mut Self::Target` is still tied to
         // `&mut self`.
         //
-        // Usually we don't want to allow `&mut` of immutable objects like
-        // `NSString`, because their `NSCopying` implementation returns the
-        // same object, and would violate aliasing rules.
+        // Usually we don't want to allow `&mut` of immutable objects, because
+        // their `NSCopying` implementation returns the same object, and that
+        // would violate aliasing rules.
         //
-        // But `&mut NSMutableString` -> `&mut NSString` safe, since the
-        // `NSCopying` implementation of `NSMutableString` is still used on
-        // the `&mut NSString`, and that is guaranteed to return a different
-        // object.
+        // But even then, `&mut MyMutableObject` -> `&mut MyObject` is still
+        // safe, as it's the `NSCopying` implementation of `MyMutableObject`
+        // that is used on the `&mut MyObject`, and that is guaranteed to
+        // return a different object.
         $(#[$impl_m])*
         impl<$($t)*> $crate::__macro_helpers::DerefMut for $for {
             #[inline]

--- a/crates/objc2/src/macros/extern_protocol.rs
+++ b/crates/objc2/src/macros/extern_protocol.rs
@@ -70,7 +70,9 @@
 ///
 /// # Examples
 ///
-/// Create a trait to represent the `NSItemProviderWriting` protocol.
+/// Create a trait to represent the `NSItemProviderWriting` protocol (in
+/// practice, you would import this from `objc2-foundation`, this is just for
+/// demonstration purposes).
 ///
 /// ```
 /// use std::ffi::c_void;
@@ -78,13 +80,12 @@
 /// use objc2::rc::Retained;
 /// use objc2::runtime::{NSObject, NSObjectProtocol};
 /// use objc2::{extern_protocol, ProtocolType};
-///
-/// // Assume these were correctly defined, as if they came from
-/// // `objc2-foundation`
-/// type NSArray<T> = T;
-/// type NSString = NSObject;
-/// type NSProgress = NSObject;
-/// type NSItemProviderRepresentationVisibility = NSInteger;
+/// # type NSArray<T> = T;
+/// # type NSString = NSObject;
+/// # type NSProgress = NSObject;
+/// # type NSItemProviderRepresentationVisibility = NSInteger;
+/// # #[cfg(defined_in_foundation)]
+/// use objc2_foundation::{NSArray, NSString, NSProgress, NSItemProviderRepresentationVisibility};
 ///
 /// extern_protocol!(
 ///     /// This comment will appear on the trait as expected.

--- a/crates/objc2/src/mutability.rs
+++ b/crates/objc2/src/mutability.rs
@@ -160,23 +160,6 @@ pub struct Mutable {
 /// - [`IsAllowedMutable`].
 /// - You are allowed to hand out pointers / references to an instance's
 ///   internal data, since you know such data will never be mutated.
-///
-///
-/// # Example
-///
-/// ```ignore
-/// unsafe impl ClassType for NSString {
-///     type Super = NSObject;
-///     type Mutability = ImmutableWithMutableSubclass<NSMutableString>;
-///     // ...
-/// }
-///
-/// unsafe impl ClassType for NSMutableString {
-///     type Super = NSString;
-///     type Mutability = MutableWithImmutableSubclass<NSString>;
-///     // ...
-/// }
-/// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ImmutableWithMutableSubclass<MS: ?Sized> {
     inner: Never,
@@ -196,23 +179,6 @@ pub struct ImmutableWithMutableSubclass<MS: ?Sized> {
 /// - You are allowed to hand out pointers / references to an instance's
 ///   internal data, since you know such data will never be mutated without
 ///   the borrowchecker catching it.
-///
-///
-/// # Example
-///
-/// ```ignore
-/// unsafe impl ClassType for NSData {
-///     type Super = NSObject;
-///     type Mutability = ImmutableWithMutableSubclass<NSMutableData>;
-///     // ...
-/// }
-///
-/// unsafe impl ClassType for NSMutableData {
-///     type Super = NSData;
-///     type Mutability = MutableWithImmutableSubclass<NSData>;
-///     // ...
-/// }
-/// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct MutableWithImmutableSuperclass<IS: ?Sized> {
     inner: Never,
@@ -251,6 +217,28 @@ pub struct InteriorMutable {
 ///
 /// This is effectively the same as [`InteriorMutable`], except that the type
 /// returned by `NSMutableCopying::mutableCopy` is the mutable counterpart.
+///
+/// Functionality that is provided with this:
+/// - [`IsRetainable`] -> [`ClassType::retain`].
+/// - [`IsIdCloneable`] -> [`Retained::clone`][crate::rc::Retained#impl-Clone-for-Retained<T>].
+/// - [`IsAllocableAnyThread`] -> [`ClassType::alloc`].
+///
+///
+/// # Example
+///
+/// ```ignore
+/// unsafe impl ClassType for NSString {
+///     type Super = NSObject;
+///     type Mutability = InteriorMutableWithSubclass<NSMutableString>;
+///     // ...
+/// }
+///
+/// unsafe impl ClassType for NSMutableString {
+///     type Super = NSString;
+///     type Mutability = InteriorMutableWithSuperclass<NSString>;
+///     // ...
+/// }
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct InteriorMutableWithSubclass<Subclass: ?Sized> {
     inner: Never,
@@ -261,6 +249,28 @@ pub struct InteriorMutableWithSubclass<Subclass: ?Sized> {
 ///
 /// This is effectively the same as [`InteriorMutable`], except that the type
 /// returned by `NSCopying::copy` is the immutable counterpart.
+///
+/// Functionality that is provided with this:
+/// - [`IsRetainable`] -> [`ClassType::retain`].
+/// - [`IsIdCloneable`] -> [`Retained::clone`][crate::rc::Retained#impl-Clone-for-Retained<T>].
+/// - [`IsAllocableAnyThread`] -> [`ClassType::alloc`].
+
+///
+/// # Example
+///
+/// ```ignore
+/// unsafe impl ClassType for NSData {
+///     type Super = NSObject;
+///     type Mutability = InteriorMutableWithSubclass<NSMutableData>;
+///     // ...
+/// }
+///
+/// unsafe impl ClassType for NSMutableData {
+///     type Super = NSData;
+///     type Mutability = InteriorMutableWithSuperclass<NSData>;
+///     // ...
+/// }
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct InteriorMutableWithSuperclass<Superclass: ?Sized> {
     inner: Never,

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -828,6 +828,14 @@ mod private {
         type EquivalentType = ArcLikeStorage<T>;
     }
 
+    impl<T: ?Sized, S: ?Sized> SendSyncHelper<T> for mutability::InteriorMutableWithSubclass<S> {
+        type EquivalentType = ArcLikeStorage<T>;
+    }
+
+    impl<T: ?Sized, S: ?Sized> SendSyncHelper<T> for mutability::InteriorMutableWithSuperclass<S> {
+        type EquivalentType = ArcLikeStorage<T>;
+    }
+
     impl<T: ?Sized> SendSyncHelper<T> for mutability::MainThreadOnly {
         type EquivalentType = ArcLikeStorage<T>;
     }

--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -35,9 +35,8 @@ use crate::{ffi, ClassType, Message};
 /// `Retained<T>` can be thought of as kind of a weird combination of [`Arc`]
 /// and [`Box`]:
 ///
-/// If `T` implements [`IsMutable`] (like it does on `NSMutableString` and
-/// `NSMutableArray<_>`), `Retained<T>` acts like `Box<T>`, and allows mutable
-/// / unique access to the type.
+/// If `T` implements [`IsMutable`], `Retained<T>` acts like `Box<T>`, and
+/// allows mutable / unique access to the type.
 ///
 /// Otherwise, which is the most common case, `Retained<T>` acts like
 /// `Arc<T>`, and allows cloning by bumping the reference count.
@@ -53,9 +52,10 @@ use crate::{ffi, ClassType, Message};
 ///
 /// It also forwards the implementation of a bunch of standard library traits
 /// such as [`PartialEq`], [`AsRef`], and so on, so that it becomes possible
-/// to use e.g. `Retained<NSString>` as if it was `NSString`. (Having
+/// to use e.g. `Retained<NSString>` as if it was `NSString`. Note that having
 /// `NSString` directly is not possible since Objective-C objects cannot live
-/// on the stack, but instead must reside on the heap).
+/// on the stack, but instead must reside on the heap, and as such must be
+/// accessed behind a pointer or a reference (i.e. `&NSString`).
 ///
 /// Note that because of current limitations in the Rust trait system, some
 /// traits like [`Default`], [`IntoIterator`], [`FromIterator`], [`From`] and
@@ -84,9 +84,9 @@ use crate::{ffi, ClassType, Message};
 /// Various usage of `Retained` on an immutable object.
 ///
 /// ```
-/// # #[cfg(not_available)]
-/// use objc2_foundation::{NSObject, NSString};
 /// # use objc2::runtime::NSObject;
+/// # #[cfg(available_in_foundation)]
+/// use objc2_foundation::{NSObject, NSString};
 /// use objc2::rc::Retained;
 /// use objc2::{ClassType, msg_send_id};
 /// #
@@ -109,11 +109,10 @@ use crate::{ffi, ClassType, Message};
 /// // let string = NSString::new();
 ///
 /// // Methods on `NSString` is usable via. `Deref`
-/// #[cfg(not_available)]
-/// assert_eq!(string.len(), 0);
+/// # #[cfg(available_in_foundation)]
+/// assert_eq!(string.length(), 0);
 ///
-/// // Bump the reference count of the object (possible because the object is
-/// // immutable, would not be possible for `NSMutableString`).
+/// // Bump the reference count of the object.
 /// let another_ref: Retained<NSString> = string.clone();
 ///
 /// // Convert one of the references to a reference to `NSObject` instead
@@ -335,11 +334,14 @@ impl<T: Message> Retained<T> {
     /// Additionally, you must ensure that any safety invariants that the new
     /// type has are upheld.
     ///
-    /// Note that it is not in general safe to cast e.g. `Retained<NSString>` to
-    /// `Retained<NSMutableString>`, even if you've checked at runtime that the
-    /// object is an instance of `NSMutableString`! This is because
-    /// `Retained<NSMutableString>` assumes the string is unique, whereas it may
-    /// have been cloned while being an `Retained<NSString>`.
+    /// Note that it is generally discouraged to cast e.g. `NSString` to
+    /// `NSMutableString`, even if you've checked at runtime that the object
+    /// is an instance of `NSMutableString`! This is because APIs are
+    /// generally allowed to return mutable objects internally, but still
+    /// assume that no-one mutates those objects if the API declares the
+    /// object as immutable, see [Apple's documentation on this][recv-mut].
+    ///
+    /// [recv-mut]: https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/ObjectMutability/ObjectMutability.html#//apple_ref/doc/uid/TP40010810-CH5-SW66
     #[inline]
     pub unsafe fn cast<U: Message>(this: Self) -> Retained<U> {
         let ptr = ManuallyDrop::new(this).ptr.cast();
@@ -703,12 +705,12 @@ impl<T: Message + IsIdCloneable> Clone for Retained<T> {
     fn clone(&self) -> Self {
         // SAFETY:
         // - The object is known to not be mutable due to the `IsIdCloneable`
-        //   bound. Additionally, since the object is already an `Retained`, types
-        //   like `NSObject` and `NSString` that have a mutable subclass is
-        //   also allowed (since even if the object is originally an
-        //   `Retained<NSMutableString>`, by converting it into `Retained<NSObject>` or
-        //   `Retained<NSString>` that fact is wholly forgotten, and the object
-        //   cannot ever be mutated again).
+        //   bound. Additionally, since the object is already a `Retained`,
+        //   types that have a mutable subclass are also allowed (since even
+        //   if the object is originally a `Retained<MyMutableObject>`, by
+        //   converting it into `Retained<NSObject>` or `Retained<MyObject>`,
+        //   that fact is wholly forgotten, and the object cannot ever be
+        //   mutated again).
         // - The pointer is valid.
         let obj = unsafe { Retained::retain(self.ptr.as_ptr()) };
         // SAFETY: `objc_retain` always returns the same object pointer, and

--- a/crates/objc2/src/runtime/nsobject.rs
+++ b/crates/objc2/src/runtime/nsobject.rs
@@ -152,7 +152,9 @@ pub unsafe trait NSObjectProtocol {
     //
     // For example, something may have a return type of `NSString`, while
     // behind the scenes they really return `NSMutableString` and expect it to
-    // not be modified.
+    // not be modified, see [Apple's doc][apple-mut].
+    //
+    // [apple-mut]: https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/ObjectMutability/ObjectMutability.html
 
     /// Check if the object is an instance of a specific class, without
     /// checking subclasses.

--- a/crates/objc2/src/top_level_traits.rs
+++ b/crates/objc2/src/top_level_traits.rs
@@ -229,8 +229,8 @@ pub unsafe trait ClassType: Message {
     // Note: No `Self: IsMutable` bound required here, since there is no way
     // to get `&mut self` in the first place.
     //
-    // Or at least, if we have `&mut NSMutableString`, we're allowed to get
-    // `&mut NSString`, and from that it will also make sense to allow getting
+    // Or at least, if we have `&mut MyMutableObject`, we're allowed to get
+    // `&mut MyObject`, and from that it will also make sense to allow getting
     // `&mut NSObject`.
     fn as_super_mut(&mut self) -> &mut Self::Super;
 
@@ -241,14 +241,11 @@ pub unsafe trait ClassType: Message {
     ///
     /// This is similar to using [`Clone` on `Retained<Self>`][clone-id], with
     /// the addition that it can be used on a plain reference. Note however
-    /// that this is not possible to use on certain types like `NSString`,
-    /// since if you only hold `&NSString`, that may have come from
-    /// `&mut NSMutableString`, in which case it would be unsound to erase the
-    /// lifetime information carried by the reference.
+    /// that this is not possible to use on types that may have come from
+    /// mutable types, as it would be unsound to erase the lifetime
+    /// information carried by such a reference.
     ///
-    /// In cases like that, you should rather use `NSCopying::copy` (since
-    /// that gives you a `NSString` whether the string was originally a
-    /// `NSString` or a `NSMutableString`).
+    /// In cases like that, you should rather use `NSCopying::copy`.
     ///
     /// [clone-id]: crate::rc::Retained#impl-Clone-for-Retained<T>
     //

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   hash is changed, but that's not the same as it being unsound).
 * `objc2-foundation` **BREAKING**: Made the following types `InteriorMutable`:
   - `NSString` and `NSMutableString`.
+  - `NSAttributedString` and `NSMutableAttributedString`.
 
   This means that these can now be `retain`-ed like you would expect, and you
   no longer need to use `mut` to mutate them, but it also means that they are

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * `objc2-foundation` **BREAKING**: Made the following types `InteriorMutable`:
   - `NSString` and `NSMutableString`.
   - `NSAttributedString` and `NSMutableAttributedString`.
+  - `NSCharacterSet` and `NSMutableCharacterSet`.
+  - `NSURLRequest` and `NSMutableURLRequest`.
 
   This means that these can now be `retain`-ed like you would expect, and you
   no longer need to use `mut` to mutate them, but it also means that they are

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   creating main-thread only statics.
 * `objc2-foundation`: `MainThreadMarker::from` now debug-asserts that it is
   actually running on the main thread.
+* `objc2-foundation`: Added `NSData::to_vec` and `NSData::iter` helper methods.
 
 ### Changed
 * `objc2-foundation`: Allow using `MainThreadBound` without the `NSThread`
@@ -32,10 +33,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `NSAttributedString` and `NSMutableAttributedString`.
   - `NSCharacterSet` and `NSMutableCharacterSet`.
   - `NSURLRequest` and `NSMutableURLRequest`.
+  - `NSData` and `NSMutableData`.
 
   This means that these can now be `retain`-ed like you would expect, and you
   no longer need to use `mut` to mutate them, but it also means that they are
   no longer `Send + Sync`.
+* `objc2-foundation` **BREAKING**: Renamed the `bytes[_mut]` methods on
+  `NSData` to `as[_mut]_slice_unchecked`, and made them `unsafe`, since the
+  data can no longer ensure that it is not mutated while the bytes are in use.
 
 ### Deprecated
 * `objc2-foundation`: Moved `MainThreadMarker` to `objc2`.

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   prevents real-world usage of these types, and isn't actually needed for
   soundness (the documentation mentions the collection being "corrupt" if the
   hash is changed, but that's not the same as it being unsound).
+* `objc2-foundation` **BREAKING**: Made the following types `InteriorMutable`:
+  - `NSString` and `NSMutableString`.
+
+  This means that these can now be `retain`-ed like you would expect, and you
+  no longer need to use `mut` to mutate them, but it also means that they are
+  no longer `Send + Sync`.
 
 ### Deprecated
 * `objc2-foundation`: Moved `MainThreadMarker` to `objc2`.

--- a/crates/objc2/src/topics/core_foundation_interop.md
+++ b/crates/objc2/src/topics/core_foundation_interop.md
@@ -118,11 +118,9 @@ fn cf_string_to_ns(s: &CFString) -> &NSString {
     unsafe { ptr.as_ref().unwrap() }
 }
 
-// Note: `NSString` is currently a bit special, and requires that we convert from
-// `Retained<NSString>`, as it could otherwise have come from `&NSMutableString`,
-// and then we'd loose lifetime information by converting to `CFString`.
-//
-// This will be changed in the future, see https://github.com/madsmtm/objc2/issues/563.
+// Note: The `core_foundation` crate does not allow zero-cost (non-owning)
+// references to objects, so we have to convert from a `Retained<NSString>` to
+// the owning `CFString` (i.e. `&NSString -> &CFString` is not possible).
 fn ns_string_to_cf(s: Retained<NSString>) -> CFString {
     // Yield ownership over the string
     let ptr: *const NSString = Retained::into_raw(s);

--- a/crates/test-assembly/crates/test_ns_string/lib.rs
+++ b/crates/test-assembly/crates/test_ns_string/lib.rs
@@ -6,18 +6,26 @@ use objc2_foundation::{ns_string, NSString};
 // Temporary to allow testing putting string references in statics.
 // This doesn't yet compile on other platforms, but could in the future!
 #[cfg(all(target_vendor = "apple", feature = "assembly-features"))]
-#[no_mangle]
-static EMPTY: &NSString = {
-    const INPUT: &[u8] = b"";
-    objc2_foundation::__ns_string_static!(INPUT);
-    CFSTRING.as_nsstring_const()
-};
+#[repr(transparent)]
+struct StaticString(&'static NSString);
+
+#[cfg(all(target_vendor = "apple", feature = "assembly-features"))]
+unsafe impl Sync for StaticString {}
+
 #[cfg(all(target_vendor = "apple", feature = "assembly-features"))]
 #[no_mangle]
-static XYZ: &NSString = {
+static EMPTY: StaticString = {
+    const INPUT: &[u8] = b"";
+    objc2_foundation::__ns_string_static!(INPUT);
+    StaticString(CFSTRING.as_nsstring_const())
+};
+
+#[cfg(all(target_vendor = "apple", feature = "assembly-features"))]
+#[no_mangle]
+static XYZ: StaticString = {
     const INPUT: &[u8] = b"xyz";
     objc2_foundation::__ns_string_static!(INPUT);
-    CFSTRING.as_nsstring_const()
+    StaticString(CFSTRING.as_nsstring_const())
 };
 
 #[no_mangle]

--- a/crates/test-ui/ui/array_iter_correct_lifetime.rs
+++ b/crates/test-ui/ui/array_iter_correct_lifetime.rs
@@ -1,17 +1,17 @@
-use objc2_foundation::{NSArray, NSCopying, NSMutableArray, NSMutableString, NSString};
+use objc2_foundation::{NSArray, NSCopying, NSMutableArray};
 
 fn main() {
-    let arr: &mut NSArray<NSMutableString> = &mut NSMutableArray::new();
+    let arr: &mut NSArray<NSMutableArray> = &mut NSMutableArray::new();
     for _ in &mut *arr {
         let _ = &arr[0];
     }
 
-    let arr: &mut NSMutableArray<NSString> = &mut NSMutableArray::new();
+    let arr: &mut NSMutableArray<NSArray> = &mut NSMutableArray::new();
     for s in arr.iter_retained() {
         arr.push(s);
     }
 
-    let arr: &mut NSMutableArray<NSString> = &mut NSMutableArray::new();
+    let arr: &mut NSMutableArray<NSArray> = &mut NSMutableArray::new();
     for s in &*arr {
         arr.push(s.copy());
     }

--- a/crates/test-ui/ui/array_iter_invalid.rs
+++ b/crates/test-ui/ui/array_iter_invalid.rs
@@ -1,29 +1,29 @@
 use objc2::rc::Retained;
-use objc2_foundation::{NSArray, NSMutableArray, NSMutableString, NSString};
+use objc2_foundation::{NSArray, NSMutableArray};
 
 fn main() {
-    let arr: Retained<NSArray<NSString>> = NSArray::new();
+    let arr: Retained<NSArray<NSArray>> = NSArray::new();
     for s in &mut arr {
-        let s: &mut NSString = s;
+        let s: &mut NSArray = s;
     }
 
-    let arr: Retained<NSArray<NSMutableString>> = NSArray::new();
+    let arr: Retained<NSArray<NSMutableArray>> = NSArray::new();
     for s in &mut arr {
-        let s: &mut NSMutableString = s;
+        let s: &mut NSMutableArray = s;
     }
 
-    let arr: Retained<NSMutableArray<NSString>> = NSMutableArray::new();
+    let arr: Retained<NSMutableArray<NSArray>> = NSMutableArray::new();
     for s in &mut arr {
-        let s: &mut NSString = s;
+        let s: &mut NSArray = s;
     }
 
     // Should succeed, included for completeness
-    let arr: Retained<NSMutableArray<NSMutableString>> = NSMutableArray::new();
+    let arr: Retained<NSMutableArray<NSMutableArray>> = NSMutableArray::new();
     for s in &mut arr {
-        let s: &mut NSString = s;
+        let s: &mut NSArray = s;
     }
 
     // RetainedIntoIterator not available for mutable children
-    let arr: Retained<NSArray<NSMutableString>> = NSArray::new();
+    let arr: Retained<NSArray<NSMutableArray>> = NSArray::new();
     for _ in arr {}
 }

--- a/crates/test-ui/ui/array_iter_invalid.stderr
+++ b/crates/test-ui/ui/array_iter_invalid.stderr
@@ -1,51 +1,51 @@
-error[E0277]: `&mut Retained<NSArray<NSString>>` is not an iterator
+error[E0277]: `&mut Retained<NSArray<NSArray>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ `&mut Retained<NSArray<NSString>>` is not an iterator
+  |              ^^^^^^^^ `&mut Retained<NSArray<NSArray>>` is not an iterator
   |
-  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSArray<NSString>>`
-  = note: `IntoIterator` is implemented for `&Retained<NSArray<NSString>>`, but not for `&mut Retained<NSArray<NSString>>`
+  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSArray<NSArray>>`
+  = note: `IntoIterator` is implemented for `&Retained<NSArray<NSArray>>`, but not for `&mut Retained<NSArray<NSArray>>`
 help: consider removing the leading `&`-reference
   |
 6 -     for s in &mut arr {
 6 +     for s in arr {
   |
 
-error[E0277]: `&mut Retained<NSArray<NSMutableString>>` is not an iterator
+error[E0277]: `&mut Retained<NSArray<NSMutableArray>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ `&mut Retained<NSArray<NSMutableString>>` is not an iterator
+  |              ^^^^^^^^ `&mut Retained<NSArray<NSMutableArray>>` is not an iterator
   |
-  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSArray<NSMutableString>>`
+  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSArray<NSMutableArray>>`
   = help: the following other types implement trait `IntoIterator`:
             &'a Retained<T>
             &'a mut Retained<T>
             Retained<T>
-  = note: `IntoIterator` is implemented for `&Retained<NSArray<NSMutableString>>`, but not for `&mut Retained<NSArray<NSMutableString>>`
+  = note: `IntoIterator` is implemented for `&Retained<NSArray<NSMutableArray>>`, but not for `&mut Retained<NSArray<NSMutableArray>>`
 
-error[E0277]: `&mut Retained<NSMutableArray<NSString>>` is not an iterator
+error[E0277]: `&mut Retained<NSMutableArray<NSArray>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for s in &mut arr {
-  |              ^^^^^^^^ `&mut Retained<NSMutableArray<NSString>>` is not an iterator
+  |              ^^^^^^^^ `&mut Retained<NSMutableArray<NSArray>>` is not an iterator
   |
-  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSMutableArray<NSString>>`
-  = note: `IntoIterator` is implemented for `&Retained<NSMutableArray<NSString>>`, but not for `&mut Retained<NSMutableArray<NSString>>`
+  = help: the trait `IntoIterator` is not implemented for `&mut Retained<NSMutableArray<NSArray>>`
+  = note: `IntoIterator` is implemented for `&Retained<NSMutableArray<NSArray>>`, but not for `&mut Retained<NSMutableArray<NSArray>>`
 help: consider removing the leading `&`-reference
   |
 16 -     for s in &mut arr {
 16 +     for s in arr {
    |
 
-error[E0277]: `Retained<NSArray<NSMutableString>>` is not an iterator
+error[E0277]: `Retained<NSArray<NSMutableArray>>` is not an iterator
  --> ui/array_iter_invalid.rs
   |
   |     for _ in arr {}
-  |              ^^^ `Retained<NSArray<NSMutableString>>` is not an iterator
+  |              ^^^ `Retained<NSArray<NSMutableArray>>` is not an iterator
   |
-  = help: the trait `IntoIterator` is not implemented for `Retained<NSArray<NSMutableString>>`
+  = help: the trait `IntoIterator` is not implemented for `Retained<NSArray<NSMutableArray>>`
   = help: the following other types implement trait `IntoIterator`:
             &'a Retained<T>
             &'a mut Retained<T>

--- a/crates/test-ui/ui/main_thread_only_not_allocable.stderr
+++ b/crates/test-ui/ui/main_thread_only_not_allocable.stderr
@@ -8,6 +8,8 @@ error[E0277]: the trait bound `MainThreadOnly: mutability::MutabilityIsAllocable
             Immutable
             ImmutableWithMutableSubclass<MS>
             InteriorMutable
+            InteriorMutableWithSubclass<S>
+            InteriorMutableWithSuperclass<S>
             Mutable
             MutableWithImmutableSuperclass<IS>
             Root

--- a/crates/test-ui/ui/msg_send_id_underspecified_error1.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error1.rs
@@ -1,9 +1,9 @@
 //! Test underspecified msg_send_id! errors.
 use objc2::msg_send_id;
 use objc2::rc::Retained;
-use objc2_foundation::NSString;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let obj: &NSString;
-    let _: Result<Retained<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
+    let obj: &NSObject;
+    let _: Result<Retained<NSObject>, _> = unsafe { msg_send_id![obj, error: _] };
 }

--- a/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error1.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
  --> ui/msg_send_id_underspecified_error1.rs
   |
-  |     let _: Result<Retained<NSString>, _> = unsafe { msg_send_id![obj, error: _] };
+  |     let _: Result<Retained<NSObject>, _> = unsafe { msg_send_id![obj, error: _] };
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type

--- a/crates/test-ui/ui/msg_send_id_underspecified_error2.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error2.rs
@@ -1,9 +1,9 @@
 //! Test underspecified msg_send_id! errors.
 use objc2::msg_send_id;
 use objc2::rc::Retained;
-use objc2_foundation::{NSError, NSString};
+use objc2_foundation::{NSError, NSObject};
 
 fn main() {
-    let obj: &NSString;
+    let obj: &NSObject;
     let _: Result<_, Retained<NSError>> = unsafe { msg_send_id![obj, error: _] };
 }

--- a/crates/test-ui/ui/msg_send_id_underspecified_error3.rs
+++ b/crates/test-ui/ui/msg_send_id_underspecified_error3.rs
@@ -1,8 +1,8 @@
 //! Test underspecified msg_send_id! errors.
 use objc2::msg_send_id;
-use objc2_foundation::NSString;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let obj: &NSString;
+    let obj: &NSObject;
     let _: Result<_, _> = unsafe { msg_send_id![obj, error: _] };
 }

--- a/crates/test-ui/ui/msg_send_underspecified_error.rs
+++ b/crates/test-ui/ui/msg_send_underspecified_error.rs
@@ -1,8 +1,8 @@
 //! Test underspecified msg_send! errors.
 use objc2::msg_send;
-use objc2_foundation::NSString;
+use objc2::runtime::NSObject;
 
 fn main() {
-    let obj: &NSString;
+    let obj: &NSObject;
     let _: Result<(), _> = unsafe { msg_send![obj, error: _] };
 }

--- a/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
+++ b/crates/test-ui/ui/mutable_id_not_clone_not_retain.stderr
@@ -39,6 +39,8 @@ error[E0277]: the trait bound `Mutable: mutability::MutabilityIsRetainable` is n
   = help: the following other types implement trait `mutability::MutabilityIsRetainable`:
             Immutable
             InteriorMutable
+            InteriorMutableWithSubclass<S>
+            InteriorMutableWithSuperclass<S>
             MainThreadOnly
   = note: required for `NSMutableObject` to implement `IsRetainable`
 note: required by a bound in `retain`

--- a/crates/test-ui/ui/ns_string_output_not_const.rs
+++ b/crates/test-ui/ui/ns_string_output_not_const.rs
@@ -1,5 +1,9 @@
 use objc2_foundation::{ns_string, NSString};
 
 fn main() {
-    static STRING: &NSString = ns_string!("abc");
+    struct SyncString(&'static NSString);
+
+    unsafe impl Sync for SyncString {}
+
+    static STRING: SyncString = SyncString(ns_string!("abc"));
 }

--- a/crates/test-ui/ui/ns_string_output_not_const.stderr
+++ b/crates/test-ui/ui/ns_string_output_not_const.stderr
@@ -1,8 +1,8 @@
 error[E0015]: cannot call non-const fn `CachedId::<NSString>::get::<{closure@$WORKSPACE/framework-crates/objc2-foundation/src/macros/ns_string.rs:189:29: 189:31}>` in statics
  --> ui/ns_string_output_not_const.rs
   |
-  |     static STRING: &NSString = ns_string!("abc");
-  |                                ^^^^^^^^^^^^^^^^^
+  |     static STRING: SyncString = SyncString(ns_string!("abc"));
+  |                                            ^^^^^^^^^^^^^^^^^
   |
   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
   = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`

--- a/framework-crates/objc2-app-kit/translation-config.toml
+++ b/framework-crates/objc2-app-kit/translation-config.toml
@@ -241,10 +241,6 @@ class.NSEvent.mutability = "Immutable"
 class.NSTouch.mutability = "Immutable"
 class.NSUserInterfaceCompressionOptions.mutability = "Immutable"
 
-# Subclasses `NSMutableAttributedString`, though I think this should
-# actually be `InteriorMutable`?
-class.NSTextStorage.mutability = "Mutable"
-
 ###
 ### Safety
 ###

--- a/framework-crates/objc2-foundation/src/attributed_string.rs
+++ b/framework-crates/objc2-foundation/src/attributed_string.rs
@@ -6,11 +6,6 @@ use objc2::ClassType;
 
 use crate::Foundation::*;
 
-// SAFETY: `NSAttributedString` is immutable and `NSMutableAttributedString`
-// can only be mutated from `&mut` methods.
-unsafe impl Sync for NSAttributedString {}
-unsafe impl Send for NSAttributedString {}
-
 // Same reasoning as `NSString`.
 impl UnwindSafe for NSAttributedString {}
 impl RefUnwindSafe for NSAttributedString {}

--- a/framework-crates/objc2-foundation/src/dictionary.rs
+++ b/framework-crates/objc2-foundation/src/dictionary.rs
@@ -160,6 +160,18 @@ impl<K: Message + Eq + Hash, V: Message> NSMutableDictionary<K, V> {
 
 extern_methods!(
     unsafe impl<K: Message + Eq + Hash, V: Message> NSDictionary<K, V> {
+        /// Returns a reference to the value corresponding to the key.
+        ///
+        /// # Examples
+        ///
+        #[cfg_attr(feature = "NSString", doc = "```")]
+        #[cfg_attr(not(feature = "NSString"), doc = "```ignore")]
+        /// use objc2_foundation::{ns_string, NSMutableDictionary};
+        ///
+        /// let mut dict = NSMutableDictionary::new();
+        /// dict.insert(ns_string!("key"), ns_string!("value"));
+        /// assert_eq!(dict.get(ns_string!("key")), Some(ns_string!("value")));
+        /// ```
         #[doc(alias = "objectForKey:")]
         #[method(objectForKey:)]
         pub fn get(&self, key: &K) -> Option<&V>;
@@ -175,20 +187,6 @@ extern_methods!(
         }
 
         /// Returns a mutable reference to the value corresponding to the key.
-        ///
-        /// # Examples
-        ///
-        #[cfg_attr(all(feature = "NSString", feature = "NSObject"), doc = "```")]
-        #[cfg_attr(
-            not(all(feature = "NSString", feature = "NSObject")),
-            doc = "```ignore"
-        )]
-        /// use objc2_foundation::{ns_string, NSMutableDictionary, NSMutableString, NSString};
-        ///
-        /// let mut dict = NSMutableDictionary::new();
-        /// dict.insert_id(ns_string!("one"), NSMutableString::new());
-        /// println!("{:?}", dict.get_mut(ns_string!("one")));
-        /// ```
         #[doc(alias = "objectForKey:")]
         #[method(objectForKey:)]
         pub fn get_mut(&mut self, key: &K) -> Option<&mut V>
@@ -233,25 +231,6 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     }
 
     /// Returns a vector of mutable references to the values in the dictionary.
-    ///
-    /// # Examples
-    ///
-    #[cfg_attr(
-        all(feature = "NSString", feature = "NSObject", feature = "NSEnumerator"),
-        doc = "```"
-    )]
-    #[cfg_attr(
-        not(all(feature = "NSString", feature = "NSObject", feature = "NSEnumerator")),
-        doc = "```ignore"
-    )]
-    /// use objc2_foundation::{ns_string, NSMutableDictionary, NSMutableString, NSString};
-    ///
-    /// let mut dict = NSMutableDictionary::new();
-    /// dict.insert_id(ns_string!("one"), NSMutableString::from_str("two"));
-    /// for val in dict.values_mut() {
-    ///     println!("{:?}", val);
-    /// }
-    /// ```
     #[doc(alias = "getObjects:andKeys:")]
     pub fn values_vec_mut(&mut self) -> Vec<&mut V>
     where
@@ -351,10 +330,10 @@ impl<K: Message + Eq + Hash, V: Message> NSMutableDictionary<K, V> {
     /// # Examples
     ///
     /// ```
-    /// use objc2_foundation::{ns_string, NSCopying, NSMutableDictionary};
+    /// use objc2_foundation::{ns_string, NSMutableDictionary};
     ///
     /// let mut dict = NSMutableDictionary::new();
-    /// dict.insert_id(ns_string!("key"), ns_string!("value").copy());
+    /// dict.insert(ns_string!("key"), ns_string!("value"));
     /// ```
     #[cfg(feature = "NSObject")]
     #[doc(alias = "setObject:forKey:")]
@@ -427,6 +406,24 @@ impl<K: Message, V: Message> NSDictionary<K, V> {
     //     todo!()
     // }
 
+    /// Returns an iterator of references to the values in the dictionary.
+    ///
+    /// # Examples
+    ///
+    #[cfg_attr(all(feature = "NSString", feature = "NSEnumerator"), doc = "```")]
+    #[cfg_attr(
+        not(all(feature = "NSString", feature = "NSEnumerator")),
+        doc = "```ignore"
+    )]
+    /// use objc2_foundation::{ns_string, NSMutableDictionary, NSString};
+    ///
+    /// let mut dict = NSMutableDictionary::new();
+    /// dict.insert(ns_string!("key1"), ns_string!("value1"));
+    /// dict.insert(ns_string!("key2"), ns_string!("value2"));
+    /// for val in dict.values() {
+    ///     assert!(val.hasPrefix(ns_string!("value")));
+    /// }
+    /// ```
     #[doc(alias = "objectEnumerator")]
     #[cfg(feature = "NSEnumerator")]
     pub fn values(&self) -> Values<'_, K, V> {

--- a/framework-crates/objc2-foundation/src/lib.rs
+++ b/framework-crates/objc2-foundation/src/lib.rs
@@ -48,7 +48,7 @@
 //! let string = ns_string!("world");
 //! println!("hello {string}");
 //!
-//! let array = NSArray::from_id_slice(&[string.copy()]);
+//! let array = NSArray::from_slice(&[string]);
 //! println!("{array:?}");
 //! ```
 //!

--- a/framework-crates/objc2-foundation/src/set.rs
+++ b/framework-crates/objc2-foundation/src/set.rs
@@ -19,10 +19,10 @@ impl<T: Message> NSSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use objc2_foundation::{NSSet, NSString};
+    /// use objc2_foundation::{ns_string, NSSet};
     ///
-    /// let strs = ["one", "two", "three"].map(NSString::from_str);
-    /// let set = NSSet::from_id_slice(&strs);
+    /// let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    /// let set = NSSet::from_slice(&strs);
     /// assert_eq!(set.len(), 3);
     /// ```
     #[doc(alias = "count")]
@@ -35,9 +35,9 @@ impl<T: Message> NSSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use objc2_foundation::{NSSet, NSString};
+    /// use objc2_foundation::{NSSet, NSObject};
     ///
-    /// let set = NSSet::<NSString>::new();
+    /// let set = NSSet::<NSObject>::new();
     /// assert!(set.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -235,10 +235,10 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let strs = ["one", "two", "three"].map(NSString::from_str);
-        /// let set = NSSet::from_id_slice(&strs);
+        /// let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+        /// let set = NSSet::from_slice(&strs);
         /// let any = set.get_any().unwrap();
         /// assert!(any == &*strs[0] || any == &*strs[1] || any == &*strs[2]);
         /// ```
@@ -253,10 +253,10 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{ns_string, NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let strs = ["one", "two", "three"].map(NSString::from_str);
-        /// let set = NSSet::from_id_slice(&strs);
+        /// let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+        /// let set = NSSet::from_slice(&strs);
         /// assert!(set.contains(ns_string!("one")));
         /// ```
         #[doc(alias = "containsObject:")]
@@ -270,10 +270,10 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{ns_string, NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let strs = ["one", "two", "three"].map(NSString::from_str);
-        /// let set = NSSet::from_id_slice(&strs);
+        /// let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+        /// let set = NSSet::from_slice(&strs);
         /// assert_eq!(set.get(ns_string!("one")), Some(&*strs[0]));
         /// assert_eq!(set.get(ns_string!("four")), None);
         /// ```
@@ -299,10 +299,10 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-        /// let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+        /// let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+        /// let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
         ///
         /// assert!(set1.is_subset(&set2));
         /// assert!(!set2.is_subset(&set1));
@@ -318,10 +318,10 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-        /// let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+        /// let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+        /// let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
         ///
         /// assert!(!set1.is_superset(&set2));
         /// assert!(set2.is_superset(&set1));
@@ -335,11 +335,11 @@ extern_methods!(
         /// # Examples
         ///
         /// ```
-        /// use objc2_foundation::{NSSet, NSString};
+        /// use objc2_foundation::{ns_string, NSSet};
         ///
-        /// let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-        /// let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
-        /// let set3 = NSSet::from_id_slice(&["four", "five", "six"].map(NSString::from_str));
+        /// let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+        /// let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
+        /// let set3 = NSSet::from_slice(&[ns_string!("four"), ns_string!("five"), ns_string!("six")]);
         ///
         /// assert!(!set1.is_disjoint(&set2));
         /// assert!(set1.is_disjoint(&set3));
@@ -432,10 +432,9 @@ impl<T: Message> NSSet<T> {
     /// # Examples
     ///
     /// ```
-    /// use objc2_foundation::{NSSet, NSString};
+    /// use objc2_foundation::{ns_string, NSSet};
     ///
-    /// let strs = ["one", "two", "three"].map(NSString::from_str);
-    /// let set = NSSet::from_id_slice(&strs);
+    /// let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
     /// for s in &set {
     ///     println!("{s}");
     /// }

--- a/framework-crates/objc2-foundation/src/string.rs
+++ b/framework-crates/objc2-foundation/src/string.rs
@@ -16,11 +16,6 @@ use objc2::{ClassType, Message};
 
 use crate::{NSMutableString, NSString};
 
-// SAFETY: `NSString` is immutable and `NSMutableString` can only be mutated
-// from `&mut` methods.
-unsafe impl Sync for NSString {}
-unsafe impl Send for NSString {}
-
 // Even if an exception occurs inside a string method, the state of the string
 // (should) still be perfectly safe to access.
 impl UnwindSafe for NSString {}
@@ -296,7 +291,7 @@ impl Ord for NSMutableString {
 // See `fruity`'s implementation:
 // https://github.com/nvzqz/fruity/blob/320efcf715c2c5fbd2f3084f671f2be2e03a6f2b/src/foundation/ns_string/mod.rs#L69-L163
 
-impl AddAssign<&NSString> for NSMutableString {
+impl AddAssign<&NSString> for &NSMutableString {
     #[inline]
     fn add_assign(&mut self, other: &NSString) {
         self.appendString(other);
@@ -342,7 +337,7 @@ impl fmt::Debug for NSMutableString {
     }
 }
 
-impl fmt::Write for NSMutableString {
+impl fmt::Write for &NSMutableString {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let nsstring = NSString::from_str(s);
         self.appendString(&nsstring);

--- a/framework-crates/objc2-foundation/src/tests/attributed_string.rs
+++ b/framework-crates/objc2-foundation/src/tests/attributed_string.rs
@@ -6,7 +6,7 @@ use alloc::{format, vec};
 use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::AnyObject;
 
-use crate::Foundation::{self, NSAttributedString, NSObject, NSString};
+use crate::Foundation::{self, ns_string, NSAttributedString, NSObject, NSString};
 
 #[test]
 fn test_new() {
@@ -26,7 +26,7 @@ fn test_string_bound_to_attributed() {
 
 #[test]
 fn test_from_nsstring() {
-    let s = NSAttributedString::from_nsstring(&NSString::from_str("abc"));
+    let s = NSAttributedString::from_nsstring(ns_string!("abc"));
     assert_eq!(&s.string().to_string(), "abc");
 }
 
@@ -34,7 +34,7 @@ fn test_from_nsstring() {
 fn test_copy() {
     use Foundation::{NSCopying, NSMutableCopying, NSObjectProtocol};
 
-    let s1 = NSAttributedString::from_nsstring(&NSString::from_str("abc"));
+    let s1 = NSAttributedString::from_nsstring(ns_string!("abc"));
     let s2 = s1.copy();
     // NSAttributedString performs this optimization in GNUStep's runtime,
     // but not in Apple's; so we don't test for it!
@@ -49,7 +49,7 @@ fn test_copy() {
 #[test]
 #[cfg(feature = "NSDictionary")]
 fn test_debug() {
-    let s = NSAttributedString::from_nsstring(&NSString::from_str("abc"));
+    let s = NSAttributedString::from_nsstring(ns_string!("abc"));
     let expected = if cfg!(feature = "gnustep-1-7") {
         "abc{}"
     } else {
@@ -61,8 +61,8 @@ fn test_debug() {
     let ptr: *const AnyObject = &*obj;
     let s = unsafe {
         NSAttributedString::new_with_attributes(
-            &NSString::from_str("abc"),
-            &Foundation::NSDictionary::from_vec(&[&*NSString::from_str("test")], vec![obj]),
+            ns_string!("abc"),
+            &Foundation::NSDictionary::from_vec(&[ns_string!("test")], vec![obj]),
         )
     };
     let expected = if cfg!(feature = "gnustep-1-7") {
@@ -87,7 +87,7 @@ fn test_new_mutable() {
 fn test_copy_mutable() {
     use Foundation::{NSCopying, NSMutableCopying, NSObjectProtocol};
 
-    let s1 = Foundation::NSMutableAttributedString::from_nsstring(&NSString::from_str("abc"));
+    let s1 = Foundation::NSMutableAttributedString::from_nsstring(ns_string!("abc"));
     let s2 = s1.copy();
     assert_ne!(Retained::as_ptr(&s1).cast(), Retained::as_ptr(&s2));
     assert!(s2.is_kind_of::<NSAttributedString>());

--- a/framework-crates/objc2-foundation/src/tests/auto_traits.rs
+++ b/framework-crates/objc2-foundation/src/tests/auto_traits.rs
@@ -128,7 +128,7 @@ fn test_generic_auto_traits() {
 
 #[test]
 fn send_sync_unwindsafe() {
-    assert_auto_traits::<NSAttributedString>();
+    assert_unwindsafe::<NSAttributedString>();
     assert_auto_traits::<NSComparisonResult>();
     assert_auto_traits::<NSData>();
     assert_auto_traits::<NSDictionary<NSProcessInfo, NSProcessInfo>>();
@@ -144,7 +144,7 @@ fn send_sync_unwindsafe() {
     assert_auto_traits::<NSRect>();
     assert_auto_traits::<NSSize>();
     assert_auto_traits::<NSMutableArray<NSProcessInfo>>();
-    assert_auto_traits::<NSMutableAttributedString>();
+    assert_unwindsafe::<NSMutableAttributedString>();
     assert_auto_traits::<NSMutableData>();
     assert_auto_traits::<NSMutableDictionary<NSProcessInfo, NSProcessInfo>>();
     assert_auto_traits::<NSMutableSet<NSProcessInfo>>();

--- a/framework-crates/objc2-foundation/src/tests/auto_traits.rs
+++ b/framework-crates/objc2-foundation/src/tests/auto_traits.rs
@@ -13,13 +13,13 @@ use objc2::{declare_class, ClassType, DeclaredClass};
 // since they follow Rust's usual mutability rules (&T = immutable).
 //
 // A _lot_ of Objective-C code out there would be subtly broken if e.g.
-// `NSString` wasn't exception safe!
-// As an example: -[NSArray objectAtIndex:] can throw, but it is still
-// perfectly valid to access the array after that!
+// `NSString` wasn't exception safe! As an example: `-[NSArray objectAtIndex:]`
+// can throw, but it is still perfectly valid to access the array after that!
 //
-// Note that e.g. `&mut NSMutableString` is still not exception safe, but
-// that is the entire idea of `UnwindSafe` (that if the object could have
-// been mutated, it is not exception safe).
+// I'm pretty sure that even mutable classes like `NSMutableString` is still
+// exception safe, since preconditions are checked before the mutation is
+// executed, and more "internal" errors like Out-Of-Memory either crash the
+// application, or return / throw an error value.
 //
 // Also note that this is still only a speed bump, not actually part of any
 // unsafe contract; we can't really protect against it if something is not
@@ -66,12 +66,12 @@ unsafe impl Sync for MutableSendSyncObject {}
 
 #[test]
 fn test_generic_auto_traits() {
-    assert_auto_traits::<NSArray<NSString>>();
-    assert_auto_traits::<Retained<NSArray<NSString>>>();
-    assert_auto_traits::<NSMutableArray<NSString>>();
-    assert_auto_traits::<Retained<NSMutableArray<NSString>>>();
-    assert_auto_traits::<NSDictionary<NSString, NSString>>();
-    assert_auto_traits::<Retained<NSDictionary<NSString, NSString>>>();
+    assert_auto_traits::<NSArray<NSProcessInfo>>();
+    assert_auto_traits::<Retained<NSArray<NSProcessInfo>>>();
+    assert_auto_traits::<NSMutableArray<NSProcessInfo>>();
+    assert_auto_traits::<Retained<NSMutableArray<NSProcessInfo>>>();
+    assert_auto_traits::<NSDictionary<NSProcessInfo, NSProcessInfo>>();
+    assert_auto_traits::<Retained<NSDictionary<NSProcessInfo, NSProcessInfo>>>();
 
     macro_rules! assert_id_like {
         ($wrapper:ident<T>) => {
@@ -131,29 +131,29 @@ fn send_sync_unwindsafe() {
     assert_auto_traits::<NSAttributedString>();
     assert_auto_traits::<NSComparisonResult>();
     assert_auto_traits::<NSData>();
-    assert_auto_traits::<NSDictionary<NSString, NSString>>();
-    assert_auto_traits::<NSSet<NSString>>();
-    assert_auto_traits::<Retained<NSSet<NSString>>>();
+    assert_auto_traits::<NSDictionary<NSProcessInfo, NSProcessInfo>>();
+    assert_auto_traits::<NSSet<NSProcessInfo>>();
+    assert_auto_traits::<Retained<NSSet<NSProcessInfo>>>();
     // TODO: Figure out if Send + Sync is safe?
-    // assert_auto_traits::<NSEnumerator2<NSString>>();
-    // assert_auto_traits::<NSFastEnumerator2<NSArray<NSString>>>();
+    // assert_auto_traits::<NSEnumerator2<NSProcessInfo>>();
+    // assert_auto_traits::<NSFastEnumerator2<NSArray<NSProcessInfo>>>();
     assert_auto_traits::<NSError>();
     assert_auto_traits::<NSException>();
     assert_auto_traits::<CGFloat>();
     assert_auto_traits::<NSPoint>();
     assert_auto_traits::<NSRect>();
     assert_auto_traits::<NSSize>();
-    assert_auto_traits::<NSMutableArray<NSString>>();
+    assert_auto_traits::<NSMutableArray<NSProcessInfo>>();
     assert_auto_traits::<NSMutableAttributedString>();
     assert_auto_traits::<NSMutableData>();
-    assert_auto_traits::<NSMutableDictionary<NSString, NSString>>();
-    assert_auto_traits::<NSMutableSet<NSString>>();
-    assert_auto_traits::<NSMutableString>();
+    assert_auto_traits::<NSMutableDictionary<NSProcessInfo, NSProcessInfo>>();
+    assert_auto_traits::<NSMutableSet<NSProcessInfo>>();
+    assert_unwindsafe::<NSMutableString>();
     assert_auto_traits::<NSNumber>();
     // assert_auto_traits::<NSObject>(); // Intentional
     assert_auto_traits::<NSProcessInfo>();
     assert_auto_traits::<NSRange>();
-    assert_auto_traits::<NSString>();
+    assert_unwindsafe::<NSString>();
     assert_unwindsafe::<MainThreadMarker>(); // Intentional
     assert_auto_traits::<NSThread>();
     assert_auto_traits::<NSUUID>();

--- a/framework-crates/objc2-foundation/src/tests/auto_traits.rs
+++ b/framework-crates/objc2-foundation/src/tests/auto_traits.rs
@@ -130,7 +130,7 @@ fn test_generic_auto_traits() {
 fn send_sync_unwindsafe() {
     assert_unwindsafe::<NSAttributedString>();
     assert_auto_traits::<NSComparisonResult>();
-    assert_auto_traits::<NSData>();
+    assert_unwindsafe::<NSData>();
     assert_auto_traits::<NSDictionary<NSProcessInfo, NSProcessInfo>>();
     assert_auto_traits::<NSSet<NSProcessInfo>>();
     assert_auto_traits::<Retained<NSSet<NSProcessInfo>>>();
@@ -145,7 +145,7 @@ fn send_sync_unwindsafe() {
     assert_auto_traits::<NSSize>();
     assert_auto_traits::<NSMutableArray<NSProcessInfo>>();
     assert_unwindsafe::<NSMutableAttributedString>();
-    assert_auto_traits::<NSMutableData>();
+    assert_unwindsafe::<NSMutableData>();
     assert_auto_traits::<NSMutableDictionary<NSProcessInfo, NSProcessInfo>>();
     assert_auto_traits::<NSMutableSet<NSProcessInfo>>();
     assert_unwindsafe::<NSMutableString>();

--- a/framework-crates/objc2-foundation/src/tests/data.rs
+++ b/framework-crates/objc2-foundation/src/tests/data.rs
@@ -8,13 +8,13 @@ fn test_bytes() {
     let bytes = [3, 7, 16, 52, 112, 19];
     let data = NSData::with_bytes(&bytes);
     assert_eq!(data.len(), bytes.len());
-    assert_eq!(data.bytes(), bytes);
+    assert_eq!(data.to_vec(), bytes);
 }
 
 #[test]
 fn test_no_bytes() {
     let data = NSData::new();
-    assert!(Some(data.bytes()).is_some());
+    assert!(Some(data.to_vec()).is_some());
 }
 
 #[cfg(feature = "block2")]
@@ -24,7 +24,7 @@ fn test_from_vec() {
     let bytes_ptr = bytes.as_ptr();
 
     let data = NSData::from_vec(bytes);
-    assert_eq!(data.bytes().as_ptr(), bytes_ptr);
+    assert_eq!(unsafe { data.as_slice_unchecked() }.as_ptr(), bytes_ptr);
 }
 
 #[test]

--- a/framework-crates/objc2-foundation/src/tests/dictionary.rs
+++ b/framework-crates/objc2-foundation/src/tests/dictionary.rs
@@ -6,7 +6,7 @@ use alloc::{format, vec};
 
 use objc2::rc::Retained;
 
-use crate::{NSDictionary, NSObject, NSString};
+use crate::{ns_string, NSDictionary, NSObject, NSString};
 
 fn sample_dict(key: &str) -> Retained<NSDictionary<NSString, NSObject>> {
     let string = NSString::from_str(key);
@@ -24,11 +24,8 @@ fn test_len() {
 fn test_get() {
     let dict = sample_dict("abcd");
 
-    let string = NSString::from_str("abcd");
-    assert!(dict.get(&string).is_some());
-
-    let string = NSString::from_str("abcde");
-    assert!(dict.get(&string).is_none());
+    assert!(dict.get(ns_string!("abcd")).is_some());
+    assert!(dict.get(ns_string!("abcde")).is_none());
 }
 
 #[test]
@@ -89,20 +86,16 @@ fn test_arrays() {
 
 #[test]
 fn test_debug() {
-    let key = NSString::from_str("a");
-    let val = NSString::from_str("b");
-    let dict = NSDictionary::from_id_slice(&[&*key], &[val]);
+    let key = ns_string!("a");
+    let val = ns_string!("b");
+    let dict = NSDictionary::from_slice(&[key], &[val]);
     assert_eq!(format!("{dict:?}"), r#"{"a": "b"}"#);
 }
 
 #[test]
 fn new_different_lengths() {
     let dict = NSDictionary::from_id_slice(
-        &[
-            &*NSString::from_str("a"),
-            &*NSString::from_str("b"),
-            &*NSString::from_str("c"),
-        ],
+        &[ns_string!("a"), ns_string!("b"), ns_string!("c")],
         &[NSObject::new(), NSObject::new()],
     );
     assert_eq!(dict.len(), 2);

--- a/framework-crates/objc2-foundation/src/tests/exception.rs
+++ b/framework-crates/objc2-foundation/src/tests/exception.rs
@@ -4,19 +4,14 @@
 #![cfg(feature = "NSObjCRuntime")]
 use alloc::format;
 
-use crate::Foundation::{NSException, NSObject, NSString};
+use crate::{ns_string, NSException, NSObject};
 
 #[test]
 fn create_and_query() {
-    let exc = NSException::new(
-        &NSString::from_str("abc"),
-        Some(&NSString::from_str("def")),
-        None,
-    )
-    .unwrap();
+    let exc = NSException::new(ns_string!("abc"), Some(ns_string!("def")), None).unwrap();
 
-    assert_eq!(exc.name(), NSString::from_str("abc"));
-    assert_eq!(exc.reason().unwrap(), NSString::from_str("def"));
+    assert_eq!(&*exc.name(), ns_string!("abc"));
+    assert_eq!(&*exc.reason().unwrap(), ns_string!("def"));
     assert!(exc.userInfo().is_none());
 
     let debug = format!("<NSException: {exc:p}> 'abc' reason:def");
@@ -42,12 +37,7 @@ fn create_and_query() {
 #[test]
 #[should_panic = "'abc' reason:def"]
 fn unwrap() {
-    let exc = NSException::new(
-        &NSString::from_str("abc"),
-        Some(&NSString::from_str("def")),
-        None,
-    )
-    .unwrap();
+    let exc = NSException::new(ns_string!("abc"), Some(ns_string!("def")), None).unwrap();
 
     panic!("{exc:?}");
 }

--- a/framework-crates/objc2-foundation/src/tests/mutable_data.rs
+++ b/framework-crates/objc2-foundation/src/tests/mutable_data.rs
@@ -1,52 +1,49 @@
 #![cfg(feature = "NSData")]
 
-use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
-
-use crate::Foundation::{NSData, NSMutableData, NSObject};
+use crate::Foundation::{NSData, NSMutableData};
 
 #[test]
 fn test_bytes_mut() {
-    let mut data = NSMutableData::with_bytes(&[7, 16]);
-    data.bytes_mut()[0] = 3;
-    assert_eq!(data.bytes(), [3, 16]);
+    let data = NSMutableData::with_bytes(&[7, 16]);
+    unsafe { data.as_mut_slice_unchecked()[0] = 3 };
+    assert_eq!(data.to_vec(), [3, 16]);
 }
 
 #[test]
 fn test_set_len() {
-    let mut data = NSMutableData::with_bytes(&[7, 16]);
+    let data = NSMutableData::with_bytes(&[7, 16]);
     data.setLength(4);
     assert_eq!(data.len(), 4);
-    assert_eq!(data.bytes(), [7, 16, 0, 0]);
+    assert_eq!(data.to_vec(), [7, 16, 0, 0]);
 
     data.setLength(1);
     assert_eq!(data.len(), 1);
-    assert_eq!(data.bytes(), [7]);
+    assert_eq!(data.to_vec(), [7]);
 }
 
 #[test]
 fn test_append() {
-    let mut data = NSMutableData::with_bytes(&[7, 16]);
+    let data = NSMutableData::with_bytes(&[7, 16]);
     data.extend_from_slice(&[3, 52]);
     assert_eq!(data.len(), 4);
-    assert_eq!(data.bytes(), [7, 16, 3, 52]);
+    assert_eq!(data.to_vec(), [7, 16, 3, 52]);
 }
 
 #[test]
 #[cfg(feature = "NSRange")]
 fn test_replace() {
-    let mut data = NSMutableData::with_bytes(&[7, 16]);
+    let data = NSMutableData::with_bytes(&[7, 16]);
     data.replace_range(0..0, &[3]);
-    assert_eq!(data.bytes(), [3, 7, 16]);
+    assert_eq!(data.to_vec(), [3, 7, 16]);
 
     data.replace_range(1..2, &[52, 13]);
-    assert_eq!(data.bytes(), [3, 52, 13, 16]);
+    assert_eq!(data.to_vec(), [3, 52, 13, 16]);
 
     data.replace_range(2..4, &[6]);
-    assert_eq!(data.bytes(), [3, 52, 6]);
+    assert_eq!(data.to_vec(), [3, 52, 6]);
 
     data.set_bytes(&[8, 17]);
-    assert_eq!(data.bytes(), [8, 17]);
+    assert_eq!(data.to_vec(), [8, 17]);
 }
 
 #[test]
@@ -58,66 +55,19 @@ fn test_from_data() {
 
 #[test]
 fn test_with_capacity() {
-    let mut data = NSMutableData::dataWithCapacity(5).unwrap();
-    assert_eq!(data.bytes(), &[]);
+    let data = NSMutableData::dataWithCapacity(5).unwrap();
+    assert_eq!(data.to_vec(), &[]);
     data.extend_from_slice(&[1, 2, 3, 4, 5]);
-    assert_eq!(data.bytes(), &[1, 2, 3, 4, 5]);
+    assert_eq!(data.to_vec(), &[1, 2, 3, 4, 5]);
     data.extend_from_slice(&[6, 7]);
-    assert_eq!(data.bytes(), &[1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(data.to_vec(), &[1, 2, 3, 4, 5, 6, 7]);
 }
 
 #[test]
 fn test_extend() {
-    let mut data = NSMutableData::with_bytes(&[1, 2]);
-    data.extend(3..=5);
-    assert_eq!(data.bytes(), &[1, 2, 3, 4, 5]);
-    data.extend(&*NSData::with_bytes(&[6, 7]));
-    assert_eq!(data.bytes(), &[1, 2, 3, 4, 5, 6, 7]);
-}
-
-#[test]
-fn test_as_ref_borrow() {
-    use core::borrow::{Borrow, BorrowMut};
-
-    fn impls_borrow<T: AsRef<U> + Borrow<U> + ?Sized, U: ?Sized>(_: &T) {}
-    fn impls_borrow_mut<T: AsMut<U> + BorrowMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
-
-    // TODO: For some reason `new` doesn't work on GNUStep in release mode?
-    let mut obj = if cfg!(feature = "gnustep-1-8") {
-        NSMutableData::with_bytes(&[])
-    } else {
-        NSMutableData::new()
-    };
-    impls_borrow::<Retained<NSMutableData>, NSMutableData>(&obj);
-    impls_borrow_mut::<Retained<NSMutableData>, NSMutableData>(&mut obj);
-
-    impls_borrow::<NSMutableData, NSMutableData>(&obj);
-    impls_borrow_mut::<NSMutableData, NSMutableData>(&mut obj);
-    impls_borrow::<NSMutableData, NSData>(&obj);
-    impls_borrow_mut::<NSMutableData, NSData>(&mut obj);
-    impls_borrow::<NSMutableData, NSObject>(&obj);
-    impls_borrow_mut::<NSMutableData, NSObject>(&mut obj);
-    impls_borrow::<NSMutableData, AnyObject>(&obj);
-    impls_borrow_mut::<NSMutableData, AnyObject>(&mut obj);
-
-    impls_borrow::<NSData, NSData>(&obj);
-    impls_borrow_mut::<NSData, NSData>(&mut obj);
-    impls_borrow::<NSData, NSObject>(&obj);
-    impls_borrow_mut::<NSData, NSObject>(&mut obj);
-    impls_borrow::<NSData, AnyObject>(&obj);
-    impls_borrow_mut::<NSData, AnyObject>(&mut obj);
-
-    fn impls_as_ref<T: AsRef<U> + ?Sized, U: ?Sized>(_: &T) {}
-    fn impls_as_mut<T: AsMut<U> + ?Sized, U: ?Sized>(_: &mut T) {}
-
-    impls_as_ref::<NSMutableData, [u8]>(&obj);
-    impls_as_mut::<NSMutableData, [u8]>(&mut obj);
-    impls_as_ref::<NSData, [u8]>(&obj);
-
-    let obj: &mut NSMutableData = &mut obj;
-    let _: &[u8] = obj.as_ref();
-    let _: &mut [u8] = obj.as_mut();
-
-    let obj: &mut NSData = obj;
-    let _: &[u8] = obj.as_ref();
+    let data = NSMutableData::with_bytes(&[1, 2]);
+    (&*data).extend(3..=5);
+    assert_eq!(data.to_vec(), &[1, 2, 3, 4, 5]);
+    (&*data).extend(&*NSData::with_bytes(&[6, 7]));
+    assert_eq!(data.to_vec(), &[1, 2, 3, 4, 5, 6, 7]);
 }

--- a/framework-crates/objc2-foundation/src/tests/mutable_dictionary.rs
+++ b/framework-crates/objc2-foundation/src/tests/mutable_dictionary.rs
@@ -6,7 +6,7 @@ use alloc::vec;
 use objc2::msg_send;
 use objc2::rc::Retained;
 
-use crate::Foundation::{self, NSMutableDictionary, NSNumber, NSObject};
+use crate::Foundation::{NSMutableDictionary, NSNumber, NSObject};
 
 fn sample_dict() -> Retained<NSMutableDictionary<NSNumber, NSObject>> {
     NSMutableDictionary::from_id_slice(
@@ -19,8 +19,7 @@ fn sample_dict() -> Retained<NSMutableDictionary<NSNumber, NSObject>> {
     )
 }
 
-#[cfg(feature = "NSString")]
-fn sample_dict_mut() -> Retained<NSMutableDictionary<NSNumber, Foundation::NSMutableString>> {
+fn sample_dict_mut() -> Retained<NSMutableDictionary<NSNumber, NSMutableDictionary>> {
     NSMutableDictionary::from_vec(
         &[
             &*NSNumber::new_i32(1),
@@ -28,9 +27,9 @@ fn sample_dict_mut() -> Retained<NSMutableDictionary<NSNumber, Foundation::NSMut
             &*NSNumber::new_i32(3),
         ],
         vec![
-            Foundation::NSMutableString::from_str("a"),
-            Foundation::NSMutableString::from_str("b"),
-            Foundation::NSMutableString::from_str("c"),
+            NSMutableDictionary::new(),
+            NSMutableDictionary::new(),
+            NSMutableDictionary::new(),
         ],
     )
 }
@@ -38,13 +37,12 @@ fn sample_dict_mut() -> Retained<NSMutableDictionary<NSNumber, Foundation::NSMut
 #[test]
 #[cfg(feature = "NSString")]
 fn dict_from_mutable() {
-    let _: Retained<NSMutableDictionary<Foundation::NSString, Foundation::NSString>> =
-        NSMutableDictionary::from_id_slice(
-            &[&*Foundation::NSMutableString::from_str("a")],
-            &[Retained::into_super(Foundation::NSMutableString::from_str(
-                "b",
-            ))],
-        );
+    use crate::{NSMutableString, NSString};
+
+    let _: Retained<NSMutableDictionary<NSString, NSString>> = NSMutableDictionary::from_slice(
+        &[&*NSMutableString::from_str("a")],
+        &[&**NSMutableString::from_str("b")],
+    );
 }
 
 #[test]
@@ -54,7 +52,6 @@ fn test_new() {
 }
 
 #[test]
-#[cfg(feature = "NSString")]
 fn test_get_mut() {
     let mut dict = sample_dict_mut();
 
@@ -64,7 +61,6 @@ fn test_get_mut() {
 }
 
 #[test]
-#[cfg(feature = "NSString")]
 fn test_values_mut() {
     let mut dict = sample_dict_mut();
     let vec = dict.values_vec_mut();

--- a/framework-crates/objc2-foundation/src/tests/mutable_set.rs
+++ b/framework-crates/objc2-foundation/src/tests/mutable_set.rs
@@ -2,22 +2,22 @@
 #![cfg(feature = "NSString")]
 use alloc::vec;
 
-use crate::Foundation::{self, ns_string, NSMutableSet, NSString};
+use crate::Foundation::{ns_string, NSMutableSet, NSMutableString};
 
 #[test]
 fn test_insert() {
     let mut set = NSMutableSet::new();
     assert!(set.is_empty());
 
-    assert!(set.insert_id(NSString::from_str("one")));
-    assert!(!set.insert_id(NSString::from_str("one")));
-    assert!(set.insert_id(NSString::from_str("two")));
+    assert!(set.insert(ns_string!("one")));
+    assert!(!set.insert(ns_string!("one")));
+    assert!(set.insert(ns_string!("two")));
 }
 
 #[test]
 fn test_remove() {
-    let strs = ["one", "two", "three"].map(NSString::from_str);
-    let mut set = NSMutableSet::from_id_slice(&strs);
+    let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    let mut set = NSMutableSet::from_slice(&strs);
 
     assert!(set.remove(ns_string!("one")));
     assert!(!set.remove(ns_string!("one")));
@@ -25,8 +25,8 @@ fn test_remove() {
 
 #[test]
 fn test_clear() {
-    let strs = ["one", "two", "three"].map(NSString::from_str);
-    let mut set = NSMutableSet::from_id_slice(&strs);
+    let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    let mut set = NSMutableSet::from_slice(&strs);
     assert_eq!(set.len(), 3);
 
     set.removeAllObjects();
@@ -34,12 +34,11 @@ fn test_clear() {
 }
 
 #[test]
-#[cfg(feature = "NSString")]
 fn test_into_vec() {
     let strs = vec![
-        Foundation::NSMutableString::from_str("one"),
-        Foundation::NSMutableString::from_str("two"),
-        Foundation::NSMutableString::from_str("three"),
+        NSMutableString::from_str("one"),
+        NSMutableString::from_str("two"),
+        NSMutableString::from_str("three"),
     ];
     let set = NSMutableSet::from_vec(strs);
 
@@ -49,8 +48,7 @@ fn test_into_vec() {
     }
 
     assert_eq!(vec.len(), 3);
-    let suffix = ns_string!("zero");
-    assert!(vec.iter().all(|str| str.hasSuffix(suffix)));
+    assert!(vec.iter().all(|str| str.hasSuffix(ns_string!("zero"))));
 }
 
 #[test]
@@ -58,18 +56,18 @@ fn test_extend() {
     let mut set = NSMutableSet::new();
     assert!(set.is_empty());
 
-    set.extend(["one", "two", "three"].map(NSString::from_str));
+    set.extend([ns_string!("one"), ns_string!("two"), ns_string!("three")]);
     assert_eq!(set.len(), 3);
 }
 
 #[test]
 #[cfg(feature = "NSObject")]
 fn test_mutable_copy() {
-    use Foundation::{NSMutableCopying, NSSet};
+    use crate::{NSMutableCopying, NSSet};
 
-    let set1 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+    let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
     let mut set2 = set1.mutableCopy();
-    set2.insert_id(NSString::from_str("four"));
+    set2.insert(ns_string!("four"));
 
     assert!(set1.is_subset(&set2));
     assert_ne!(set1.mutableCopy(), set2);

--- a/framework-crates/objc2-foundation/src/tests/set.rs
+++ b/framework-crates/objc2-foundation/src/tests/set.rs
@@ -4,17 +4,17 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
-use crate::Foundation::{self, ns_string, NSNumber, NSObject, NSSet, NSString};
+use crate::Foundation::{ns_string, NSNumber, NSObject, NSSet, NSString};
 
 #[test]
 fn test_new() {
-    let set = NSSet::<NSString>::new();
+    let set = NSSet::<NSObject>::new();
     assert!(set.is_empty());
 }
 
 #[test]
 fn test_from_vec() {
-    let set = NSSet::<NSString>::from_vec(Vec::new());
+    let set = NSSet::<NSObject>::from_vec(Vec::new());
     assert!(set.is_empty());
 
     let strs = ["one", "two", "three"].map(NSString::from_str);
@@ -27,13 +27,13 @@ fn test_from_vec() {
 }
 
 #[test]
-fn test_from_id_slice() {
-    let set = NSSet::<NSString>::from_id_slice(&[]);
+fn test_from_slice() {
+    let set = NSSet::<NSString>::from_slice(&[]);
     assert!(set.is_empty());
 
-    let strs = ["one", "two", "three"].map(NSString::from_str);
-    let set = NSSet::from_id_slice(&strs);
-    assert!(strs.into_iter().all(|s| set.contains(&s)));
+    let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    let set = NSSet::from_slice(&strs);
+    assert!(strs.into_iter().all(|s| set.contains(s)));
 
     let nums = [1, 2, 3].map(NSNumber::new_i32);
     let set = NSSet::from_id_slice(&nums);
@@ -42,10 +42,10 @@ fn test_from_id_slice() {
 
 #[test]
 fn test_len() {
-    let set = NSSet::<NSString>::new();
+    let set = NSSet::<NSObject>::new();
     assert!(set.is_empty());
 
-    let set = NSSet::from_id_slice(&["one", "two", "two"].map(NSString::from_str));
+    let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("two")]);
     assert_eq!(set.len(), 2);
 
     let set = NSSet::from_vec(vec![
@@ -61,14 +61,14 @@ fn test_get() {
     let set = NSSet::<NSString>::new();
     assert!(set.get(ns_string!("one")).is_none());
 
-    let set = NSSet::from_id_slice(&["one", "two", "two"].map(NSString::from_str));
+    let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("two")]);
     assert!(set.get(ns_string!("two")).is_some());
     assert!(set.get(ns_string!("three")).is_none());
 }
 
 #[test]
 fn test_get_return_lifetime() {
-    let set = NSSet::from_id_slice(&["one", "two", "two"].map(NSString::from_str));
+    let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("two")]);
 
     let res = {
         let value = NSString::from_str("one");
@@ -80,13 +80,13 @@ fn test_get_return_lifetime() {
 
 #[test]
 fn test_get_any() {
-    let set = NSSet::<NSString>::new();
+    let set = NSSet::<NSObject>::new();
     assert!(set.get_any().is_none());
 
-    let strs = ["one", "two", "three"].map(NSString::from_str);
-    let set = NSSet::from_id_slice(&strs);
+    let strs = [ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    let set = NSSet::from_slice(&strs);
     let any = set.get_any().unwrap();
-    assert!(any == &*strs[0] || any == &*strs[1] || any == &*strs[2]);
+    assert!(any == strs[0] || any == strs[1] || any == strs[2]);
 }
 
 #[test]
@@ -94,15 +94,15 @@ fn test_contains() {
     let set = NSSet::<NSString>::new();
     assert!(!set.contains(ns_string!("one")));
 
-    let set = NSSet::from_id_slice(&["one", "two", "two"].map(NSString::from_str));
+    let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("two")]);
     assert!(set.contains(ns_string!("one")));
     assert!(!set.contains(ns_string!("three")));
 }
 
 #[test]
 fn test_is_subset() {
-    let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-    let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+    let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+    let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
 
     assert!(set1.is_subset(&set2));
     assert!(!set2.is_subset(&set1));
@@ -110,8 +110,8 @@ fn test_is_subset() {
 
 #[test]
 fn test_is_superset() {
-    let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-    let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+    let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+    let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
 
     assert!(!set1.is_superset(&set2));
     assert!(set2.is_superset(&set1));
@@ -119,9 +119,9 @@ fn test_is_superset() {
 
 #[test]
 fn test_is_disjoint() {
-    let set1 = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
-    let set2 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
-    let set3 = NSSet::from_id_slice(&["four", "five", "six"].map(NSString::from_str));
+    let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
+    let set2 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
+    let set3 = NSSet::from_slice(&[ns_string!("four"), ns_string!("five"), ns_string!("six")]);
 
     assert!(!set1.is_disjoint(&set2));
     assert!(set1.is_disjoint(&set3));
@@ -156,14 +156,9 @@ fn test_into_iter() {
 }
 
 #[test]
-#[cfg(feature = "NSString")]
 fn test_into_vec() {
-    let strs = vec![
-        Foundation::NSString::from_str("one"),
-        Foundation::NSString::from_str("two"),
-        Foundation::NSString::from_str("three"),
-    ];
-    let set = NSSet::from_vec(strs);
+    let strs = vec![ns_string!("one"), ns_string!("two"), ns_string!("three")];
+    let set = NSSet::from_slice(&strs);
 
     assert_eq!(set.len(), 3);
     assert_eq!(set.to_vec().len(), 3);
@@ -171,27 +166,27 @@ fn test_into_vec() {
 
 #[test]
 fn test_equality() {
-    let set1 = NSSet::<NSString>::new();
-    let set2 = NSSet::<NSString>::new();
+    let set1 = NSSet::<NSObject>::new();
+    let set2 = NSSet::<NSObject>::new();
     assert_eq!(set1, set2);
 }
 
 #[test]
 #[cfg(feature = "NSObject")]
 fn test_copy() {
-    use Foundation::NSCopying;
+    use crate::NSCopying;
 
-    let set1 = NSSet::from_id_slice(&["one", "two", "three"].map(NSString::from_str));
+    let set1 = NSSet::from_slice(&[ns_string!("one"), ns_string!("two"), ns_string!("three")]);
     let set2 = set1.copy();
     assert_eq!(set1, set2);
 }
 
 #[test]
 fn test_debug() {
-    let set = NSSet::<NSString>::new();
+    let set = NSSet::<NSObject>::new();
     assert_eq!(format!("{set:?}"), "{}");
 
-    let set = NSSet::from_id_slice(&["one", "two"].map(NSString::from_str));
+    let set = NSSet::from_slice(&[ns_string!("one"), ns_string!("two")]);
     assert!(matches!(
         &*format!("{set:?}"),
         "{\"one\", \"two\"}" | "{\"two\", \"one\"}"
@@ -203,10 +198,8 @@ fn test_debug() {
 #[cfg(all(feature = "NSArray", feature = "NSCalendar"))]
 #[allow(deprecated)]
 fn invalid_generic() {
-    let something_interior_mutable = unsafe { Foundation::NSCalendar::currentCalendar() };
-    let set = NSSet::from_id_slice(&[Foundation::NSArray::from_id_slice(&[
-        something_interior_mutable,
-    ])]);
+    let something_interior_mutable = unsafe { crate::NSCalendar::currentCalendar() };
+    let set = NSSet::from_id_slice(&[crate::NSArray::from_id_slice(&[something_interior_mutable])]);
     let _ = set.get_any().unwrap().get(0).unwrap();
     // something_interior_mutable.setAbc(...)
 }

--- a/framework-crates/objc2-foundation/translation-config.toml
+++ b/framework-crates/objc2-foundation/translation-config.toml
@@ -269,8 +269,8 @@ class.NSMutableArray.mutability = "MutableWithImmutableSuperclass(Foundation::NS
 class.NSString.mutability = "InteriorMutableWithSubclass(Foundation::NSString::NSMutableString)"
 class.NSMutableString.mutability = "InteriorMutableWithSuperclass(Foundation::NSString::NSString)"
 
-class.NSAttributedString.mutability = "ImmutableWithMutableSubclass(Foundation::NSAttributedString::NSMutableAttributedString)"
-class.NSMutableAttributedString.mutability = "MutableWithImmutableSuperclass(Foundation::NSAttributedString::NSAttributedString)"
+class.NSAttributedString.mutability = "InteriorMutableWithSubclass(Foundation::NSAttributedString::NSMutableAttributedString)"
+class.NSMutableAttributedString.mutability = "InteriorMutableWithSuperclass(Foundation::NSAttributedString::NSAttributedString)"
 
 class.NSData.mutability = "ImmutableWithMutableSubclass(Foundation::NSData::NSMutableData)"
 class.NSMutableData.mutability = "MutableWithImmutableSuperclass(Foundation::NSData::NSData)"

--- a/framework-crates/objc2-foundation/translation-config.toml
+++ b/framework-crates/objc2-foundation/translation-config.toml
@@ -266,8 +266,8 @@ class.NSXPCCoder.methods."decodeXPCObjectOfType:forKey:".skipped = true
 class.NSArray.mutability = "ImmutableWithMutableSubclass(Foundation::NSArray::NSMutableArray)"
 class.NSMutableArray.mutability = "MutableWithImmutableSuperclass(Foundation::NSArray::NSArray)"
 
-class.NSString.mutability = "ImmutableWithMutableSubclass(Foundation::NSString::NSMutableString)"
-class.NSMutableString.mutability = "MutableWithImmutableSuperclass(Foundation::NSString::NSString)"
+class.NSString.mutability = "InteriorMutableWithSubclass(Foundation::NSString::NSMutableString)"
+class.NSMutableString.mutability = "InteriorMutableWithSuperclass(Foundation::NSString::NSString)"
 
 class.NSAttributedString.mutability = "ImmutableWithMutableSubclass(Foundation::NSAttributedString::NSMutableAttributedString)"
 class.NSMutableAttributedString.mutability = "MutableWithImmutableSuperclass(Foundation::NSAttributedString::NSAttributedString)"
@@ -308,11 +308,6 @@ class.NSMutableURLRequest.mutability = "MutableWithImmutableSuperclass(Foundatio
 class.NSEnumerator.mutability = "Mutable"
 class.NSDirectoryEnumerator.mutability = "Mutable"
 
-# Allowed to be just `Immutable` since we've removed the `NSCopying` and
-# `NSMutableCopying` impls from these for now (they'd return the wrong
-# type).
-class.NSSimpleCString.mutability = "Immutable"
-class.NSConstantString.mutability = "Immutable"
 # Allowed to be just `Mutable` since we've removed the `NSCopying` and
 # `NSMutableCopying` impls from this for now (since they'd return the
 # wrong type).

--- a/framework-crates/objc2-foundation/translation-config.toml
+++ b/framework-crates/objc2-foundation/translation-config.toml
@@ -272,8 +272,8 @@ class.NSMutableString.mutability = "InteriorMutableWithSuperclass(Foundation::NS
 class.NSAttributedString.mutability = "InteriorMutableWithSubclass(Foundation::NSAttributedString::NSMutableAttributedString)"
 class.NSMutableAttributedString.mutability = "InteriorMutableWithSuperclass(Foundation::NSAttributedString::NSAttributedString)"
 
-class.NSData.mutability = "ImmutableWithMutableSubclass(Foundation::NSData::NSMutableData)"
-class.NSMutableData.mutability = "MutableWithImmutableSuperclass(Foundation::NSData::NSData)"
+class.NSData.mutability = "InteriorMutableWithSubclass(Foundation::NSData::NSMutableData)"
+class.NSMutableData.mutability = "InteriorMutableWithSuperclass(Foundation::NSData::NSData)"
 
 class.NSDictionary.mutability = "ImmutableWithMutableSubclass(Foundation::NSDictionary::NSMutableDictionary)"
 class.NSMutableDictionary.mutability = "MutableWithImmutableSuperclass(Foundation::NSDictionary::NSDictionary)"
@@ -307,11 +307,6 @@ class.NSMutableURLRequest.mutability = "InteriorMutableWithSuperclass(Foundation
 # `&'a NSArray<T: IsCloneable> -> Retained<NSEnumerator<T>> + 'a`.
 class.NSEnumerator.mutability = "Mutable"
 class.NSDirectoryEnumerator.mutability = "Mutable"
-
-# Allowed to be just `Mutable` since we've removed the `NSCopying` and
-# `NSMutableCopying` impls from this for now (since they'd return the
-# wrong type).
-class.NSPurgeableData.mutability = "Mutable"
 
 class.NSValue.mutability = "Immutable"
 class.NSNumber.mutability = "Immutable"

--- a/framework-crates/objc2-foundation/translation-config.toml
+++ b/framework-crates/objc2-foundation/translation-config.toml
@@ -281,8 +281,8 @@ class.NSMutableDictionary.mutability = "MutableWithImmutableSuperclass(Foundatio
 class.NSSet.mutability = "ImmutableWithMutableSubclass(Foundation::NSSet::NSMutableSet)"
 class.NSMutableSet.mutability = "MutableWithImmutableSuperclass(Foundation::NSSet::NSSet)"
 
-class.NSCharacterSet.mutability = "ImmutableWithMutableSubclass(Foundation::NSCharacterSet::NSMutableCharacterSet)"
-class.NSMutableCharacterSet.mutability = "MutableWithImmutableSuperclass(Foundation::NSCharacterSet::NSCharacterSet)"
+class.NSCharacterSet.mutability = "InteriorMutableWithSubclass(Foundation::NSCharacterSet::NSMutableCharacterSet)"
+class.NSMutableCharacterSet.mutability = "InteriorMutableWithSuperclass(Foundation::NSCharacterSet::NSCharacterSet)"
 
 class.NSOrderedSet.mutability = "ImmutableWithMutableSubclass(Foundation::NSOrderedSet::NSMutableOrderedSet)"
 class.NSMutableOrderedSet.mutability = "MutableWithImmutableSuperclass(Foundation::NSOrderedSet::NSOrderedSet)"
@@ -290,8 +290,8 @@ class.NSMutableOrderedSet.mutability = "MutableWithImmutableSuperclass(Foundatio
 class.NSIndexSet.mutability = "ImmutableWithMutableSubclass(Foundation::NSIndexSet::NSMutableIndexSet)"
 class.NSMutableIndexSet.mutability = "MutableWithImmutableSuperclass(Foundation::NSIndexSet::NSIndexSet)"
 
-class.NSURLRequest.mutability = "ImmutableWithMutableSubclass(Foundation::NSURLRequest::NSMutableURLRequest)"
-class.NSMutableURLRequest.mutability = "MutableWithImmutableSuperclass(Foundation::NSURLRequest::NSURLRequest)"
+class.NSURLRequest.mutability = "InteriorMutableWithSubclass(Foundation::NSURLRequest::NSMutableURLRequest)"
+class.NSMutableURLRequest.mutability = "InteriorMutableWithSuperclass(Foundation::NSURLRequest::NSURLRequest)"
 
 # SAFETY: `NSEnumerator` and subclasses are safe as mutable because even
 # though the items it contains are not mutable, the enumerator itself is

--- a/framework-crates/objc2-ui-kit/translation-config.toml
+++ b/framework-crates/objc2-ui-kit/translation-config.toml
@@ -20,9 +20,6 @@ static.UIKeyInputF1.skipped = true
 
 # These protocol impls would return the wrong types
 class.NSTextStorage.skipped-protocols = ["NSCopying", "NSMutableCopying"]
-# Subclasses `NSMutableAttributedString`, though I think this should
-# actually be `InteriorMutable`?
-class.NSTextStorage.mutability = "Mutable"
 
 # These subclass a generic struct, and hence the type parameter defaults to
 # `AnyObject`, which is not PartialEq, Eq nor Hash.


### PR DESCRIPTION
Part of https://github.com/madsmtm/objc2/issues/563.

Remove non-interior mutability from the types `NSString`, `NSAttributedString`, `NSData`, and a few others. Remaining are only the generic types `NSArray`, `NSSet`, `NSDictionary`, `NSEnumerator` and so on, which will be handled by https://github.com/madsmtm/objc2/pull/587.

The move of `NSString` was facilitated by #628.

The changes to `NSData` might incur a performance cost if users decide to use the safe `to_vec` over the unsafe `as_slice_unchecked`, and the iteration methods are also less performant now.

Notes:
- Send+Sync was removed from all of the above types, as they're now interior mutable.
- The trait impls like `std::io::Write` that require `&mut` was changed to be implemented on `&T` instead of `T`. This could be further improved with different impls on `Retained<T>`.