### PR TITLE
Experiment with arbitrary self types

### DIFF
--- a/crates/objc2/src/macros/extern_methods.rs
+++ b/crates/objc2/src/macros/extern_methods.rs
@@ -218,6 +218,33 @@ macro_rules! extern_methods {
     ) => {};
 
     (
+        $(#[$($m:tt)*])*
+        $v:vis unsafe fn $fn_name:ident(this: Allocated<Self> $(, $($params_rest:tt)*)?) $(-> $ret:ty)?
+        $(where $($where:ty : $bound:path),+ $(,)?)?;
+
+        $($rest:tt)*
+    ) => {
+        $crate::__extract_method_attributes! {
+            ($(#[$($m)*])*)
+
+            ($crate::__extern_methods_method_out)
+            ($v unsafe fn $fn_name(self: Allocated<Self> $(, $($params_rest)*)?) $(-> $ret)?)
+            ($($($where : $bound ,)+)?)
+
+            (add_method)
+            (self)
+            (Allocated<Self>)
+            (
+                self: Allocated<Self>,
+                _: $crate::runtime::Sel,
+            )
+            ($($($params_rest)*)?)
+        }
+
+        $crate::extern_methods!($($rest)*);
+    };
+
+    (
         // Unsafe method.
         //
         // Special attributes:
@@ -240,6 +267,33 @@ macro_rules! extern_methods {
             ($crate::__extern_methods_method_out)
             ($v unsafe fn $fn_name($($params)*) $(-> $ret)?)
             ($($($where : $bound ,)+)?)
+        }
+
+        $crate::extern_methods!($($rest)*);
+    };
+
+    (
+        $(#[$($m:tt)*])*
+        $v:vis fn $fn_name:ident(this: Allocated<Self> $(, $($params_rest:tt)*)?) $(-> $ret:ty)?
+        $(where $($where:ty : $bound:path),+ $(,)?)?;
+
+        $($rest:tt)*
+    ) => {
+        $crate::__extract_method_attributes! {
+            ($(#[$($m)*])*)
+
+            ($crate::__extern_methods_method_out)
+            ($v fn $fn_name(self: Allocated<Self> $(, $($params_rest)*)?) $(-> $ret)?)
+            ($($($where : $bound ,)+)?)
+
+            (add_method)
+            (self)
+            (Allocated<Self>)
+            (
+                self: Allocated<Self>,
+                _: $crate::runtime::Sel,
+            )
+            ($($($params_rest)*)?)
         }
 
         $crate::extern_methods!($($rest)*);

--- a/framework-crates/objc2-app-kit/src/lib.rs
+++ b/framework-crates/objc2-app-kit/src/lib.rs
@@ -35,6 +35,7 @@
 //! ```
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-app-kit/0.3.0")]
 #![recursion_limit = "512"]

--- a/framework-crates/objc2-cloud-kit/src/lib.rs
+++ b/framework-crates/objc2-cloud-kit/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-cloud-kit/0.3.0")]
 

--- a/framework-crates/objc2-contacts/src/lib.rs
+++ b/framework-crates/objc2-contacts/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-contacts/0.3.0")]
 

--- a/framework-crates/objc2-core-data/src/lib.rs
+++ b/framework-crates/objc2-core-data/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-core-data/0.3.0")]
 

--- a/framework-crates/objc2-core-image/src/lib.rs
+++ b/framework-crates/objc2-core-image/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-core-image/0.3.0")]
 #![recursion_limit = "256"]

--- a/framework-crates/objc2-core-location/src/lib.rs
+++ b/framework-crates/objc2-core-location/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-core-location/0.3.0")]
 

--- a/framework-crates/objc2-foundation/src/lib.rs
+++ b/framework-crates/objc2-foundation/src/lib.rs
@@ -71,6 +71,7 @@
 #![doc(html_root_url = "https://docs.rs/objc2-foundation/0.3.0")]
 #![allow(non_snake_case)]
 #![recursion_limit = "512"]
+#![feature(arbitrary_self_types)]
 
 #[cfg(not(feature = "alloc"))]
 compile_error!("The `alloc` feature currently must be enabled.");

--- a/framework-crates/objc2-metal-kit/src/lib.rs
+++ b/framework-crates/objc2-metal-kit/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-metal-kit/0.3.0")]
 

--- a/framework-crates/objc2-metal/examples/triangle.rs
+++ b/framework-crates/objc2-metal/examples/triangle.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::incompatible_msrv)]
 #![cfg_attr(not(target_os = "macos"), allow(dead_code, unused))]
+#![feature(arbitrary_self_types)]
 
 use core::{cell::OnceCell, ptr::NonNull};
 
@@ -92,8 +93,7 @@ define_class!(
                 let backing_store_type = NSBackingStoreType::Buffered;
                 let flag = false;
                 unsafe {
-                    NSWindow::initWithContentRect_styleMask_backing_defer(
-                        NSWindow::alloc(mtm),
+                    NSWindow::alloc(mtm).initWithContentRect_styleMask_backing_defer(
                         content_rect,
                         style,
                         backing_store_type,
@@ -115,7 +115,7 @@ define_class!(
             let mtk_view = {
                 let frame_rect = window.frame();
                 unsafe {
-                    MTKView::initWithFrame_device(MTKView::alloc(mtm), frame_rect, Some(&device))
+                    MTKView::alloc(mtm).initWithFrame_device(frame_rect, Some(&device))
                 }
             };
 

--- a/framework-crates/objc2-metal/src/lib.rs
+++ b/framework-crates/objc2-metal/src/lib.rs
@@ -42,6 +42,7 @@
 #![allow(non_snake_case)]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-metal/0.3.0")]
 

--- a/framework-crates/objc2-model-io/src/lib.rs
+++ b/framework-crates/objc2-model-io/src/lib.rs
@@ -6,6 +6,7 @@
 //! [framework-crates]: https://docs.rs/objc2/latest/objc2/topics/about_generated/index.html
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-model-io/0.3.0")]
 

--- a/framework-crates/objc2-quartz-core/src/lib.rs
+++ b/framework-crates/objc2-quartz-core/src/lib.rs
@@ -10,6 +10,7 @@
 #![recursion_limit = "256"]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-quartz-core/0.3.0")]
 

--- a/framework-crates/objc2-web-kit/examples/browser.rs
+++ b/framework-crates/objc2-web-kit/examples/browser.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::incompatible_msrv)]
 #![cfg_attr(not(target_os = "macos"), allow(dead_code, unused))]
+#![feature(arbitrary_self_types)]
 use core::cell::OnceCell;
 
 use objc2::{
@@ -80,8 +81,7 @@ define_class!(
                 let backing_store_type = NSBackingStoreType::Buffered;
                 let flag = false;
                 unsafe {
-                    NSWindow::initWithContentRect_styleMask_backing_defer(
-                        NSWindow::alloc(mtm),
+                    NSWindow::alloc(mtm).initWithContentRect_styleMask_backing_defer(
                         content_rect,
                         style,
                         backing_store_type,
@@ -93,14 +93,14 @@ define_class!(
             // create the web view
             let web_view = {
                 let frame_rect = NSRect::ZERO;
-                unsafe { WKWebView::initWithFrame(WKWebView::alloc(mtm), frame_rect) }
+                unsafe { WKWebView::alloc(mtm).initWithFrame(frame_rect) }
             };
 
             // create the nav bar view
             let nav_bar = {
                 let frame_rect = NSRect::ZERO;
                 let this =
-                    unsafe { NSStackView::initWithFrame(NSStackView::alloc(mtm), frame_rect) };
+                    unsafe { NSStackView::alloc(mtm).initWithFrame(frame_rect) };
                 unsafe {
                     this.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
                     this.setAlignment(NSLayoutAttribute::Height);
@@ -114,7 +114,7 @@ define_class!(
             let nav_buttons = {
                 let frame_rect = NSRect::ZERO;
                 let this =
-                    unsafe { NSStackView::initWithFrame(NSStackView::alloc(mtm), frame_rect) };
+                    unsafe { NSStackView::alloc(mtm).initWithFrame(frame_rect) };
                 unsafe {
                     this.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
                     this.setAlignment(NSLayoutAttribute::Height);
@@ -163,7 +163,7 @@ define_class!(
             let nav_url = {
                 let frame_rect = NSRect::ZERO;
                 let this =
-                    unsafe { NSTextField::initWithFrame(NSTextField::alloc(mtm), frame_rect) };
+                    unsafe { NSTextField::alloc(mtm).initWithFrame(frame_rect) };
                 unsafe {
                     this.setDrawsBackground(true);
                     this.setBackgroundColor(Some(&NSColor::lightGrayColor()));
@@ -181,7 +181,7 @@ define_class!(
             let content_view = {
                 let frame_rect = window.frame();
                 let this =
-                    unsafe { NSStackView::initWithFrame(NSStackView::alloc(mtm), frame_rect) };
+                    unsafe { NSStackView::alloc(mtm).initWithFrame(frame_rect) };
                 unsafe {
                     this.setOrientation(NSUserInterfaceLayoutOrientation::Vertical);
                     this.setAlignment(NSLayoutAttribute::Width);
@@ -208,14 +208,13 @@ define_class!(
 
             // create the menu with a "quit" entry
             unsafe {
-                let menu = NSMenu::initWithTitle(NSMenu::alloc(mtm), ns_string!(""));
-                let menu_app_item = NSMenuItem::initWithTitle_action_keyEquivalent(
-                    NSMenuItem::alloc(mtm),
+                let menu = NSMenu::alloc(mtm).initWithTitle(ns_string!(""));
+                let menu_app_item = NSMenuItem::alloc(mtm).initWithTitle_action_keyEquivalent(
                     ns_string!(""),
                     None,
                     ns_string!(""),
                 );
-                let menu_app_menu = NSMenu::initWithTitle(NSMenu::alloc(mtm), ns_string!(""));
+                let menu_app_menu = NSMenu::alloc(mtm).initWithTitle(ns_string!(""));
                 menu_app_menu.addItemWithTitle_action_keyEquivalent(
                     ns_string!("Quit"),
                     Some(sel!(terminate:)),

--- a/framework-crates/objc2-web-kit/src/lib.rs
+++ b/framework-crates/objc2-web-kit/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(non_snake_case)]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(arbitrary_self_types)]
 // Update in Cargo.toml as well.
 #![doc(html_root_url = "https://docs.rs/objc2-web-kit/0.3.0")]
 


### PR DESCRIPTION
To see what it's like to use. A bit difficult for me to enable on nightly because every downstream crate has to enable `#![feature(arbitrary_self_types)]`.

Once stable, I will implement a better mapping in `extern_methods!`, to allow users to take advantage of the feature if they enable a Cargo feature flag.

This feature is probably also necessary for https://github.com/madsmtm/objc2/issues/455 to progress.