### PR TITLE
Refactor `dispatch2`

### DIFF
--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `dispatch_testcancel`
 
   Using these would have resulted in a linker error before.
+* **BREAKING**: Removed direct access to most modules. Instead, types are
+  publicly exported in the root.
 
 
 ## 0.2.0 - 2025-01-22

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
-### Fixed
+### Removed
+- **BREAKING**: Removed `TargetQueueError` and the error case in
+  `DispatchObject::set_target_queue` (it now instead aborts on error,
+  as that's what the underlying function does).
 - Removed `ffi` methods that are actually macros:
   - `dispatch_wait`
   - `dispatch_notify`

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow `Queue::exec_sync` on workloops.
   This is discouraged for performance reasons, but doesn't need to be
   outright disallowed.
+- Added `DispatchRetained<T>`, which is a smart pointer which allows
+  retain/release operations on dispatch objects, similar in spirit to
+  `objc2::rc::Retained`. This mostly replaces `DispatchObject<T>`.
 
 ### Removed
 - **BREAKING**: Removed `TargetQueueError` and the error case in

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `objc2::rc::Retained`. This mostly replaces `DispatchObject<T>`.
 
 ### Changed
+- Changed how memory management works to match other `objc2` crates. Instead
+  of types like `DispatchGroup` holding the retain count internally, it is now
+  done externally by `DispatchRetained<DispatchGroup>`.
 - Renamed dispatch types to be prefixed with `Dispatch` (e.g. `DispatchGroup`,
   `DispatchQueue`, `DispatchOnce` etc).
 

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -19,10 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of types like `DispatchGroup` holding the retain count internally, it is now
   done externally by `DispatchRetained<DispatchGroup>`.
 - Converted `DispatchObject` to a trait.
-- Renamed dispatch types to be prefixed with `Dispatch` (e.g. `DispatchGroup`,
-  `DispatchQueue`, `DispatchOnce` etc).
+- **BREAKING**: Renamed dispatch types to be prefixed with `Dispatch`
+  (e.g. `DispatchGroup`, `DispatchQueue` and `DispatchOnce`).
 
-  The old names are kept (but deprecated) for easier migration.
+  Some of the old names are kept (but deprecated) for easier migration.
 
 ### Removed
 - **BREAKING**: Removed `TargetQueueError` and the error case in

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed how memory management works to match other `objc2` crates. Instead
   of types like `DispatchGroup` holding the retain count internally, it is now
   done externally by `DispatchRetained<DispatchGroup>`.
+- Converted `DispatchObject` to a trait.
 - Renamed dispatch types to be prefixed with `Dispatch` (e.g. `DispatchGroup`,
   `DispatchQueue`, `DispatchOnce` etc).
 

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+- Allow `Queue::exec_sync` on workloops.
+  This is discouraged for performance reasons, but doesn't need to be
+  outright disallowed.
+
 ### Removed
 - **BREAKING**: Removed `TargetQueueError` and the error case in
   `DispatchObject::set_target_queue` (it now instead aborts on error,

--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   retain/release operations on dispatch objects, similar in spirit to
   `objc2::rc::Retained`. This mostly replaces `DispatchObject<T>`.
 
+### Changed
+- Renamed dispatch types to be prefixed with `Dispatch` (e.g. `DispatchGroup`,
+  `DispatchQueue`, `DispatchOnce` etc).
+
+  The old names are kept (but deprecated) for easier migration.
+
 ### Removed
 - **BREAKING**: Removed `TargetQueueError` and the error case in
   `DispatchObject::set_target_queue` (it now instead aborts on error,

--- a/crates/dispatch2/src/group.rs
+++ b/crates/dispatch2/src/group.rs
@@ -5,8 +5,7 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 use core::time::Duration;
 
-use crate::retained::DispatchObject;
-use crate::{DispatchQueue, DispatchRetained};
+use crate::{DispatchObject, DispatchQueue, DispatchRetained};
 
 use super::utils::function_wrapper;
 use super::{ffi::*, WaitError};

--- a/crates/dispatch2/src/group.rs
+++ b/crates/dispatch2/src/group.rs
@@ -1,5 +1,3 @@
-//! Dispatch group definition.
-
 use alloc::boxed::Box;
 use core::ffi::c_void;
 use core::ptr::NonNull;

--- a/crates/dispatch2/src/group.rs
+++ b/crates/dispatch2/src/group.rs
@@ -5,22 +5,22 @@ use core::ffi::c_void;
 use core::time::Duration;
 
 use super::object::DispatchObject;
-use super::queue::Queue;
+use super::queue::DispatchQueue;
 use super::utils::function_wrapper;
 use super::{ffi::*, WaitError};
 
 /// Dispatch group.
 #[derive(Debug, Clone)]
-pub struct Group {
+pub struct DispatchGroup {
     dispatch_object: DispatchObject<dispatch_group_s>,
 }
 
 /// Dispatch group guard.
 #[derive(Debug)]
-pub struct GroupGuard(Group, bool);
+pub struct GroupGuard(DispatchGroup, bool);
 
-impl Group {
-    /// Creates a new [Group].
+impl DispatchGroup {
+    /// Creates a new [`DispatchGroup`].
     pub fn new() -> Option<Self> {
         // Safety: valid to call.
         let object = unsafe { dispatch_group_create() };
@@ -32,11 +32,11 @@ impl Group {
         // Safety: object cannot be null.
         let dispatch_object = unsafe { DispatchObject::new_owned(object.cast()) };
 
-        Some(Group { dispatch_object })
+        Some(DispatchGroup { dispatch_object })
     }
 
-    /// Submit a function to a [Queue] and associates it with the [Group].
-    pub fn exec_async<F>(&self, queue: &Queue, work: F)
+    /// Submit a function to a [`DispatchQueue`] and associates it with the [`DispatchGroup`].
+    pub fn exec_async<F>(&self, queue: &DispatchQueue, work: F)
     where
         // We need `'static` to make sure any referenced values are borrowed for
         // long enough since `work` will be performed asynchronously.
@@ -78,8 +78,8 @@ impl Group {
         }
     }
 
-    /// Schedule a function to be submitted to a [Queue] when a group of previously submitted functions have completed.
-    pub fn notify<F>(&self, queue: &Queue, work: F)
+    /// Schedule a function to be submitted to a [`DispatchQueue`] when a group of previously submitted functions have completed.
+    pub fn notify<F>(&self, queue: &DispatchQueue, work: F)
     where
         F: Send + FnOnce(),
     {
@@ -96,7 +96,7 @@ impl Group {
         }
     }
 
-    /// Explicitly indicates that the function has entered the [Group].
+    /// Explicitly indicates that the function has entered the [`DispatchGroup`].
     pub fn enter(&self) -> GroupGuard {
         // Safety: object cannot be null.
         unsafe {
@@ -126,7 +126,7 @@ impl Group {
 }
 
 impl GroupGuard {
-    /// Explicitly indicates that the function in the [Group] finished executing.
+    /// Explicitly indicates that the function in the [`DispatchGroup`] finished executing.
     pub fn leave(mut self) {
         // Safety: object cannot be null.
         unsafe {

--- a/crates/dispatch2/src/lib.rs
+++ b/crates/dispatch2/src/lib.rs
@@ -54,6 +54,7 @@ mod queue;
 mod retained;
 mod semaphore;
 mod utils;
+mod workloop;
 
 /// Wait error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -105,11 +106,11 @@ pub use self::main_thread_bound::{run_on_main, MainThreadBound};
 pub use self::object::{DispatchObject, QualityOfServiceClassFloorError};
 pub use self::once::DispatchOnce;
 pub use self::queue::{
-    DispatchAutoReleaseFrequency, DispatchQueue, DispatchWorkloop, GlobalQueueIdentifier,
-    QueueAfterError, QueueAttribute, QueuePriority,
+    DispatchQueue, GlobalQueueIdentifier, QueueAfterError, QueueAttribute, QueuePriority,
 };
 pub use self::retained::DispatchRetained;
 pub use self::semaphore::{DispatchSemaphore, DispatchSemaphoreGuard};
+pub use self::workloop::{DispatchAutoReleaseFrequency, DispatchWorkloop};
 
 // Helper type
 type OpaqueData = UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>;

--- a/crates/dispatch2/src/lib.rs
+++ b/crates/dispatch2/src/lib.rs
@@ -45,14 +45,14 @@ use self::ffi::dispatch_qos_class_t;
 pub mod ffi;
 #[allow(clippy::undocumented_unsafe_blocks)]
 mod generated;
-pub mod group;
+mod group;
 #[cfg(feature = "objc2")]
 mod main_thread_bound;
-pub mod object;
+mod object;
 mod once;
-pub mod queue;
+mod queue;
 mod retained;
-pub mod semaphore;
+mod semaphore;
 mod utils;
 
 /// Wait error.
@@ -99,14 +99,17 @@ impl From<QualityOfServiceClass> for dispatch_qos_class_t {
     }
 }
 
-pub use self::group::*;
+pub use self::group::{DispatchGroup, DispatchGroupGuard};
 #[cfg(feature = "objc2")]
 pub use self::main_thread_bound::{run_on_main, MainThreadBound};
-pub use self::object::*;
-pub use self::once::*;
-pub use self::queue::*;
+pub use self::object::{DispatchObject, QualityOfServiceClassFloorError};
+pub use self::once::DispatchOnce;
+pub use self::queue::{
+    DispatchAutoReleaseFrequency, DispatchQueue, DispatchWorkloop, GlobalQueueIdentifier,
+    QueueAfterError, QueueAttribute, QueuePriority,
+};
 pub use self::retained::DispatchRetained;
-pub use self::semaphore::*;
+pub use self::semaphore::{DispatchSemaphore, DispatchSemaphoreGuard};
 
 // Helper type
 type OpaqueData = UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>;

--- a/crates/dispatch2/src/lib.rs
+++ b/crates/dispatch2/src/lib.rs
@@ -34,6 +34,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[macro_use]
+mod macros;
+
+use core::cell::UnsafeCell;
+use core::marker::{PhantomData, PhantomPinned};
+
 use self::ffi::dispatch_qos_class_t;
 
 pub mod ffi;
@@ -101,6 +107,9 @@ pub use self::once::*;
 pub use self::queue::*;
 pub use self::retained::DispatchRetained;
 pub use self::semaphore::*;
+
+// Helper type
+type OpaqueData = UnsafeCell<PhantomData<(*const UnsafeCell<()>, PhantomPinned)>>;
 
 /// Deprecated alias for [`DispatchGroup`].
 #[deprecated = "renamed to DispatchGroup"]

--- a/crates/dispatch2/src/lib.rs
+++ b/crates/dispatch2/src/lib.rs
@@ -11,9 +11,9 @@
 //! ## Example
 //!
 //! ```
-//! use dispatch2::{Queue, QueueAttribute};
+//! use dispatch2::{DispatchQueue, QueueAttribute};
 //!
-//! let queue = Queue::new("example_queue", QueueAttribute::Serial);
+//! let queue = DispatchQueue::new("example_queue", QueueAttribute::Serial);
 //! queue.exec_async(|| println!("Hello"));
 //! queue.exec_sync(|| println!("World"));
 //! ```
@@ -101,3 +101,23 @@ pub use self::once::*;
 pub use self::queue::*;
 pub use self::retained::DispatchRetained;
 pub use self::semaphore::*;
+
+/// Deprecated alias for [`DispatchGroup`].
+#[deprecated = "renamed to DispatchGroup"]
+pub type Group = DispatchGroup;
+
+/// Deprecated alias for [`DispatchOnce`].
+#[deprecated = "renamed to DispatchOnce"]
+pub type Once = DispatchOnce;
+
+/// Deprecated alias for [`DispatchQueue`].
+#[deprecated = "renamed to DispatchQueue"]
+pub type Queue = DispatchQueue;
+
+/// Deprecated alias for [`DispatchSemaphore`].
+#[deprecated = "renamed to DispatchSemaphore"]
+pub type Semaphore = DispatchSemaphore;
+
+/// Deprecated alias for [`DispatchWorkloop`].
+#[deprecated = "renamed to DispatchWorkloop"]
+pub type WorkloopQueue = DispatchWorkloop;

--- a/crates/dispatch2/src/lib.rs
+++ b/crates/dispatch2/src/lib.rs
@@ -45,6 +45,7 @@ mod main_thread_bound;
 pub mod object;
 mod once;
 pub mod queue;
+mod retained;
 pub mod semaphore;
 mod utils;
 
@@ -98,4 +99,5 @@ pub use self::main_thread_bound::{run_on_main, MainThreadBound};
 pub use self::object::*;
 pub use self::once::*;
 pub use self::queue::*;
+pub use self::retained::DispatchRetained;
 pub use self::semaphore::*;

--- a/crates/dispatch2/src/macros.rs
+++ b/crates/dispatch2/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! dispatch_object {
         }
 
         // SAFETY: The object is a dispatch object.
-        unsafe impl $crate::retained::DispatchObject for $type {}
+        unsafe impl $crate::DispatchObject for $type {}
 
         // Reflexive impl
         impl core::convert::AsRef<Self> for $type {

--- a/crates/dispatch2/src/macros.rs
+++ b/crates/dispatch2/src/macros.rs
@@ -1,0 +1,86 @@
+macro_rules! dispatch_object {
+    (
+        $(#[$m:meta])*
+        pub struct $type:ident;
+    ) => {
+        $(#[$m])*
+        #[repr(C)]
+        pub struct $type {
+            inner: [u8; 0],
+            _p: $crate::OpaqueData,
+        }
+
+        // SAFETY: The object is a dispatch object.
+        unsafe impl $crate::retained::DispatchObject for $type {}
+
+        // Reflexive impl
+        impl core::convert::AsRef<Self> for $type {
+            #[inline]
+            fn as_ref(&self) -> &Self {
+                self
+            }
+        }
+
+        impl PartialEq for $type {
+            /// Compare this [`$type`] with another using pointer equality.
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                // Dispatch objects use pointer equality.
+                core::ptr::eq(self, other)
+            }
+        }
+
+        // Pointer equality is reflexive.
+        impl Eq for $type {}
+
+        // Hash based on pointer.
+        impl core::hash::Hash for $type {
+            #[inline]
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                let ptr: *const Self = self;
+                ptr.hash(state);
+            }
+        }
+
+        impl core::fmt::Debug for $type {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let ptr: *const Self = self;
+                f.debug_struct(core::stringify!($type))
+                    .field("ptr", &ptr)
+                    .finish_non_exhaustive()
+            }
+        }
+
+        #[cfg(feature = "objc2")]
+        // SAFETY: Dispatch objects are internally objects.
+        unsafe impl objc2::encode::RefEncode for $type {
+            const ENCODING_REF: objc2::encode::Encoding
+                = objc2::encode::Encoding::Object;
+        }
+
+        #[cfg(feature = "objc2")]
+        // SAFETY: Dispatch objects can act as Objective-C objects
+        // (and respond to e.g. retain/release messages).
+        unsafe impl objc2::Message for $type {}
+
+        #[cfg(feature = "objc2")]
+        impl core::convert::AsRef<objc2::runtime::AnyObject> for $type {
+            #[inline]
+            fn as_ref(&self) -> &objc2::runtime::AnyObject {
+                let ptr: *const Self = self;
+                let ptr: *const objc2::runtime::AnyObject = ptr.cast();
+                // SAFETY: Dispatch objects can act as Objective-C objects.
+                unsafe { &*ptr }
+            }
+        }
+
+        // TODO: Implement `ClassType` and `DowncastTarget` using
+        // OS_dispatch_group classes etc.?
+        //
+        // They are available since macOS 10.12, so we could safely use
+        // `objc2::class!`.
+        //
+        // They cannot be subclassed / cannot have categories defined for them
+        // though (they're marked `objc_runtime_visible`).
+    };
+}

--- a/crates/dispatch2/src/main_thread_bound.rs
+++ b/crates/dispatch2/src/main_thread_bound.rs
@@ -3,7 +3,7 @@ use core::mem::{self, ManuallyDrop};
 
 use objc2::MainThreadMarker;
 
-use crate::Queue;
+use crate::DispatchQueue;
 
 /// Submit the given closure to the runloop on the main thread.
 ///
@@ -35,7 +35,7 @@ where
         f(mtm)
     } else {
         let mut ret = None;
-        Queue::main().exec_sync(|| {
+        DispatchQueue::main().exec_sync(|| {
             // SAFETY: The outer closure is submitted to run on the main
             // thread, so now, when the closure actually runs, it's
             // guaranteed to be on the main thread.

--- a/crates/dispatch2/src/object.rs
+++ b/crates/dispatch2/src/object.rs
@@ -2,7 +2,7 @@
 
 use alloc::boxed::Box;
 
-use super::{ffi::*, queue::Queue, utils::function_wrapper, QualityOfServiceClass};
+use super::{ffi::*, queue::DispatchQueue, utils::function_wrapper, QualityOfServiceClass};
 
 /// Error returned by [DispatchObject::set_qos_class_floor].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -61,7 +61,7 @@ impl<T> DispatchObject<T> {
         }
     }
 
-    /// Set the target [Queue] of this object.
+    /// Set the target [`DispatchQueue`] of this object.
     ///
     /// # Aborts
     ///
@@ -71,7 +71,7 @@ impl<T> DispatchObject<T> {
     ///
     /// - There must not be a cycle in the hierarchy of queues.
     #[doc(alias = "dispatch_set_target_queue")]
-    pub unsafe fn set_target_queue(&self, queue: &Queue) {
+    pub unsafe fn set_target_queue(&self, queue: &DispatchQueue) {
         // SAFETY: `object` and `queue` cannot be null, rest is upheld by caller.
         unsafe { dispatch_set_target_queue(self.as_raw().cast(), queue.as_raw()) };
     }

--- a/crates/dispatch2/src/object.rs
+++ b/crates/dispatch2/src/object.rs
@@ -1,5 +1,3 @@
-//! Dispatch object definition.
-
 use core::ptr::NonNull;
 
 use alloc::boxed::Box;

--- a/crates/dispatch2/src/queue.rs
+++ b/crates/dispatch2/src/queue.rs
@@ -7,7 +7,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::time::Duration;
 
-use super::object::{DispatchObject, QualityOfServiceClassFloorError, TargetQueueError};
+use super::object::{DispatchObject, QualityOfServiceClassFloorError};
 use super::utils::function_wrapper;
 use super::{ffi::*, QualityOfServiceClass};
 
@@ -323,7 +323,7 @@ impl Queue {
     }
 
     /// Set the target [Queue] of this [Queue].
-    pub fn set_target_queue(&self, queue: &Queue) -> Result<(), TargetQueueError> {
+    pub fn set_target_queue(&self, queue: &Queue) {
         // Safety: We are in Queue instance.
         unsafe { self.dispatch_object.set_target_queue(queue) }
     }

--- a/crates/dispatch2/src/queue.rs
+++ b/crates/dispatch2/src/queue.rs
@@ -1,7 +1,5 @@
 use alloc::boxed::Box;
 use alloc::ffi::CString;
-use core::borrow::Borrow;
-use core::ops::Deref;
 use core::ptr::NonNull;
 use core::time::Duration;
 
@@ -86,35 +84,6 @@ impl GlobalQueueIdentifier {
             GlobalQueueIdentifier::QualityOfService(qos_class) => {
                 dispatch_qos_class_t::from(qos_class).0 as isize
             }
-        }
-    }
-}
-
-/// Auto release frequency for [`DispatchWorkloop::set_autorelease_frequency`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[non_exhaustive]
-pub enum DispatchAutoReleaseFrequency {
-    /// Inherit autorelease frequency from the target [`DispatchQueue`].
-    Inherit,
-    /// Configure an autorelease pool before the execution of a function and releases the objects in that pool after the function finishes executing.
-    WorkItem,
-    /// Never setup an autorelease pool.
-    Never,
-}
-
-impl From<DispatchAutoReleaseFrequency> for dispatch_autorelease_frequency_t {
-    fn from(value: DispatchAutoReleaseFrequency) -> Self {
-        match value {
-            DispatchAutoReleaseFrequency::Inherit => {
-                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_INHERIT
-            }
-            DispatchAutoReleaseFrequency::WorkItem => {
-                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM
-            }
-            DispatchAutoReleaseFrequency::Never => {
-                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_NEVER
-            }
-            _ => panic!("Unknown DispatchAutoReleaseFrequency value: {:?}", value),
         }
     }
 }
@@ -308,80 +277,5 @@ impl DispatchQueue {
     pub const unsafe fn as_raw(&self) -> dispatch_queue_t {
         let ptr: *const Self = self;
         ptr as dispatch_queue_t
-    }
-}
-
-dispatch_object!(
-    /// Dispatch workloop queue.
-    pub struct DispatchWorkloop;
-);
-
-impl DispatchWorkloop {
-    /// Create a new [`DispatchWorkloop`].
-    pub fn new(label: &str, inactive: bool) -> DispatchRetained<Self> {
-        let label = CString::new(label).expect("Invalid label!");
-
-        // Safety: label can only be valid.
-        let object = unsafe {
-            if inactive {
-                dispatch_workloop_create_inactive(label.as_ptr())
-            } else {
-                dispatch_workloop_create(label.as_ptr())
-            }
-        };
-
-        let object = NonNull::new(object).expect("dispatch_workloop_create returned NULL");
-        // SAFETY: Object came from a "create" method.
-        unsafe { DispatchRetained::from_raw(object.cast()) }
-    }
-
-    /// Configure how the [`DispatchWorkloop`] manage the autorelease pools for the functions it executes.
-    pub fn set_autorelease_frequency(&self, frequency: DispatchAutoReleaseFrequency) {
-        // Safety: object and frequency can only be valid.
-        unsafe {
-            dispatch_workloop_set_autorelease_frequency(
-                self.as_raw(),
-                dispatch_autorelease_frequency_t::from(frequency),
-            );
-        }
-    }
-
-    /// Get the raw [dispatch_workloop_t] value.
-    ///
-    /// # Safety
-    ///
-    /// - Object shouldn't be released manually.
-    pub const unsafe fn as_raw(&self) -> dispatch_workloop_t {
-        let ptr: *const Self = self;
-        ptr as dispatch_workloop_t
-    }
-}
-
-impl Deref for DispatchWorkloop {
-    type Target = DispatchQueue;
-
-    /// Access the workloop as a [`DispatchQueue`].
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        let ptr: *const DispatchWorkloop = self;
-        let ptr: *const DispatchQueue = ptr.cast();
-        // SAFETY: Workloop queues are "subclasses" of queues (they can be
-        // used in all the same places that normal queues can).
-        unsafe { &*ptr }
-    }
-}
-
-impl AsRef<DispatchQueue> for DispatchWorkloop {
-    #[inline]
-    fn as_ref(&self) -> &DispatchQueue {
-        self
-    }
-}
-
-// PartialEq, Eq and Hash work the same for workloops and queues.
-impl Borrow<DispatchQueue> for DispatchWorkloop {
-    #[inline]
-    fn borrow(&self) -> &DispatchQueue {
-        self
     }
 }

--- a/crates/dispatch2/src/queue.rs
+++ b/crates/dispatch2/src/queue.rs
@@ -298,10 +298,8 @@ impl DispatchQueue {
         qos_class: QualityOfServiceClass,
         relative_priority: i32,
     ) -> Result<(), QualityOfServiceClassFloorError> {
-        let obj = unsafe { DispatchObject::new_shared(self.as_raw()) };
-
-        // Safety: We are a queue.
-        unsafe { obj.set_qos_class_floor(qos_class, relative_priority) }
+        // SAFETY: We are a queue.
+        unsafe { DispatchObject::set_qos_class_floor(self, qos_class, relative_priority) }
     }
 
     /// Get the raw [dispatch_queue_t] value.

--- a/crates/dispatch2/src/queue.rs
+++ b/crates/dispatch2/src/queue.rs
@@ -1,5 +1,3 @@
-//! Dispatch queue definition.
-
 use alloc::boxed::Box;
 use alloc::ffi::CString;
 use core::borrow::Borrow;

--- a/crates/dispatch2/src/retained.rs
+++ b/crates/dispatch2/src/retained.rs
@@ -6,25 +6,13 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::NonNull;
 
 use crate::ffi::{dispatch_release, dispatch_retain};
+use crate::DispatchObject;
 
 // Symlinked to `objc2/src/rc/retained_forwarding_impls.rs`, Cargo will make
 // a copy when publishing.
 mod forwarding_impls;
 // Allow the `use super::Retained;` in `forwarding_impls` to work.
 use DispatchRetained as Retained;
-
-/// TODO
-pub unsafe trait DispatchObject {
-    /// TODO
-    fn retain(&self) -> DispatchRetained<Self> {
-        let ptr: NonNull<Self> = NonNull::from(self);
-        // SAFETY:
-        // - The pointer is valid since it came from `&self`.
-        // - The lifetime of the pointer itself is extended, but any lifetime
-        //   that the object may carry is still kept within the type itself.
-        unsafe { DispatchRetained::retain(ptr) }
-    }
-}
 
 /// A reference counted pointer type for Dispatch objects.
 ///

--- a/crates/dispatch2/src/retained.rs
+++ b/crates/dispatch2/src/retained.rs
@@ -1,0 +1,331 @@
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ops::Deref;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+use core::ptr::NonNull;
+
+use crate::ffi::{dispatch_release, dispatch_retain};
+
+// Symlinked to `objc2/src/rc/retained_forwarding_impls.rs`, Cargo will make
+// a copy when publishing.
+mod forwarding_impls;
+// Allow the `use super::Retained;` in `forwarding_impls` to work.
+use DispatchRetained as Retained;
+
+/// TODO
+pub unsafe trait DispatchObject {
+    /// TODO
+    fn retain(&self) -> DispatchRetained<Self> {
+        let ptr: NonNull<Self> = NonNull::from(self);
+        // SAFETY:
+        // - The pointer is valid since it came from `&self`.
+        // - The lifetime of the pointer itself is extended, but any lifetime
+        //   that the object may carry is still kept within the type itself.
+        unsafe { DispatchRetained::retain(ptr) }
+    }
+}
+
+/// A reference counted pointer type for Dispatch objects.
+///
+/// [`DispatchRetained`] strongly references or "retains" the given object
+/// `T`, and decrements the retain count or "releases" it again when dropped,
+/// thereby ensuring it will be deallocated at the right time.
+///
+/// The type `T` inside `DispatchRetained<T>` can be anything that implements
+/// [`DispatchObject`], i.e. any Dispatch object.
+///
+///
+/// # Comparison to other types
+///
+/// `DispatchRetained<T>` is equivalent to [`objc2::rc::Retained`], and can be
+/// converted to/from that when the `"objc2"` feature is enabled. Note though
+/// that this type uses the underlying Dispatch primitives `dispatch_retain` /
+/// `dispatch_release` instead of `objc_retain` / `objc_release` for
+/// performance, and to avoid depending on the Objective-C runtime if not
+/// needed.
+///
+/// You can also view `DispatchRetained<T>` as the Dispatch equivalent of
+/// [`std::sync::Arc`], that is, it is a thread-safe reference-counting smart
+/// pointer that allows cloning by bumping the reference count.
+///
+/// Unlike `Arc`, objects can be retained directly from a `&T` using
+/// [`DispatchObject::retain`] (for `Arc` you need `&Arc<T>`).
+///
+/// Weak references are not supported, for that you need to convert to
+/// `objc2::rc::Retained`.
+///
+#[cfg_attr(
+    not(feature = "objc2"),
+    doc = "[`objc2::rc::Retained`]: #objc2-not-available"
+)]
+///
+///
+/// # Forwarding implementations
+///
+/// Since `DispatchRetained<T>` is a smart pointer, it [`Deref`]s to `T`.
+///
+/// It also forwards the implementation of a bunch of standard library traits
+/// such as [`PartialEq`], [`AsRef`], and so on, so that it becomes possible
+/// to use e.g. `DispatchRetained<DispatchQueue>` as-if it you had a
+/// `&DispatchQueue`. Note that having a `DispatchQueue` directly is not
+/// possible since dispatch objects cannot live on the stack, but instead must
+/// reside on the heap, and as such must be accessed behind a pointer or a
+/// reference.
+///
+///
+/// # Memory layout
+///
+/// This is guaranteed to have the same size and alignment as a pointer to the
+/// object, i.e. same as `*const T` or `dispatch_object_t`.
+///
+/// Additionally, it participates in the null-pointer optimization, that is,
+/// `Option<DispatchRetained<T>>` is guaranteed to have the same size as
+/// `DispatchRetained<T>`.
+#[repr(transparent)]
+#[doc(alias = "Retained")]
+#[doc(alias = "objc2::rc::Retained")]
+// TODO: Add `ptr::Thin` bound on `T` to allow for only extern types
+pub struct DispatchRetained<T: ?Sized> {
+    /// A pointer to the contained object. The pointer is always retained.
+    ///
+    /// It is important that this is `NonNull`, since we want to dereference
+    /// it later, and be able to use the null-pointer optimization.
+    ptr: NonNull<T>,
+    /// Necessary for dropck even though we never actually run T's destructor,
+    /// because it might have a `dealloc` that assumes that contained
+    /// references outlive the type.
+    ///
+    /// See <https://doc.rust-lang.org/nightly/nomicon/phantom-data.html>
+    item: PhantomData<T>,
+    /// Marks the type as !UnwindSafe. Later on we'll re-enable this.
+    ///
+    /// See <https://github.com/rust-lang/rust/issues/93367> for why this is
+    /// required.
+    notunwindsafe: PhantomData<&'static mut ()>,
+}
+
+// Same as `objc::rc::Retained`, `#[may_dangle]` does not apply here.
+impl<T: ?Sized> Drop for DispatchRetained<T> {
+    /// Releases the contained object.
+    #[doc(alias = "dispatch_release")]
+    #[doc(alias = "release")]
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: The `ptr` is guaranteed to be valid, is not NULL, and has
+        // at least one retain count.
+        unsafe { dispatch_release(self.ptr.as_ptr().cast()) };
+    }
+}
+
+impl<T: ?Sized + DispatchObject> DispatchRetained<T> {
+    /// Construct a `DispatchRetained` from a pointer that already has +1
+    /// retain count.
+    ///
+    /// This is useful when you have been given a pointer to an object from
+    /// some API that returns a retained pointer, and expects you to release
+    /// it. That is, an API that follows [the create rule].
+    ///
+    /// [the create rule]: https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-103029
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be a valid and live object according to Dispatch, and
+    /// it must be of type `T`.
+    ///
+    /// Additionally, you must ensure the given object pointer has +1 retain
+    /// count.
+    #[inline]
+    pub unsafe fn from_raw(ptr: NonNull<T>) -> Self {
+        Self {
+            ptr,
+            item: PhantomData,
+            notunwindsafe: PhantomData,
+        }
+    }
+
+    /// Retain the pointer and construct a [`DispatchRetained`] from it.
+    ///
+    /// This is useful when you have been given a pointer to an object from
+    /// some API that follows [the get rule], and you would like to keep it
+    /// around for longer than the current memory context.
+    ///
+    /// [the get rule]: https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW1
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be a valid and live object according to Dispatch, and
+    /// it must be of type `T`.
+    #[doc(alias = "dispatch_retain")]
+    #[inline]
+    pub unsafe fn retain(ptr: NonNull<T>) -> Self {
+        // SAFETY: The caller upholds that the pointer is valid, and it came
+        // from NonNull, so we know it's not NULL.
+        unsafe { dispatch_retain(ptr.as_ptr().cast()) };
+
+        // SAFETY: We just retained the object, so it has +1 retain count.
+        // Validity of the pointer is upheld by the caller.
+        unsafe { Self::from_raw(ptr) }
+    }
+
+    /// Consumes the `DispatchRetained`, returning a raw pointer with +1
+    /// retain count.
+    ///
+    /// After calling this function, the caller is responsible for the memory
+    /// previously managed by the `DispatchRetained`.
+    ///
+    /// This is effectively the opposite of [`DispatchRetained::from_raw`].
+    ///
+    /// This is an associated method, and must be called as
+    /// `DispatchRetained::into_raw(obj)`.
+    #[inline]
+    pub fn into_raw(this: Self) -> NonNull<T> {
+        ManuallyDrop::new(this).ptr
+    }
+
+    /// Returns a raw pointer to the object.
+    ///
+    /// The pointer is valid for at least as long as the `DispatchRetained` is
+    /// held.
+    ///
+    /// This is an associated method, and must be called as
+    /// `DispatchRetained::as_ptr(&obj)`.
+    #[inline]
+    pub fn as_ptr(this: &Self) -> NonNull<T> {
+        this.ptr
+    }
+
+    /// Unchecked conversion to another Dispatch object.
+    ///
+    /// This is equivalent to a `cast` between two pointers.
+    ///
+    /// This is an associated method, and must be called as
+    /// `DispatchRetained::cast_unchecked(obj)`.
+    ///
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that the object can be reinterpreted as the given
+    /// type.
+    ///
+    /// If `T` is not `'static`, you must ensure that `U` ensures that the
+    /// data contained by `T` is kept alive for as long as `U` lives.
+    ///
+    /// Additionally, you must ensure that any safety invariants that the new
+    /// type has are upheld.
+    #[inline]
+    // TODO: Add ?Sized bound
+    pub unsafe fn cast_unchecked<U: DispatchObject>(this: Self) -> DispatchRetained<U> {
+        // SAFETY: The object is forgotten, so we have +1 retain count.
+        //
+        // Caller verifies that the object is of the correct type.
+        unsafe { DispatchRetained::from_raw(Self::into_raw(this).cast()) }
+    }
+}
+
+impl<T: ?Sized + DispatchObject> Clone for DispatchRetained<T> {
+    /// Retain the object, increasing its reference count.
+    ///
+    /// This calls [`DispatchObject::retain`] internally.
+    #[doc(alias = "dispatch_retain")]
+    #[doc(alias = "retain")]
+    #[inline]
+    fn clone(&self) -> Self {
+        self.retain()
+    }
+}
+
+impl<T: ?Sized> Deref for DispatchRetained<T> {
+    type Target = T;
+
+    /// Obtain a reference to the object.
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: The pointer's validity is verified when the type is
+        // created.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: ?Sized> fmt::Pointer for DispatchRetained<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr.as_ptr(), f)
+    }
+}
+
+// Same as what's implemented for `objc2::rc::Retained`.
+impl<T: ?Sized + AsRef<U>, U: DispatchObject> From<&T> for DispatchRetained<U> {
+    /// Cast the object to a superclass, and retain it.
+    #[inline]
+    fn from(obj: &T) -> Self {
+        obj.as_ref().retain()
+    }
+}
+
+#[cfg(feature = "objc2")]
+impl<T: ?Sized + DispatchObject + objc2::Message> From<objc2::rc::Retained<T>>
+    for DispatchRetained<T>
+{
+    /// Convert a [`objc2::rc::Retained`] into a [`DispatchRetained`].
+    ///
+    /// This only works if the type is a Dispatch object (implements the
+    /// [`DispatchObject`] trait).
+    ///
+    /// This conversion is cost-free.
+    #[inline]
+    fn from(obj: objc2::rc::Retained<T>) -> Self {
+        let ptr = objc2::rc::Retained::into_raw(obj);
+        let ptr = NonNull::new(ptr).unwrap();
+        // SAFETY: `T` is bound by `DispatchObject`, so we know that the type
+        // is a Dispatch object, and hence we know that it will respond to
+        // `dispatch_retain`/`dispatch_release`.
+        //
+        // Additionally, the pointer is valid and has +1 retain count, since
+        // we're passing it from `Retained::into_raw`.
+        unsafe { Self::from_raw(ptr) }
+    }
+}
+
+#[cfg(feature = "objc2")]
+impl<T: ?Sized + DispatchObject + objc2::Message> From<DispatchRetained<T>>
+    for objc2::rc::Retained<T>
+{
+    /// Convert a [`DispatchRetained`] into a [`objc2::rc::Retained`].
+    ///
+    /// This conversion is cost-free, since Dispatch objects are fully
+    /// interoperable with Objective-C retain/release message sending.
+    #[inline]
+    fn from(obj: DispatchRetained<T>) -> Self {
+        let ptr = DispatchRetained::into_raw(obj);
+        // SAFETY: `T` is bound by `Message`, so we know that the type is an
+        // Objective-C object, and hence we know that it will respond to
+        // `objc_retain`, `objc_release` etc.
+        //
+        // Additionally, the pointer is valid and has +1 retain count, since
+        // we're passing it from `DispatchRetained::into_raw`.
+        unsafe { Self::from_raw(ptr.as_ptr()) }.unwrap()
+    }
+}
+
+/// `DispatchRetained<T>` is `Send` if `T` is `Send + Sync`.
+//
+// SAFETY: dispatch_retain/dispatch_release is thread safe, rest is the same
+// as `std::sync::Arc` and `objc2::rc::Retained`.
+unsafe impl<T: ?Sized + Sync + Send> Send for DispatchRetained<T> {}
+
+/// `DispatchRetained<T>` is `Sync` if `T` is `Send + Sync`.
+//
+// SAFETY: dispatch_retain/dispatch_release is thread safe, rest is the same
+// as `std::sync::Arc` and `objc2::rc::Retained`.
+unsafe impl<T: ?Sized + Sync + Send> Sync for DispatchRetained<T> {}
+
+// Same as `std::sync::Arc` and `objc2::rc::Retained`.
+impl<T: ?Sized> Unpin for DispatchRetained<T> {}
+
+// Same as `std::sync::Arc` and `objc2::rc::Retained`.
+impl<T: ?Sized + RefUnwindSafe> RefUnwindSafe for DispatchRetained<T> {}
+
+// Same as `std::sync::Arc` and `objc2::rc::Retained`.
+impl<T: ?Sized + RefUnwindSafe> UnwindSafe for DispatchRetained<T> {}

--- a/crates/dispatch2/src/retained/forwarding_impls.rs
+++ b/crates/dispatch2/src/retained/forwarding_impls.rs
@@ -1,0 +1,1 @@
+../../../../crates/objc2/src/rc/retained_forwarding_impls.rs

--- a/crates/dispatch2/src/semaphore.rs
+++ b/crates/dispatch2/src/semaphore.rs
@@ -3,8 +3,7 @@
 use core::ptr::NonNull;
 use core::time::Duration;
 
-use crate::retained::DispatchObject;
-use crate::DispatchRetained;
+use crate::{DispatchObject, DispatchRetained};
 
 use super::ffi::*;
 use super::WaitError;

--- a/crates/dispatch2/src/semaphore.rs
+++ b/crates/dispatch2/src/semaphore.rs
@@ -1,5 +1,6 @@
 //! Dispatch semaphore definition.
 
+use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 use core::time::Duration;
 
@@ -31,14 +32,17 @@ impl DispatchSemaphore {
         })
     }
 
-    /// Attempt to acquire the [`DispatchSemaphore`] and return a [`SemaphoreGuard`].
+    /// Attempt to acquire the [`DispatchSemaphore`] and return a [`DispatchSemaphoreGuard`].
     ///
     /// # Errors
     ///
     /// Return [WaitError::TimeOverflow] if the passed ``timeout`` is too big.
     ///
     /// Return [WaitError::Timeout] in case of timeout.
-    pub fn try_acquire(&self, timeout: Option<Duration>) -> Result<SemaphoreGuard, WaitError> {
+    pub fn try_acquire(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<DispatchSemaphoreGuard, WaitError> {
         let timeout = if let Some(timeout) = timeout {
             dispatch_time_t::try_from(timeout).map_err(|_| WaitError::TimeOverflow)?
         } else {
@@ -49,7 +53,7 @@ impl DispatchSemaphore {
         let result = unsafe { dispatch_semaphore_wait(self.as_raw(), timeout) };
 
         match result {
-            0 => Ok(SemaphoreGuard(self.retain(), false)),
+            0 => Ok(DispatchSemaphoreGuard(self.retain())),
             _ => Err(WaitError::Timeout),
         }
     }
@@ -67,29 +71,23 @@ impl DispatchSemaphore {
 
 /// Dispatch semaphore guard.
 #[derive(Debug)]
-pub struct SemaphoreGuard(DispatchRetained<DispatchSemaphore>, bool);
+pub struct DispatchSemaphoreGuard(DispatchRetained<DispatchSemaphore>);
 
-impl SemaphoreGuard {
+impl DispatchSemaphoreGuard {
     /// Release the [`DispatchSemaphore`].
-    pub fn release(mut self) -> bool {
-        // Safety: DispatchSemaphore cannot be null.
-        let result = unsafe { dispatch_semaphore_signal(self.0.as_raw()) };
+    pub fn release(self) -> bool {
+        let this = ManuallyDrop::new(self);
 
-        self.1 = true;
+        // SAFETY: DispatchSemaphore cannot be null.
+        let result = unsafe { dispatch_semaphore_signal(this.0.as_raw()) };
 
         result != 0
     }
 }
 
-impl Drop for SemaphoreGuard {
+impl Drop for DispatchSemaphoreGuard {
     fn drop(&mut self) {
-        if !self.1 {
-            // Safety: DispatchSemaphore cannot be null.
-            unsafe {
-                dispatch_semaphore_signal(self.0.as_raw());
-            }
-
-            self.1 = true;
-        }
+        // SAFETY: DispatchSemaphore cannot be null.
+        unsafe { dispatch_semaphore_signal(self.0.as_raw()) };
     }
 }

--- a/crates/dispatch2/src/semaphore.rs
+++ b/crates/dispatch2/src/semaphore.rs
@@ -8,12 +8,12 @@ use super::WaitError;
 
 /// Dispatch semaphore.
 #[derive(Debug, Clone)]
-pub struct Semaphore {
+pub struct DispatchSemaphore {
     dispatch_object: DispatchObject<dispatch_semaphore_s>,
 }
 
-impl Semaphore {
-    /// Creates a new [Semaphore] with an initial value.
+impl DispatchSemaphore {
+    /// Creates a new [`DispatchSemaphore`] with an initial value.
     ///
     /// Returns None if value is negative or if creation failed.
     pub fn new(value: isize) -> Option<Self> {
@@ -32,10 +32,10 @@ impl Semaphore {
         // Safety: object cannot be null.
         let dispatch_object = unsafe { DispatchObject::new_owned(object.cast()) };
 
-        Some(Semaphore { dispatch_object })
+        Some(Self { dispatch_object })
     }
 
-    /// Attempt to acquire the [Semaphore] and return a [SemaphoreGuard].
+    /// Attempt to acquire the [`DispatchSemaphore`] and return a [`SemaphoreGuard`].
     ///
     /// # Errors
     ///
@@ -49,7 +49,7 @@ impl Semaphore {
             DISPATCH_TIME_FOREVER
         };
 
-        // Safety: Semaphore cannot be null.
+        // Safety: DispatchSemaphore cannot be null.
         let result = unsafe { dispatch_semaphore_wait(self.as_raw(), timeout) };
 
         match result {
@@ -79,12 +79,12 @@ impl Semaphore {
 
 /// Dispatch semaphore guard.
 #[derive(Debug)]
-pub struct SemaphoreGuard(Semaphore, bool);
+pub struct SemaphoreGuard(DispatchSemaphore, bool);
 
 impl SemaphoreGuard {
-    /// Release the [Semaphore].
+    /// Release the [`DispatchSemaphore`].
     pub fn release(mut self) -> bool {
-        // Safety: Semaphore cannot be null.
+        // Safety: DispatchSemaphore cannot be null.
         let result = unsafe { dispatch_semaphore_signal(self.0.as_raw()) };
 
         self.1 = true;
@@ -96,7 +96,7 @@ impl SemaphoreGuard {
 impl Drop for SemaphoreGuard {
     fn drop(&mut self) {
         if !self.1 {
-            // Safety: Semaphore cannot be null.
+            // Safety: DispatchSemaphore cannot be null.
             unsafe {
                 dispatch_semaphore_signal(self.0.as_raw());
             }

--- a/crates/dispatch2/src/semaphore.rs
+++ b/crates/dispatch2/src/semaphore.rs
@@ -1,5 +1,3 @@
-//! Dispatch semaphore definition.
-
 use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 use core::time::Duration;

--- a/crates/dispatch2/src/workloop.rs
+++ b/crates/dispatch2/src/workloop.rs
@@ -1,0 +1,108 @@
+use alloc::ffi::CString;
+use core::{borrow::Borrow, ops::Deref, ptr::NonNull};
+
+use crate::{ffi::*, DispatchQueue, DispatchRetained};
+
+dispatch_object!(
+    /// Dispatch workloop queue.
+    pub struct DispatchWorkloop;
+);
+
+impl DispatchWorkloop {
+    /// Create a new [`DispatchWorkloop`].
+    pub fn new(label: &str, inactive: bool) -> DispatchRetained<Self> {
+        let label = CString::new(label).expect("Invalid label!");
+
+        // Safety: label can only be valid.
+        let object = unsafe {
+            if inactive {
+                dispatch_workloop_create_inactive(label.as_ptr())
+            } else {
+                dispatch_workloop_create(label.as_ptr())
+            }
+        };
+
+        let object = NonNull::new(object).expect("dispatch_workloop_create returned NULL");
+        // SAFETY: Object came from a "create" method.
+        unsafe { DispatchRetained::from_raw(object.cast()) }
+    }
+
+    /// Configure how the [`DispatchWorkloop`] manage the autorelease pools for the functions it executes.
+    pub fn set_autorelease_frequency(&self, frequency: DispatchAutoReleaseFrequency) {
+        // Safety: object and frequency can only be valid.
+        unsafe {
+            dispatch_workloop_set_autorelease_frequency(
+                self.as_raw(),
+                dispatch_autorelease_frequency_t::from(frequency),
+            );
+        }
+    }
+
+    /// Get the raw [dispatch_workloop_t] value.
+    ///
+    /// # Safety
+    ///
+    /// - Object shouldn't be released manually.
+    pub const unsafe fn as_raw(&self) -> dispatch_workloop_t {
+        let ptr: *const Self = self;
+        ptr as dispatch_workloop_t
+    }
+}
+
+impl Deref for DispatchWorkloop {
+    type Target = DispatchQueue;
+
+    /// Access the workloop as a [`DispatchQueue`].
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        let ptr: *const DispatchWorkloop = self;
+        let ptr: *const DispatchQueue = ptr.cast();
+        // SAFETY: Workloop queues are "subclasses" of queues (they can be
+        // used in all the same places that normal queues can).
+        unsafe { &*ptr }
+    }
+}
+
+impl AsRef<DispatchQueue> for DispatchWorkloop {
+    #[inline]
+    fn as_ref(&self) -> &DispatchQueue {
+        self
+    }
+}
+
+// PartialEq, Eq and Hash work the same for workloops and queues.
+impl Borrow<DispatchQueue> for DispatchWorkloop {
+    #[inline]
+    fn borrow(&self) -> &DispatchQueue {
+        self
+    }
+}
+
+/// Auto release frequency for [`DispatchWorkloop::set_autorelease_frequency`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum DispatchAutoReleaseFrequency {
+    /// Inherit autorelease frequency from the target [`DispatchQueue`].
+    Inherit,
+    /// Configure an autorelease pool before the execution of a function and releases the objects in that pool after the function finishes executing.
+    WorkItem,
+    /// Never setup an autorelease pool.
+    Never,
+}
+
+impl From<DispatchAutoReleaseFrequency> for dispatch_autorelease_frequency_t {
+    fn from(value: DispatchAutoReleaseFrequency) -> Self {
+        match value {
+            DispatchAutoReleaseFrequency::Inherit => {
+                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_INHERIT
+            }
+            DispatchAutoReleaseFrequency::WorkItem => {
+                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM
+            }
+            DispatchAutoReleaseFrequency::Never => {
+                dispatch_autorelease_frequency_t::DISPATCH_AUTORELEASE_FREQUENCY_NEVER
+            }
+            _ => panic!("Unknown DispatchAutoReleaseFrequency value: {:?}", value),
+        }
+    }
+}

--- a/crates/objc2/src/rc/retained_forwarding_impls.rs
+++ b/crates/objc2/src/rc/retained_forwarding_impls.rs
@@ -1,7 +1,8 @@
 //! Trivial forwarding impls on `Retained`-like types.
 //!
 //! Kept here to keep `retained.rs` free from this boilerplate, and to allow
-//! re-use in `objc2-core-foundation` (this file is symlinked there as well).
+//! re-use in `objc2-core-foundation` and `dispatch2` (this file is symlinked
+//! there as well).
 
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
Refactor `dispatch2` to use the `DispatchRetained<T>` pattern instead of types owning the retain count internally. This should allow us to use Dispatch types in the auto-generated headers. See https://github.com/madsmtm/objc2/pull/681#issuecomment-2559982918 for why we don't use a more general approach to these `*Retained` types.

I've also decided to prefix types with "Dispatch", to better match Swift, and to allow easily glob-importing from `dispatch2` without fear that the symbols will clash with something else. This isn't that "rusty", but it plays much nicer with the rest of the `objc2` ecosystem, and matches what Swift does.

It's also clearer at the usage-site. Compare:
```rust
// Hmm, what queue are we referring to?
Queue::main().exec_sync(|| ...);

// Ah, it's a Dispatch queue.
DispatchQueue::main().exec_sync(|| ...);
```

Part of https://github.com/madsmtm/objc2/issues/77. Unblocks https://github.com/madsmtm/objc2/pull/681 and https://github.com/madsmtm/objc2/pull/710.