### PR TITLE
Metal: Port existing and extend new Metal 4 no-`unsafe` annotations

### DIFF
--- a/crates/dispatch2/src/object.rs
+++ b/crates/dispatch2/src/object.rs
@@ -44,7 +44,7 @@ enum_with_val! {
 #[allow(missing_docs)] // TODO
 pub const QOS_MIN_RELATIVE_PRIORITY: i32 = -15;
 
-/// Error returned by [DispatchObject::set_qos_class_floor].
+/// Error returned by [`DispatchObject::set_qos_class_floor()`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum QualityOfServiceClassFloorError {

--- a/framework-crates/objc2-metal/src/device.rs
+++ b/framework-crates/objc2-metal/src/device.rs
@@ -1,7 +1,10 @@
-use crate::MTLDevice;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSArray;
+
+#[cfg(doc)]
+use crate::MTLCreateSystemDefaultDevice;
+use crate::MTLDevice;
 
 /// Returns all Metal devices in the system.
 ///
@@ -10,7 +13,7 @@ use objc2_foundation::NSArray;
 /// application based on whatever criteria it deems appropriate.
 ///
 /// On iOS, tvOS and visionOS, this API returns an array containing the same
-/// device that MTLCreateSystemDefaultDevice would have returned, or an empty
+/// device that [`MTLCreateSystemDefaultDevice()`] would have returned, or an empty
 /// array if it would have failed.
 #[inline]
 #[allow(unexpected_cfgs)]

--- a/framework-crates/objc2-metal/src/lib.rs
+++ b/framework-crates/objc2-metal/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! [apple-doc]: https://developer.apple.com/documentation/xcode/validating-your-apps-metal-api-usage/.
 //!
-//! NOTE: To use [`MTLCreateSystemDefaultDevice`] you need to link to
+//! NOTE: To use [`MTLCreateSystemDefaultDevice()`] you need to link to
 //! `CoreGraphics`, this can be done by using `objc2-core-graphics`, or by
 //! doing:
 //! ```rust

--- a/framework-crates/objc2-metal/translation-config.toml
+++ b/framework-crates/objc2-metal/translation-config.toml
@@ -38,6 +38,8 @@ enum.MTLTensorDataType.use-value = true
 fn.MTLCreateSystemDefaultDevice.unsafe = false
 fn.MTLCopyAllDevices.unsafe = false
 
+class.MTLAllocation.methods.allocatedSize.unsafe = false
+
 class.MTLPrimitiveAccelerationStructureDescriptor.methods.descriptor.unsafe = false
 class.MTLPrimitiveAccelerationStructureDescriptor.methods."setGeometryDescriptors:".unsafe = false
 
@@ -62,9 +64,32 @@ class.MTLInstanceAccelerationStructureDescriptor.methods."setInstancedAccelerati
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceCount:".unsafe = false
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceDescriptorBuffer:".unsafe = false
 
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray.methods.new.unsafe = false
+
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptor.methods.new.unsafe = false
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptor.methods.sampleBuffer.unsafe = false
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptor.methods."setSampleBuffer:".unsafe = false
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptor.methods.startOfEncoderSampleIndex.unsafe = false
+# setStartOfEncoderSampleIndex:
+class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptor.methods.endOfEncoderSampleIndex.unsafe = false
+# setEndOfEncoderSampleIndex:
+
+class.MTLAccelerationStructurePassDescriptor.methods.new.unsafe = false
+class.MTLAccelerationStructurePassDescriptor.methods.accelerationStructurePassDescriptor.unsafe = false
+class.MTLAccelerationStructurePassDescriptor.methods.sampleBufferAttachments.unsafe = false
+
 protocol.MTLAccelerationStructureCommandEncoder.methods."buildAccelerationStructure:descriptor:scratchBuffer:scratchBufferOffset:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."refitAccelerationStructure:descriptor:destination:scratchBuffer:scratchBufferOffset:options:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."copyAccelerationStructure:toAccelerationStructure:".unsafe = false
 protocol.MTLAccelerationStructureCommandEncoder.methods."writeCompactedAccelerationStructureSize:toBuffer:offset:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."writeCompactedAccelerationStructureSize:toBuffer:offset:sizeDataType:".unsafe = false
 protocol.MTLAccelerationStructureCommandEncoder.methods."copyAndCompactAccelerationStructure:toAccelerationStructure:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."updateFence:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."waitForFence:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."useResource:usage:".unsafe = false
+protocol.MTLAccelerationStructureCommandEncoder.methods."useHeap:".unsafe = false
+# sampleCountersInBuffer:atSampleIndex:withBarrier:
 
 class.MTLIntersectionFunctionTableDescriptor.methods.init.unsafe = false
 class.MTLIntersectionFunctionTableDescriptor.methods.new.unsafe = false
@@ -102,11 +127,19 @@ class.MTLArgument.methods.textureType.unsafe = false
 class.MTLArgument.methods.textureDataType.unsafe = false
 
 class.MTLArgumentDescriptor.methods.argumentDescriptor.unsafe = false
+class.MTLArgumentDescriptor.methods.dataType.unsafe = false
 class.MTLArgumentDescriptor.methods."setDataType:".unsafe = false
+class.MTLArgumentDescriptor.methods.index.unsafe = false
 class.MTLArgumentDescriptor.methods."setIndex:".unsafe = false
+class.MTLArgumentDescriptor.methods.arrayLength.unsafe = false
+class.MTLArgumentDescriptor.methods.access.unsafe = false
 class.MTLArgumentDescriptor.methods."setAccess:".unsafe = false
 # class.MTLArgumentDescriptor.methods."setArrayLength:".unsafe = false
+class.MTLArgumentDescriptor.methods.textureType.unsafe = false
 class.MTLArgumentDescriptor.methods."setTextureType:".unsafe = false
+class.MTLArgumentDescriptor.methods.constantBlockAlignment.unsafe = false
+class.MTLArgumentDescriptor.methods."setConstantBlockAlignment:".unsafe = false
+class.MTLArgumentDescriptor.methods.new.unsafe = false
 
 protocol.MTLBuffer.methods.length.unsafe = false
 protocol.MTLBuffer.methods.contents.unsafe = false
@@ -128,6 +161,7 @@ class.MTLCaptureDescriptor.methods."setOutputURL:".unsafe = false
 protocol.MTLCaptureScope.methods.beginScope.unsafe = false
 protocol.MTLCaptureScope.methods.endScope.unsafe = false
 protocol.MTLCaptureScope.methods.label.unsafe = false
+protocol.MTLCaptureScope.methods."setLabel:".unsafe = false
 
 # Note: MTLCaptureManager is not documented thread-safe, so
 # +sharedCaptureManager is not safe either, since we do interior mutation here.
@@ -143,31 +177,74 @@ class.MTLCaptureManager.methods.defaultCaptureScope.unsafe = false
 class.MTLCaptureManager.methods."setDefaultCaptureScope:".unsafe = false
 class.MTLCaptureManager.methods.isCapturing.unsafe = false
 
+protocol.MTLCommandBuffer.methods.device.unsafe = false
+protocol.MTLCommandBuffer.methods.commandQueue.unsafe = false
+protocol.MTLCommandBuffer.methods.retainedReferences.unsafe = false
+protocol.MTLCommandBuffer.methods.errorOptions.unsafe = false
 protocol.MTLCommandBuffer.methods.label.unsafe = false
 protocol.MTLCommandBuffer.methods."setLabel:".unsafe = false
+protocol.MTLCommandBuffer.methods.kernelStartTime.unsafe = false
+protocol.MTLCommandBuffer.methods.kernelEndTime.unsafe = false
+protocol.MTLCommandBuffer.methods.logs.unsafe = false
+protocol.MTLCommandBuffer.methods.GPUStartTime.unsafe = false
+protocol.MTLCommandBuffer.methods.GPUEndTime.unsafe = false
 protocol.MTLCommandBuffer.methods.enqueue.unsafe = false
 protocol.MTLCommandBuffer.methods.commit.unsafe = false
 protocol.MTLCommandBuffer.methods."presentDrawable:".unsafe = false
+# protocol.MTLCommandBuffer.methods."presentDrawable:atTime:".unsafe = false
+# protocol.MTLCommandBuffer.methods."presentDrawable:afterMinimumDuration:".unsafe = false
 protocol.MTLCommandBuffer.methods.waitUntilScheduled.unsafe = false
 # TODO once blocks are better
 # protocol.MTLCommandBuffer.methods."addCompletedHandler:".unsafe = false
+protocol.MTLCommandBuffer.methods.waitUntilCompleted.unsafe = false
 protocol.MTLCommandBuffer.methods.status.unsafe = false
+protocol.MTLCommandBuffer.methods.error.unsafe = false
 protocol.MTLCommandBuffer.methods.blitCommandEncoder.unsafe = false
 protocol.MTLCommandBuffer.methods."renderCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods."computeCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods."blitCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods.computeCommandEncoder.unsafe = false
 protocol.MTLCommandBuffer.methods."computeCommandEncoderWithDispatchType:".unsafe = false
 protocol.MTLCommandBuffer.methods."encodeWaitForEvent:value:".unsafe = false
 protocol.MTLCommandBuffer.methods."encodeSignalEvent:value:".unsafe = false
 protocol.MTLCommandBuffer.methods."parallelRenderCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTLCommandBuffer.methods.resourceStateCommandEncoder.unsafe = false
+protocol.MTLCommandBuffer.methods."resourceStateCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods.accelerationStructureCommandEncoder.unsafe = false
+protocol.MTLCommandBuffer.methods."accelerationStructureCommandEncoderWithDescriptor:".unsafe = false
 protocol.MTLCommandBuffer.methods."pushDebugGroup:".unsafe = false
 protocol.MTLCommandBuffer.methods.popDebugGroup.unsafe = false
+protocol.MTLCommandBuffer.methods."useResidencySet:".unsafe = false
+# protocol.MTLCommandBuffer.methods."useResidencySets:count:".unsafe = false
 
 protocol.MTLCommandQueue.methods.label.unsafe = false
 protocol.MTLCommandQueue.methods."setLabel:".unsafe = false
 protocol.MTLCommandQueue.methods.device.unsafe = false
 protocol.MTLCommandQueue.methods.commandBuffer.unsafe = false
+protocol.MTLCommandQueue.methods."commandBufferWithDescriptor:".unsafe = false
+protocol.MTLCommandQueue.methods.commandBufferWithUnretainedReferences.unsafe = false
+protocol.MTLCommandQueue.methods."addResidencySet:".unsafe = false
+# protocol.MTLCommandQueue.methods."addResidencySets:count:".unsafe = false
+protocol.MTLCommandQueue.methods."removeResidencySet:".unsafe = false
+# protocol.MTLCommandQueue.methods."removeResidencySets:count:".unsafe = false
 
+class.MTLComputePassSampleBufferAttachmentDescriptorArray.methods.new.unsafe = false
+
+class.MTLComputePassSampleBufferAttachmentDescriptor.methods.new.unsafe = false
+class.MTLComputePassSampleBufferAttachmentDescriptor.methods.sampleBuffer.unsafe = false
+class.MTLComputePassSampleBufferAttachmentDescriptor.methods."setSampleBuffer:".unsafe = false
+class.MTLComputePassSampleBufferAttachmentDescriptor.methods.startOfEncoderSampleIndex.unsafe = false
+# setStartOfEncoderSampleIndex:
+class.MTLComputePassSampleBufferAttachmentDescriptor.methods.endOfEncoderSampleIndex.unsafe = false
+# setEndOfEncoderSampleIndex:
+
+class.MTLComputePassDescriptor.methods.new.unsafe = false
+class.MTLComputePassDescriptor.methods.computePassDescriptor.unsafe = false
+class.MTLComputePassDescriptor.methods.dispatchType.unsafe = false
+class.MTLComputePassDescriptor.methods."setDispatchType:".unsafe = false
+class.MTLComputePassDescriptor.methods.sampleBufferAttachments.unsafe = false
+
+class.MTLStencilDescriptor.methods.new.unsafe = false
 class.MTLStencilDescriptor.methods.stencilCompareFunction.unsafe = false
 class.MTLStencilDescriptor.methods."setStencilCompareFunction:".unsafe = false
 class.MTLStencilDescriptor.methods.stencilFailureOperation.unsafe = false
@@ -181,6 +258,7 @@ class.MTLStencilDescriptor.methods."setReadMask:".unsafe = false
 class.MTLStencilDescriptor.methods.writeMask.unsafe = false
 class.MTLStencilDescriptor.methods."setWriteMask:".unsafe = false
 
+class.MTLDepthStencilDescriptor.methods.new.unsafe = false
 class.MTLDepthStencilDescriptor.methods.depthCompareFunction.unsafe = false
 class.MTLDepthStencilDescriptor.methods."setDepthCompareFunction:".unsafe = false
 class.MTLDepthStencilDescriptor.methods.isDepthWriteEnabled.unsafe = false
@@ -251,14 +329,19 @@ protocol.MTLDevice.methods."newBinaryArchiveWithDescriptor:error:".unsafe = fals
 protocol.MTLDevice.methods.supportsRaytracing.unsafe = false
 protocol.MTLDevice.methods."accelerationStructureSizesWithDescriptor:".unsafe = false
 protocol.MTLDevice.methods."newAccelerationStructureWithSize:".unsafe = false
+protocol.MTLDevice.methods."newAccelerationStructureWithDescriptor:".unsafe = false
+protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:size:".unsafe = false
+protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:descriptor:".unsafe = false
 protocol.MTLDevice.methods.supportsFunctionPointers.unsafe = false
 
 protocol.MTLDrawable.methods.present.unsafe = false
 protocol.MTLDrawable.methods.drawableID.unsafe = false
 
+protocol.MTLCommandEncoder.methods.device.unsafe = false
 protocol.MTLCommandEncoder.methods.label.unsafe = false
 protocol.MTLCommandEncoder.methods."setLabel:".unsafe = false
 protocol.MTLCommandEncoder.methods.endEncoding.unsafe = false
+protocol.MTLCommandEncoder.methods."barrierAfterQueueStages:beforeStages:".unsafe = false
 protocol.MTLCommandEncoder.methods."insertDebugSignpost:".unsafe = false
 protocol.MTLCommandEncoder.methods."pushDebugGroup:".unsafe = false
 protocol.MTLCommandEncoder.methods.popDebugGroup.unsafe = false
@@ -285,15 +368,36 @@ protocol.MTLRenderCommandEncoder.methods."setDepthStencilState:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setStencilReferenceValue:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setStencilFrontReferenceValue:backReferenceValue:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."setVisibilityResultMode:offset:".unsafe = false
-# drawPrimitives:...
-# ...
+protocol.MTLRenderCommandEncoder.methods."setDepthStoreAction:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setStencilStoreAction:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setDepthStoreActionOptions:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setStencilStoreActionOptions:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."drawMeshThreadgroups:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."drawMeshThreads:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:".unsafe = false
+# drawMeshThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerObjectThreadgroup:threadsPerMeshThreadgroup:
+# drawPrimitives:vertexStart:vertexCount:instanceCount:
+# drawPrimitives:vertexStart:vertexCount:
+# drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:
+# drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:
+# drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:
+# drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:instanceCount:baseVertex:baseInstance:
+# drawPrimitives:indirectBuffer:indirectBufferOffset:
+# drawIndexedPrimitives:indexType:indexBuffer:indexBufferOffset:indirectBuffer:indirectBufferOffset:
+# textureBarrier
 protocol.MTLRenderCommandEncoder.methods."updateFence:afterStages:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."waitForFence:beforeStages:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods."setTessellationFactorScale:".unsafe = false
+protocol.MTLRenderCommandEncoder.methods.tileWidth.unsafe = false
+protocol.MTLRenderCommandEncoder.methods.tileHeight.unsafe = false
 # setThreadgroupMemoryLength:offset:atIndex:
 protocol.MTLRenderCommandEncoder.methods."useResource:usage:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useResource:usage:stages:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useHeap:".unsafe = false
 protocol.MTLRenderCommandEncoder.methods."useHeap:stages:".unsafe = false
+# executeCommandsInBuffer:withRange:
+# executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:
+protocol.MTLRenderCommandEncoder.methods."memoryBarrierWithScope:afterStages:beforeStages:".unsafe = false
+# sampleCountersInBuffer:atSampleIndex:withBarrier: is the GPU-based sample indes OOB sound?
 
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLBlitCommandEncoder.methods."synchronizeResource:".unsafe = false
@@ -305,10 +409,16 @@ protocol.MTLBlitCommandEncoder.methods."waitForFence:".unsafe = false
 protocol.MTLBlitCommandEncoder.methods."optimizeContentsForGPUAccess:".unsafe = false
 # optimizeContentsForGPUAccess:slice:level:
 
+protocol.MTLComputeCommandEncoder.methods.dispatchType.unsafe = false
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLComputeCommandEncoder.methods."setComputePipelineState:".unsafe = false
 # setBuffer:...
 # setIntersectionFunctionTable:atBufferIndex:
+# protocol.MTLComputeCommandEncoder.methods."setThreadGroupMemoryLength:atIndex:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."setImageBlockWidth:Height:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."setStageInRegion:".unsafe = false
+# TODO: OOB offset?
+protocol.MTLComputeCommandEncoder.methods."setStageInRegionWithIndirectBuffer:indirectBufferOffset:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."dispatchThreadgroups:threadsPerThreadgroup:".unsafe = false
 # dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup:
 protocol.MTLComputeCommandEncoder.methods."dispatchThreads:threadsPerThreadgroup:".unsafe = false
@@ -316,6 +426,11 @@ protocol.MTLComputeCommandEncoder.methods."updateFence:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."waitForFence:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."useResource:usage:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."useHeap:".unsafe = false
+# TODO: GPU-side range?
+# protocol.MTLComputeCommandEncoder.methods."executeCommandsInBuffer:withRange:".unsafe = false
+# protocol.MTLComputeCommandEncoder.methods."executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:".unsafe = false
+protocol.MTLComputeCommandEncoder.methods."memoryBarrierWithScope:".unsafe = false
+# sampleCountersInBuffer:atSampleIndex:withBarrier: is the GPU-based sample indes OOB sound?
 
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLArgumentEncoder.methods.encodedLength.unsafe = false
@@ -352,8 +467,12 @@ protocol.MTLHeap.methods."newTextureWithDescriptor:".unsafe = false
 protocol.MTLHeap.methods."setPurgeableState:".unsafe = false
 # TODO: type
 # TODO: Verify that offset out-of-bounds is sound.
-# newBufferWithLength:options:offset:
-# newTextureWithDescriptor:offset:
+protocol.MTLHeap.methods."newBufferWithLength:options:offset:".unsafe = false
+protocol.MTLHeap.methods."newTextureWithDescriptor:offset:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithSize:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithSize:offset:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithDescriptor:".unsafe = false
+protocol.MTLHeap.methods."newAccelerationStructureWithDescriptor:offset:".unsafe = false
 
 class.MTLIndirectCommandBufferDescriptor.methods.commandTypes.unsafe = false
 class.MTLIndirectCommandBufferDescriptor.methods."setCommandTypes:".unsafe = false
@@ -483,6 +602,7 @@ class.MTLLinkedFunctions.methods."setGroups:".unsafe = false
 class.MTLLinkedFunctions.methods.privateFunctions.unsafe = false
 class.MTLLinkedFunctions.methods."setPrivateFunctions:".unsafe = false
 
+class.MTLRenderPassAttachmentDescriptor.methods.new.unsafe = false
 class.MTLRenderPassAttachmentDescriptor.methods.texture.unsafe = false
 class.MTLRenderPassAttachmentDescriptor.methods."setTexture:".unsafe = false
 class.MTLRenderPassAttachmentDescriptor.methods.level.unsafe = false
@@ -506,21 +626,28 @@ class.MTLRenderPassAttachmentDescriptor.methods."setStoreAction:".unsafe = false
 class.MTLRenderPassAttachmentDescriptor.methods.storeActionOptions.unsafe = false
 class.MTLRenderPassAttachmentDescriptor.methods."setStoreActionOptions:".unsafe = false
 
-class.MTLRenderPassColorAttachmentDescriptor.methods.init.unsafe = false
+class.MTLRenderPassColorAttachmentDescriptorArray.methods.new.unsafe = false
+
+class.MTLRenderPassColorAttachmentDescriptor.methods.init.unsafe = false # init safe?
 class.MTLRenderPassColorAttachmentDescriptor.methods.new.unsafe = false
 class.MTLRenderPassColorAttachmentDescriptor.methods.clearColor.unsafe = false
 class.MTLRenderPassColorAttachmentDescriptor.methods."setClearColor:".unsafe = false
+class.MTLRenderPassDepthAttachmentDescriptor.methods.new.unsafe = false
 class.MTLRenderPassDepthAttachmentDescriptor.methods.clearDepth.unsafe = false
 class.MTLRenderPassDepthAttachmentDescriptor.methods."setClearDepth:".unsafe = false
 class.MTLRenderPassDepthAttachmentDescriptor.methods.depthResolveFilter.unsafe = false
 class.MTLRenderPassDepthAttachmentDescriptor.methods."setDepthResolveFilter:".unsafe = false
 
+class.MTLRenderPassStencilAttachmentDescriptor.methods.new.unsafe = false
 class.MTLRenderPassStencilAttachmentDescriptor.methods.clearStencil.unsafe = false
 class.MTLRenderPassStencilAttachmentDescriptor.methods."setClearStencil:".unsafe = false
 class.MTLRenderPassStencilAttachmentDescriptor.methods.stencilResolveFilter.unsafe = false
 class.MTLRenderPassStencilAttachmentDescriptor.methods."setStencilResolveFilter:".unsafe = false
 
+class.MTLRenderPassSampleBufferAttachmentDescriptorArray.methods.new.unsafe = false
+
 # TODO: Verify that index out-of-bounds is sound.
+class.MTLRenderPassSampleBufferAttachmentDescriptor.methods.new.unsafe = false
 class.MTLRenderPassSampleBufferAttachmentDescriptor.methods.sampleBuffer.unsafe = false
 class.MTLRenderPassSampleBufferAttachmentDescriptor.methods."setSampleBuffer:".unsafe = false
 class.MTLRenderPassSampleBufferAttachmentDescriptor.methods.startOfVertexSampleIndex.unsafe = false
@@ -532,7 +659,22 @@ class.MTLRenderPassSampleBufferAttachmentDescriptor.methods.startOfFragmentSampl
 class.MTLRenderPassSampleBufferAttachmentDescriptor.methods.endOfFragmentSampleIndex.unsafe = false
 # setEndOfFragmentSampleIndex:
 
+class.MTLBlitPassSampleBufferAttachmentDescriptor.methods.new.unsafe = false
+class.MTLBlitPassSampleBufferAttachmentDescriptor.methods.sampleBuffer.unsafe = false
+class.MTLBlitPassSampleBufferAttachmentDescriptor.methods."setSampleBuffer:".unsafe = false
+class.MTLBlitPassSampleBufferAttachmentDescriptor.methods.startOfEncoderSampleIndex.unsafe = false
+# class.MTLBlitPassSampleBufferAttachmentDescriptor.methods."setStartOfEncoderSampleIndex:".unsafe = false
+class.MTLBlitPassSampleBufferAttachmentDescriptor.methods.endOfEncoderSampleIndex.unsafe = false
+# class.MTLBlitPassSampleBufferAttachmentDescriptor.methods."setEndOfEncoderSampleIndex:".unsafe = false
+
+class.MTLBlitPassSampleBufferAttachmentDescriptorArray.methods.new.unsafe = false
+
+class.MTLBlitPassDescriptor.methods.new.unsafe = false
+class.MTLBlitPassDescriptor.methods.blitPassDescriptor.unsafe = false
+class.MTLBlitPassDescriptor.methods.sampleBufferAttachments.unsafe = false
+
 # TODO: Verify that index out-of-bounds is sound.
+class.MTLRenderPassDescriptor.methods.new.unsafe = false
 class.MTLRenderPassDescriptor.methods.renderPassDescriptor.unsafe = false
 class.MTLRenderPassDescriptor.methods.colorAttachments.unsafe = false
 class.MTLRenderPassDescriptor.methods.depthAttachment.unsafe = false
@@ -560,6 +702,26 @@ class.MTLRenderPassDescriptor.methods."setRenderTargetHeight:".unsafe = false
 class.MTLRenderPassDescriptor.methods.rasterizationRateMap.unsafe = false
 class.MTLRenderPassDescriptor.methods."setRasterizationRateMap:".unsafe = false
 class.MTLRenderPassDescriptor.methods.sampleBufferAttachments.unsafe = false
+
+class.MTLResidencySetDescriptor.methods.new.unsafe = false
+class.MTLResidencySetDescriptor.methods.label.unsafe = false
+class.MTLResidencySetDescriptor.methods."setLabel:".unsafe = false
+class.MTLResidencySetDescriptor.methods.initialCapacity.unsafe = false
+class.MTLResidencySetDescriptor.methods."setInitialCapacity:".unsafe = false
+
+protocol.MTLResidencySet.methods.device.unsafe = false
+protocol.MTLResidencySet.methods.label.unsafe = false
+protocol.MTLResidencySet.methods."setLabel:".unsafe = false
+protocol.MTLResidencySet.methods.allocatedSize.unsafe = false
+protocol.MTLResidencySet.methods.requestResidency.unsafe = false
+protocol.MTLResidencySet.methods.endResidency.unsafe = false
+protocol.MTLResidencySet.methods."addAllocation:".unsafe = false
+protocol.MTLResidencySet.methods."removeAllocation:".unsafe = false
+protocol.MTLResidencySet.methods.removeAllAllocations.unsafe = false
+protocol.MTLResidencySet.methods."containsAllocation:".unsafe = false
+protocol.MTLResidencySet.methods.allAllocations.unsafe = false
+protocol.MTLResidencySet.methods.allocationCount.unsafe = false
+protocol.MTLResidencySet.methods.commit.unsafe = false
 
 protocol.MTLResource.methods.label.unsafe = false
 protocol.MTLResource.methods."setLabel:".unsafe = false

--- a/framework-crates/objc2-metal/translation-config.toml
+++ b/framework-crates/objc2-metal/translation-config.toml
@@ -40,6 +40,8 @@ fn.MTLCopyAllDevices.unsafe = false
 
 class.MTLAllocation.methods.allocatedSize.unsafe = false
 
+# class.MTL4AccelerationStructureDescriptor.methods.new.unsafe = false
+
 class.MTLPrimitiveAccelerationStructureDescriptor.methods.descriptor.unsafe = false
 class.MTLPrimitiveAccelerationStructureDescriptor.methods."setGeometryDescriptors:".unsafe = false
 
@@ -55,14 +57,20 @@ class.MTLAccelerationStructureTriangleGeometryDescriptor.methods."setVertexBuffe
 class.MTLAccelerationStructureTriangleGeometryDescriptor.methods."setVertexStride:".unsafe = false
 class.MTLAccelerationStructureTriangleGeometryDescriptor.methods."setTriangleCount:".unsafe = false
 
+class.MTL4AccelerationStructureTriangleGeometryDescriptor.methods.new.unsafe = false
+
 class.MTLAccelerationStructureBoundingBoxGeometryDescriptor.methods.descriptor.unsafe = false
 class.MTLAccelerationStructureBoundingBoxGeometryDescriptor.methods."setBoundingBoxBuffer:".unsafe = false
 class.MTLAccelerationStructureBoundingBoxGeometryDescriptor.methods."setBoundingBoxCount:".unsafe = false
+
+class.MTL4AccelerationStructureBoundingBoxGeometryDescriptor.methods.new.unsafe = false
 
 class.MTLInstanceAccelerationStructureDescriptor.methods.descriptor.unsafe = false
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstancedAccelerationStructures:".unsafe = false
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceCount:".unsafe = false
 class.MTLInstanceAccelerationStructureDescriptor.methods."setInstanceDescriptorBuffer:".unsafe = false
+
+class.MTL4InstanceAccelerationStructureDescriptor.methods.new.unsafe = false
 
 class.MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray.methods.new.unsafe = false
 
@@ -217,6 +225,39 @@ protocol.MTLCommandBuffer.methods.popDebugGroup.unsafe = false
 protocol.MTLCommandBuffer.methods."useResidencySet:".unsafe = false
 # protocol.MTLCommandBuffer.methods."useResidencySets:count:".unsafe = false
 
+class.MTL4CommandBufferOptions.methods.logState.unsafe = false
+class.MTL4CommandBufferOptions.methods."setLogState:".unsafe = false
+
+protocol.MTL4CommandBuffer.methods.device.unsafe = false
+protocol.MTL4CommandBuffer.methods.label.unsafe = false
+protocol.MTL4CommandBuffer.methods."setLabel:".unsafe = false
+# protocol.MTL4CommandBuffer.methods.enqueue.unsafe = false
+# protocol.MTL4CommandBuffer.methods.commit.unsafe = false
+protocol.MTL4CommandBuffer.methods."beginCommandBufferWithAllocator:".unsafe = false
+protocol.MTL4CommandBuffer.methods."beginCommandBufferWithAllocator:options:".unsafe = false
+protocol.MTL4CommandBuffer.methods.endCommandBuffer.unsafe = false
+# protocol.MTL4CommandBuffer.methods."presentDrawable:".unsafe = false
+# protocol.MTL4CommandBuffer.methods.waitUntilScheduled.unsafe = false
+# # TODO once blocks are better
+# # protocol.MTL4CommandBuffer.methods."addCompletedHandler:".unsafe = false
+# protocol.MTL4CommandBuffer.methods.status.unsafe = false
+# protocol.MTL4CommandBuffer.methods.blitCommandEncoder.unsafe = false
+protocol.MTL4CommandBuffer.methods."renderCommandEncoderWithDescriptor:".unsafe = false
+protocol.MTL4CommandBuffer.methods."renderCommandEncoderWithDescriptor:options:".unsafe = false
+protocol.MTL4CommandBuffer.methods.computeCommandEncoder.unsafe = false
+protocol.MTL4CommandBuffer.methods.machineLearningCommandEncoder.unsafe = false
+# protocol.MTL4CommandBuffer.methods."computeCommandEncoderWithDispatchType:".unsafe = false
+# protocol.MTL4CommandBuffer.methods."encodeWaitForEvent:value:".unsafe = false
+# protocol.MTL4CommandBuffer.methods."encodeSignalEvent:value:".unsafe = false
+# protocol.MTL4CommandBuffer.methods."parallelRenderCommandEncoderWithDescriptor:".unsafe = false
+# protocol.MTL4CommandBuffer.methods.accelerationStructureCommandEncoder.unsafe = false
+protocol.MTL4CommandBuffer.methods."useResidencySet:".unsafe = false
+# protocol.MTL4CommandBuffer.methods."useResidencySets:count:".unsafe = false
+protocol.MTL4CommandBuffer.methods."pushDebugGroup:".unsafe = false
+protocol.MTL4CommandBuffer.methods.popDebugGroup.unsafe = false
+protocol.MTL4CommandBuffer.methods."writeTimestampIntoHeap:atIndex:".unsafe = false
+protocol.MTL4CommandBuffer.methods."resolveCounterHeap:withRange:intoBuffer:waitFence:updateFence:".unsafe = false
+
 protocol.MTLCommandQueue.methods.label.unsafe = false
 protocol.MTLCommandQueue.methods."setLabel:".unsafe = false
 protocol.MTLCommandQueue.methods.device.unsafe = false
@@ -245,6 +286,40 @@ class.MTLComputePassDescriptor.methods."setDispatchType:".unsafe = false
 class.MTLComputePassDescriptor.methods.sampleBufferAttachments.unsafe = false
 
 class.MTLStencilDescriptor.methods.new.unsafe = false
+
+# Probably also pending block improvements?
+# class.MTL4CommitOptions.methods."addFeedbackHandler:".unsafe = false
+
+class.MTL4CommitOptions.methods.new.unsafe = false
+
+class.MTL4CommandQueueDescriptor.methods.new.unsafe = false
+class.MTL4CommandQueueDescriptor.methods.label.unsafe = false
+class.MTL4CommandQueueDescriptor.methods."setLabel:".unsafe = false
+class.MTL4CommandQueueDescriptor.methods."feedbackQueue".unsafe = false
+class.MTL4CommandQueueDescriptor.methods."setFeedbackQueue:".unsafe = false
+
+protocol.MTL4CommandQueue.methods.device.unsafe = false
+protocol.MTL4CommandQueue.methods.label.unsafe = false
+# protocol.MTL4CommandQueue.methods."commit:count:".unsafe = false
+# protocol.MTL4CommandQueue.methods."commit:count:options:".unsafe = false
+protocol.MTL4CommandQueue.methods."signalEvent:value:".unsafe = false
+protocol.MTL4CommandQueue.methods."waitForEvent:value:".unsafe = false
+protocol.MTL4CommandQueue.methods."signalDrawable:".unsafe = false
+protocol.MTL4CommandQueue.methods."waitForDrawable:".unsafe = false
+protocol.MTL4CommandQueue.methods."addResidencySet:".unsafe = false
+# protocol.MTL4CommandQueue.methods."addResidencySets:count:".unsafe = false
+protocol.MTL4CommandQueue.methods."removeResidencySet:".unsafe = false
+# protocol.MTL4CommandQueue.methods."removeResidencySets:count:".unsafe = false
+
+class.MTL4CommandAllocatorDescriptor.methods.new.unsafe = false
+class.MTL4CommandAllocatorDescriptor.methods.label.unsafe = false
+class.MTL4CommandAllocatorDescriptor.methods."setLabel:".unsafe = false
+
+protocol.MTL4CommandAllocator.methods.device.unsafe = false
+protocol.MTL4CommandAllocator.methods.label.unsafe = false
+protocol.MTL4CommandAllocator.methods.allocatedSize.unsafe = false
+protocol.MTL4CommandAllocator.methods.reset.unsafe = false
+
 class.MTLStencilDescriptor.methods.stencilCompareFunction.unsafe = false
 class.MTLStencilDescriptor.methods."setStencilCompareFunction:".unsafe = false
 class.MTLStencilDescriptor.methods.stencilFailureOperation.unsafe = false
@@ -273,6 +348,7 @@ class.MTLDepthStencilDescriptor.methods."setLabel:".unsafe = false
 protocol.MTLDepthStencilState.methods.label.unsafe = false
 protocol.MTLDepthStencilState.methods.device.unsafe = false
 
+# TODO: This is not sorted with respect to the file...
 protocol.MTLDevice.methods.name.unsafe = false
 protocol.MTLDevice.methods.registryID.unsafe = false
 protocol.MTLDevice.methods.maxThreadsPerThreadgroup.unsafe = false
@@ -334,6 +410,22 @@ protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:size:".unsafe 
 protocol.MTLDevice.methods."heapAccelerationStructureSizeAndAlign:descriptor:".unsafe = false
 protocol.MTLDevice.methods.supportsFunctionPointers.unsafe = false
 
+protocol.MTLDevice.methods.newCommandAllocator.unsafe = false
+protocol.MTLDevice.methods."newCommandAllocatorWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods.newMTL4CommandQueue.unsafe = false
+protocol.MTLDevice.methods."newMTL4CommandQueueWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods.newCommandBuffer.unsafe = false
+protocol.MTLDevice.methods."newArgumentTableWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods."newTextureViewPoolWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods."newCompilerWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods."newArchiveWithURL:error:".unsafe = false
+protocol.MTLDevice.methods."newPipelineDataSetSerializerWithDescriptor:".unsafe = false
+protocol.MTLDevice.methods."newBufferWithLength:options:placementSparsePageSize:".unsafe = false
+protocol.MTLDevice.methods."newCounterHeapWithDescriptor:error:".unsafe = false
+protocol.MTLDevice.methods."sizeOfCounterHeapEntry:".unsafe = false
+protocol.MTLDevice.methods.queryTimestampFrequency.unsafe = false
+protocol.MTLDevice.methods."functionHandleWithBinaryFunction:".unsafe = false
+
 protocol.MTLDrawable.methods.present.unsafe = false
 protocol.MTLDrawable.methods.drawableID.unsafe = false
 
@@ -346,7 +438,50 @@ protocol.MTLCommandEncoder.methods."insertDebugSignpost:".unsafe = false
 protocol.MTLCommandEncoder.methods."pushDebugGroup:".unsafe = false
 protocol.MTLCommandEncoder.methods.popDebugGroup.unsafe = false
 
+protocol.MTL4CommandEncoder.methods.label.unsafe = false
+protocol.MTL4CommandEncoder.methods."setLabel:".unsafe = false
+protocol.MTL4CommandEncoder.methods.commandBuffer.unsafe = false
+protocol.MTL4CommandEncoder.methods."barrierAfterQueueStages:beforeStages:visibilityOptions:".unsafe = false
+protocol.MTL4CommandEncoder.methods."barrierAfterStages:beforeQueueStages:visibilityOptions:".unsafe = false
+protocol.MTL4CommandEncoder.methods."barrierAfterEncoderStages:beforeEncoderStages:visibilityOptions:".unsafe = false
+protocol.MTL4CommandEncoder.methods."updateFence:afterEncoderStages:".unsafe = false
+protocol.MTL4CommandEncoder.methods."waitForFence:beforeEncoderStages:".unsafe = false
+protocol.MTL4CommandEncoder.methods."insertDebugSignpost:".unsafe = false
+protocol.MTL4CommandEncoder.methods."pushDebugGroup:".unsafe = false
+protocol.MTL4CommandEncoder.methods.popDebugGroup.unsafe = false
+protocol.MTL4CommandEncoder.methods.endEncoding.unsafe = false
+
 protocol.MTLParallelRenderCommandEncoder.methods.renderCommandEncoder.unsafe = false
+
+protocol.MTL4RenderCommandEncoder.methods.tileWidth.unsafe = false
+protocol.MTL4RenderCommandEncoder.methods.tileHeight.unsafe = false
+# protocol.MTL4RenderCommandEncoder.methods."setColorAttachmentMap:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setRenderPipelineState:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setViewport:".unsafe = false
+# protocol.MTL4RenderCommandEncoder.methods."setViewports:count:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setCullMode:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setDepthClipMode:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setDepthBias:slopeScale:clamp:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setScissorRect:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setTriangleFillMode:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setBlendColorRed:green:blue:alpha:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setDepthStencilState:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setStencilReferenceValue:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setStencilFrontReferenceValue:backReferenceValue:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setVisibilityResultMode:offset:".unsafe = false
+# TODO: Index OOB for setColorStoreAction
+protocol.MTL4RenderCommandEncoder.methods."setDepthStoreAction:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setStencilStoreAction:".unsafe = false
+# drawPrimitives:, drawIndexedPrimitives: ...
+# executeCommandsInBuffer:withRange: (the indirectRangeBuffer: variant is definitely unsafe)
+# TODO: Retype indirectRangeBuffer: from u64 to GPU ptr type?
+# drawMesh...:,
+# TODO: What if going out of tileWidth/tileHeight bounds?
+# protocol.MTL4RenderCommandEncoder.methods."dispatchThreadsPerTile:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setArgumentTable:atStages:".unsafe = false
+protocol.MTL4RenderCommandEncoder.methods."setFrontFacingWinding:".unsafe = false
+# TODO: Test what happens if this GPU index is out of bounds?
+# protocol.MTL4RenderCommandEncoder.methods."writeTimestampWithGranularity:afterStage:intoHeap:atIndex:".unsafe = false
 
 # TODO: Verify that offset out-of-bounds is sound.
 # TODO: Verify that index out-of-bounds is sound.
@@ -431,6 +566,41 @@ protocol.MTLComputeCommandEncoder.methods."useHeap:".unsafe = false
 # protocol.MTLComputeCommandEncoder.methods."executeCommandsInBuffer:indirectBuffer:indirectBufferOffset:".unsafe = false
 protocol.MTLComputeCommandEncoder.methods."memoryBarrierWithScope:".unsafe = false
 # sampleCountersInBuffer:atSampleIndex:withBarrier: is the GPU-based sample indes OOB sound?
+
+protocol.MTL4ComputeCommandEncoder.methods.stages.unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."setComputePipelineState:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."setImageBlockWidth:Height:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."dispatchThreads:threadsPerThreadgroup:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."dispatchThreadgroups:threadsPerThreadgroup:".unsafe = false
+# dispatchThreadgroupsWithIndirectBuffer:threadsPerThreadgroup:
+# dispatchThreadsWithIndirectBuffer:
+protocol.MTL4ComputeCommandEncoder.methods."executeCommandsInBuffer:withRange:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."executeCommandsInBuffer:indirectBuffer:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromTexture:toTexture:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromTexture:sourceSlice:sourceLevel:toTexture:destinationSlice:destinationLevel:sliceCount:levelCount:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toBuffer:destinationOffset:destinationBytesPerRow:destinationBytesPerImage:options:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:options:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyFromTensor:sourceOrigin:sourceDimensions:toTensor:destinationOrigin:destinationDimensions:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."generateMipmapsForTexture:".unsafe = false
+# TODO: Bounds?
+# protocol.MTL4ComputeCommandEncoder.methods."fillBuffer:range:value:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."optimizeContentsForGPUAccess:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."optimizeContentsForGPUAccess:slice:level:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."optimizeContentsForCPUAccess:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."optimizeContentsForCPUAccess:slice:level:".unsafe = false
+# protocol.MTL4ComputeCommandEncoder.methods."resetCommandsInBuffer:withRange:".unsafe = false
+# protocol.MTL4ComputeCommandEncoder.methods."copyIndirectCommandBuffer:sourceRange:destination:destinationIndex:".unsafe = false
+# protocol.MTL4ComputeCommandEncoder.methods."optimizeIndirectCommandBuffer:withRange:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."setArgumentTable:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."buildAccelerationStructure:descriptor:scratchBuffer:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."refitAccelerationStructure:descriptor:destination:scratchBuffer:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."refitAccelerationStructure:descriptor:destination:scratchBuffer:options:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyAccelerationStructure:toAccelerationStructure:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."writeCompactedAccelerationStructureSize:toBuffer:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."copyAndCompactAccelerationStructure:toAccelerationStructure:".unsafe = false
+protocol.MTL4ComputeCommandEncoder.methods."writeTimestampWithGranularity:intoHeap:atIndex:".unsafe = false
 
 # TODO: Verify out-of-bounds access is sound.
 protocol.MTLArgumentEncoder.methods.encodedLength.unsafe = false
@@ -703,6 +873,36 @@ class.MTLRenderPassDescriptor.methods.rasterizationRateMap.unsafe = false
 class.MTLRenderPassDescriptor.methods."setRasterizationRateMap:".unsafe = false
 class.MTLRenderPassDescriptor.methods.sampleBufferAttachments.unsafe = false
 
+class.MTL4RenderPassDescriptor.methods.colorAttachments.unsafe = false
+class.MTL4RenderPassDescriptor.methods.depthAttachment.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setDepthAttachment:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.stencilAttachment.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setStencilAttachment:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.renderTargetArrayLength.unsafe = false
+# setRenderTargetArrayLength:
+class.MTL4RenderPassDescriptor.methods.imageblockSampleLength.unsafe = false
+# setImageblockSampleLength:
+class.MTL4RenderPassDescriptor.methods.threadgroupMemoryLength.unsafe = false
+# setThreadgroupMemoryLength:
+class.MTL4RenderPassDescriptor.methods.tileWidth.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setTileWidth:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.tileHeight.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setTileHeight:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.defaultRasterSampleCount.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setDefaultRasterSampleCount:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.renderTargetWidth.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setRenderTargetWidth:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.renderTargetHeight.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setRenderTargetHeight:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.rasterizationRateMap.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setRasterizationRateMap:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.visibilityResultBuffer.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setVisibilityResultBuffer:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.visibilityResultType.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setVisibilityResultType:".unsafe = false
+class.MTL4RenderPassDescriptor.methods.supportColorAttachmentMapping.unsafe = false
+class.MTL4RenderPassDescriptor.methods."setSupportColorAttachmentMapping:".unsafe = false
+
 class.MTLResidencySetDescriptor.methods.new.unsafe = false
 class.MTLResidencySetDescriptor.methods.label.unsafe = false
 class.MTLResidencySetDescriptor.methods."setLabel:".unsafe = false
@@ -862,6 +1062,29 @@ class.MTLBufferLayoutDescriptor.methods.stepFunction.unsafe = false
 class.MTLBufferLayoutDescriptor.methods."setStepFunction:".unsafe = false
 class.MTLBufferLayoutDescriptor.methods.stepRate.unsafe = false
 class.MTLBufferLayoutDescriptor.methods."setStepRate:".unsafe = false
+
+class.MTL4ArgumentTableDescriptor.methods.maxBufferBindCount.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setMaxBufferBindCount:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.maxTextureBindCount.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setMaxTextureBindCount:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.maxSamplerStateBindCount.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setMaxSamplerStateBindCount:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.initializeBindings.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setInitializeBindings:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.supportAttributeStrides.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setSupportAttributeStrides:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.label.unsafe = false
+class.MTL4ArgumentTableDescriptor.methods."setLabel:".unsafe = false
+class.MTL4ArgumentTableDescriptor.methods.new.unsafe = false
+
+# TODO: Buffer index out of bounds? GPU address invalid?
+protocol.MTL4ArgumentTable.methods."setAddress:atIndex:".unsafe = false
+protocol.MTL4ArgumentTable.methods."setAddress:attributeStride:atIndex:".unsafe = false
+protocol.MTL4ArgumentTable.methods."setResource:atBufferIndex:".unsafe = false
+protocol.MTL4ArgumentTable.methods."setTexture:atIndex:".unsafe = false
+protocol.MTL4ArgumentTable.methods."setSamplerState:atIndex:".unsafe = false
+protocol.MTL4ArgumentTable.methods.device.unsafe = false
+protocol.MTL4ArgumentTable.methods.label.unsafe = false
 
 class.MTLAttributeDescriptor.methods.format.unsafe = false
 class.MTLAttributeDescriptor.methods."setFormat:".unsafe = false


### PR DESCRIPTION
Targets #762 (probably postponing this until that's merged)
Depends on #772, #773

See #773 for more details. We should resolve things there first before considering this PR, but I'm opening it already for completeness (and because it's very useful in my daily work on Metal 4) nevertheless.

---

The new `MTL4` types inherit a lot of functions from older Metal versions that need to be annotated to not be unsafe, so that they can be more trivially called.