### PR TITLE
dispatch2: Add `fn data_create()` which copies a slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ version = "0.3.0"
 dependencies = [
  "bitflags",
  "block2",
+ "dispatch2",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",

--- a/crates/dispatch2/src/queue.rs
+++ b/crates/dispatch2/src/queue.rs
@@ -127,7 +127,7 @@ pub struct Queue {
 }
 
 impl Queue {
-    /// Create a new [Queue].
+    /// Create a new [`Queue`].
     pub fn new(label: &str, queue_attribute: QueueAttribute) -> Self {
         let label = CString::new(label).expect("Invalid label!");
 
@@ -147,7 +147,7 @@ impl Queue {
         }
     }
 
-    /// Create a new [Queue] with a given target [Queue].
+    /// Create a new [`Queue`] with a given target [`Queue`].
     pub fn new_with_target(label: &str, queue_attribute: QueueAttribute, target: &Queue) -> Self {
         let label = CString::new(label).expect("Invalid label!");
 

--- a/framework-crates/objc2-metal/Cargo.toml
+++ b/framework-crates/objc2-metal/Cargo.toml
@@ -18,6 +18,10 @@ workspace = true
 [dependencies]
 bitflags = { version = "2.5.0", default-features = false, optional = true, features = ["std"] }
 block2 = { path = "../../crates/block2", version = "0.6.0", default-features = false, optional = true, features = ["alloc"] }
+dispatch2 = { path = "../../crates/dispatch2", version = "0.2.0", default-features = false, optional = true, features = [
+    "alloc",
+    "objc2",
+] }
 objc2 = { path = "../../crates/objc2", version = "0.6.0", default-features = false, features = ["std"] }
 objc2-core-foundation = { path = "../objc2-core-foundation", version = "0.3.0", default-features = false, optional = true, features = [
     "CFDate",
@@ -106,6 +110,7 @@ default = [
     "MTLVisibleFunctionTable",
     "bitflags",
     "block2",
+    "dispatch2",
     "objc2-core-foundation",
 ]
 std = ["alloc"]
@@ -116,6 +121,7 @@ unstable-private = [
 ]
 bitflags = ["dep:bitflags"]
 block2 = ["dep:block2"]
+dispatch2 = ["dep:dispatch2"]
 objc2-core-foundation = ["dep:objc2-core-foundation"]
 objc2-io-surface = ["dep:objc2-io-surface"]
 

--- a/framework-crates/objc2-metal/translation-config.toml
+++ b/framework-crates/objc2-metal/translation-config.toml
@@ -15,11 +15,6 @@ class.MTLRasterizationRateLayerDescriptor.methods.sampleCount.skipped = true
 # Swift also skips this.
 class.MTLRasterizationRateMapDescriptor.methods."rasterizationRateMapDescriptorWithScreenSize:layerCount:layers:".skipped = true
 
-# Needs dispatch
-class.MTLSharedEventListener.methods."initWithDispatchQueue:".skipped = true
-class.MTLSharedEventListener.methods.dispatchQueue.skipped = true
-protocol.MTLDevice.methods."newLibraryWithData:error:".skipped = true
-
 # Needs mach / kernel types
 protocol.MTLResource.methods."setOwnerWithIdentity:".skipped = true
 


### PR DESCRIPTION
Fixes https://github.com/madsmtm/objc2/issues/699

# TODO
- Add a variant that takes ownership over a `Box` (or `T`?) and calls its destructor (EDIT: This requires a raw `Block` pointer, which we can probably get via a `Deref` on `GlobalBlock`).
- Make regenerated Metal code import/use the correct `dispatch_data_t` type (preferably taking `&DispatchObject` and calling `.as_raw()`?).
- Ensure calling `set_finalizer()` is still a valid thing to do?
- Can the header translator parse `#define` or are we expected to redefine them ourselves?