### PR TITLE
Fix reference counting in `DispatchSemaphoreGuard::release`

### DIFF
--- a/crates/dispatch2/CHANGELOG.md
+++ b/crates/dispatch2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased - YYYY-MM-DD
 
+### Fixed
+- Fixed reference counting in `DispatchSemaphoreGuard::release`.
+
 
 ## [0.3.0] - 2025-04-19
 [0.3.0]: https://github.com/madsmtm/objc2/compare/dispatch2-0.2.0...dispatch2-0.3.0


### PR DESCRIPTION
The `ManuallyDrop` was suppressing both the drop of the guard (as intended, to avoid double-signalling) and the drop of the `DispatchRetained` (not intended).