### PR TITLE
Remove unsafe from some vision framework functions

### DIFF
--- a/framework-crates/objc2-vision/translation-config.toml
+++ b/framework-crates/objc2-vision/translation-config.toml
@@ -91,3 +91,30 @@ class.VNTargetedImageRequest.methods."initWithTargetedImageData:orientation:opti
 class.VNTargetedImageRequest.methods."initWithTargetedImageData:orientation:options:completionHandler:".skipped = true
 class.VNTargetedImageRequest.methods."initWithTargetedCMSampleBuffer:orientation:options:".skipped = true
 class.VNTargetedImageRequest.methods."initWithTargetedCMSampleBuffer:orientation:options:completionHandler:".skipped = true
+
+
+###
+### Safety
+###
+
+class.VNImageRequestHandler.methods."initWithData:options:".unsafe = false
+class.VNImageRequestHandler.methods."performRequests:error:".unsafe = false
+
+class.VNRecognizedText.methods.string.unsafe = false
+class.VNRecognizedText.methods.confidence.unsafe = false
+
+class.VNRecognizedTextObservation.methods."topCandidates:".unsafe = false
+
+class.VNRecognizeTextRequest.methods.new.unsafe = false
+class.VNRecognizeTextRequest.methods.results.unsafe = false
+class.VNRecognizeTextRequest.methods."setRecognitionLanguages:".unsafe = false
+class.VNRecognizeTextRequest.methods.usesLanguageCorrection.unsafe = false
+class.VNRecognizeTextRequest.methods.customWords.unsafe = false
+class.VNRecognizeTextRequest.methods."setCustomWords:".unsafe = false
+class.VNRecognizeTextRequest.methods.recognitionLevel.unsafe = false
+class.VNRecognizeTextRequest.methods."setRecognitionLevel:".unsafe = false
+class.VNRecognizeTextRequest.methods."setUsesLanguageCorrection:".unsafe = false
+class.VNRecognizeTextRequest.methods.automaticallyDetectsLanguage.unsafe = false
+class.VNRecognizeTextRequest.methods."setAutomaticallyDetectsLanguage:".unsafe = false
+class.VNRecognizeTextRequest.methods.minimumTextHeight.unsafe = false
+class.VNRecognizeTextRequest.methods."setMinimumTextHeight:".unsafe = false


### PR DESCRIPTION
This is far from comprehensive but is all of the functions that I am currently using from vision framework.

I tried following the guide in [the README](https://github.com/madsmtm/objc2/blob/master/crates/header-translator/README.md#adding-a-new-framework-crate) - none of these functions have any meaningful limitations on their parameters.

The only point that I am unsure of is the last one:

```
If the method can throw an exception if provided with invalid inputs, it is not safe. Consider declaring a helper method that checks the preconditions first!
```

I would really like to add the function `VNImageRequestHandler::performRequests_error` as a safe function as well. It can throw an exception if it gets invalid parameters, but the rust function returns a `Result<(), Retained<NSError>>` so I'm not sure why it should be considered unsafe.

Either way - I couldn't get header-translator to generate a version of the function marked safe - tried with `class.VNImageRequestHandler.methods."performRequests:error:_".unsafe = false` but it didn't work (possibly due to the underscore)