### PR TITLE
Metal: Misc non-`unsafe` translation fixes

### DIFF
--- a/crates/dispatch2/src/object.rs
+++ b/crates/dispatch2/src/object.rs
@@ -44,7 +44,7 @@ enum_with_val! {
 #[allow(missing_docs)] // TODO
 pub const QOS_MIN_RELATIVE_PRIORITY: i32 = -15;
 
-/// Error returned by [DispatchObject::set_qos_class_floor].
+/// Error returned by [`DispatchObject::set_qos_class_floor()`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum QualityOfServiceClassFloorError {

--- a/framework-crates/objc2-metal/src/device.rs
+++ b/framework-crates/objc2-metal/src/device.rs
@@ -10,7 +10,7 @@ use objc2_foundation::NSArray;
 /// application based on whatever criteria it deems appropriate.
 ///
 /// On iOS, tvOS and visionOS, this API returns an array containing the same
-/// device that MTLCreateSystemDefaultDevice would have returned, or an empty
+/// device that [`MTLCreateSystemDefaultDevice()`] would have returned, or an empty
 /// array if it would have failed.
 #[inline]
 pub extern "C-unwind" fn MTLCopyAllDevices() -> Retained<NSArray<ProtocolObject<dyn MTLDevice>>> {

--- a/framework-crates/objc2-metal/src/lib.rs
+++ b/framework-crates/objc2-metal/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! [apple-doc]: https://developer.apple.com/documentation/xcode/validating-your-apps-metal-api-usage/.
 //!
-//! NOTE: To use [`MTLCreateSystemDefaultDevice`] you need to link to
+//! NOTE: To use [`MTLCreateSystemDefaultDevice()`] you need to link to
 //! `CoreGraphics`, this can be done by using `objc2-core-graphics`, or by
 //! doing:
 //! ```rust

--- a/framework-crates/objc2-metal/translation-config.toml
+++ b/framework-crates/objc2-metal/translation-config.toml
@@ -59,6 +59,8 @@ class.MTLInstanceAccelerationStructureDescriptor.methods."setInstancedAccelerati
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceCount:".unsafe = false
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceDescriptorBuffer:".unsafe = false
 
+protocol.MTLAccelerationStructureCommandEncoder.methods."updateFence:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."waitForFence:".unsafe = false
 protocol.MTLAccelerationStructureCommandEncoder.methods."buildAccelerationStructure:descriptor:scratchBuffer:scratchBufferOffset:".unsafe = false
 protocol.MTLAccelerationStructureCommandEncoder.methods."writeCompactedAccelerationStructureSize:toBuffer:offset:".unsafe = false
 protocol.MTLAccelerationStructureCommandEncoder.methods."copyAndCompactAccelerationStructure:toAccelerationStructure:".unsafe = false
@@ -99,11 +101,19 @@ class.MTLArgument.methods.textureType.unsafe = false
 class.MTLArgument.methods.textureDataType.unsafe = false
 
 class.MTLArgumentDescriptor.methods.argumentDescriptor.unsafe = false
+class.MTLArgumentDescriptor.methods.dataType.unsafe = false
 class.MTLArgumentDescriptor.methods."setDataType:".unsafe = false
+class.MTLArgumentDescriptor.methods.index.unsafe = false
 class.MTLArgumentDescriptor.methods."setIndex:".unsafe = false
+class.MTLArgumentDescriptor.methods.arrayLength.unsafe = false
+class.MTLArgumentDescriptor.methods.access.unsafe = false
 class.MTLArgumentDescriptor.methods."setAccess:".unsafe = false
 # class.MTLArgumentDescriptor.methods."setArrayLength:".unsafe = false
+class.MTLArgumentDescriptor.methods.textureType.unsafe = false
 class.MTLArgumentDescriptor.methods."setTextureType:".unsafe = false
+class.MTLArgumentDescriptor.methods.constantBlockAlignment.unsafe = false
+class.MTLArgumentDescriptor.methods."setConstantBlockAlignment:".unsafe = false
+class.MTLArgumentDescriptor.methods.new.unsafe = false
 
 protocol.MTLBuffer.methods.length.unsafe = false
 protocol.MTLBuffer.methods.contents.unsafe = false
@@ -125,6 +135,7 @@ class.MTLCaptureDescriptor.methods."setOutputURL:".unsafe = false
 protocol.MTLCaptureScope.methods.beginScope.unsafe = false
 protocol.MTLCaptureScope.methods.endScope.unsafe = false
 protocol.MTLCaptureScope.methods.label.unsafe = false
+protocol.MTLCaptureScope.methods."setLabel:".unsafe = false
 
 # Note: MTLCaptureManager is not documented thread-safe, so
 # +sharedCaptureManager is not safe either, since we do interior mutation here.
@@ -140,30 +151,56 @@ class.MTLCaptureManager.methods.defaultCaptureScope.unsafe = false
 class.MTLCaptureManager.methods."setDefaultCaptureScope:".unsafe = false
 class.MTLCaptureManager.methods.isCapturing.unsafe = false
 
+protocol.MTLCommandBuffer.methods.device.unsafe = false
+protocol.MTLCommandBuffer.methods.commandQueue.unsafe = false
+protocol.MTLCommandBuffer.methods.retainedReferences.unsafe = false
+protocol.MTLCommandBuffer.methods.errorOptions.unsafe = false
 protocol.MTLCommandBuffer.methods.label.unsafe = false
 protocol.MTLCommandBuffer.methods."setLabel:".unsafe = false
+protocol.MTLCommandBuffer.methods.kernelStartTime.unsafe = false
+protocol.MTLCommandBuffer.methods.kernelEndTime.unsafe = false
+protocol.MTLCommandBuffer.methods.logs.unsafe = false
+protocol.MTLCommandBuffer.methods.GPUStartTime.unsafe = false
+protocol.MTLCommandBuffer.methods.GPUEndTime.unsafe = false
 protocol.MTLCommandBuffer.methods.enqueue.unsafe = false
 protocol.MTLCommandBuffer.methods.commit.unsafe = false
 protocol.MTLCommandBuffer.methods."presentDrawable:".unsafe = false
+# protocol.MTLCommandBuffer.methods."presentDrawable:atTime:".unsafe = false
+# protocol.MTLCommandBuffer.methods."presentDrawable:afterMinimumDuration:".unsafe = false
 protocol.MTLCommandBuffer.methods.waitUntilScheduled.unsafe = false
 # TODO once blocks are better
 # protocol.MTLCommandBuffer.methods."addCompletedHandler:".unsafe = false
+protocol.MTLCommandBuffer.methods.waitUntilCompleted.unsafe = false
 protocol.MTLCommandBuffer.methods.status.unsafe = false
+protocol.MTLCommandBuffer.methods.error.unsafe = false
 protocol.MTLCommandBuffer.methods.blitCommandEncoder.unsafe = false
 protocol.MTLCommandBuffer.methods."renderCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods."computeCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods."blitCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods.computeCommandEncoder.unsafe = false
 protocol.MTLCommandBuffer.methods."computeCommandEncoderWithDispatchType:".unsafe = false
 protocol.MTLCommandBuffer.methods."encodeWaitForEvent:value:".unsafe = false
 protocol.MTLCommandBuffer.methods."encodeSignalEvent:value:".unsafe = false
 protocol.MTLCommandBuffer.methods."parallelRenderCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods.resourceStateCommandEncoder.unsafe = false
+protocol.MTLCommandBuffer.methods."resourceStateCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods.accelerationStructureCommandEncoder.unsafe = false
+protocol.MTLCommandBuffer.methods."accelerationStructureCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods."pushDebugGroup:".unsafe = false
 protocol.MTLCommandBuffer.methods.popDebugGroup.unsafe = false
+protocol.MTLCommandBuffer.methods."useResidencySet:".unsafe = false
+# protocol.MTLCommandBuffer.methods."useResidencySets:count:".unsafe = false
 
 protocol.MTLCommandQueue.methods.label.unsafe = false
 protocol.MTLCommandQueue.methods."setLabel:".unsafe = false
 protocol.MTLCommandQueue.methods.device.unsafe = false
 protocol.MTLCommandQueue.methods.commandBuffer.unsafe = false
+protocol.MTLCommandQueue.methods."commandBufferWithDescriptor:".unsafe = false
+protocol.MTLCommandQueue.methods.commandBufferWithUnretainedReferences.unsafe = false
+protocol.MTLCommandQueue.methods."addResidencySet:".unsafe = false
+# protocol.MTLCommandQueue.methods."addResidencySets:count:".unsafe = false
+protocol.MTLCommandQueue.methods."removeResidencySet:".unsafe = false
+# protocol.MTLCommandQueue.methods."removeResidencySets:count:".unsafe = false
 
 class.MTLStencilDescriptor.methods.stencilCompareFunction.unsafe = false
 class.MTLStencilDescriptor.methods."setStencilCompareFunction:".unsafe = false
@@ -248,14 +285,19 @@ protocol.MTLDevice.methods."newBinaryArchiveWithDescriptor:error:".unsafe = fals
 protocol.MTLDevice.methods.supportsRaytracing.unsafe = false
 protocol.MTLDevice.methods."accelerationStructureSizesWithDescriptor:".unsafe = false
 protocol.MTLDevice.methods."newAccelerationStructureWithSize:".unsafe = false
+protocol.MTLDevice.methods."newAccelerationStructureWithDescriptor:".unsafe = false
+protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:size:".unsafe = false
+protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:descriptor:".unsafe = false
 protocol.MTLDevice.methods.supportsFunctionPointers.unsafe = false
 
 protocol.MTLDrawable.methods.present.unsafe = false
 protocol.MTLDrawable.methods.drawableID.unsafe = false
 
+protocol.MTLCommandEncoder.methods.device.unsafe = false
 protocol.MTLCommandEncoder.methods.label.unsafe = false
 protocol.MTLCommandEncoder.methods."setLabel:".unsafe = false
 protocol.MTLCommandEncoder.methods.endEncoding.unsafe = false
+protocol.MTLCommandEncoder.methods."barrierAfterQueueStages:beforeStages:".unsafe = false
 protocol.MTLCommandEncoder.methods."insertDebugSignpost:".unsafe = false
 protocol.MTLCommandEncoder.methods."pushDebugGroup:".unsafe = false
 protocol.MTLCommandEncoder.methods.popDebugGroup.unsafe = false
@@ -282,15 +324,26 @@ protocol.MTLRenderCommandEncoder.methods."setDepthStencilState:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setStencilReferenceValue:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setStencilFrontReferenceValue:backReferenceValue:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setVisibilityResultMode:offset:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setDepthStoreAction:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setStencilStoreAction:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setDepthStoreActionOptions:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setStencilStoreActionOptions:".unsafe = false
 # drawPrimitives:...
 # ...
 protocol.MTLRenderCommandEncoder.methods."updateFence:afterStages:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."waitForFence:beforeStages:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setTessellationFactorScale:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods.tileWidth.unsafe = false
+protocol.MTLRenderCommandEncoder.methods.tileHeight.unsafe = false
 # setThreadgroupMemoryLength:offset:atIndex:
 protocol.MTLRenderCommandEncoder.methods."useResource:usage:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useResource:usage:stages:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useHeap:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useHeap:stages:".unsafe = false
+# executeCommandsInBuffer:withRange:
+# executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:
+protocol.MTLRenderCommandEncoder.methods."memoryBarrierWithScope:afterStages:beforeStages:".unsafe = false
+# sampleCountersInBuffer:atSampleIndex:withBarrier: is the GPU-based sample indes OOB sound?
 
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLBlitCommandEncoder.methods."synchronizeResource:".unsafe = false
@@ -302,10 +355,16 @@ protocol.MTLBlitCommandEncoder.methods."waitForFence:".unsafe = false
 protocol.MTLBlitCommandEncoder.methods."optimizeContentsForGPUAccess:".unsafe = false
 # optimizeContentsForGPUAccess:slice:level:
 
+protocol.MTLComputeCommandEncoder.methods.dispatchType.unsafe = false
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLComputeCommandEncoder.methods."setComputePipelineState:".unsafe = false
 # setBuffer:...
 # setIntersectionFunctionTable:atBufferIndex:
+# protocol.MTLComputeCommandEncoder.methods."setThreadGroupMemoryLength:atIndex:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."setImageBlockWidth:Height:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."setStageInRegion:".unsafe = false
+# TODO: OOB offset?
+protocol.MTLComputeCommandEncoder.methods."setStageInRegionWithIndirectBuffer:indirectBufferOffset:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."dispatchThreadgroups:threadsPerThreadgroup:".unsafe = false
 # dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup:
 protocol.MTLComputeCommandEncoder.methods."dispatchThreads:threadsPerThreadgroup:".unsafe = false
@@ -313,6 +372,11 @@ protocol.MTLComputeCommandEncoder.methods."updateFence:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."waitForFence:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."useResource:usage:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."useHeap:".unsafe = false
+# TODO: GPU-side range?
+# protocol.MTLComputeCommandEncoder.methods."executeCommandsInBuffer:withRange:".unsafe = false
+# protocol.MTLComputeCommandEncoder.methods."executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."memoryBarrierWithScope:".unsafe = false
+# sampleCountersInBuffer:atSampleIndex:withBarrier: is the GPU-based sample indes OOB sound?
 
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLArgumentEncoder.methods.encodedLength.unsafe = false
@@ -349,8 +413,12 @@ protocol.MTLHeap.methods."newTextureWithDescriptor:".unsafe = false
 protocol.MTLHeap.methods."setPurgeableState:".unsafe = false
 # TODO: type
 # TODO: Verify that offset out-of-bounds is sound.
-# newBufferWithLength:options:offset:
-# newTextureWithDescriptor:offset:
+protocol.MTLHeap.methods."newBufferWithLength:options:offset:".unsafe = false
+protocol.MTLHeap.methods."newTextureWithDescriptor:offset:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithSize:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithSize:offset:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithDescriptor:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithDescriptor:offset:".unsafe = false
 
 class.MTLIndirectCommandBufferDescriptor.methods.commandTypes.unsafe = false
 class.MTLIndirectCommandBufferDescriptor.methods."setCommandTypes:".unsafe = false
@@ -557,6 +625,25 @@ class.MTLRenderPassDescriptor.methods."setRenderTargetHeight:".unsafe = false
 class.MTLRenderPassDescriptor.methods.rasterizationRateMap.unsafe = false
 class.MTLRenderPassDescriptor.methods."setRasterizationRateMap:".unsafe = false
 class.MTLRenderPassDescriptor.methods.sampleBufferAttachments.unsafe = false
+
+class.MTLResidencySetDescriptor.methods.label.unsafe = false
+class.MTLResidencySetDescriptor.methods."setLabel:".unsafe = false
+class.MTLResidencySetDescriptor.methods.initialCapacity.unsafe = false
+class.MTLResidencySetDescriptor.methods."setInitialCapacity:".unsafe = false
+
+protocol.MTLResidencySet.methods.device.unsafe = false
+protocol.MTLResidencySet.methods.label.unsafe = false
+protocol.MTLResidencySet.methods."setLabel:".unsafe = false
+protocol.MTLResidencySet.methods.allocatedSize.unsafe = false
+protocol.MTLResidencySet.methods.requestResidency.unsafe = false
+protocol.MTLResidencySet.methods.endResidency.unsafe = false
+protocol.MTLResidencySet.methods."addAllocation:".unsafe = false
+protocol.MTLResidencySet.methods."removeAllocation:".unsafe = false
+protocol.MTLResidencySet.methods.removeAllAllocations.unsafe = false
+protocol.MTLResidencySet.methods."containsAllocation:".unsafe = false
+protocol.MTLResidencySet.methods.allAllocations.unsafe = false
+protocol.MTLResidencySet.methods.allocationCount.unsafe = false
+protocol.MTLResidencySet.methods.commit.unsafe = false
 
 protocol.MTLResource.methods.label.unsafe = false
 protocol.MTLResource.methods."setLabel:".unsafe = false


### PR DESCRIPTION
Draft until this becomes more complete, and while I figure out the correct semantics.

### Obvious things that should remain `unsafe`:
- CPU-side indexing operations (that are not known to be bounds-checked internally).
- Functions that involve raw pointers and/or data ranges (not translated to slices yet).

### Things that are dubious:
- GPU indices: `sampleCountersInBuffer:atSampleIndex:withBarrier:`, and also all the calls that set resources on encoders and argument buffers like `setBuffer:offset:atIndex:`.
- GPU ranges: `executeCommandsInBuffer:withRange:`.
- GPU buffer offsets: `executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:` (note that `MTLBuffer newTextureWithDescriptor:offset:bytesPerRow:` was marked safe).

Here I am not sure if Rust's safety model should extend to the GPU, if at least CPU-side encoding is fully safe. It would be more convenient to not have to wrap them in `unsafe` on the call-side.

### Things that seem obviously safe to me:
- Various object getters and setters with high-level safe types.
- Especially when they return `Option` to handle nullability?