### PR TITLE
Fix main-thread detection on macOS 26 (compare pthread_main_np() != 0)

### DIFF
--- a/crates/objc2/src/main_thread_marker.rs
+++ b/crates/objc2/src/main_thread_marker.rs
@@ -38,10 +38,15 @@ fn is_main_thread() -> bool {
         // > Returns non-zero if the current thread is the main thread.
         //
         // So unclear if we should be doing a comparison against 1, or a negative comparison against 0?
-        // To be safe, we compare against 1, though in reality, the current implementation can only ever
-        // return 0 or 1:
+        // We follow Apple's header ("non-zero if the current thread is the main thread") and compare
+        // against 0, NOT against 1.
+        //
+        // This matters on macOS 26 (Tahoe): during `applicationDidFinishLaunching` the main thread can
+        // be reported with `pthread_main_np() == -1` ("thread's initialization has not yet completed").
+        // The old `== 1` check then wrongly returned `false`, so `MainThreadMarker::new()` returned
+        // `None` and downstream callers (`tao`/`winit`) panicked on launch — see tauri-apps/tao#1171.
         // https://github.com/apple-oss-distributions/libpthread/blob/libpthread-535/src/pthread.c#L1084-L1089
-        unsafe { pthread_main_np() == 1 }
+        unsafe { pthread_main_np() != 0 }
     }
 
     #[cfg(not(target_vendor = "apple"))]


### PR DESCRIPTION
On macOS 26 (Tahoe), `pthread_main_np()` can return `-1` ("the thread's initialization has not yet completed") for the **main thread** during early launch — in particular inside `applicationDidFinishLaunching`.

`is_main_thread()` currently checks `pthread_main_np() == 1`, so in that window it returns `false`, `MainThreadMarker::new()` yields `None`, and downstream callers that `.unwrap()` it abort at startup. This breaks app launch for every `tao`/`winit`-based app (Tauri, etc.) on macOS 26.

### Fix
Compare against `0` instead of `1`, matching Apple's own header comment already quoted in the code:

> Returns non-zero if the current thread is the main thread.

A non-main thread still returns `0`, so the check remains correct there; this only additionally treats the transient `-1` ("init not complete") main-thread state as main, which is what the header promises.

### Refs
- Downstream crash report: tauri-apps/tao#1171
- libpthread source for the return values: https://github.com/apple-oss-distributions/libpthread/blob/libpthread-535/src/pthread.c#L1084-L1089

Verified by launching a Tauri app on macOS 26.5.1 (the `MainThreadMarker::new().unwrap()` in tao's app delegate no longer panics with this change).