### PR TITLE
iokit: enable power management mod

### DIFF
--- a/framework-crates/objc2-io-kit/Cargo.toml
+++ b/framework-crates/objc2-io-kit/Cargo.toml
@@ -62,6 +62,7 @@ default = [
     "libc",
     "network",
     "objc2",
+    "pwr_mgt",
     "serial",
     "usb",
 ]
@@ -106,5 +107,10 @@ hidsystem = [
     "objc2-core-foundation/CFDictionary",
 ]
 network = []
+pwr_mgt = [
+    "objc2-core-foundation/CFArray",
+    "objc2-core-foundation/CFDate",
+    "objc2-core-foundation/CFDictionary",
+]
 serial = []
 usb = []

--- a/framework-crates/objc2-io-kit/src/lib.rs
+++ b/framework-crates/objc2-io-kit/src/lib.rs
@@ -36,6 +36,11 @@ pub type IOReturn = core::ffi::c_int; // kern_return_t
 #[allow(non_upper_case_globals)]
 pub const kIOReturnSuccess: IOReturn = 0;
 
+// IOKit/IOPM.h
+/// [Apple's documentation](https://developer.apple.com/documentation/kernel/2876248-anonymous/kiopsfamilycodeunsupported/)
+#[allow(non_upper_case_globals)]
+pub const kIOPSFamilyCodeUnsupported: core::ffi::c_int = kIOReturnUnsupported as core::ffi::c_int;
+
 // MacTypes.h
 #[allow(dead_code)]
 pub(crate) type Boolean = u8;

--- a/framework-crates/objc2-io-kit/src/macros.rs
+++ b/framework-crates/objc2-io-kit/src/macros.rs
@@ -44,6 +44,20 @@ macro_rules! iokit_common_msg {
     };
 }
 
+macro_rules! iokit_family_msg {
+    ($sub:expr, $message:expr) => {
+        // (sys_iokit | sub| message)
+        (err_system!(0x38) | ($sub as i32) | $message) as u32
+    };
+}
+
+macro_rules! iokit_family_err {
+    ($sub:expr, $return:expr) => {
+        // (sys_iokit | sub| return)
+        (err_system!(0x38) | ($sub as i32) | $return) as i32
+    };
+}
+
 macro_rules! iokit_usb_msg {
     ($message:expr) => {
         // (sys_iokit | sub_iokit_usb | message)
@@ -68,6 +82,8 @@ pub(crate) use err_sub;
 pub(crate) use err_system;
 pub(crate) use iokit_common_msg;
 pub(crate) use iokit_common_msg as iokit_common_err;
+pub(crate) use iokit_family_err;
+pub(crate) use iokit_family_msg;
 pub(crate) use iokit_usb_msg as iokit_usb_err;
 pub(crate) use iokit_usb_msg;
 pub(crate) use iokit_vendor_specific_msg;

--- a/framework-crates/objc2-io-kit/translation-config.toml
+++ b/framework-crates/objc2-io-kit/translation-config.toml
@@ -16,11 +16,53 @@ module.iokitmig.skipped = true
 module.kext.skipped = true
 module.ndrvsupport.skipped = true
 module.ps.skipped = true
-module.pwr_mgt.skipped = true
 module.sbp2.skipped = true
 module.scsi.skipped = true
 module.storage.skipped = true
 module.stream.skipped = true
+
+# IOPM.h
+# Cast to (void*)1
+const.kIOPMMessageSleepWakeUUIDSet.skipped = true
+# Cast to (void*)NULL
+const.kIOPMMessageSleepWakeUUIDCleared.skipped = true
+
+# References kIOReturnUnsupported (u32) in enum (i32)
+const.kIOPSFamilyCodeUnsupported.skipped = true
+
+# IOKit/IOReturn.h
+# Defines
+const.sub_iokit_common.skipped = false
+const.sub_iokit_usb.skipped = false
+const.sub_iokit_firewire.skipped = false
+const.sub_iokit_block_storage.skipped = false
+const.sub_iokit_graphics.skipped = false
+const.sub_iokit_networking.skipped = false
+const.sub_iokit_bluetooth.skipped = false
+const.sub_iokit_pmu.skipped = false
+const.sub_iokit_acpi.skipped = false
+const.sub_iokit_smbus.skipped = false
+const.sub_iokit_ahci.skipped = false
+const.sub_iokit_powermanagement.skipped = false
+const.sub_iokit_hidsystem.skipped = false
+const.sub_iokit_scsi.skipped = false
+const.sub_iokit_usbaudio.skipped = false
+const.sub_iokit_wirelesscharging.skipped = false
+const.sub_iokit_thunderbol.skipped = false
+const.sub_iokit_graphics_acceleration.skipped = false
+const.sub_iokit_keystore.skipped = false
+const.sub_iokit_apfs.skipped = false
+const.sub_iokit_acpiec.skipped = false
+const.sub_iokit_timesync_avb.skipped = false
+
+# usb/IOUSB.h
+# Constants using CFUUIDGetConstantUUIDWithBytes
+const.kIOUSBDeviceInterfaceID.skipped = true
+const.kIOUSBInterfaceInterfaceID.skipped = true
+
+# usb/USB.h
+# Redefine for kUSBHostMessageRenegotiateCurrent
+const.kIOUSBMessageRenegotiateCurrent.skipped = true
 
 # Requires C++
 module.video.skipped = true


### PR DESCRIPTION
This PR adds power management for IOKit.

1. Verified that `iokit_family_err!` macro works with objc:
  ```objc
  int value = kIOPSFamilyCodeFirewire;
  NSLog(@"Value: %d", value);
  ```
  and Rust test:
  ```rs
  #[test]
  fn test() {
      let value = crate::kIOPSFamilyCodeFirewire;
      std::println!("kIOPSFamilyCodeFirewire = {}", value);
  }
  ```
  Both emit `-536838144`.
1. Some of the constants from `IOPM.h` use `iokit_family_msg` macro which for some reason is not being picked up so I simply decided to skip those defines for now
1. `iokit_family_msg` and `iokit_family_err` are used in different contexts. The latter is often used in enums which default to C `int`. But `iokit_family_msg` seems to be used in contexts where it's expected to be cast to `UInt32`. Go figure..

_Generated with XCode 16.2, sorry I can't install 16.3 on macOS 14_

### Further thoughts

If we could run C preprocessor and evaluate some of the #defines, such as the ones using `iokit_family_err` then we could perhaps plug in computed values instead of re-implementing macro definitions. Unless those vary per platform, it should be alright.