### PR TITLE
Add more ServiceManagement functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,9 @@ version = "0.2.2"
 dependencies = [
  "block2",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-security",
 ]
 
 [[package]]

--- a/crates/objc2/src/topics/about_generated/CHANGELOG.md
+++ b/crates/objc2/src/topics/about_generated/CHANGELOG.md
@@ -58,6 +58,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   return types (similar to what's done on methods).
 * Added automatic conversion to `Retained` in external function return types
   (similar to what's done on methods).
+* Added the following types to `ServiceManagement`:
+  - `SMJobBless`
+  - `SMLoginItemSetEnabled`
+  - `kSMDomainSystemLaunchd`
+  - `kSMDomainUserLaunchd`
+  - `kSMErrorDomainFramework`
+  - `kSMErrorDomainIPC`
+  - `kSMErrorDomainLaunchd`
+  - `SMCopyAllJobDictionaries`
+  - `SMJobCopyDictionary`
+  - `SMJobRemove`
+  - `SMJobSubmit`
 
 ### Changed
 * Enabled all Cargo features by default, and removed the previous `"all"`

--- a/framework-crates/objc2-service-management/Cargo.toml
+++ b/framework-crates/objc2-service-management/Cargo.toml
@@ -17,8 +17,20 @@ workspace = true
 
 [dependencies]
 block2 = { path = "../../crates/block2", version = "0.5.1", default-features = false, optional = true, features = ["alloc"] }
-objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false, features = ["std"] }
-objc2-foundation = { path = "../objc2-foundation", version = "0.2.2", default-features = false, features = ["alloc"] }
+objc2 = { path = "../../crates/objc2", version = "0.5.2", default-features = false, optional = true, features = ["std"] }
+objc2-core-foundation = { path = "../objc2-core-foundation", version = "0.2.2", default-features = false, features = [
+    "CFArray",
+    "CFBase",
+    "CFDictionary",
+    "CFError",
+] }
+objc2-foundation = { path = "../objc2-foundation", version = "0.2.2", default-features = false, optional = true, features = [
+    "NSError",
+    "NSString",
+    "NSURL",
+    "alloc",
+] }
+objc2-security = { path = "../objc2-security", version = "0.2.2", default-features = false, optional = true, features = ["Authorization"] }
 
 [package.metadata.docs.rs]
 default-target = "aarch64-apple-darwin"
@@ -36,15 +48,17 @@ default = [
     "SMErrors",
     "SMLoginItem",
     "block2",
+    "objc2",
+    "objc2-foundation",
+    "objc2-security",
 ]
 std = ["alloc"]
 alloc = []
 block2 = ["dep:block2"]
+objc2 = ["dep:objc2"]
+objc2-foundation = ["dep:objc2-foundation"]
+objc2-security = ["dep:objc2-security"]
 
-SMAppService = [
-    "objc2-foundation/NSError",
-    "objc2-foundation/NSString",
-    "objc2-foundation/NSURL",
-]
-SMErrors = []
-SMLoginItem = []
+SMAppService = []
+SMErrors = ["objc2-core-foundation/CFBase"]
+SMLoginItem = ["objc2-core-foundation/CFBase"]

--- a/framework-crates/objc2-service-management/src/lib.rs
+++ b/framework-crates/objc2-service-management/src/lib.rs
@@ -18,3 +18,7 @@ extern crate std;
 mod generated;
 #[allow(unused_imports, unreachable_pub)]
 pub use self::generated::*;
+
+// MacTypes.h
+#[allow(dead_code)]
+pub(crate) type Boolean = u8; // unsigned char

--- a/framework-crates/objc2-service-management/translation-config.toml
+++ b/framework-crates/objc2-service-management/translation-config.toml
@@ -1,18 +1,6 @@
 framework = "ServiceManagement"
 crate = "objc2-service-management"
-required-crates = ["objc2", "objc2-foundation"]
+required-crates = ["objc2-core-foundation"]
+custom-lib-rs = true
 macos = "10.6"
 maccatalyst = "13.0"
-
-# Items from ServiceManagement that uses types from CoreFoundation
-fn.SMJobBless.skipped = true
-fn.SMLoginItemSetEnabled.skipped = true
-static.kSMDomainSystemLaunchd.skipped = true
-static.kSMDomainUserLaunchd.skipped = true
-static.kSMErrorDomainFramework.skipped = true
-static.kSMErrorDomainIPC.skipped = true
-static.kSMErrorDomainLaunchd.skipped = true
-fn.SMCopyAllJobDictionaries.skipped = true
-fn.SMJobCopyDictionary.skipped = true
-fn.SMJobRemove.skipped = true
-fn.SMJobSubmit.skipped = true


### PR DESCRIPTION
I have allowed the `ServiceManagement` framework crate to have more functions, in particular I was missing `SMJobBless`. I see that previously functions referring to CoreFoundation were not generated. I might not have all the context on why that was, so please tell me if I did something incorrectly.