### PR TITLE
Metal: Reexpose safe wrappers for static `MTLDevice` getters

### DIFF
--- a/crates/objc2/src/rc/id.rs
+++ b/crates/objc2/src/rc/id.rs
@@ -162,7 +162,7 @@ pub type Id<T> = Retained<T>;
 
 impl<T: ?Sized> Retained<T> {
     #[inline]
-    pub(crate) unsafe fn new_nonnull(ptr: NonNull<T>) -> Self {
+    pub unsafe fn new_nonnull(ptr: NonNull<T>) -> Self {
         Self {
             ptr,
             item: PhantomData,

--- a/framework-crates/objc2-metal/examples/triangle.rs
+++ b/framework-crates/objc2-metal/examples/triangle.rs
@@ -106,10 +106,7 @@ declare_class!(
             };
 
             // get the default device
-            let device = {
-                let ptr = unsafe { MTLCreateSystemDefaultDevice() };
-                unsafe { Retained::retain(ptr) }.expect("Failed to get default system device.")
-            };
+            let device = MTLCreateSystemDefaultDevice().expect("Failed to get default system device.");
 
             // create the command queue
             let command_queue = device

--- a/framework-crates/objc2-metal/src/device.rs
+++ b/framework-crates/objc2-metal/src/device.rs
@@ -1,16 +1,12 @@
-// use crate::MTLDevice;
-//
-// pub trait MTLDeviceExtension {
-//     pub fn system_default() -> Option<Self> {
-//         MTLCreateSystemDefaultDevice()
-//     }
-//
-//     pub fn all() -> Retained<NSArray<Self>> {
-//         #[cfg(target_os = "macos")]
-//         MTLCopyAllDevices()
-//         #[cfg(not(target_os = "macos"))]
-//         NSArray::from(MTLCreateSystemDefaultDevice())
-//     }
-// }
-//
-// impl<P: MTLDevice> MTLDeviceExtension for P {}
+use objc2::{rc::Id, runtime::ProtocolObject};
+use objc2_foundation::NSArray;
+
+use crate::MTLDevice;
+
+pub fn MTLCreateSystemDefaultDevice() -> Option<Id<ProtocolObject<dyn MTLDevice>>> {
+    unsafe { Id::from_raw(crate::generated::MTLCreateSystemDefaultDevice()) }
+}
+
+pub fn MTLCopyAllDevices() -> Id<NSArray<ProtocolObject<dyn MTLDevice>>> {
+    unsafe { Id::new_nonnull(crate::generated::MTLCopyAllDevices()) }
+}

--- a/framework-crates/objc2-metal/src/lib.rs
+++ b/framework-crates/objc2-metal/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! [apple-doc]: https://developer.apple.com/documentation/xcode/validating-your-apps-metal-api-usage/.
 //!
-//! Note: To use `MTLCreateSystemDefaultDevice` you need to link to
+//! Note: To use [`MTLCreateSystemDefaultDevice()`] you need to link to
 //! `CoreGraphics`, this can be done by using `objc2-app-kit`, or by doing:
 //! ```rust
 //! #[link(name = "CoreGraphics", kind = "framework")]
@@ -64,6 +64,8 @@ mod texture;
 
 #[cfg(feature = "MTLCounters")]
 pub use self::counters::*;
+#[cfg(feature = "MTLDevice")]
+pub use self::device::*;
 #[allow(unused_imports, unreachable_pub)]
 pub use self::generated::*;
 #[cfg(feature = "MTLAccelerationStructureTypes")]
@@ -72,6 +74,7 @@ pub use self::packed::MTLPackedFloat3;
 pub use self::private::MTLDevicePrivate;
 #[cfg(feature = "MTLResource")]
 pub use self::resource::*;
+// TODO: CFG is already internal, use *?
 #[cfg(all(feature = "MTLRenderCommandEncoder", feature = "MTLCommandEncoder"))]
 pub use self::slice::MTLRenderCommandEncoderSliceExt;
 #[cfg(feature = "MTLTexture")]

--- a/framework-crates/objc2-metal/tests/runs_with_core_graphics.rs
+++ b/framework-crates/objc2-metal/tests/runs_with_core_graphics.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "MTLDevice")]
-use objc2::rc::Retained;
 use objc2_metal::MTLCreateSystemDefaultDevice;
 
 #[link(name = "CoreGraphics", kind = "framework")]
@@ -8,11 +7,13 @@ extern "C" {}
 #[test]
 #[ignore = "doesn't work in CI"]
 fn test_create_default() {
-    let _ = unsafe { Retained::from_raw(MTLCreateSystemDefaultDevice()).unwrap() };
+    let _ = MTLCreateSystemDefaultDevice();
 }
 
 #[test]
 #[cfg(target_os = "macos")]
 fn get_all() {
-    let _ = unsafe { Retained::from_raw(objc2_metal::MTLCopyAllDevices().as_ptr()).unwrap() };
+    use objc2_metal::MTLCopyAllDevices;
+
+    let _ = MTLCopyAllDevices();
 }


### PR DESCRIPTION
The safe wrappers for these static functions seem to have been commented out as it is really hard to extend a dynamic `trait` object with some concrete static functions (that exist regardless of a concrete type implementing the `MTLDevice` trait).  Instead, make them available as free functions prefixed with `mtl_device_*()`, to allow users to more easily read the "system default" device or get a list of all devices.
