### PR TITLE
Use documentation from Apple's documentation bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,7 @@ dependencies = [
 name = "header-translator"
 version = "0.1.0"
 dependencies = [
+ "apple-doc",
  "apple-sdk",
  "clang",
  "clang-sys",

--- a/crates/apple-doc/src/fs_json.rs
+++ b/crates/apple-doc/src/fs_json.rs
@@ -206,10 +206,24 @@ pub enum Reference {
 #[serde(deny_unknown_fields)]
 pub struct ReferenceVariant {
     pub url: String,
-    pub traits: Vec<String>,
+    pub traits: Vec<ReferenceVariantTrait>,
 
     #[serde(rename = "svgID")]
     pub svg_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub enum ReferenceVariantTrait {
+    #[serde(rename = "1x")]
+    X1,
+    #[serde(rename = "2x")]
+    X2,
+    #[serde(rename = "3x")]
+    X3,
+    #[serde(rename = "dark")]
+    Dark,
+    #[serde(rename = "light")]
+    Light,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]

--- a/crates/header-translator/Cargo.toml
+++ b/crates/header-translator/Cargo.toml
@@ -28,6 +28,7 @@ four-char-code = "2.3.0"
 regex = "1.6"
 clap = { version = "4.5.31", features = ["derive"] }
 itertools = "0.14.0"
+apple-doc = { path = "../apple-doc" }
 
 [package.metadata.release]
 release = false

--- a/crates/header-translator/src/config.rs
+++ b/crates/header-translator/src/config.rs
@@ -487,11 +487,11 @@ impl LibraryConfig {
         let allowed_in = self.class_data.values();
         for data in all.clone().filter(filter_ptr(allowed_in)) {
             assert_eq!(data.derives, Default::default());
-            assert_eq!(data.definition_skipped, Default::default());
+            assert_eq!(data.definition_skipped, false);
             assert_eq!(data.categories, Default::default());
             assert_eq!(data.counterpart, Default::default());
             assert_eq!(data.skipped_protocols, Default::default());
-            assert_eq!(data.main_thread_only, Default::default());
+            assert_eq!(data.main_thread_only, false);
             assert_eq!(data.bridged_to, Default::default());
         }
 
@@ -507,7 +507,7 @@ impl LibraryConfig {
 
         let allowed_in = self.fns.values();
         for data in all.clone().filter(filter_ptr(allowed_in)) {
-            assert_eq!(data.no_implementor, Default::default());
+            assert_eq!(data.no_implementor, false);
             assert_eq!(data.implementor, Default::default());
             assert_eq!(data.arguments, Default::default());
             assert_eq!(data.return_, Default::default());

--- a/crates/header-translator/src/context.rs
+++ b/crates/header-translator/src/context.rs
@@ -5,6 +5,7 @@ use clang::Entity;
 use proc_macro2::TokenStream;
 
 use crate::config::Config;
+use crate::documentation::DocState;
 use crate::expr::Expr;
 use crate::unexposed_attr::{get_argument_tokens, parse_macro_arguments};
 use crate::ItemIdentifier;
@@ -77,15 +78,24 @@ pub struct Context<'config> {
     pub macro_invocations: HashMap<MacroLocation, MacroEntity>,
     pub ident_mapping: HashMap<String, Expr>,
     pub current_library: &'config str,
+    pub current_library_title: &'config str,
+    pub doc: &'config DocState<'config>,
 }
 
 impl<'config> Context<'config> {
-    pub fn new(config: &'config Config, current_library: &'config str) -> Self {
+    pub fn new(
+        config: &'config Config,
+        current_library: &'config str,
+        current_library_title: &'config str,
+        doc: &'config DocState<'config>,
+    ) -> Self {
         Self {
             config,
             macro_invocations: Default::default(),
             ident_mapping: Default::default(),
             current_library,
+            current_library_title,
+            doc,
         }
     }
 }

--- a/crates/header-translator/src/documentation.rs
+++ b/crates/header-translator/src/documentation.rs
@@ -146,13 +146,14 @@ impl Documentation {
             EntityKind::UnionDecl => Some(Kind::Union),
             EntityKind::EnumDecl => Some(Kind::Enum),
             EntityKind::VarDecl => Some(Kind::GlobalVariable),
-            EntityKind::FunctionDecl => None, // TODO Function
+            EntityKind::FunctionDecl => Some(Kind::Function),
             EntityKind::ObjCInstanceMethodDecl => None, // TODO
-            EntityKind::ObjCPropertyDecl => None, // TODO
-            EntityKind::ObjCClassMethodDecl => None, // TODO
+            EntityKind::ObjCPropertyDecl => None,       // TODO
+            EntityKind::ObjCClassMethodDecl => None,    // TODO
             EntityKind::EnumConstantDecl => Some(Kind::EnumCase),
-            EntityKind::FieldDecl => None,       // TODO
-            EntityKind::MacroDefinition => None, // TODO
+            EntityKind::FieldDecl => None,                    // TODO
+            EntityKind::MacroDefinition => Some(Kind::Macro), // TODO
+            EntityKind::UnexposedDecl => None,
             _ => {
                 warn!(?entity, "unknown entity being documented");
                 None

--- a/crates/header-translator/src/documentation.rs
+++ b/crates/header-translator/src/documentation.rs
@@ -2,7 +2,10 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::{self, Write as _};
 
-use apple_doc::{BlobStore, Doc, Kind, SqliteDb};
+use apple_doc::{
+    BlobStore, Content, Doc, DocKind, Kind, PrimaryContentSection, Reference, ReferenceVariant,
+    ReferenceVariantTrait, SqliteDb,
+};
 use clang::documentation::{
     BlockCommand, CommentChild, HtmlStartTag, InlineCommand, InlineCommandStyle, ParamCommand,
     TParamCommand,
@@ -193,6 +196,12 @@ impl Documentation {
 
     pub fn fmt<'a>(&'a self) -> impl fmt::Display + 'a {
         FormatterFn(move |f| {
+            let apple = if let Some(apple) = &self.apple {
+                format!("{}", apple_to_md(apple))
+            } else {
+                String::new()
+            };
+
             let mut from_header = String::new();
 
             for child in &self.from_header {
@@ -200,39 +209,21 @@ impl Documentation {
             }
 
             let from_header = fix_code_blocks(&from_header).trim().replace("\t", "    ");
-            let from_header = if from_header.is_empty() {
+
+            let content = if apple.is_empty() && from_header.is_empty() {
                 None
+            } else if apple == from_header {
+                // TODO: Merge these instead, by comparing nodes
+                Some(apple)
             } else {
-                Some(from_header.to_string())
+                Some(format!("{apple}{from_header}"))
             };
 
-            // Generate a markdown link to Apple's documentation.
-            let mut first = None;
-            let mut last = None;
-            if let Some(doc) = &self.apple {
-                // Output the URL only if we know the true one.
-                let url_path = doc
-                    .identifier
-                    .url
-                    .strip_prefix("doc://com.apple.documentation")
-                    .unwrap();
-                let doc_link = format_args!("https://developer.apple.com{url_path}?language=objc");
-                if from_header.is_none() && self.first.is_none() {
-                    // If there is no documentation, put this as the primary
-                    // docs. This looks better in rustdoc.
-                    first = Some(format!("[Apple's documentation]({doc_link})"));
-                } else {
-                    // Otherwise, put it at the very end.
-                    last = Some(format!("See also [Apple's documentation]({doc_link})"));
-                }
-            }
-
-            let groups = first
+            let groups = self
+                .first
                 .iter()
-                .chain(self.first.iter())
-                .chain(from_header.iter())
-                .chain(self.extras.iter())
-                .chain(last.iter());
+                .chain(content.iter())
+                .chain(self.extras.iter());
 
             for (i, group) in groups.enumerate() {
                 if i != 0 {
@@ -442,6 +433,360 @@ fn format_child(child: &CommentChild) -> impl fmt::Display + '_ {
 
         Ok(())
     })
+}
+
+/// Format Apple's documentation as markdown link.
+fn apple_to_md(doc: &Doc) -> impl fmt::Display + '_ {
+    FormatterFn(move |f| match &doc.kind {
+        DocKind::Symbol(page) => {
+            if !page.abstract_.is_empty() {
+                writeln!(f, "{}", contents_to_md(doc, &page.abstract_))?;
+            }
+
+            for section in &doc.sections {
+                match section {
+                    _ => {
+                        write!(f, "SECTION: {section:?}")?;
+                    }
+                }
+            }
+
+            for section in &page.primary_content_sections {
+                match section {
+                    PrimaryContentSection::Declarations { .. } => {}
+                    PrimaryContentSection::Mentions { .. } => {}
+                    PrimaryContentSection::Content { content } => {
+                        writeln!(f)?;
+                        writeln!(f, "{}", contents_to_md(doc, content))?;
+                    }
+                    PrimaryContentSection::Parameters { parameters } => {
+                        writeln!(f)?;
+                        writeln!(f, "Parameters:")?;
+                        for parameter in parameters {
+                            write!(f, "- ")?;
+                            if let Some(name) = &parameter.name {
+                                write!(f, "{name}: ")?;
+                            }
+                            write!(f, "{}", contents_to_md(doc, &parameter.content))?;
+                        }
+                    }
+                    _ => {
+                        write!(f, "PRIMSECTION: {section:?}")?;
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        _ => writeln!(f, "TODO doc: {doc:?}"),
+    })
+}
+
+fn contents_to_md<'a>(doc: &'a Doc, contents: &'a [Content]) -> impl fmt::Display + 'a {
+    FormatterFn(move |f| {
+        for content in contents {
+            write!(f, "{}", content_to_md(doc, content))?;
+        }
+        Ok(())
+    })
+}
+
+fn content_to_md<'a>(doc: &'a Doc, content: &'a Content) -> impl fmt::Display + 'a {
+    FormatterFn(move |f| match content {
+        Content::Text { text } => write!(f, "{text}"),
+        Content::CodeVoice { code } => write!(f, "`{code}`"),
+        Content::Emphasis { inline_content } => {
+            write!(f, "_{}_", contents_to_md(doc, inline_content))
+        }
+        Content::Strong { inline_content } => {
+            write!(f, "**{}**", contents_to_md(doc, inline_content))
+        }
+        Content::ThematicBreak {} => writeln!(f, "---"),
+        Content::CodeListing {
+            syntax,
+            code,
+            metadata: _,
+        } => {
+            write!(f, "```")?;
+            if let Some(syntax) = syntax {
+                write!(f, "{syntax}")?;
+            } else {
+                write!(f, "text")?;
+            }
+            writeln!(f)?;
+            for line in code {
+                writeln!(f, "{line}")?;
+            }
+            writeln!(f, "```")?;
+            writeln!(f)?;
+            Ok(())
+        }
+        Content::Image {
+            identifier,
+            metadata,
+        } => {
+            if let Some(Reference::Image { variants, alt, .. }) = doc.references.get(identifier) {
+                let alt = metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.title.clone())
+                    .unwrap_or_else(|| alt.clone().unwrap_or_default());
+                match &**variants {
+                    [] => {
+                        error!(identifier, "image must have at least one variant");
+                        Ok(())
+                    }
+                    [ReferenceVariant { url, .. }] => {
+                        writeln!(f)?;
+                        writeln!(f, "![{alt}]({url})")?;
+                        Ok(())
+                    }
+                    variants => {
+                        let mut light_srcset = String::new();
+                        let mut dark_srcset = String::new();
+                        let mut fallback = None;
+
+                        for variant in variants {
+                            let mut pixel_density = "";
+                            let mut srcset = &mut light_srcset;
+
+                            for trait_ in &variant.traits {
+                                match trait_ {
+                                    ReferenceVariantTrait::X1 => pixel_density = " 1x",
+                                    ReferenceVariantTrait::X2 => pixel_density = " 2x",
+                                    ReferenceVariantTrait::X3 => pixel_density = " 3x",
+                                    ReferenceVariantTrait::Dark => srcset = &mut dark_srcset,
+                                    ReferenceVariantTrait::Light => srcset = &mut light_srcset,
+                                }
+                            }
+
+                            if !srcset.is_empty() {
+                                write!(&mut srcset, ", ").unwrap();
+                            }
+                            write!(&mut srcset, "{}{pixel_density}", variant.url).unwrap();
+
+                            fallback = Some(&variant.url);
+                        }
+
+                        writeln!(f)?;
+                        writeln!(f, "<picture>")?;
+                        if !dark_srcset.is_empty() {
+                            writeln!(
+                                f,
+                                "    <source media=\"(prefers-color-scheme: dark)\" srcset=\"{dark_srcset}\" />"
+                            )?;
+                        }
+                        if !light_srcset.is_empty() {
+                            writeln!(
+                                f,
+                                "    <source media=\"(prefers-color-scheme: light)\" srcset=\"{light_srcset}\" />"
+                            )?;
+                        }
+                        writeln!(f, "    <img alt={alt:?} src={:?} />", fallback.unwrap())?;
+                        writeln!(f, "</picture>")?;
+                        Ok(())
+                    }
+                }
+            } else {
+                error!(identifier, "could not find image reference");
+                Ok(())
+            }
+        }
+        Content::Video { identifier, .. } => {
+            writeln!(f, "(TODO vid: {:?})", doc.references.get(identifier))
+        }
+        Content::Links { style, items } => write!(f, "(TODO links: {content:?})"),
+        Content::Superscript { inline_content } => {
+            writeln!(f, "<sup>{}</sup>", contents_to_md(doc, inline_content))
+        }
+        Content::Small { inline_content } => {
+            writeln!(f, "<sub>{}</sub>", contents_to_md(doc, inline_content))
+        }
+        Content::Row {
+            number_of_columns,
+            columns,
+        } => writeln!(f, "(TODO row: {content:?})"),
+        Content::Table {
+            header,
+            extended_data,
+            rows,
+            alignments,
+            metadata,
+        } => writeln!(f, "(TODO table: {content:?})"),
+        Content::TabNavigator { tabs } => writeln!(f, "(TODO tabnav: {content:?})"),
+        Content::UnorderedList { items } => {
+            for item in items {
+                write!(f, "-")?;
+                let mut iter = item.content.iter();
+                if let Some(first) = iter.next() {
+                    write!(f, " {}", content_to_md(doc, first))?;
+                } else {
+                    writeln!(f)?;
+                }
+                for content in iter {
+                    write!(f, "  {}", content_to_md(doc, content))?;
+                }
+            }
+            Ok(())
+        }
+        Content::OrderedList { start, items } => {
+            let mut value = start.unwrap_or(1);
+            let width = (items.len() + value as usize) / 10;
+            for item in items {
+                write!(f, "{value:>width$}.")?;
+                let mut iter = item.content.iter();
+                if let Some(first) = iter.next() {
+                    write!(f, " {}", content_to_md(doc, first))?;
+                } else {
+                    writeln!(f)?;
+                }
+                for content in iter {
+                    write!(f, "{:>width$} {}", "", content_to_md(doc, content))?;
+                }
+                value += 1;
+            }
+            Ok(())
+        }
+        Content::Topic {
+            identifier,
+            is_active,
+        } => writeln!(f, "(TODO topic: {content:?})"),
+        Content::Reference {
+            identifier,
+            is_active,
+            overriding_title,
+            overriding_title_inline_content,
+        } => {
+            let reference = doc
+                .references
+                .get(identifier)
+                .expect("must have reference in doc");
+            write!(
+                f,
+                "{}",
+                reference_to_md(
+                    doc,
+                    reference,
+                    overriding_title.as_ref(),
+                    overriding_title_inline_content.as_ref()
+                )
+            )
+        }
+        Content::Paragraph { inline_content } => {
+            writeln!(f, "{}", contents_to_md(doc, inline_content))?;
+            writeln!(f)?;
+            Ok(())
+        }
+        Content::Heading {
+            anchor,
+            level,
+            text,
+        } => {
+            // Remove anchor if it's (likely) what `rustdoc` is going to output.
+            // https://github.com/rust-lang/rust/blob/ddaf12390d3ffb7d5ba74491a48f3cd528e5d777/src/librustdoc/html/markdown.rs#L571
+            //
+            // TODO: Normalize the anchor (lowercase).
+            let anchor = anchor.to_ascii_lowercase();
+            if text.chars().filter_map(slugify).collect::<String>() != anchor {
+                writeln!(f, "<a id={anchor:?}></a>")?;
+            }
+            for _ in 0..*level {
+                write!(f, "#")?;
+            }
+            writeln!(f, " {text}")?;
+            writeln!(f)?;
+            Ok(())
+        }
+        Content::NewTerm { inline_content } => {
+            writeln!(f, "(TODO newterm: {})", contents_to_md(doc, inline_content))?;
+            Ok(())
+        }
+        Content::Aside {
+            name,
+            // Styles include "warning", "important", "note" and "tip".
+            // Only "warning" is supported by Rustdoc though:
+            // https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#adding-a-warning-block
+            style: _,
+            content,
+        } => {
+            writeln!(f, "<div class=\"warning\">")?;
+            writeln!(f)?;
+
+            writeln!(f, "### {}", name.as_deref().unwrap_or("Aside"))?;
+
+            writeln!(f, "{}", contents_to_md(doc, content))?;
+
+            writeln!(f)?;
+            writeln!(f, "</div>")?;
+
+            Ok(())
+        }
+        Content::TermList { items } => {
+            for term in items {
+                write!(
+                    f,
+                    "- {}: {}",
+                    contents_to_md(doc, &term.term.inline_content),
+                    contents_to_md(doc, &term.definition.content)
+                )?;
+            }
+
+            Ok(())
+        }
+    })
+}
+
+fn reference_to_md<'a>(
+    doc: &'a Doc,
+    reference: &'a Reference,
+    overriding_title: Option<&'a String>,
+    overriding_title_inline_content: Option<&'a Vec<Content>>,
+) -> impl fmt::Display + 'a {
+    FormatterFn(move |f| match reference {
+        Reference::Link {
+            identifier: _,
+            url,
+            title: _,
+            title_inline_content,
+        } => {
+            let title_inline_content =
+                overriding_title_inline_content.unwrap_or(title_inline_content);
+            write!(f, "[{}]({url})", contents_to_md(doc, title_inline_content))
+        }
+        Reference::Topic {
+            identifier: _,
+            kind,
+            title,
+            name: _,
+            title_style: _,
+            url,
+            ..
+        } => {
+            let title = overriding_title.unwrap_or(title);
+            // TODO: Make these a doc link to the actual item.
+            //
+            // Probably requires using the identifier to look up the item.
+            if kind == "symbol" {
+                write!(f, "[`{title}`](https://developer.apple.com{url})")
+            } else {
+                write!(f, "[{title}](https://developer.apple.com{url})")
+            }
+        }
+        _ => write!(f, "REFERENCE TODO: {reference:?}"),
+    })
+}
+
+fn slugify(c: char) -> Option<char> {
+    if c.is_alphanumeric() || c == '-' || c == '_' {
+        if c.is_ascii() {
+            Some(c.to_ascii_lowercase())
+        } else {
+            Some(c)
+        }
+    } else if c.is_whitespace() && c.is_ascii() {
+        Some('-')
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/header-translator/src/lib.rs
+++ b/crates/header-translator/src/lib.rs
@@ -36,6 +36,7 @@ pub use self::availability::HOST_MACOS;
 pub use self::cfgs::PlatformCfg;
 pub use self::config::{load_config, load_skipped, Config, LibraryConfig};
 pub use self::context::{Context, MacroEntity, MacroLocation};
+pub use self::documentation::TxtMap;
 pub use self::global_analysis::global_analysis;
 pub use self::id::{ItemIdentifier, Location};
 pub use self::library::{EntryExt, Library};

--- a/crates/header-translator/src/method.rs
+++ b/crates/header-translator/src/method.rs
@@ -1109,7 +1109,7 @@ impl fmt::Display for Method {
         // Attributes
         //
 
-        write!(f, "{}", self.documentation.fmt(None))?;
+        write!(f, "{}", self.documentation.fmt())?;
         write!(f, "{}", self.availability)?;
 
         if self.must_use {

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1601,9 +1601,6 @@ impl Stmt {
                         };
 
                         let mut documentation = Documentation::from_entity(&entity, context);
-                        if c_name.is_some() {
-                            documentation.set_apple(None); // TEMPORARY
-                        }
 
                         if ty.is_simple_uint() {
                             ty = expr.guess_type(id.location());

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1600,7 +1600,10 @@ impl Stmt {
                             });
                         };
 
-                        let documentation = Documentation::from_entity(&entity, context);
+                        let mut documentation = Documentation::from_entity(&entity, context);
+                        if c_name.is_some() {
+                            documentation.set_apple(None); // TEMPORARY
+                        }
 
                         if ty.is_simple_uint() {
                             ty = expr.guess_type(id.location());
@@ -2380,7 +2383,7 @@ impl Stmt {
                     let cfg = self.cfg_gate_ln_for([ItemTree::objc("extern_class")], config);
                     write!(f, "{cfg}")?;
                     writeln!(f, "extern_class!(")?;
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "    #[unsafe(super(")?;
                     for (i, (superclass, generics)) in superclasses.iter().enumerate() {
                         if 0 < i {
@@ -2508,7 +2511,7 @@ impl Stmt {
                     methods,
                     documentation,
                 } => {
-                    write!(f, "{}", documentation.fmt(None))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{availability}")?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     // TODO: Add ?Sized here once `extern_methods!` supports it.
@@ -2568,7 +2571,7 @@ impl Stmt {
 
                     writeln!(f)?;
 
-                    write!(f, "{}", documentation.fmt(None))?;
+                    write!(f, "{}", documentation.fmt())?;
 
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
@@ -2751,7 +2754,7 @@ impl Stmt {
                     write!(f, "{cfg}")?;
                     writeln!(f, "extern_protocol!(")?;
 
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "    {}", self.cfg_gate_ln(config))?;
                     write!(f, "    {availability}")?;
                     if *objc_name != id.name {
@@ -2810,7 +2813,7 @@ impl Stmt {
                     documentation,
                     is_union,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
 
@@ -2849,7 +2852,7 @@ impl Stmt {
                         writeln!(f, "pub struct {} {{", id.name)?;
                     }
                     for (name, documentation, ty) in fields {
-                        write!(f, "{}", documentation.fmt(None))?;
+                        write!(f, "{}", documentation.fmt())?;
                         write!(f, "    ")?;
                         if name.starts_with('_') {
                             write!(f, "pub(crate) ")?;
@@ -2906,7 +2909,7 @@ impl Stmt {
                     sendable,
                     documentation,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
 
                     let mut relevant_enum_cases = variants
                         .iter()
@@ -2973,7 +2976,7 @@ impl Stmt {
                         writeln!(f, "impl {} {{", id.name)?;
 
                         for (name, documentation, availability, expr, _) in variants {
-                            write!(f, "{}", documentation.fmt(None))?;
+                            write!(f, "{}", documentation.fmt())?;
                             let pretty_name = name.strip_prefix(prefix).unwrap_or(name);
                             if pretty_name != name {
                                 writeln!(f, "    #[doc(alias = \"{name}\")]")?;
@@ -3006,7 +3009,7 @@ impl Stmt {
                         writeln!(f, "    impl {}: {} {{", id.name, ty.enum_())?;
 
                         for (name, documentation, availability, expr, _) in variants {
-                            write!(f, "{}", documentation.fmt(None))?;
+                            write!(f, "{}", documentation.fmt())?;
                             let pretty_name = name.strip_prefix(prefix).unwrap_or(name);
                             if pretty_name != name {
                                 writeln!(f, "        #[doc(alias = \"{name}\")]")?;
@@ -3036,7 +3039,7 @@ impl Stmt {
                         writeln!(f, "pub enum {} {{", id.name)?;
 
                         for (name, documentation, availability, expr, is_zero) in variants {
-                            write!(f, "{}", documentation.fmt(None))?;
+                            write!(f, "{}", documentation.fmt())?;
                             let pretty_name = name.strip_prefix(prefix).unwrap_or(name);
                             if pretty_name != name {
                                 writeln!(f, "    #[doc(alias = \"{name}\")]")?;
@@ -3085,7 +3088,7 @@ impl Stmt {
                     is_last,
                     documentation,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
                     write!(f, "pub const {}: {} = {value};", id.name, ty.const_())?;
@@ -3102,7 +3105,7 @@ impl Stmt {
                     documentation,
                 } => {
                     writeln!(f, "extern \"C\" {{")?;
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
                     if *link_name != id.name {
@@ -3119,7 +3122,7 @@ impl Stmt {
                     value: Some(expr),
                     documentation,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
                     write!(f, "pub static {}: {} = ", id.name, ty.var())?;
@@ -3209,7 +3212,7 @@ impl Stmt {
                     };
 
                     if needs_wrapper {
-                        write!(f, "{}", documentation.fmt(None))?;
+                        write!(f, "{}", documentation.fmt())?;
                         write!(f, "{}", self.cfg_gate_ln(config))?;
                         write!(f, "{availability}")?;
                         if *must_use {
@@ -3286,7 +3289,7 @@ impl Stmt {
                     } else {
                         writeln!(f, "{}{{", abi.extern_outer())?;
 
-                        write!(f, "{}", documentation.fmt(None))?;
+                        write!(f, "{}", documentation.fmt())?;
                         write!(f, "    {}", self.cfg_gate_ln(config))?;
                         write!(f, "    {availability}")?;
                         if *must_use {
@@ -3316,7 +3319,7 @@ impl Stmt {
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     writeln!(f, "unsafe impl ConcreteType for {} {{", cf_item.id().path())?;
 
-                    write!(f, "{}", documentation.fmt(None))?;
+                    write!(f, "{}", documentation.fmt())?;
                     writeln!(f, "    #[inline]")?;
                     writeln!(f, "    {}fn {}(){ret} {{", abi.extern_outer(), id.name)?;
 
@@ -3337,7 +3340,7 @@ impl Stmt {
                     kind,
                     documentation,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{availability}")?;
                     match kind {
                         Some(UnexposedAttr::TypedEnum) => {
@@ -3378,7 +3381,7 @@ impl Stmt {
                     bridged: _,
                     superclass,
                 } => {
-                    write!(f, "{}", documentation.fmt(Some(id)))?;
+                    write!(f, "{}", documentation.fmt())?;
                     write!(f, "{}", self.cfg_gate_ln(config))?;
                     write!(f, "{availability}")?;
                     writeln!(f, "#[repr(C)]")?;

--- a/crates/header-translator/src/stmt.rs
+++ b/crates/header-translator/src/stmt.rs
@@ -1600,7 +1600,7 @@ impl Stmt {
                             });
                         };
 
-                        let mut documentation = Documentation::from_entity(&entity, context);
+                        let documentation = Documentation::from_entity(&entity, context);
 
                         if ty.is_simple_uint() {
                             ty = expr.guess_type(id.location());


### PR DESCRIPTION
Use the `apple-doc` crate I introduced in 0dd51d5060662288f5c7d900fd1d111c5d2a735f to parse the data that Xcode's documentation viewer uses (this is the same data as on https://developer.apple.com/documentation), and use that in `header-translator` to enhance the documentation we emit.

Fixes https://github.com/madsmtm/objc2/issues/309.

TODO:
- [ ] Finish the implementation, methods don't get this documentation yet, and links are currently to Apple's website instead of to the Rust item.
- [ ] Consider if there's some way we can include Apple's examples / tutorials, to truly make it unnecessary to want to go to Apple's website?
- [ ] Figure out the legal implications of this? We're already redistributing basically the entire Xcode SDK, this would just be taking and redistributing more of Xcode, but maybe there's a difference? Especially given that you _cannot_ interface with Apple's platform without the SDK, and there is not other way to write them, whereas the documentation is maybe more legally protected?
  - I had a discussion with the Rust Foundation about this in September, but they're taking a long time to get back to me.
- [ ] Optimize this, `cargo run --bin header-translator --release -- all` now takes quite a bit longer.

---

As an example of how this would look, compare the documentation for `NSVisualEffectView` [on Apple's website](https://developer.apple.com/documentation/appkit/nsvisualeffectview?language=objc) with what it would be in `objc2-app-kit` after this PR:

<img width="990" height="888" alt="1" src="https://github.com/user-attachments/assets/ca6a3455-df43-4828-a287-58d229bceb58" />
<img width="990" height="887" alt="2" src="https://github.com/user-attachments/assets/66e67e4a-7f43-4606-b471-551fe2d1de41" />
<img width="990" height="887" alt="3" src="https://github.com/user-attachments/assets/93779717-98c4-40e9-948b-5e73e96e9bb5" />
