### PR TITLE
Remove `no_dead_strip` marks

### DIFF
--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -439,9 +439,10 @@ macro_rules! __statics_sel {
         /// info on "life before main".
         #[cfg_attr(
             not(all(target_os = "macos", target_arch = "x86")),
-            // Clang uses `no_dead_strip` in the link section for some reason,
-            // which other tools (notably some LLVM tools) now assume is
-            // present, so we have to add it as well.
+            // Clang uses `no_dead_strip` in the link section for some unknown reason,
+            // but it makes LTO fail to trim the unused symbols.
+            // https://github.com/madsmtm/objc2/issues/667
+            // https://github.com/llvm/llvm-project/issues/114111
             link_section = "__DATA,__objc_selrefs,literal_pointers",
         )]
         #[cfg_attr(

--- a/crates/objc2/src/macros/mod.rs
+++ b/crates/objc2/src/macros/mod.rs
@@ -442,11 +442,11 @@ macro_rules! __statics_sel {
             // Clang uses `no_dead_strip` in the link section for some reason,
             // which other tools (notably some LLVM tools) now assume is
             // present, so we have to add it as well.
-            link_section = "__DATA,__objc_selrefs,literal_pointers,no_dead_strip",
+            link_section = "__DATA,__objc_selrefs,literal_pointers",
         )]
         #[cfg_attr(
             all(target_os = "macos", target_arch = "x86"),
-            link_section = "__OBJC,__message_refs,literal_pointers,no_dead_strip",
+            link_section = "__OBJC,__message_refs,literal_pointers",
         )]
         #[export_name = $crate::__macro_helpers::concat!("\x01L_OBJC_SELECTOR_REFERENCES_", $hash)]
         static REF: $crate::__macro_helpers::SyncUnsafeCell<$crate::runtime::Sel> = unsafe {
@@ -504,7 +504,7 @@ macro_rules! __statics_class {
         }
 
         /// SAFETY: Same as `REF` above in `__statics_sel!`.
-        #[link_section = "__DATA,__objc_classrefs,regular,no_dead_strip"]
+        #[link_section = "__DATA,__objc_classrefs,regular"]
         #[export_name = $crate::__macro_helpers::concat!(
             "\x01L_OBJC_CLASSLIST_REFERENCES_$_",
             $hash,
@@ -536,7 +536,7 @@ macro_rules! __statics_class {
         static NAME_DATA: [$crate::__macro_helpers::u8; X.len()] = $crate::__statics_string_to_known_length_bytes!(X);
 
         /// SAFETY: Same as `REF` above in `__statics_sel!`.
-        #[link_section = "__OBJC,__cls_refs,literal_pointers,no_dead_strip"]
+        #[link_section = "__OBJC,__cls_refs,literal_pointers"]
         #[export_name = $crate::__macro_helpers::concat!(
             "\x01L_OBJC_CLASS_REFERENCES_",
             $hash,

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-aarch64.s
@@ -1626,7 +1626,7 @@ l_anon.[ID].23:
 L_OBJC_METH_VAR_NAME_518803e84ea38a73:
 	.asciz	"classMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_518803e84ea38a73
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_518803e84ea38a73:
@@ -1643,7 +1643,7 @@ L_OBJC_IMAGE_INFO_518803e84ea38a73:
 L_OBJC_METH_VAR_NAME_05fa1b2ffc15d267:
 	.asciz	"method"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_05fa1b2ffc15d267
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_05fa1b2ffc15d267:
@@ -1660,7 +1660,7 @@ L_OBJC_IMAGE_INFO_05fa1b2ffc15d267:
 L_OBJC_METH_VAR_NAME_58736195c9ca7c7f:
 	.asciz	"methodBool:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_58736195c9ca7c7f
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_58736195c9ca7c7f:
@@ -1677,7 +1677,7 @@ L_OBJC_IMAGE_INFO_58736195c9ca7c7f:
 L_OBJC_METH_VAR_NAME_61b74dbf9c375668:
 	.asciz	"methodId"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_61b74dbf9c375668
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_61b74dbf9c375668:
@@ -1694,7 +1694,7 @@ L_OBJC_IMAGE_INFO_61b74dbf9c375668:
 L_OBJC_METH_VAR_NAME_96586542870e42e5:
 	.asciz	"methodIdWithParam:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_96586542870e42e5
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_96586542870e42e5:
@@ -1711,7 +1711,7 @@ L_OBJC_IMAGE_INFO_96586542870e42e5:
 L_OBJC_METH_VAR_NAME_f4e71677dafa88a8:
 	.asciz	"copyWithZone:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_f4e71677dafa88a8
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_f4e71677dafa88a8:
@@ -1738,7 +1738,7 @@ l_anon.[ID].24:
 L_OBJC_METH_VAR_NAME_7f51a873b0d59f00:
 	.asciz	"init"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_7f51a873b0d59f00
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_7f51a873b0d59f00:
@@ -1765,7 +1765,7 @@ l_anon.[ID].25:
 L_OBJC_METH_VAR_NAME_802cb9c5fa0b19dd:
 	.asciz	"init"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_802cb9c5fa0b19dd
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_802cb9c5fa0b19dd:

--- a/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_declare_class/expected/apple-x86_64.s
@@ -1168,7 +1168,7 @@ l_anon.[ID].23:
 L_OBJC_METH_VAR_NAME_518803e84ea38a73:
 	.asciz	"classMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_518803e84ea38a73
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_518803e84ea38a73:
@@ -1185,7 +1185,7 @@ L_OBJC_IMAGE_INFO_518803e84ea38a73:
 L_OBJC_METH_VAR_NAME_05fa1b2ffc15d267:
 	.asciz	"method"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_05fa1b2ffc15d267
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_05fa1b2ffc15d267:
@@ -1202,7 +1202,7 @@ L_OBJC_IMAGE_INFO_05fa1b2ffc15d267:
 L_OBJC_METH_VAR_NAME_58736195c9ca7c7f:
 	.asciz	"methodBool:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_58736195c9ca7c7f
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_58736195c9ca7c7f:
@@ -1219,7 +1219,7 @@ L_OBJC_IMAGE_INFO_58736195c9ca7c7f:
 L_OBJC_METH_VAR_NAME_61b74dbf9c375668:
 	.asciz	"methodId"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_61b74dbf9c375668
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_61b74dbf9c375668:
@@ -1236,7 +1236,7 @@ L_OBJC_IMAGE_INFO_61b74dbf9c375668:
 L_OBJC_METH_VAR_NAME_96586542870e42e5:
 	.asciz	"methodIdWithParam:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_96586542870e42e5
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_96586542870e42e5:
@@ -1253,7 +1253,7 @@ L_OBJC_IMAGE_INFO_96586542870e42e5:
 L_OBJC_METH_VAR_NAME_f4e71677dafa88a8:
 	.asciz	"copyWithZone:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_f4e71677dafa88a8
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_f4e71677dafa88a8:
@@ -1282,7 +1282,7 @@ l_anon.[ID].24:
 L_OBJC_METH_VAR_NAME_7f51a873b0d59f00:
 	.asciz	"init"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_7f51a873b0d59f00
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_7f51a873b0d59f00:
@@ -1311,7 +1311,7 @@ l_anon.[ID].25:
 L_OBJC_METH_VAR_NAME_802cb9c5fa0b19dd:
 	.asciz	"init"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_802cb9c5fa0b19dd
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_802cb9c5fa0b19dd:

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-aarch64.s
@@ -47,7 +47,7 @@ l_anon.[ID].0:
 L_OBJC_METH_VAR_NAME_b79c3c5185d5ed67:
 	.asciz	"aMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67:

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-armv7s.s
@@ -46,7 +46,7 @@ l_anon.[ID].0:
 L_OBJC_METH_VAR_NAME_b79c3c5185d5ed67:
 	.asciz	"aMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67:

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-old-x86.s
@@ -61,7 +61,7 @@ l_anon.[ID].0:
 L_OBJC_METH_VAR_NAME_b79c3c5185d5ed67:
 	.asciz	"aMethod"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67:

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86.s
@@ -61,7 +61,7 @@ l_anon.[ID].0:
 L_OBJC_METH_VAR_NAME_b79c3c5185d5ed67:
 	.asciz	"aMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67:

--- a/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_extern_protocol/expected/apple-x86_64.s
@@ -44,7 +44,7 @@ l_anon.[ID].0:
 L_OBJC_METH_VAR_NAME_b79c3c5185d5ed67:
 	.asciz	"aMethod"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_b79c3c5185d5ed67:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-aarch64.s
@@ -89,7 +89,7 @@ l_anon.[ID].1:
 L_OBJC_METH_VAR_NAME_664c1e40eb8cd76e:
 	.asciz	"someSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e:
@@ -106,7 +106,7 @@ L_OBJC_IMAGE_INFO_664c1e40eb8cd76e:
 L_OBJC_METH_VAR_NAME_80036160fc60677b:
 	.asciz	"generic:selector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_80036160fc60677b
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_80036160fc60677b:
@@ -123,7 +123,7 @@ L_OBJC_IMAGE_INFO_80036160fc60677b:
 L_OBJC_METH_VAR_NAME_e4e4edcd2d17efb8:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8:
@@ -140,7 +140,7 @@ L_OBJC_IMAGE_INFO_e4e4edcd2d17efb8:
 L_OBJC_METH_VAR_NAME_bf9373a91792acd9:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9:
@@ -157,7 +157,7 @@ L_OBJC_IMAGE_INFO_bf9373a91792acd9:
 L_OBJC_METH_VAR_NAME_65f663aa0a6ddc1d:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-armv7s.s
@@ -90,7 +90,7 @@ l_anon.[ID].1:
 L_OBJC_METH_VAR_NAME_664c1e40eb8cd76e:
 	.asciz	"someSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e:
@@ -107,7 +107,7 @@ L_OBJC_IMAGE_INFO_664c1e40eb8cd76e:
 L_OBJC_METH_VAR_NAME_80036160fc60677b:
 	.asciz	"generic:selector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_80036160fc60677b
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_80036160fc60677b:
@@ -124,7 +124,7 @@ L_OBJC_IMAGE_INFO_80036160fc60677b:
 L_OBJC_METH_VAR_NAME_e4e4edcd2d17efb8:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8:
@@ -141,7 +141,7 @@ L_OBJC_IMAGE_INFO_e4e4edcd2d17efb8:
 L_OBJC_METH_VAR_NAME_bf9373a91792acd9:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9:
@@ -158,7 +158,7 @@ L_OBJC_IMAGE_INFO_bf9373a91792acd9:
 L_OBJC_METH_VAR_NAME_65f663aa0a6ddc1d:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-old-x86.s
@@ -106,7 +106,7 @@ l_anon.[ID].1:
 L_OBJC_METH_VAR_NAME_664c1e40eb8cd76e:
 	.asciz	"someSelector"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e:
@@ -123,7 +123,7 @@ L_OBJC_IMAGE_INFO_664c1e40eb8cd76e:
 L_OBJC_METH_VAR_NAME_80036160fc60677b:
 	.asciz	"generic:selector:"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_80036160fc60677b
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_80036160fc60677b:
@@ -140,7 +140,7 @@ L_OBJC_IMAGE_INFO_80036160fc60677b:
 L_OBJC_METH_VAR_NAME_e4e4edcd2d17efb8:
 	.asciz	"performSelector:"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8:
@@ -157,7 +157,7 @@ L_OBJC_IMAGE_INFO_e4e4edcd2d17efb8:
 L_OBJC_METH_VAR_NAME_bf9373a91792acd9:
 	.asciz	"performSelector:"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9:
@@ -174,7 +174,7 @@ L_OBJC_IMAGE_INFO_bf9373a91792acd9:
 L_OBJC_METH_VAR_NAME_65f663aa0a6ddc1d:
 	.asciz	"performSelector:"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86.s
@@ -104,7 +104,7 @@ l_anon.[ID].1:
 L_OBJC_METH_VAR_NAME_664c1e40eb8cd76e:
 	.asciz	"someSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e:
@@ -121,7 +121,7 @@ L_OBJC_IMAGE_INFO_664c1e40eb8cd76e:
 L_OBJC_METH_VAR_NAME_80036160fc60677b:
 	.asciz	"generic:selector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_80036160fc60677b
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_80036160fc60677b:
@@ -138,7 +138,7 @@ L_OBJC_IMAGE_INFO_80036160fc60677b:
 L_OBJC_METH_VAR_NAME_e4e4edcd2d17efb8:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8:
@@ -155,7 +155,7 @@ L_OBJC_IMAGE_INFO_e4e4edcd2d17efb8:
 L_OBJC_METH_VAR_NAME_bf9373a91792acd9:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9:
@@ -172,7 +172,7 @@ L_OBJC_IMAGE_INFO_bf9373a91792acd9:
 L_OBJC_METH_VAR_NAME_65f663aa0a6ddc1d:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d:

--- a/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_msg_send_static_sel/expected/apple-x86_64.s
@@ -73,7 +73,7 @@ l_anon.[ID].1:
 L_OBJC_METH_VAR_NAME_664c1e40eb8cd76e:
 	.asciz	"someSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_664c1e40eb8cd76e:
@@ -90,7 +90,7 @@ L_OBJC_IMAGE_INFO_664c1e40eb8cd76e:
 L_OBJC_METH_VAR_NAME_80036160fc60677b:
 	.asciz	"generic:selector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_80036160fc60677b
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_80036160fc60677b:
@@ -107,7 +107,7 @@ L_OBJC_IMAGE_INFO_80036160fc60677b:
 L_OBJC_METH_VAR_NAME_e4e4edcd2d17efb8:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_e4e4edcd2d17efb8:
@@ -124,7 +124,7 @@ L_OBJC_IMAGE_INFO_e4e4edcd2d17efb8:
 L_OBJC_METH_VAR_NAME_bf9373a91792acd9:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_bf9373a91792acd9:
@@ -141,7 +141,7 @@ L_OBJC_IMAGE_INFO_bf9373a91792acd9:
 L_OBJC_METH_VAR_NAME_65f663aa0a6ddc1d:
 	.asciz	"performSelector:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_65f663aa0a6ddc1d:

--- a/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-aarch64.s
@@ -77,7 +77,7 @@ Lloh15:
 _use_in_loop:
 	ret
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
@@ -89,7 +89,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
 L_OBJC_IMAGE_INFO_7443a74fb2d1e4c6:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
@@ -101,7 +101,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
 L_OBJC_IMAGE_INFO_8f52a951012bf702:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
@@ -113,7 +113,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
 L_OBJC_IMAGE_INFO_4882212c6ef400ba:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
@@ -125,7 +125,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
 L_OBJC_IMAGE_INFO_9c6ceff32d4e4b8b:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
@@ -137,7 +137,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
 L_OBJC_IMAGE_INFO_5ca3eecf631727de:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39:

--- a/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-armv7s.s
@@ -77,7 +77,7 @@ LPC5_0:
 _use_in_loop:
 	bx	lr
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
@@ -89,7 +89,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
 L_OBJC_IMAGE_INFO_7443a74fb2d1e4c6:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
@@ -101,7 +101,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
 L_OBJC_IMAGE_INFO_8f52a951012bf702:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
@@ -113,7 +113,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
 L_OBJC_IMAGE_INFO_4882212c6ef400ba:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
@@ -125,7 +125,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
 L_OBJC_IMAGE_INFO_9c6ceff32d4e4b8b:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
@@ -137,7 +137,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
 L_OBJC_IMAGE_INFO_5ca3eecf631727de:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39:

--- a/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-old-x86.s
@@ -96,7 +96,7 @@ _use_in_loop:
 L_OBJC_CLASS_NAME_7443a74fb2d1e4c6:
 	.ascii	"NSObject"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_7443a74fb2d1e4c6
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_7443a74fb2d1e4c6:
@@ -126,7 +126,7 @@ L_OBJC_MODULES_7443a74fb2d1e4c6:
 L_OBJC_CLASS_NAME_8f52a951012bf702:
 	.ascii	"NSObject"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_8f52a951012bf702
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_8f52a951012bf702:
@@ -156,7 +156,7 @@ L_OBJC_MODULES_8f52a951012bf702:
 L_OBJC_CLASS_NAME_4882212c6ef400ba:
 	.ascii	"NSString"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_4882212c6ef400ba
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_4882212c6ef400ba:
@@ -186,7 +186,7 @@ L_OBJC_MODULES_4882212c6ef400ba:
 L_OBJC_CLASS_NAME_9c6ceff32d4e4b8b:
 	.ascii	"NSData"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_9c6ceff32d4e4b8b
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_9c6ceff32d4e4b8b:
@@ -216,7 +216,7 @@ L_OBJC_MODULES_9c6ceff32d4e4b8b:
 L_OBJC_CLASS_NAME_5ca3eecf631727de:
 	.ascii	"NSException"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_5ca3eecf631727de
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_5ca3eecf631727de:
@@ -246,7 +246,7 @@ L_OBJC_MODULES_5ca3eecf631727de:
 L_OBJC_CLASS_NAME_76a360f1704b1e39:
 	.ascii	"NSLock"
 
-	.section	__OBJC,__cls_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__cls_refs,literal_pointers
 	.globl	L_OBJC_CLASS_REFERENCES_76a360f1704b1e39
 	.p2align	2, 0x0
 L_OBJC_CLASS_REFERENCES_76a360f1704b1e39:

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86.s
@@ -91,7 +91,7 @@ _use_in_loop:
 	pop	ebp
 	ret
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
@@ -103,7 +103,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
 L_OBJC_IMAGE_INFO_7443a74fb2d1e4c6:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
@@ -115,7 +115,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
 L_OBJC_IMAGE_INFO_8f52a951012bf702:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
@@ -127,7 +127,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
 L_OBJC_IMAGE_INFO_4882212c6ef400ba:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
@@ -139,7 +139,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
 L_OBJC_IMAGE_INFO_9c6ceff32d4e4b8b:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
@@ -151,7 +151,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
 L_OBJC_IMAGE_INFO_5ca3eecf631727de:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39
 	.p2align	2, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39:

--- a/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_static_class/expected/apple-x86_64.s
@@ -72,7 +72,7 @@ _use_in_loop:
 	pop	rbp
 	ret
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
@@ -84,7 +84,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_7443a74fb2d1e4c6:
 L_OBJC_IMAGE_INFO_7443a74fb2d1e4c6:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
@@ -96,7 +96,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_8f52a951012bf702:
 L_OBJC_IMAGE_INFO_8f52a951012bf702:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
@@ -108,7 +108,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_4882212c6ef400ba:
 L_OBJC_IMAGE_INFO_4882212c6ef400ba:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
@@ -120,7 +120,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_9c6ceff32d4e4b8b:
 L_OBJC_IMAGE_INFO_9c6ceff32d4e4b8b:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
@@ -132,7 +132,7 @@ L_OBJC_CLASSLIST_REFERENCES_$_5ca3eecf631727de:
 L_OBJC_IMAGE_INFO_5ca3eecf631727de:
 	.asciz	"\000\000\000\000@\000\000"
 
-	.section	__DATA,__objc_classrefs,regular,no_dead_strip
+	.section	__DATA,__objc_classrefs
 	.globl	L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39
 	.p2align	3, 0x0
 L_OBJC_CLASSLIST_REFERENCES_$_76a360f1704b1e39:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-aarch64.s
@@ -95,7 +95,7 @@ _use_in_loop:
 L_OBJC_METH_VAR_NAME_caedaca3f40015a7:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7:
@@ -112,7 +112,7 @@ L_OBJC_IMAGE_INFO_caedaca3f40015a7:
 L_OBJC_METH_VAR_NAME_a7c7f3067f40b513:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513:
@@ -129,7 +129,7 @@ L_OBJC_IMAGE_INFO_a7c7f3067f40b513:
 L_OBJC_METH_VAR_NAME_bae8570d40d73864:
 	.asciz	"i:am:different:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864:
@@ -146,7 +146,7 @@ L_OBJC_IMAGE_INFO_bae8570d40d73864:
 L_OBJC_METH_VAR_NAME_9c1b77e8cf40622d:
 	.asciz	"unused"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d:
@@ -163,7 +163,7 @@ L_OBJC_IMAGE_INFO_9c1b77e8cf40622d:
 L_OBJC_METH_VAR_NAME_408f5be8f4fd2627:
 	.asciz	"fourthSel"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627:
@@ -180,7 +180,7 @@ L_OBJC_IMAGE_INFO_408f5be8f4fd2627:
 L_OBJC_METH_VAR_NAME_82483a8131827890:
 	.asciz	"loopedSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_82483a8131827890
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_82483a8131827890:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-armv7s.s
@@ -94,7 +94,7 @@ _use_in_loop:
 L_OBJC_METH_VAR_NAME_caedaca3f40015a7:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7:
@@ -111,7 +111,7 @@ L_OBJC_IMAGE_INFO_caedaca3f40015a7:
 L_OBJC_METH_VAR_NAME_a7c7f3067f40b513:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513:
@@ -128,7 +128,7 @@ L_OBJC_IMAGE_INFO_a7c7f3067f40b513:
 L_OBJC_METH_VAR_NAME_bae8570d40d73864:
 	.asciz	"i:am:different:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864:
@@ -145,7 +145,7 @@ L_OBJC_IMAGE_INFO_bae8570d40d73864:
 L_OBJC_METH_VAR_NAME_9c1b77e8cf40622d:
 	.asciz	"unused"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d:
@@ -162,7 +162,7 @@ L_OBJC_IMAGE_INFO_9c1b77e8cf40622d:
 L_OBJC_METH_VAR_NAME_408f5be8f4fd2627:
 	.asciz	"fourthSel"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627:
@@ -179,7 +179,7 @@ L_OBJC_IMAGE_INFO_408f5be8f4fd2627:
 L_OBJC_METH_VAR_NAME_82483a8131827890:
 	.asciz	"loopedSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_82483a8131827890
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_82483a8131827890:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-old-x86.s
@@ -110,7 +110,7 @@ _use_in_loop:
 L_OBJC_METH_VAR_NAME_caedaca3f40015a7:
 	.asciz	"simple"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7:
@@ -127,7 +127,7 @@ L_OBJC_IMAGE_INFO_caedaca3f40015a7:
 L_OBJC_METH_VAR_NAME_a7c7f3067f40b513:
 	.asciz	"simple"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513:
@@ -144,7 +144,7 @@ L_OBJC_IMAGE_INFO_a7c7f3067f40b513:
 L_OBJC_METH_VAR_NAME_bae8570d40d73864:
 	.asciz	"i:am:different:"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864:
@@ -161,7 +161,7 @@ L_OBJC_IMAGE_INFO_bae8570d40d73864:
 L_OBJC_METH_VAR_NAME_9c1b77e8cf40622d:
 	.asciz	"unused"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d:
@@ -178,7 +178,7 @@ L_OBJC_IMAGE_INFO_9c1b77e8cf40622d:
 L_OBJC_METH_VAR_NAME_408f5be8f4fd2627:
 	.asciz	"fourthSel"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627:
@@ -195,7 +195,7 @@ L_OBJC_IMAGE_INFO_408f5be8f4fd2627:
 L_OBJC_METH_VAR_NAME_82483a8131827890:
 	.asciz	"loopedSelector"
 
-	.section	__OBJC,__message_refs,literal_pointers,no_dead_strip
+	.section	__OBJC,__message_refs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_82483a8131827890
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_82483a8131827890:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-x86.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-x86.s
@@ -110,7 +110,7 @@ _use_in_loop:
 L_OBJC_METH_VAR_NAME_caedaca3f40015a7:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7:
@@ -127,7 +127,7 @@ L_OBJC_IMAGE_INFO_caedaca3f40015a7:
 L_OBJC_METH_VAR_NAME_a7c7f3067f40b513:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513:
@@ -144,7 +144,7 @@ L_OBJC_IMAGE_INFO_a7c7f3067f40b513:
 L_OBJC_METH_VAR_NAME_bae8570d40d73864:
 	.asciz	"i:am:different:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864:
@@ -161,7 +161,7 @@ L_OBJC_IMAGE_INFO_bae8570d40d73864:
 L_OBJC_METH_VAR_NAME_9c1b77e8cf40622d:
 	.asciz	"unused"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d:
@@ -178,7 +178,7 @@ L_OBJC_IMAGE_INFO_9c1b77e8cf40622d:
 L_OBJC_METH_VAR_NAME_408f5be8f4fd2627:
 	.asciz	"fourthSel"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627:
@@ -195,7 +195,7 @@ L_OBJC_IMAGE_INFO_408f5be8f4fd2627:
 L_OBJC_METH_VAR_NAME_82483a8131827890:
 	.asciz	"loopedSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_82483a8131827890
 	.p2align	2, 0x0
 L_OBJC_SELECTOR_REFERENCES_82483a8131827890:

--- a/crates/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
+++ b/crates/test-assembly/crates/test_static_sel/expected/apple-x86_64.s
@@ -88,7 +88,7 @@ _use_in_loop:
 L_OBJC_METH_VAR_NAME_caedaca3f40015a7:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_caedaca3f40015a7:
@@ -105,7 +105,7 @@ L_OBJC_IMAGE_INFO_caedaca3f40015a7:
 L_OBJC_METH_VAR_NAME_a7c7f3067f40b513:
 	.asciz	"simple"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_a7c7f3067f40b513:
@@ -122,7 +122,7 @@ L_OBJC_IMAGE_INFO_a7c7f3067f40b513:
 L_OBJC_METH_VAR_NAME_bae8570d40d73864:
 	.asciz	"i:am:different:"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_bae8570d40d73864:
@@ -139,7 +139,7 @@ L_OBJC_IMAGE_INFO_bae8570d40d73864:
 L_OBJC_METH_VAR_NAME_9c1b77e8cf40622d:
 	.asciz	"unused"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_9c1b77e8cf40622d:
@@ -156,7 +156,7 @@ L_OBJC_IMAGE_INFO_9c1b77e8cf40622d:
 L_OBJC_METH_VAR_NAME_408f5be8f4fd2627:
 	.asciz	"fourthSel"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_408f5be8f4fd2627:
@@ -173,7 +173,7 @@ L_OBJC_IMAGE_INFO_408f5be8f4fd2627:
 L_OBJC_METH_VAR_NAME_82483a8131827890:
 	.asciz	"loopedSelector"
 
-	.section	__DATA,__objc_selrefs,literal_pointers,no_dead_strip
+	.section	__DATA,__objc_selrefs,literal_pointers
 	.globl	L_OBJC_SELECTOR_REFERENCES_82483a8131827890
 	.p2align	3, 0x0
 L_OBJC_SELECTOR_REFERENCES_82483a8131827890:


### PR DESCRIPTION
Closes #667 

I think there won't be a person to explain why objc ABI 2 uses `no_dead_strip` in a short time. Maybe it is better to remove it first. If there were more problems, we would know why it is necessary:)