### PR TITLE
Chore: Fully deprecate `objc2::rc::Id`

### DIFF
--- a/crates/objc2/src/rc/mod.rs
+++ b/crates/objc2/src/rc/mod.rs
@@ -62,8 +62,14 @@ pub use self::allocated_partial_init::{Allocated, PartialInit};
 pub use self::autorelease::{
     autoreleasepool, autoreleasepool_leaking, AutoreleasePool, AutoreleaseSafe,
 };
-pub use self::retained::{Id, Retained};
+// Re-export `Id` for backwards compatibility, but still mark it as deprecated.
+#[allow(deprecated)]
+pub use self::retained::Id;
+pub use self::retained::Retained;
 pub use self::retained_traits::{DefaultRetained, RetainedFromIterator, RetainedIntoIterator};
 #[cfg(test)]
 pub(crate) use self::test_object::{RcTestObject, ThreadTestData};
-pub use self::weak::{Weak, WeakId};
+pub use self::weak::Weak;
+// Same as above.
+#[allow(deprecated)]
+pub use self::weak::WeakId;

--- a/crates/objc2/src/rc/retained.rs
+++ b/crates/objc2/src/rc/retained.rs
@@ -146,11 +146,8 @@ pub struct Retained<T: ?Sized> {
 
 /// Short type-alias to [`Retained`].
 ///
-/// This type is soft-deprecated, and will be fully deprecated in `v0.6.0`,
-/// see [#617].
-///
-/// [`Retained<T>`]: Retained
-/// [#617]: https://github.com/madsmtm/objc2/issues/617
+/// This is fully deprecated since `v0.6.0`, use [`Retained`] instead.
+#[deprecated(since = "0.6.0", note = "Renamed to `Retained`.")]
 pub type Id<T> = Retained<T>;
 
 impl<T: ?Sized> Retained<T> {

--- a/crates/objc2/src/rc/weak.rs
+++ b/crates/objc2/src/rc/weak.rs
@@ -48,7 +48,8 @@ pub struct Weak<T: ?Sized> {
     item: PhantomData<Retained<T>>,
 }
 
-/// Soft-deprecated type-alias to [`Weak`].
+/// Fully-deprecated type-alias to [`Weak`].
+#[deprecated(since = "0.6.0", note = "Renamed to `Weak`.")]
 pub type WeakId<T> = Weak<T>;
 
 impl<T: Message> Weak<T> {


### PR DESCRIPTION
As part of #617.

With this, 0.6 should be in a good position to be delivered, or are there still a lot of things to do? What I see in https://github.com/madsmtm/objc2/milestone/6 seems that it could be optional while the important changes that are already completed would be nice if published and back-porting things I would need in a fork would be cumbersome.